### PR TITLE
fix: agents delegate by fit rather than to whoever is free

### DIFF
--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -29,9 +29,13 @@ pub fn specs() -> Vec<ToolSpec> {
     vec![
         ToolSpec {
             name: DIRECTORY.to_string(),
-            description: "List the other agents in this workspace, with their skills and current \
-                          status. Call this before send_message whenever you are not certain of \
-                          an agent's exact name."
+            // Framed as the routing decision, not a spelling check. Described
+            // as a name lookup, it got used as one: a coordinator called it,
+            // read three names, and sent the same research task to all three.
+            description: "List the agents you can reach, with what each one is for and its \
+                          current status. Call this to decide who should do a piece of work: \
+                          the skills are how you tell which agent the task belongs to, not \
+                          decoration on a list of addresses."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -114,12 +118,18 @@ pub fn specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: SCHEDULE.to_string(),
+            // The prohibition is here because a fired routine is a fresh run
+            // with a fresh budget: polling for a reply is the one use of this
+            // tool that routes around every limit on what a run may spend.
             description: "Keep your own schedule. Use this to do something later, or to keep \
                           doing it: `add` with `every_secs` repeats, `add` with only `in_secs` \
                           fires once. When it fires you get the instruction back as a new \
                           message and work as usual, so write it as something you will be able \
                           to act on with no other context. Nothing is running while you wait, \
-                          and a routine outlives restarts."
+                          and a routine outlives restarts. Never schedule a check for a reply, a \
+                          result, or anything else you are waiting on: those arrive as new \
+                          messages on their own, so a routine that fires to look for one only \
+                          spends a turn finding nothing."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -223,10 +233,16 @@ pub fn specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: SEND_MESSAGE.to_string(),
-            description: "Send a message to one or more other agents. Delivery is asynchronous \
-                          and non-blocking: this returns as soon as the messages are queued. \
-                          Replies, if any, arrive later as new messages addressed to you. Do not \
-                          wait for a reply and do not call this again to check for one."
+            description: "Send a message to the other agents a piece of work belongs to. Choose \
+                          them by fit: the agents whose skills cover this task, and no others. \
+                          Reaching every agent in the directory is not thoroughness, it is \
+                          skipping the decision, and cutting the task into a piece each is the \
+                          same thing with a plan attached: both buy answers from agents the work \
+                          was never for. Address several only when the content is genuinely for \
+                          all of them. Delivery is asynchronous and non-blocking: this returns as \
+                          soon as the messages are queued. Replies, if any, arrive later as new \
+                          messages addressed to you. Do not wait for a reply and do not call \
+                          this again to check for one."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -235,7 +251,8 @@ pub fn specs() -> Vec<ToolSpec> {
                         "type": "array",
                         "items": { "type": "string" },
                         "minItems": 1,
-                        "description": "Exact agent names, as returned by directory."
+                        "description": "Exact agent names, as returned by directory. Only the \
+                                        agents this particular message is for."
                     },
                     "text": {
                         "type": "string",
@@ -728,6 +745,62 @@ mod tests {
         // replying that it has no graphical browser.
         let spec = specs().into_iter().find(|s| s.name == OPEN_ON_DESKTOP).unwrap();
         assert!(spec.description.contains("google-chrome"), "{}", spec.description);
+    }
+
+    /// The one description under test, by name.
+    fn description(name: &str) -> String {
+        specs().into_iter().find(|s| s.name == name).unwrap().description
+    }
+
+    #[test]
+    fn the_directory_reads_as_a_routing_decision() {
+        // Described as a name lookup, it was used as one: a coordinator asked
+        // for research called it, read three names back, and sent the task to
+        // all three. The schema cannot express "pick the right one", so this
+        // sentence is the only place the decision can live.
+        let spec = description(DIRECTORY);
+        assert!(spec.contains("decide who should do a piece of work"), "{spec}");
+        assert!(
+            !spec.contains("not certain of an agent's exact name"),
+            "the spelling-check framing is what produced the broadcast: {spec}"
+        );
+    }
+
+    #[test]
+    fn send_message_tells_the_model_to_choose_its_recipients() {
+        // `to` is an array with minItems 1 and no maximum, so one call to every
+        // agent costs the model exactly what one call to the right agent costs.
+        // Nothing in the schema can charge for breadth; the description has to.
+        let spec = description(SEND_MESSAGE);
+        assert!(spec.contains("Choose them by fit"), "{spec}");
+        assert!(spec.contains("no others"), "{spec}");
+        assert!(
+            spec.contains("genuinely for all of them"),
+            "an announcement is legitimate, so the rule has to leave room for one: {spec}"
+        );
+
+        let to = specs().into_iter().find(|s| s.name == SEND_MESSAGE).unwrap().parameters
+            ["properties"]["to"]["description"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(
+            to.contains("this particular message is for"),
+            "the parameter is read closer to the call than the description is: {to}"
+        );
+    }
+
+    #[test]
+    fn schedule_forbids_polling_for_something_that_will_arrive_by_itself() {
+        // A fired routine is a fresh run with a fresh step budget. Scheduling a
+        // check for a reply is therefore the one use of this tool that spends
+        // outside every limit the guard applies to the run that made it.
+        let spec = description(SCHEDULE);
+        assert!(spec.contains("Never schedule a check for a reply"), "{spec}");
+        assert!(
+            spec.contains("arrive as new messages on their own"),
+            "a prohibition without the alternative gets reworded and retried: {spec}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -98,7 +98,10 @@ pub fn system_prompt(
          doing. When a routine fires you receive its instruction as a new message, so write it \
          as something you can act on with nothing else in front of you. Use it whenever you are \
          asked for something recurring, and prefer one routine that does the whole job over \
-         several that each do a piece of it.\n\n\
+         several that each do a piece of it. Never schedule a check for a reply, a result or \
+         anything else you are waiting on: those reach you as new messages by themselves. A \
+         routine that fires to go looking finds nothing, because whatever you were waiting for \
+         would already have arrived.\n\n\
          Never say you have no computer, no browser, or no way to look something up. You have \
          all three. Say what you ran and what it returned rather than presenting a result as \
          something you simply knew.\n",
@@ -260,7 +263,18 @@ pub fn system_prompt(
 
     out.push_str(
         "\n## Talking to other agents\n\
-         - `directory` lists the agents you can reach. Call it when you are unsure of a name.\n\
+         - `directory` lists the agents you can reach and what each one is for. It answers who \
+         should do a piece of work, not merely how a name is spelled.\n\
+         - Send to the agents whose skills fit the work, and to nobody else. Deciding who fits is \
+         the work of delegating, and spreading a task over everyone available skips it. Cutting \
+         it into a piece each is the same mistake with a plan attached: a question about history \
+         handed to a mathematician is still handed to the wrong agent, however the covering note \
+         is worded. A peer with no part in this costs the operator a model call and answers from \
+         outside its competence, which is worse than not answering. One fitting agent means one \
+         message.\n\
+         - Send to everyone only when the content is genuinely for everyone, such as an \
+         announcement. If nobody fits, handle it yourself or tell the operator the crew has no \
+         one for it; the nearest available name is not a fit.\n\
          - `send_message` delivers to one or more agents. It is asynchronous and non-blocking: it \
          returns once the message is queued. Any reply arrives later as a separate message. Never \
          wait for a reply, and never call `send_message` again just to check for one.\n\
@@ -666,6 +680,75 @@ mod tests {
             "knowing who has it is only useful with the instruction to use them"
         );
         assert!(prompt.contains("not yours to use"), "and that it cannot borrow the session");
+    }
+
+    #[test]
+    fn an_agent_is_told_to_pick_recipients_by_fit() {
+        // The observed failure, and it was not a broadcast. A coordinator asked
+        // for research called `directory`, read back three names, and wrote
+        // three different briefs: the history to a Mathematician, the casualty
+        // figures to a Scientist to "independently assess". Every message was
+        // well formed and each had a rationale. The roster printed skills and
+        // never said what they were for, so with no criterion for narrowing,
+        // one piece per available body is the reading that looks most like
+        // work.
+        let prompt = prompt_for(
+            &card("Manager"),
+            &[
+                entry("Researcher", &["web research"]),
+                entry("Mathematician", &["arithmetic"]),
+                entry("Scientist", &["experiments"]),
+            ],
+            "",
+            ReplyMode::ToOperator,
+        );
+        assert!(
+            prompt.contains("whose skills fit the work, and to nobody else"),
+            "the roster's skills have to be named as the basis for choosing"
+        );
+        assert!(
+            prompt.contains("Cutting it into a piece each"),
+            "the shape that was actually observed was a split, not one text sent to everyone, \
+             and a rule that only forbids broadcasting leaves it untouched"
+        );
+        assert!(
+            prompt.contains("Send to everyone only when"),
+            "an announcement is still a real thing; the rule cannot forbid it outright"
+        );
+        assert!(
+            prompt.contains("the nearest available name is not a fit"),
+            "an agent with nobody to ask needs somewhere to go that is not the wrong peer"
+        );
+    }
+
+    #[test]
+    fn the_directory_is_offered_as_a_decision_rather_than_a_spelling_check() {
+        // Described as a name lookup, it was used as one: the names came back
+        // and all of them were used. What an agent is for is the half that
+        // decides who should get the work.
+        let prompt =
+            prompt_for(&card("Manager"), &[entry("Chef", &["cooking"])], "", ReplyMode::ToOperator);
+        assert!(prompt.contains("what each one is for"));
+        assert!(
+            !prompt.contains("Call it when you are unsure of a name"),
+            "the old framing is what produced the broadcast"
+        );
+    }
+
+    #[test]
+    fn an_agent_is_told_not_to_schedule_a_check_for_a_reply() {
+        // A fired routine is a fresh run with a fresh budget, so polling for a
+        // reply is the one use of `schedule` that routes around every limit on
+        // what a run may spend. Observed twice in one turn, 19 and 34 seconds
+        // out, both of them ahead of any reply.
+        let prompt =
+            prompt_for(&card("Manager"), &[entry("Chef", &["cooking"])], "", ReplyMode::ToOperator);
+        assert!(prompt.contains("Never schedule a check for a reply"));
+        assert!(
+            prompt.contains("arrive as new messages")
+                || prompt.contains("reach you as new messages"),
+            "the prohibition only holds if the agent knows what happens instead"
+        );
     }
 
     #[test]

--- a/src-tauri/tests/evals.rs
+++ b/src-tauri/tests/evals.rs
@@ -509,15 +509,95 @@ mod live {
     }
 
     /// Everything a live scenario needs: real agents, real model, real prompt.
-    async fn run_live(names: &[&str], instruction: &str) -> Option<Eval> {
-        let config = configured()?;
-        let h = live_harness(config, names);
-        let run = h.runtime.send_from_human(h.id(names[0]), instruction).unwrap();
+    async fn run_live(names: &[&'static str], instruction: &str) -> Option<Eval> {
+        let crew: Vec<LiveAgent> = names.iter().map(|n| LiveAgent::generic(n)).collect();
         // Generous: several sequential model calls, over a network, and a
         // failure here should mean "this crew never stopped talking", not
         // "the endpoint was slow".
-        h.settle_within(run, 180).await;
-        Some(read(&h, names))
+        run_live_crew(&crew, instruction, 180).await.map(|(_, eval)| eval)
+    }
+
+    /// The same, for scenarios that have to look at who was messaged rather
+    /// than at how much was said. The harness comes back because the answer is
+    /// in the envelopes, and `Conversation` counts peer traffic without
+    /// recording where any of it went.
+    ///
+    /// `secs` is per scenario because the settle window is a property of the
+    /// work, not of the network. These run against the operator's own limits,
+    /// which allow a hundred tool rounds, so an agent handed a real task starts
+    /// a machine and uses it: the first run of this took longer than three
+    /// minutes with nothing wrong.
+    async fn run_live_crew(
+        crew: &[LiveAgent],
+        instruction: &str,
+        secs: u64,
+    ) -> Option<(Harness, Eval)> {
+        let config = configured()?;
+        let before = machines_now(&config).await;
+        let h = live_crew(config.clone(), crew);
+        let names: Vec<&str> = crew.iter().map(|a| a.name).collect();
+        let run = h.runtime.send_from_human(h.id(names[0]), instruction).unwrap();
+
+        let settled = h.settled_within(run, secs).await;
+        // Before the assertions, because an assertion that fails takes the rest
+        // of the function with it, and what is left standing is a real machine
+        // billing for its idle period. Twenty accumulated this way in an
+        // afternoon, and the timeouts left the most behind.
+        release_machines(&config, before).await;
+
+        assert!(settled, "run did not settle in {secs}s. messages so far:\n{}", h.transcript());
+        let eval = read(&h, &names);
+        Some((h, eval))
+    }
+
+    /// Every sandbox this account holds, by id.
+    async fn machines_now(config: &guac_lib::config::AppConfig) -> Vec<String> {
+        match guac_lib::e2b::E2bClient::new(&config.e2b.api_key) {
+            Some(client) => client.list_ours().await.unwrap_or_default(),
+            None => Vec::new(),
+        }
+    }
+
+    /// Kills whatever this run brought into existence, and nothing else.
+    ///
+    /// A diff against a baseline rather than a walk over the crew's rows. An
+    /// agent whose first machine does not answer starts another and records
+    /// only the newest, so the rows name one of the several a single run can
+    /// leave behind; seventeen survived a cleanup written that way.
+    ///
+    /// It is also why `Runtime::sweep_computers` cannot be borrowed for this.
+    /// That kills every Guac sandbox its own store does not claim, so run from
+    /// a throwaway store it would spare this crew's machines and take the
+    /// operator's running app apart instead.
+    async fn release_machines(config: &guac_lib::config::AppConfig, before: Vec<String>) {
+        let Some(client) = guac_lib::e2b::E2bClient::new(&config.e2b.api_key) else {
+            return;
+        };
+        let existing: std::collections::HashSet<String> = before.into_iter().collect();
+        for sandbox in client.list_ours().await.unwrap_or_default() {
+            if existing.contains(&sandbox) {
+                continue;
+            }
+            match client.kill(&sandbox).await {
+                Ok(()) => println!("released {sandbox}"),
+                Err(err) => eprintln!("could not release {sandbox}: {err}"),
+            }
+        }
+    }
+
+    /// Which peers were sent something, by name, with a count each.
+    fn recipients(h: &Harness, names: &[&str]) -> Vec<(String, usize)> {
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        for envelope in h.feed() {
+            if let Some(id) = envelope.to.agent_id() {
+                if let Some(name) = names.iter().find(|n| h.id(n) == id) {
+                    *counts.entry((*name).to_string()).or_default() += 1;
+                }
+            }
+        }
+        let mut out: Vec<(String, usize)> = counts.into_iter().collect();
+        out.sort();
+        out
     }
 
     fn report(scenario: &str, eval: &Eval) {
@@ -597,6 +677,108 @@ mod live {
 
     #[tokio::test]
     #[ignore = "live: costs money, needs a configured key"]
+    async fn live_work_goes_only_to_the_agent_it_is_for() {
+        // The observed failure, reproduced with the crew that produced it. A
+        // coordinator told it does not do the work itself was asked a research
+        // question and sent it to the Researcher, the Mathematician and the
+        // Scientist. Every message was well formed. Nothing refused it: three
+        // recipients is inside a fan-out limit of eight, so the guard is not
+        // the thing that was supposed to catch this and lowering it would only
+        // break announcements.
+        //
+        // What was missing was a reason to choose. The roster printed each
+        // peer's skills and never said what they were for, and `directory` was
+        // described as a way to check a name. So this eval asks the one
+        // question CI cannot: reading the prompts as they now stand, does a
+        // coordinator narrow?
+        // The crew is copied off the machine this happened on, because every
+        // detail that looked incidental turned out to matter. The skills really
+        // are one word each. No card carries a system prompt: the standing
+        // instruction arrived as the operator's message, which is why it is at
+        // the front of the instruction below rather than on the Manager. And
+        // the coordinator runs a different model from the crew it directs,
+        // which is the agent under test here, so a crew put entirely on the
+        // default model is not this scenario.
+        //
+        // Three questions and three peers is what makes this the hard case. The
+        // easy reading is one question per agent, and it is wrong: all three
+        // questions are history, and only one of these agents does history.
+        let crew = [
+            LiveAgent {
+                name: "Manager",
+                skills: &["Manager"],
+                prompt: Some(""),
+                model: Some("openai/gpt-5.6-luna"),
+            },
+            LiveAgent {
+                name: "Researcher",
+                skills: &["researcher"],
+                prompt: Some(""),
+                model: None,
+            },
+            LiveAgent {
+                name: "Mathematician",
+                skills: &["mathematics"],
+                prompt: Some(""),
+                model: None,
+            },
+            LiveAgent { name: "Scientist", skills: &["scientist"], prompt: Some(""), model: None },
+        ];
+        let names: Vec<&str> = crew.iter().map(|a| a.name).collect();
+
+        // Generous, because all three specialists start machines and read
+        // Wikipedia before answering, exactly as they did on the day. A
+        // timeout here would fail the eval for the wrong reason.
+        let Some((h, eval)) = run_live_crew(
+            &crew,
+            "You are the Manager, you do not work, you delegate and escalate to me only when \
+             necessary. Now, I want research done. How many Japanese died fighting in China? Why \
+             did Japan invade China? What was the U.S.'s involvement?",
+            420,
+        )
+        .await
+        else {
+            eprintln!("no configured model; skipping");
+            return;
+        };
+        report("research delegated to a mixed crew", &eval);
+
+        let got = recipients(&h, &names);
+        println!("messaged: {got:?}");
+
+        let strangers: Vec<&(String, usize)> =
+            got.iter().filter(|(name, _)| name == "Mathematician" || name == "Scientist").collect();
+        assert!(
+            strangers.is_empty(),
+            "a research question reached {strangers:?}, who have no research skill between \
+             them. Delegating to everyone is the failure this eval exists for.\n\n{}",
+            eval.convo.script
+        );
+        assert!(
+            got.iter().any(|(name, _)| name == "Researcher"),
+            "the work still has to be delegated, and the Researcher is who it is for\n\n{}",
+            eval.convo.script
+        );
+        eval.expect_clean("research delegated to a mixed crew");
+
+        // The second half of the same turn. A fired routine starts a fresh run
+        // with a fresh step budget, so a coordinator that schedules a check for
+        // replies spends outside every limit applied to the run that scheduled
+        // it. The one observed booked two, 19 and 34 seconds out, both ahead of
+        // any reply.
+        let booked = h.runtime.store().agent_routines(h.id("Manager")).unwrap();
+        assert!(
+            booked.is_empty(),
+            "the Manager scheduled {} routine(s) instead of waiting for replies that arrive on \
+             their own: {:?}\n\n{}",
+            booked.len(),
+            booked.iter().map(|r| r.what.clone()).collect::<Vec<_>>(),
+            eval.convo.script
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "live: costs money, needs a configured key"]
     async fn live_two_step_delegation() {
         // The hard one for the current design: a manager that needs two
         // different specialists in sequence.
@@ -617,27 +799,65 @@ mod live {
     }
 }
 
+/// One agent in a live crew.
+///
+/// Skills are here because a scenario about who should get a piece of work is
+/// not testable without them: a crew of four agents with no stated skills gives
+/// a coordinator nothing to choose between, and the broadcast it produces is
+/// then the right answer.
+struct LiveAgent {
+    name: &'static str,
+    skills: &'static [&'static str],
+    /// `None` takes a serviceable default. `Some("")` means the card really
+    /// carries no instructions, which is how most agents are created and is
+    /// what the workspace rules have to hold up without.
+    prompt: Option<&'static str>,
+    /// Overrides the configured default. A crew is not obliged to share a
+    /// model, and a coordinator on a different one from the agents it directs
+    /// is the arrangement that produced the defect these evals were written
+    /// for: putting everyone on the default quietly tests a different app.
+    model: Option<&'static str>,
+}
+
+impl LiveAgent {
+    /// An agent for scenarios that are not about who does what.
+    fn generic(name: &'static str) -> Self {
+        LiveAgent { name, skills: &[], prompt: None, model: None }
+    }
+
+    fn system_prompt(&self) -> String {
+        match self.prompt {
+            Some(prompt) => prompt.to_string(),
+            None => format!(
+                "You are the {}. Work with your team the way the workspace rules say.",
+                self.name
+            ),
+        }
+    }
+}
+
 /// A harness pointed at the real configured endpoint rather than a stub.
-fn live_harness(config: guac_lib::config::AppConfig, names: &[&str]) -> Harness {
+fn live_crew(config: guac_lib::config::AppConfig, crew: &[LiveAgent]) -> Harness {
     let dir = tempfile::tempdir().unwrap();
     let store = guac_lib::db::Store::open(&dir.path().join("guac.db")).unwrap();
 
     let mut ids = HashMap::new();
-    for name in names {
+    for agent in crew {
         let card = store
             .create_agent(&CleanDraft {
-                name: (*name).to_string(),
+                name: agent.name.to_string(),
                 avatar: "plain".into(),
                 color: "#c7d96b".into(),
-                model: config.inference.default_model.clone(),
-                system_prompt: format!(
-                    "You are the {name}. Work with your team the way the workspace rules say."
-                ),
-                skills: vec![],
+                model: agent
+                    .model
+                    .map(str::to_string)
+                    .unwrap_or_else(|| config.inference.default_model.clone()),
+                system_prompt: agent.system_prompt(),
+                skills: agent.skills.iter().map(|s| (*s).to_string()).collect(),
                 group_id: None,
             })
             .unwrap();
-        ids.insert((*name).to_string(), card.id);
+        ids.insert(agent.name.to_string(), card.id);
     }
 
     let sink = guac_lib::runtime::events::RecordingSink::new();

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -343,6 +343,19 @@ impl Harness {
     /// delegation is several in sequence. The stub timeout was reporting live
     /// runs that were merely thinking as runs that had hung.
     pub async fn settle_within(&self, run: RunId, secs: u64) {
+        if !self.settled_within(run, secs).await {
+            panic!("run did not settle. messages so far:\n{}", self.transcript());
+        }
+    }
+
+    /// The same wait, reporting rather than panicking.
+    ///
+    /// A live run holds real machines, and a panic here skips whatever the
+    /// caller meant to release: the timeouts are exactly the runs that leave
+    /// the most behind, because a run that overruns is a run whose agents are
+    /// all still working. A caller that owns something has to be able to clean
+    /// up before it fails.
+    pub async fn settled_within(&self, run: RunId, secs: u64) -> bool {
         let deadline = Instant::now() + Duration::from_secs(secs);
         loop {
             let settled = self
@@ -352,19 +365,22 @@ impl Harness {
                 // Let any final persistence land before assertions read it.
                 tokio::time::sleep(Duration::from_millis(50)).await;
                 assert_eq!(settled, 1, "RunSettled must fire exactly once per run");
-                return;
+                return true;
             }
             if Instant::now() > deadline {
-                panic!(
-                    "run did not settle. messages so far:\n{:#?}",
-                    self.sink
-                        .appended_messages()
-                        .iter()
-                        .map(|m| format!("{:?} -> {:?}: {}", m.from, m.to, m.plain_text()))
-                        .collect::<Vec<_>>()
-                );
+                return false;
             }
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
+    }
+
+    /// Everything said so far, for a failure that has to be actionable.
+    pub fn transcript(&self) -> String {
+        self.sink
+            .appended_messages()
+            .iter()
+            .map(|m| format!("  {:?} -> {:?}: {}", m.from, m.to, m.plain_text()))
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 }


### PR DESCRIPTION
A Manager asked for research called `directory`, read back three names, and wrote three briefs: the history to the Mathematician, the casualty figures to the Scientist to "independently assess". Every message was well formed, each had a rationale, and nothing refused it. Three recipients is inside a fan-out limit of eight, so the guard was never going to catch this, and lowering it would only break announcements.

What was missing was a reason to choose. The roster printed each peer's skills and never said what they were for, and `directory` was described as a way to check a spelling, so it got used as one. With no criterion for narrowing, one piece per available body is the reading that looks most like work.

## What changed

- The prompt's delegation section names the decision, and says that cutting a task into a piece each is the same mistake as sending it to everyone. Announcements stay legitimate. An agent with nobody suitable is told to handle it or say so, rather than picking the nearest name.
- `directory` is described as the routing decision instead of a spelling check. `send_message` says to choose recipients by fit, and its `to` parameter says only the agents the message is for.
- `schedule` forbids booking a check for a reply. The same turn booked two routines 19 and 34 seconds out, both ahead of any reply. A fired routine starts a fresh run with a fresh step budget, so polling that way is the one use of `schedule` that spends outside every limit on the run that scheduled it.

## Verification

Seven unit tests cover the wording and fail against the text on `main`.

The live eval reproduces the original with the crew as configured, which took getting right: with invented skills, a softened question, or the coordinator on the default model instead of its own, the old prompts pass and the eval proves nothing. Against the real crew:

| | before | after |
|---|---|---|
| peer messages | 11 | 1 |
| agents messaged | Researcher, Mathematician, Scientist | Researcher |
| hop depth | 4 | 2 |
| told the operator | 9 times | twice |
| faults | `Manager answered one instruction 6 times` | none |

Three runs against the new prompts, all clean.

## Harness

The eval harness leaked sandboxes. Cleanup now runs before the assertions, so a failing or timed-out run still releases what it made; the timeouts leaked the most, because a run that overruns is one whose agents are all still working. It diffs against a baseline taken before the run rather than reading the crew's rows: an agent that retries starts another sandbox and records only the newest, so seventeen survived a cleanup written the other way.

`Runtime::sweep_computers` cannot be borrowed for this. It kills every Guac sandbox its own store does not claim, so run from a throwaway store it would spare the eval's machines and take the operator's running app apart instead.