### PR TITLE
feat: agents can add agents, and ask before they do

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,16 @@ a batch is a timing artifact: three peers answering at once can be split across
 turns, and deciding from the batch made two of them look like strangers. Ask the
 guard, which counts sends per pair for the whole run.
 
+**A protected action parks the turn that asked for it, and the row is the
+verdict.** `create_agent` stops mid-turn and waits on a person. The operator's
+click and the turn's own timeout can land in the same instant, so the answer is
+read back from the `approvals` row rather than from the channel the wakeup
+arrived on: `settle_approval` only moves a row out of `pending`, and whichever
+of the two loses that race changes nothing. Anything still pending at startup is
+expired, because nothing holds a parked turn across a restart. "Always allow" is
+the decision row itself, scoped to the one agent that asked. See
+`docs/ARCHITECTURE.md`.
+
 **Migrations are forward-only and numbered.** One has already run against a real
 database by the time you think of an improvement, and editing it leaves that
 database at the same `user_version` with a different schema. Add another.
@@ -39,12 +49,17 @@ lands on one side fails the build rather than at runtime.
 **`Store::open` has two SQLite lessons encoded in comments.** Do not reorder the
 pragmas or simplify the migration transaction without reading them.
 
-**There are two Chrome profiles on every machine, and only one of them counts.**
-Chrome ignores `--remote-debugging-port` when it re-attaches to an existing
-profile, so `browse` drives a profile of its own under `~/.guac/chrome`, while
-`open_on_desktop google-chrome` opens the default one. Sign-in detection reads
-the profile `browse` drives, so a session established in the other window is
-invisible to every agent and nothing reports an error.
+**There is one Chrome profile on every machine, and keeping it that way is
+deliberate.** Chrome ignores `--remote-debugging-port` when it re-attaches to an
+existing profile, so `browse` needs a profile it controls. There used to be a
+second, default one behind `open_on_desktop` and the desktop icon, and a
+sign-in performed there was invisible to every agent with nothing reporting an
+error. Now every route is shimmed onto `/home/user/.guac/chrome`: a wrapper
+first on `PATH`, a `.desktop` entry in the user's own XDG directory, the flags
+added again at the call site, and a browser found on any other profile is
+closed when the desktop starts. If you add a way to open a browser, it goes
+through `chrome_flags`, and the port goes with the profile or `browse` loses its
+remote interface.
 
 **Sign-ins are detected, never declared.** The browser is holding the cookies,
 so `domain/signin.rs` asks it rather than asking the operator to keep a list.
@@ -65,6 +80,14 @@ the real cookie names; do not loosen them without a fresh capture.
 only point in the system that sees one, and `CookieMark` has no field it could
 arrive in.
 
+**A failed model call is retried before the operator hears about it, and the
+row the retry reads is the transcript.** `stream_with_retries` re-attempts only
+what `is_transient` admits to, reopens the stream so a second attempt cannot
+append to a first one's half-written text, and never reserves a second step: a
+call is one call however many times the network dropped it. What survives that
+becomes a notice carrying the `cause` of the turn, which is what the operator's
+"Try again" sends again, as a new run at the original hop.
+
 **A credential's secret must never reach the model.** It goes from SQLite into
 the `envs` of one sandbox command and stops there. Not into a prompt, not into
 the transcript, not over IPC, and deliberately not into a dotfile on the sandbox
@@ -78,7 +101,8 @@ physical, not a policy: cookies are on one disk and a token is a string.
 ```
 src/                 React + TypeScript. A view over the runtime, nothing more.
 src-tauri/src/
-  domain/            AgentCard, Envelope, Routine, Connector, Signin, ids. No I/O.
+  domain/            AgentCard, Envelope, Routine, Connector, Signin, Approval,
+                     ids. No I/O.
   runtime/
     guard.rs         The loop guard. Read this one first.
     mod.rs           Agent actors and the message bus.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,6 +116,40 @@ principal. Guaca handles it in two places:
 The directory deliberately excludes `system_prompt`, so one agent cannot read
 another's instructions by listing peers. There is a test for that too.
 
+## A protected action parks the turn that asked for it
+
+Agents can add agents. Every other tool acts on the asking agent's own machine,
+notes or peers; this one changes the workspace and adds something the operator
+pays to run, so it stops and asks.
+
+The turn does not return and retry later. It parks: `create_agent` writes a
+request row, puts a card in the channel it is talking in, and awaits a channel
+under a ten-minute timeout while the actor holds its place. That costs one idle
+task and keeps the whole thing linear, so the tool result the model reads is the
+real outcome rather than a promise. It also means the run genuinely has not
+settled while a person is thinking, which is the truth.
+
+Three things follow, and each is load-bearing:
+
+- **The row is the verdict, not the channel.** The operator's click and the
+  turn's timeout can land in the same instant. `settle_approval` only moves a
+  row out of `pending`, so whichever arrives second changes nothing, and the
+  parked turn reads its answer back from the row afterwards. A button that
+  visibly said "allowed" therefore allowed it.
+- **A restart expires everything pending.** Nothing holds a parked turn across
+  one, so a `pending` row after a restart is a question that can no longer reach
+  anybody. `expire_pending_approvals` runs at startup, before the window opens.
+- **"Always allow" is one agent being let off one question.** The grant is the
+  decision row itself (`state = 'alwaysAllow'` for that agent and that action),
+  not a second table that could disagree with it. It is scoped per agent because
+  that is what the operator was asked: allowing the Manager to create agents
+  says nothing about anyone else. Deleting an agent deletes its grants, since a
+  freed name must not inherit them.
+
+The wording the operator reads is composed by the runtime from the validated
+draft, never by the model. An agent that could write its own request could
+describe creating an agent as tidying up.
+
 ## Storage
 
 SQLite, two tables, plain SQL, forward-only coded migrations. No ORM: there are

--- a/scripts/connectors.sh
+++ b/scripts/connectors.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# The live connector tests: whether a credential the operator pasted in actually
+# reaches the service it is for, from a real machine.
+#
+# CI cannot answer this. The scripted suites prove the secret goes into a
+# sandbox's environment and nowhere else; only the real API can show that an
+# agent handed the key can do the work the key is for.
+#
+#   ./scripts/connectors.sh          every connector scenario
+#   ./scripts/connectors.sh mistral  just the ones whose name matches
+#
+# The keys come from the app's own settings and database, so what is measured is
+# what the operator is actually running. A sandbox is created and released; the
+# API calls cost a few cents.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+CONFIG="$HOME/Library/Application Support/com.madebywelch.guac/config.json"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "no settings at $CONFIG; open Guaca and add an E2B key first" >&2
+  exit 1
+fi
+
+printf '\033[1m==> Live connector tests\033[0m\n'
+echo "These start a real machine and call real APIs. Ctrl-C now if that is a surprise."
+echo
+
+# --nocapture so the extracted text is printed whether or not it passed: a pass
+# with unreadable output is still worth looking at, and a failure is
+# unactionable without seeing what came back.
+cargo test --manifest-path src-tauri/Cargo.toml --test connectors \
+  "${1:-}" -- --ignored --nocapture --test-threads=1

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -63,6 +63,17 @@ pub fn run() {
             let workspace_dir = data_dir.join("workspace");
 
             let store = Store::open(&db_path)?;
+            // A permission request is answered by a turn that is holding the
+            // line for it, and nothing holds a line across a restart. Anything
+            // still pending here is waiting on an agent that no longer exists,
+            // so it is closed rather than left drawing live buttons.
+            match store.expire_pending_approvals() {
+                Ok(0) => {}
+                Ok(n) => {
+                    tracing::info!(expired = n, "closed permission requests left by a restart")
+                }
+                Err(err) => tracing::warn!(%err, "could not close stale permission requests"),
+            }
             let app_config = config::load(&config_path)?;
             let sink = Arc::new(TauriSink { app: app.handle().clone() });
 
@@ -128,6 +139,10 @@ pub fn run() {
             commands::create_group,
             commands::update_group,
             commands::delete_group,
+            commands::approval_states,
+            commands::decide_approval,
+            commands::agent_grants,
+            commands::revoke_grant,
             commands::list_agents,
             commands::create_agent,
             commands::update_agent,
@@ -140,6 +155,7 @@ pub fn run() {
             commands::channel_messages,
             commands::conversation_flow,
             commands::send_message,
+            commands::retry_turn,
             commands::clear_channel,
             commands::clear_group,
             commands::agent_routines,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,10 +13,11 @@ use tauri::State;
 
 use crate::config::{self, AppConfig, RedactedConfig};
 use crate::domain::agent::{AgentCard, AgentDraft, Lifecycle};
+use crate::domain::approval::{Approval, ApprovalState, Decision, ProtectedAction};
 use crate::domain::connector::{Connector, ConnectorDraft};
 use crate::domain::envelope::Envelope;
 use crate::domain::group::{Group, GroupDraft};
-use crate::domain::ids::{AgentId, ConnectorId, GroupId, RoutineId, RunId};
+use crate::domain::ids::{AgentId, ApprovalId, ConnectorId, GroupId, MessageId, RoutineId, RunId};
 use crate::domain::now_ms;
 use crate::domain::routine::{self, Routine};
 use crate::domain::signin::Signin;
@@ -54,7 +55,14 @@ impl From<crate::db::StoreError> for CommandError {
             StoreError::DuplicateName(_) => CommandError::new("duplicateName", err.to_string()),
             StoreError::AgentNotFound(_)
             | StoreError::GroupNotFound(_)
+            | StoreError::ApprovalNotFound(_)
             | StoreError::ConnectorNotFound(_) => CommandError::new("notFound", err.to_string()),
+            // Its own kind: a request answered twice, or answered after it
+            // lapsed, is a stale button rather than anything being wrong. The
+            // UI redraws it instead of showing a failure.
+            StoreError::ApprovalSettled { .. } => {
+                CommandError::new("alreadyAnswered", err.to_string())
+            }
             // An operator naming a variable twice is a mistake they can fix,
             // not a disk failure, and the message already says which name.
             StoreError::DuplicateEnvVar(_) => CommandError::new("validation", err.to_string()),
@@ -75,6 +83,7 @@ impl From<crate::runtime::RuntimeError> for CommandError {
             RuntimeError::Store(inner) => inner.into(),
             RuntimeError::UnknownAgent(_) => CommandError::new("notFound", err.to_string()),
             RuntimeError::AgentTerminated(_) => CommandError::new("terminated", err.to_string()),
+            RuntimeError::NothingToRetry => CommandError::new("notFound", err.to_string()),
         }
     }
 }
@@ -245,6 +254,47 @@ pub fn agent_signins(state: State<'_, AppState>, id: AgentId) -> Reply<Vec<Signi
     Ok(state.runtime.store().agent_signins(id)?)
 }
 
+// ---- permission requests -------------------------------------------------
+
+/// What every recent request came to, keyed by id.
+///
+/// The requests themselves travel in the transcript, so this is only the half
+/// that changes: whether the buttons on a request already in a channel are
+/// still live, and what was decided if they are not.
+#[tauri::command]
+pub fn approval_states(state: State<'_, AppState>) -> Reply<HashMap<ApprovalId, ApprovalState>> {
+    Ok(state.runtime.store().approval_states(500)?)
+}
+
+/// What this agent no longer has to ask about.
+#[tauri::command]
+pub fn agent_grants(state: State<'_, AppState>, id: AgentId) -> Reply<Vec<ProtectedAction>> {
+    Ok(state.runtime.store().standing_grants(id)?)
+}
+
+/// Takes one back. A permission that could only ever be given is a trap, and
+/// "always" has to stay something the operator can change their mind about.
+#[tauri::command]
+pub fn revoke_grant(
+    state: State<'_, AppState>,
+    id: AgentId,
+    action: ProtectedAction,
+) -> Reply<Vec<ProtectedAction>> {
+    state.runtime.store().revoke_grant(id, action)?;
+    Ok(state.runtime.store().standing_grants(id)?)
+}
+
+/// Answers one. Refused if it was already answered or has expired, which is
+/// what the operator's second click on a stale widget is.
+#[tauri::command]
+pub fn decide_approval(
+    state: State<'_, AppState>,
+    id: ApprovalId,
+    decision: Decision,
+) -> Reply<Approval> {
+    Ok(state.runtime.decide_approval(id, decision)?)
+}
+
 // ---- groups --------------------------------------------------------------
 
 #[tauri::command]
@@ -336,6 +386,10 @@ pub async fn delete_agent(state: State<'_, AppState>, id: AgentId) -> Reply<()> 
     // destroyed above. Left behind, the roster would keep telling the crew to
     // ask this agent for an account nothing can reach any more.
     let _ = state.runtime.store().delete_agent_signins(id);
+    // Permission the operator gave this agent dies with it. A name is free to
+    // reuse the moment an agent is deleted, and whoever takes it next must not
+    // inherit a standing grant given to somebody else.
+    let _ = state.runtime.store().delete_agent_approvals(id);
     state.runtime.emit(UiEvent::AgentsChanged);
     Ok(())
 }
@@ -412,6 +466,19 @@ pub fn send_message(state: State<'_, AppState>, agent_id: AgentId, text: String)
         return Err(CommandError::new("validation", "message must not be empty"));
     }
     Ok(state.runtime.send_from_human(agent_id, trimmed)?)
+}
+
+/// Sends a failed turn's message again, as a new run.
+///
+/// Offered on the notice the failure left behind, so the operator retries the
+/// thing that broke rather than retyping what they asked for.
+#[tauri::command]
+pub fn retry_turn(
+    state: State<'_, AppState>,
+    agent_id: AgentId,
+    message_id: MessageId,
+) -> Reply<RunId> {
+    Ok(state.runtime.retry_turn(agent_id, message_id)?)
 }
 
 #[tauri::command]

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -355,6 +355,42 @@ CREATE TABLE signins (
 CREATE INDEX signins_agent ON signins (agent_id);
 "#,
     ),
+    (
+        14,
+        r#"
+-- What an agent asked the operator for permission to do, and what they said.
+--
+-- One table for both questions, because they are the same fact read at two
+-- times: `state` is the answer to "may it do this now", and a row that says
+-- alwaysAllow is the answer to "must it ask again". A separate grants table
+-- would let the two disagree about a decision the operator made once.
+--
+-- `summary` and `detail` are Guaca's own words for what was asked, written at
+-- request time and never rewritten: the transcript has to keep saying what the
+-- operator was actually shown, whatever the agent or its instructions became
+-- afterwards.
+CREATE TABLE approvals (
+    id         TEXT    PRIMARY KEY,
+    agent_id   TEXT    NOT NULL REFERENCES agents(id),
+    group_id   TEXT    NOT NULL,
+    run_id     TEXT    NOT NULL,
+    action     TEXT    NOT NULL,
+    summary    TEXT    NOT NULL,
+    detail     TEXT    NOT NULL DEFAULT '[]',
+    state      TEXT    NOT NULL,
+    created_at INTEGER NOT NULL,
+    decided_at INTEGER
+);
+
+-- The two questions asked of this table, both partial so they stay small: what
+-- is still waiting on the operator, and what has this agent already been let
+-- off asking about.
+CREATE INDEX approvals_pending ON approvals (created_at) WHERE state = 'pending';
+CREATE INDEX approvals_granted
+    ON approvals (agent_id, action)
+    WHERE state = 'alwaysAllow';
+"#,
+    ),
 ];
 
 /// The group every agent starts in, and the one the UI keeps out of the way

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -13,10 +13,11 @@ use rusqlite::{params, OptionalExtension, Row};
 
 use crate::db::migrations;
 use crate::domain::agent::{AgentCard, CleanDraft, Lifecycle};
+use crate::domain::approval::{Approval, ApprovalState, DetailField, ProtectedAction};
 use crate::domain::connector::{CleanConnector, Connector};
 use crate::domain::envelope::{Envelope, Part, Participant, Trust};
 use crate::domain::group::{CleanGroup, Group, GroupInference};
-use crate::domain::ids::{AgentId, ConnectorId, GroupId, MessageId, RoutineId, RunId};
+use crate::domain::ids::{AgentId, ApprovalId, ConnectorId, GroupId, MessageId, RoutineId, RunId};
 use crate::domain::now_ms;
 use crate::domain::routine::Routine;
 use crate::domain::signin::Signin;
@@ -48,6 +49,10 @@ pub enum StoreError {
     RoutineNotFound(RoutineId),
     #[error("no connector with id {0}")]
     ConnectorNotFound(ConnectorId),
+    #[error("no permission request with id {0}")]
+    ApprovalNotFound(ApprovalId),
+    #[error("that request was already answered ({})", state.as_str())]
+    ApprovalSettled { state: ApprovalState },
     #[error("{0} is already used by another credential in this group")]
     DuplicateEnvVar(String),
 }
@@ -450,6 +455,194 @@ impl Store {
         Ok(conn.execute("DELETE FROM routines WHERE agent_id=?1", params![agent.to_string()])?)
     }
 
+    // ---- approvals -------------------------------------------------------
+
+    /// Records a request and returns it pending.
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_approval(
+        &self,
+        agent: AgentId,
+        group: GroupId,
+        run: RunId,
+        action: ProtectedAction,
+        summary: &str,
+        detail: &[DetailField],
+    ) -> Result<Approval, StoreError> {
+        let conn = self.conn()?;
+        let approval = Approval {
+            id: ApprovalId::new(),
+            agent_id: agent,
+            group_id: group,
+            run_id: run,
+            action,
+            summary: summary.to_string(),
+            detail: detail.to_vec(),
+            state: ApprovalState::Pending,
+            created_at: now_ms(),
+            decided_at: None,
+        };
+
+        conn.execute(
+            "INSERT INTO approvals (id,agent_id,group_id,run_id,action,summary,detail,state,created_at)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)",
+            params![
+                approval.id.to_string(),
+                agent.to_string(),
+                group.to_string(),
+                run.to_string(),
+                action.as_str(),
+                approval.summary,
+                serde_json::to_string(&approval.detail).unwrap_or_else(|_| "[]".into()),
+                approval.state.as_str(),
+                approval.created_at,
+            ],
+        )?;
+
+        Ok(approval)
+    }
+
+    pub fn get_approval(&self, id: ApprovalId) -> Result<Option<Approval>, StoreError> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT id,agent_id,group_id,run_id,action,summary,detail,state,created_at,decided_at
+               FROM approvals WHERE id=?1",
+        )?;
+        match stmt.query_row(params![id.to_string()], row_to_approval).optional()? {
+            Some(row) => Ok(Some(row?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Settles a request, and only from pending.
+    ///
+    /// The `state='pending'` in the WHERE clause is the whole point: the
+    /// operator clicking Allow and the turn's own timeout both land here, and
+    /// whichever arrives second must not overwrite the first. Losing that race
+    /// is how a request the agent has already given up on gets recorded as
+    /// granted, leaving a standing grant for an action that never happened.
+    pub fn settle_approval(
+        &self,
+        id: ApprovalId,
+        state: ApprovalState,
+    ) -> Result<Approval, StoreError> {
+        let conn = self.conn()?;
+        let changed = conn.execute(
+            "UPDATE approvals SET state=?2, decided_at=?3 WHERE id=?1 AND state='pending'",
+            params![id.to_string(), state.as_str(), now_ms()],
+        )?;
+        if changed == 0 {
+            return match self.get_approval(id)? {
+                Some(existing) => Err(StoreError::ApprovalSettled { state: existing.state }),
+                None => Err(StoreError::ApprovalNotFound(id)),
+            };
+        }
+        self.get_approval(id)?.ok_or(StoreError::ApprovalNotFound(id))
+    }
+
+    /// Whether this agent has already been let off asking about this action.
+    pub fn has_standing_grant(
+        &self,
+        agent: AgentId,
+        action: ProtectedAction,
+    ) -> Result<bool, StoreError> {
+        let conn = self.conn()?;
+        let count: i64 = conn.query_row(
+            "SELECT count(*) FROM approvals
+              WHERE agent_id=?1 AND action=?2 AND state='alwaysAllow'",
+            params![agent.to_string(), action.as_str()],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
+    /// What this agent has been let off asking about.
+    pub fn standing_grants(&self, agent: AgentId) -> Result<Vec<ProtectedAction>, StoreError> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT action FROM approvals
+              WHERE agent_id=?1 AND state='alwaysAllow' ORDER BY action",
+        )?;
+        let rows = stmt.query_map(params![agent.to_string()], |row| row.get::<_, String>(0))?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            let raw = row?;
+            out.push(
+                ProtectedAction::parse(&raw).ok_or_else(|| {
+                    StoreError::Corrupt(format!("unknown protected action {raw:?}"))
+                })?,
+            );
+        }
+        Ok(out)
+    }
+
+    /// Takes a standing grant back, so the next attempt asks again.
+    ///
+    /// The rows go rather than moving to another state. Every state this table
+    /// has is a thing the operator did at the time, and a revoked grant is not
+    /// one of them: recording it as denied or expired would put words in their
+    /// mouth about a request they actually allowed. What is lost is one line of
+    /// history; what is kept is that no state ever means two things.
+    pub fn revoke_grant(
+        &self,
+        agent: AgentId,
+        action: ProtectedAction,
+    ) -> Result<usize, StoreError> {
+        let conn = self.conn()?;
+        Ok(conn.execute(
+            "DELETE FROM approvals WHERE agent_id=?1 AND action=?2 AND state='alwaysAllow'",
+            params![agent.to_string(), action.as_str()],
+        )?)
+    }
+
+    /// What every recent request came to, for the UI to draw its widgets from.
+    ///
+    /// Bounded because this seeds a lookup table in the webview and a workspace
+    /// that has been running for a year should not send a year of decisions to
+    /// draw the four requests still on screen.
+    pub fn approval_states(
+        &self,
+        limit: u32,
+    ) -> Result<HashMap<ApprovalId, ApprovalState>, StoreError> {
+        let conn = self.conn()?;
+        let mut stmt = conn
+            .prepare("SELECT id,state FROM approvals ORDER BY created_at DESC, id DESC LIMIT ?1")?;
+        let rows = stmt.query_map(params![limit], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+
+        let mut out = HashMap::new();
+        for row in rows {
+            let (id, state) = row?;
+            let id = id.parse::<ApprovalId>().map_err(|e| StoreError::Corrupt(e.to_string()))?;
+            let state = ApprovalState::parse(&state)
+                .ok_or_else(|| StoreError::Corrupt(format!("unknown approval state {state:?}")))?;
+            out.insert(id, state);
+        }
+        Ok(out)
+    }
+
+    /// Expires everything still waiting. Called at startup.
+    ///
+    /// The turn that raised a request is holding a channel in memory, so a
+    /// restart takes every waiter with it. Left pending, those rows would draw
+    /// live buttons that answer nothing.
+    pub fn expire_pending_approvals(&self) -> Result<usize, StoreError> {
+        let conn = self.conn()?;
+        Ok(conn.execute(
+            "UPDATE approvals SET state='expired', decided_at=?1 WHERE state='pending'",
+            params![now_ms()],
+        )?)
+    }
+
+    /// Removes an agent's requests along with the agent, standing grants
+    /// included: a name can be reused, and the next holder of it inherits
+    /// nothing the operator granted this one.
+    pub fn delete_agent_approvals(&self, agent: AgentId) -> Result<usize, StoreError> {
+        let conn = self.conn()?;
+        Ok(conn.execute("DELETE FROM approvals WHERE agent_id=?1", params![agent.to_string()])?)
+    }
+
     // ---- connectors ------------------------------------------------------
 
     pub fn create_connector(&self, clean: &CleanConnector) -> Result<Connector, StoreError> {
@@ -792,6 +985,20 @@ impl Store {
 
     /// The newest `limit` messages in a channel, returned oldest-first for
     /// direct rendering.
+    /// One message, by id. Used to put a failed turn back on its feet: what to
+    /// deliver again is exactly what was delivered before.
+    pub fn get_message(&self, id: MessageId) -> Result<Option<Envelope>, StoreError> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT id,run_id,channel_id,from_kind,from_agent,to_kind,to_agent,parts,trust,hop,expects_reply,cause,created_at
+               FROM messages WHERE id=?1",
+        )?;
+        match stmt.query_row(params![id.to_string()], row_to_envelope).optional()? {
+            Some(row) => Ok(Some(row?)),
+            None => Ok(None),
+        }
+    }
+
     pub fn channel_messages(
         &self,
         channel: AgentId,
@@ -1113,6 +1320,46 @@ fn row_to_routine(row: &Row<'_>) -> RowResult<Routine> {
             next_run_at: row.get(4)?,
             last_run_at: row.get(5)?,
             created_at: row.get(6)?,
+        })
+    })())
+}
+
+fn row_to_approval(row: &Row<'_>) -> RowResult<Approval> {
+    let id_raw: String = row.get(0)?;
+    let agent_raw: String = row.get(1)?;
+    let group_raw: String = row.get(2)?;
+    let run_raw: String = row.get(3)?;
+    let action_raw: String = row.get(4)?;
+    let detail_raw: String = row.get(6)?;
+    let state_raw: String = row.get(7)?;
+
+    Ok((|| {
+        Ok(Approval {
+            id: id_raw
+                .parse::<ApprovalId>()
+                .map_err(|e| StoreError::Corrupt(format!("bad approval id {id_raw:?}: {e}")))?,
+            agent_id: agent_raw
+                .parse::<AgentId>()
+                .map_err(|e| StoreError::Corrupt(format!("bad agent id {agent_raw:?}: {e}")))?,
+            group_id: group_raw
+                .parse::<GroupId>()
+                .map_err(|e| StoreError::Corrupt(format!("bad group id {group_raw:?}: {e}")))?,
+            run_id: run_raw
+                .parse::<RunId>()
+                .map_err(|e| StoreError::Corrupt(format!("bad run id {run_raw:?}: {e}")))?,
+            action: ProtectedAction::parse(&action_raw).ok_or_else(|| {
+                StoreError::Corrupt(format!("unknown protected action {action_raw:?}"))
+            })?,
+            summary: row.get(5)?,
+            // The wording is what the operator reads, and a request whose
+            // fields would not parse is one nobody should be asked to answer.
+            detail: serde_json::from_str(&detail_raw)
+                .map_err(|e| StoreError::Corrupt(format!("bad approval detail: {e}")))?,
+            state: ApprovalState::parse(&state_raw).ok_or_else(|| {
+                StoreError::Corrupt(format!("unknown approval state {state_raw:?}"))
+            })?,
+            created_at: row.get(8)?,
+            decided_at: row.get(9)?,
         })
     })())
 }
@@ -2056,5 +2303,173 @@ mod tests {
         });
 
         assert_eq!(f.store.count_messages().unwrap(), 200);
+    }
+
+    // ---- approvals -------------------------------------------------------
+
+    /// One request from `agent`, pending.
+    fn ask(store: &Store, agent: &AgentCard) -> Approval {
+        store
+            .create_approval(
+                agent.id,
+                agent.group_id,
+                RunId::new(),
+                ProtectedAction::CreateAgent,
+                "Manager wants to create an agent called Scout",
+                &[DetailField::new("Name", "Scout")],
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn a_standing_grant_belongs_to_the_one_agent_it_was_given_to() {
+        // "Always allow" is an answer about the agent that asked. Reading it as
+        // a workspace-wide setting would let an agent the operator has never
+        // been asked about act on somebody else's permission.
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let critic = f.store.create_agent(&draft("Critic")).unwrap();
+
+        let request = ask(&f.store, &manager);
+        assert!(!f.store.has_standing_grant(manager.id, ProtectedAction::CreateAgent).unwrap());
+
+        f.store.settle_approval(request.id, ApprovalState::AlwaysAllow).unwrap();
+        assert!(f.store.has_standing_grant(manager.id, ProtectedAction::CreateAgent).unwrap());
+        assert!(!f.store.has_standing_grant(critic.id, ProtectedAction::CreateAgent).unwrap());
+    }
+
+    #[test]
+    fn allowing_once_grants_nothing_standing() {
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let request = ask(&f.store, &manager);
+
+        f.store.settle_approval(request.id, ApprovalState::Allow).unwrap();
+        assert!(
+            !f.store.has_standing_grant(manager.id, ProtectedAction::CreateAgent).unwrap(),
+            "one yes must not become every yes"
+        );
+    }
+
+    #[test]
+    fn a_request_can_only_be_answered_once() {
+        // The operator's click and the turn's own timeout both land here. The
+        // loser must not overwrite the winner: a request the agent has already
+        // given up on, recorded as granted, is a standing grant for something
+        // that never happened.
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let request = ask(&f.store, &manager);
+
+        let allowed = f.store.settle_approval(request.id, ApprovalState::Allow).unwrap();
+        assert_eq!(allowed.state, ApprovalState::Allow);
+        assert!(allowed.decided_at.is_some());
+
+        let second = f.store.settle_approval(request.id, ApprovalState::Expired);
+        assert!(
+            matches!(second, Err(StoreError::ApprovalSettled { state: ApprovalState::Allow })),
+            "{second:?}"
+        );
+        assert_eq!(
+            f.store.get_approval(request.id).unwrap().unwrap().state,
+            ApprovalState::Allow,
+            "the first answer has to survive the second"
+        );
+    }
+
+    #[test]
+    fn a_restart_closes_what_was_still_waiting_and_leaves_the_rest() {
+        // Nothing holds a parked turn across a restart, so a pending row is a
+        // question nobody can answer any more.
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let answered = ask(&f.store, &manager);
+        let waiting = ask(&f.store, &manager);
+        f.store.settle_approval(answered.id, ApprovalState::Deny).unwrap();
+
+        assert_eq!(f.store.expire_pending_approvals().unwrap(), 1);
+        assert_eq!(
+            f.store.get_approval(waiting.id).unwrap().unwrap().state,
+            ApprovalState::Expired
+        );
+        assert_eq!(
+            f.store.get_approval(answered.id).unwrap().unwrap().state,
+            ApprovalState::Deny,
+            "a decision the operator made is not a casualty of a restart"
+        );
+    }
+
+    #[test]
+    fn deleting_an_agent_takes_the_permission_it_was_given() {
+        // A deleted agent frees its name, and the next agent to hold it must
+        // not inherit what the operator allowed somebody else.
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let request = ask(&f.store, &manager);
+        f.store.settle_approval(request.id, ApprovalState::AlwaysAllow).unwrap();
+
+        assert_eq!(f.store.delete_agent_approvals(manager.id).unwrap(), 1);
+        assert!(!f.store.has_standing_grant(manager.id, ProtectedAction::CreateAgent).unwrap());
+        assert!(f.store.get_approval(request.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn a_standing_grant_can_be_taken_back() {
+        // "Always allow" is one click about every future request. A permission
+        // that could only ever be given would make that click a decision to
+        // agonise over, which is the opposite of what it is for.
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let request = ask(&f.store, &manager);
+        f.store.settle_approval(request.id, ApprovalState::AlwaysAllow).unwrap();
+        assert_eq!(
+            f.store.standing_grants(manager.id).unwrap(),
+            vec![ProtectedAction::CreateAgent]
+        );
+
+        assert_eq!(f.store.revoke_grant(manager.id, ProtectedAction::CreateAgent).unwrap(), 1);
+        assert!(f.store.standing_grants(manager.id).unwrap().is_empty());
+        assert!(!f.store.has_standing_grant(manager.id, ProtectedAction::CreateAgent).unwrap());
+
+        // And revoking again is a no-op rather than an error: the operator
+        // clicking twice has already got what they asked for.
+        assert_eq!(f.store.revoke_grant(manager.id, ProtectedAction::CreateAgent).unwrap(), 0);
+    }
+
+    #[test]
+    fn revoking_leaves_answered_requests_alone() {
+        // Only the standing grant goes. A one-off yes was an answer about one
+        // request and stays in the record as one.
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let once = ask(&f.store, &manager);
+        let standing = ask(&f.store, &manager);
+        f.store.settle_approval(once.id, ApprovalState::Allow).unwrap();
+        f.store.settle_approval(standing.id, ApprovalState::AlwaysAllow).unwrap();
+
+        f.store.revoke_grant(manager.id, ProtectedAction::CreateAgent).unwrap();
+
+        assert_eq!(f.store.get_approval(once.id).unwrap().unwrap().state, ApprovalState::Allow);
+        assert!(f.store.get_approval(standing.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn the_state_table_carries_what_the_widgets_need_and_survives_a_round_trip() {
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let request = ask(&f.store, &manager);
+
+        let stored = f.store.get_approval(request.id).unwrap().unwrap();
+        assert_eq!(stored, request, "what was written is what comes back");
+        assert_eq!(stored.detail, vec![DetailField::new("Name", "Scout")]);
+
+        let states = f.store.approval_states(500).unwrap();
+        assert_eq!(states.get(&request.id), Some(&ApprovalState::Pending));
+
+        f.store.settle_approval(request.id, ApprovalState::Deny).unwrap();
+        assert_eq!(
+            f.store.approval_states(500).unwrap().get(&request.id),
+            Some(&ApprovalState::Deny)
+        );
     }
 }

--- a/src-tauri/src/domain/agent.rs
+++ b/src-tauri/src/domain/agent.rs
@@ -222,6 +222,47 @@ pub struct CleanDraft {
     pub skills: Vec<String>,
 }
 
+/// The character keys and accents the UI offers when a person picks a look.
+///
+/// Here so an agent created by another agent gets one too. This is a courtesy
+/// and not a contract with the frontend catalog: an unrecognised key still
+/// draws, from a hash of the key itself, so the two drifting apart costs a
+/// character somebody did not choose rather than a blank avatar.
+const CHARACTERS: [&str; 16] = [
+    "avocado", "lime", "tomato", "onion", "garlic", "chilli", "cilantro", "salt", "corn", "pepper",
+    "radish", "carrot", "mushroom", "chip", "pit", "mill",
+];
+const ACCENTS: [&str; 12] = [
+    "#c7d96b", "#6faa5c", "#b0784a", "#7fd1a3", "#e2674a", "#d9534f", "#e8b84b", "#6aa9d9",
+    "#9b8ad4", "#d97ea8", "#c2926b", "#8aa0a6",
+];
+
+/// Picks a look for an agent nobody chose one for.
+///
+/// Deterministic from the name and then nudged past whatever the group is
+/// already using, so ten agents made in one turn are ten different faces rather
+/// than ten of the same one.
+pub fn suggest_look(name: &str, taken: &[AgentCard]) -> (String, String) {
+    let seed = name
+        .trim()
+        .to_lowercase()
+        .bytes()
+        .fold(0u32, |hash, byte| hash.wrapping_mul(31).wrapping_add(u32::from(byte)));
+
+    let unused = |options: &[&str], used: &[String]| -> String {
+        let start = (seed as usize) % options.len();
+        (0..options.len())
+            .map(|offset| options[(start + offset) % options.len()])
+            .find(|option| !used.iter().any(|t| t.eq_ignore_ascii_case(option)))
+            .unwrap_or(options[start])
+            .to_string()
+    };
+
+    let avatars: Vec<String> = taken.iter().map(|card| card.avatar.clone()).collect();
+    let colors: Vec<String> = taken.iter().map(|card| card.color.clone()).collect();
+    (unused(&CHARACTERS, &avatars), unused(&ACCENTS, &colors))
+}
+
 /// Accepts `#rgb` and `#rrggbb`, with or without the leading `#`, and returns
 /// a canonical lowercase `#rrggbb`.
 fn normalize_color(input: &str) -> Option<String> {

--- a/src-tauri/src/domain/approval.rs
+++ b/src-tauri/src/domain/approval.rs
@@ -1,0 +1,199 @@
+//! Asking the operator before doing something they would want a say in.
+//!
+//! An agent's tools all act on its own machine, its own notes or its own peers.
+//! Some things reach further than that, and those stop and ask. The mechanism is
+//! general because the answer has to be recorded either way: which agent asked,
+//! for what, and what the operator said. [`ProtectedAction`] has one variant
+//! today, and adding a second is a variant plus the call site that raises it.
+//!
+//! The wording an operator reads is composed here from what the runtime already
+//! validated, never by the model. An agent that could write its own request
+//! could describe creating an agent as tidying up.
+
+use serde::{Deserialize, Serialize};
+
+use super::ids::{AgentId, ApprovalId, GroupId, RunId};
+
+/// Something an agent may not do on its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ProtectedAction {
+    /// Adding an agent to the workspace. Protected because it changes who the
+    /// operator has, permanently, and every one of them costs money to run.
+    CreateAgent,
+}
+
+impl ProtectedAction {
+    /// The stored form. Identical to the serialized form on purpose: two
+    /// spellings of one token is a mapping table waiting to go wrong.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProtectedAction::CreateAgent => "createAgent",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "createAgent" => Some(ProtectedAction::CreateAgent),
+            _ => None,
+        }
+    }
+}
+
+/// What the operator can answer. Separate from [`ApprovalState`] so that the
+/// two states nobody can choose, pending and expired, cannot arrive over IPC.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Decision {
+    /// This once.
+    Allow,
+    /// This one and every later one from the same agent for the same action.
+    AlwaysAllow,
+    Deny,
+}
+
+impl Decision {
+    pub fn grants(self) -> bool {
+        matches!(self, Decision::Allow | Decision::AlwaysAllow)
+    }
+}
+
+/// Where a request has got to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ApprovalState {
+    /// Waiting on the operator. The agent that asked is parked mid-turn.
+    Pending,
+    Allow,
+    AlwaysAllow,
+    Deny,
+    /// Nobody answered in time, or the app restarted while it was waiting. A
+    /// request that outlives the turn it belongs to can never be granted: the
+    /// agent it would have unblocked is gone.
+    Expired,
+}
+
+impl ApprovalState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ApprovalState::Pending => "pending",
+            ApprovalState::Allow => "allow",
+            ApprovalState::AlwaysAllow => "alwaysAllow",
+            ApprovalState::Deny => "deny",
+            ApprovalState::Expired => "expired",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "pending" => Some(ApprovalState::Pending),
+            "allow" => Some(ApprovalState::Allow),
+            "alwaysAllow" => Some(ApprovalState::AlwaysAllow),
+            "deny" => Some(ApprovalState::Deny),
+            "expired" => Some(ApprovalState::Expired),
+            _ => None,
+        }
+    }
+}
+
+impl From<Decision> for ApprovalState {
+    fn from(decision: Decision) -> Self {
+        match decision {
+            Decision::Allow => ApprovalState::Allow,
+            Decision::AlwaysAllow => ApprovalState::AlwaysAllow,
+            Decision::Deny => ApprovalState::Deny,
+        }
+    }
+}
+
+/// One field of the request, as the operator sees it.
+///
+/// The values are what the model asked for, so they are shown as labelled data
+/// and never as prose. `value` is rendered as text, never as markdown: an agent
+/// that could format its request could draw a button.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DetailField {
+    pub label: String,
+    pub value: String,
+}
+
+impl DetailField {
+    pub fn new(label: impl Into<String>, value: impl Into<String>) -> Self {
+        Self { label: label.into(), value: value.into() }
+    }
+}
+
+/// One request, and what became of it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Approval {
+    pub id: ApprovalId,
+    /// Who asked. A grant belongs to this agent alone: allowing the Manager to
+    /// create agents says nothing about anyone else.
+    pub agent_id: AgentId,
+    pub group_id: GroupId,
+    /// The run the asking turn belongs to, so a request can be traced back to
+    /// the operator action that set it off.
+    pub run_id: RunId,
+    pub action: ProtectedAction,
+    /// Guaca's own one-line description of what was asked for.
+    pub summary: String,
+    pub detail: Vec<DetailField>,
+    pub state: ApprovalState,
+    pub created_at: i64,
+    pub decided_at: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stored_and_serialized_spellings_are_the_same_token() {
+        // One spelling, so a row written by the runtime and a state read by the
+        // UI can never mean different things.
+        for state in [
+            ApprovalState::Pending,
+            ApprovalState::Allow,
+            ApprovalState::AlwaysAllow,
+            ApprovalState::Deny,
+            ApprovalState::Expired,
+        ] {
+            let json = serde_json::to_value(state).unwrap();
+            assert_eq!(json.as_str(), Some(state.as_str()));
+            assert_eq!(ApprovalState::parse(state.as_str()), Some(state));
+        }
+
+        let action = ProtectedAction::CreateAgent;
+        assert_eq!(serde_json::to_value(action).unwrap().as_str(), Some(action.as_str()));
+        assert_eq!(ProtectedAction::parse(action.as_str()), Some(action));
+    }
+
+    #[test]
+    fn an_unknown_stored_state_is_rejected_rather_than_defaulted() {
+        // Defaulting to pending would resurrect a settled request; defaulting to
+        // denied would silently drop one. Neither is a guess worth making.
+        assert_eq!(ApprovalState::parse("maybe"), None);
+        assert_eq!(ProtectedAction::parse("delete_everything"), None);
+    }
+
+    #[test]
+    fn both_kinds_of_yes_grant_and_no_does_not() {
+        assert!(Decision::Allow.grants());
+        assert!(Decision::AlwaysAllow.grants());
+        assert!(!Decision::Deny.grants());
+    }
+
+    #[test]
+    fn the_states_an_operator_cannot_choose_are_not_a_decision() {
+        // `Decision` is the IPC input type. Pending and expired are outcomes of
+        // time passing, so they must not be expressible as an answer.
+        assert!(serde_json::from_str::<Decision>("\"pending\"").is_err());
+        assert!(serde_json::from_str::<Decision>("\"expired\"").is_err());
+        assert_eq!(
+            serde_json::from_str::<Decision>("\"alwaysAllow\"").unwrap(),
+            Decision::AlwaysAllow
+        );
+    }
+}

--- a/src-tauri/src/domain/envelope.rs
+++ b/src-tauri/src/domain/envelope.rs
@@ -10,7 +10,8 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use super::ids::{AgentId, MessageId, RunId};
+use super::approval::{DetailField, ProtectedAction};
+use super::ids::{AgentId, ApprovalId, MessageId, RunId};
 
 /// Who is at one end of an envelope.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -110,6 +111,18 @@ pub enum Part {
         name: String,
         arguments: serde_json::Value,
         outcome: ToolOutcome,
+    },
+    /// An agent asking the operator for permission, rendered as buttons.
+    ///
+    /// The request travels in the transcript rather than in a dialog, because
+    /// what was asked has to stay readable next to what the agent did next. It
+    /// carries its own wording so an old channel still says what was asked; how
+    /// it was answered is a fact about now and is read from the store by `id`.
+    Approval {
+        id: ApprovalId,
+        action: ProtectedAction,
+        summary: String,
+        detail: Vec<DetailField>,
     },
 }
 

--- a/src-tauri/src/domain/ids.rs
+++ b/src-tauri/src/domain/ids.rs
@@ -63,6 +63,7 @@ macro_rules! declare_id {
 }
 
 declare_id!(AgentId, "agent");
+declare_id!(ApprovalId, "approval");
 declare_id!(ConnectorId, "connector");
 declare_id!(GroupId, "group");
 declare_id!(MessageId, "msg");

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod approval;
 pub mod connector;
 pub mod envelope;
 pub mod group;

--- a/src-tauri/src/e2b.rs
+++ b/src-tauri/src/e2b.rs
@@ -55,6 +55,13 @@ const ENVD_PORT: u16 = 49983;
 
 const API_BASE: &str = "https://api.e2b.app";
 
+/// Everything Guaca puts on a machine. Spelled absolutely rather than as `~`,
+/// because a command daemon that runs as a different user resolves `~`
+/// somewhere else, and the failure that produces is not an error: it is a
+/// browser profile written in one place and read from another, reporting an
+/// empty jar on a machine that is signed in.
+const GUAC_DIR: &str = "/home/user/.guac";
+
 /// Where the browser keeps its profile. Under the home directory rather than
 /// /tmp so a sign-in survives: this is the whole reason a machine sleeps
 /// instead of being destroyed.
@@ -436,6 +443,10 @@ impl E2bClient {
     /// ones that would otherwise stack up a second copy.
     pub async fn start_desktop(&self, sandbox: &str, envd_token: &str) -> Result<(), E2bError> {
         for command in [
+            // Before anything can be opened on the screen, so there is no
+            // window through which the wrong profile can be reached.
+            install_chrome_shim(),
+            evict_wrong_profile_browser(),
             daemon(
                 "pgrep -x Xvfb",
                 "Xvfb",
@@ -478,15 +489,7 @@ impl E2bClient {
     ) -> Result<Output, E2bError> {
         self.start_desktop(sandbox, envd_token).await?;
 
-        // Chrome cannot use its own sandbox inside one, and refuses to start
-        // without being told so. Harmless for anything else.
-        let program = if program.trim_start().starts_with("google-chrome")
-            && !program.contains("--no-sandbox")
-        {
-            program.replacen("google-chrome", "google-chrome --no-sandbox --no-first-run", 1)
-        } else {
-            program.to_string()
-        };
+        let program = chrome_flags(program);
 
         self.run(
             sandbox,
@@ -752,8 +755,8 @@ pub async fn signed_in_state(
             sandbox,
             envd_token,
             &format!(
-                "mkdir -p ~/.guac && echo {script} | base64 -d > ~/.guac/sessions.py && \
-                 python3 ~/.guac/sessions.py"
+                "mkdir -p {GUAC_DIR} && echo {script} | base64 -d > {GUAC_DIR}/sessions.py && \
+                 python3 {GUAC_DIR}/sessions.py {CHROME_PROFILE}/Default"
             ),
         )
         .await?;
@@ -849,6 +852,118 @@ fn daemon(guard: &str, name: &str, command: &str) -> String {
 /// needs to be installed in the sandbox.
 fn port_open(port: u16) -> String {
     format!("(exec 3<>/dev/tcp/127.0.0.1/{port})")
+}
+
+/// Closes a browser that is already holding the wrong profile.
+///
+/// The shim decides where the *next* Chrome goes. A machine made before it, or
+/// one where somebody launched Chrome another way, can already have a window
+/// open on the old profile, and Chrome re-attaches to a running instance: the
+/// operator would sign in again into the same invisible jar and see the same
+/// empty list. So a browser on any other profile is ended, once, and whatever
+/// opens next opens correctly.
+///
+/// Precise about which processes it looks at. Chrome's renderers and zygotes
+/// are the same binary and do not all carry `--user-data-dir`, so matching them
+/// would read the app's own browser as a stray and close it mid-task. Only the
+/// main processes are considered, and only when one of them is on a profile
+/// that is not ours.
+fn evict_wrong_profile_browser() -> String {
+    format!(
+        "if pgrep -af 'google-chrome|chromium' | grep -v -- '--type=' | \
+         grep -v -- '--user-data-dir={CHROME_PROFILE}' | grep -q .; then \
+         pkill -f 'google-chrome|chromium' || true; sleep 1; fi"
+    )
+}
+
+/// Rewrites a browser invocation so it lands in the one profile that counts.
+///
+/// The shim on PATH does this too, and this does it again at the call site,
+/// because the two fail differently: the shim covers a name typed into a shell
+/// and the icon on the desktop, and this covers the machine whose `~/.profile`
+/// does not put `~/.local/bin` first. A duplicated flag with the same value is
+/// nothing; a window on the wrong profile is a session no agent can use.
+///
+/// Chrome also cannot use its own sandbox inside one and refuses to start
+/// without being told so, which is why `--no-sandbox` is here.
+fn chrome_flags(program: &str) -> String {
+    let trimmed = program.trim_start();
+    let Some(binary) = ["google-chrome-stable", "google-chrome", "chromium-browser", "chromium"]
+        .into_iter()
+        .find(|name| trimmed.starts_with(name))
+    else {
+        return program.to_string();
+    };
+
+    let mut flags = vec!["--no-sandbox", "--no-first-run"];
+    let profile = format!("--user-data-dir={CHROME_PROFILE}");
+    let port = format!("--remote-debugging-port={CDP_PORT}");
+    // Without the port, a window opened here would hold the profile with no
+    // remote interface, and `browse` would find Chrome running, re-attach, and
+    // never get the port it needs. That is the failure the second profile was
+    // invented to avoid, so it has to be closed here rather than reintroduced.
+    if !program.contains("--user-data-dir") {
+        flags.push(&profile);
+    }
+    if !program.contains("--remote-debugging-port") {
+        flags.push(&port);
+    }
+    flags.retain(|flag| !program.contains(flag));
+
+    program.replacen(binary, &format!("{binary} {}", flags.join(" ")), 1)
+}
+
+/// Puts one Chrome on the machine, and makes every route to it the same one.
+///
+/// There used to be two profiles. `browse` gave itself one because Chrome
+/// ignores `--remote-debugging-port` when it re-attaches to an existing
+/// profile; everything else — an agent's `open_on_desktop`, the icon on the
+/// desktop, a `google-chrome` an agent typed into a shell — got the default. An
+/// operator who signed in on the screen therefore signed in to a browser no
+/// agent could use, and nothing said so: detection reads the profile `browse`
+/// drives and truthfully reported an empty jar.
+///
+/// So the name is shadowed rather than the callers being trusted to remember.
+/// A wrapper earlier on PATH takes the flags with it wherever it is invoked
+/// from, and a desktop entry in the user's own XDG directory takes precedence
+/// over the packaged one, which is what the icon and the menu read. Both are
+/// written every time the desktop starts, because the alternative is a machine
+/// that behaves differently depending on when it was made.
+fn install_chrome_shim() -> String {
+    // Resolved past the shim itself: `/usr/bin/google-chrome` is a symlink to
+    // the first of these, and calling by name would find the wrapper again.
+    let wrapper = format!(
+        "#!/bin/sh\n\
+         # Guaca: one profile on this machine, the one agents can use.\n\
+         for real in /opt/google/chrome/google-chrome /usr/bin/google-chrome-stable \
+         /usr/bin/chromium /usr/bin/chromium-browser; do\n\
+         \x20 [ -x \"$real\" ] && exec \"$real\" --no-sandbox --no-first-run \
+         --user-data-dir={CHROME_PROFILE} --remote-debugging-port={CDP_PORT} \"$@\"\n\
+         done\n\
+         echo 'no chrome on this machine' >&2\n\
+         exit 127\n"
+    );
+    let entry = "[Desktop Entry]\n\
+                 Version=1.0\n\
+                 Type=Application\n\
+                 Name=Google Chrome\n\
+                 Exec=/home/user/.local/bin/google-chrome %U\n\
+                 Icon=google-chrome\n\
+                 Terminal=false\n\
+                 Categories=Network;WebBrowser;\n\
+                 MimeType=text/html;x-scheme-handler/http;x-scheme-handler/https;\n";
+
+    format!(
+        "mkdir -p /home/user/.local/bin /home/user/.local/share/applications && \
+         echo {wrapper} | base64 -d > /home/user/.local/bin/google-chrome && \
+         chmod +x /home/user/.local/bin/google-chrome && \
+         ln -sf /home/user/.local/bin/google-chrome /home/user/.local/bin/google-chrome-stable && \
+         echo {entry} | base64 -d > /home/user/.local/share/applications/google-chrome.desktop && \
+         (grep -q '.local/bin' ~/.profile 2>/dev/null || \
+          echo 'PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.profile)",
+        wrapper = base64_encode(wrapper.as_bytes()),
+        entry = base64_encode(entry.as_bytes()),
+    )
 }
 
 /// envd's address for one sandbox.
@@ -966,6 +1081,84 @@ mod tests {
             frame_src.contains(VIEWER_HOST),
             "the window must be allowed to frame {VIEWER_HOST}, got {frame_src:?}"
         );
+    }
+
+    #[test]
+    fn every_way_of_opening_chrome_lands_in_the_profile_agents_can_use() {
+        // The bug this closes: an operator signs in on the screen, and the
+        // session goes to a profile no agent drives. Nothing errors, and
+        // detection truthfully reports an empty jar for the browser it reads.
+        for typed in [
+            "google-chrome https://mail.google.com",
+            "google-chrome-stable",
+            "chromium https://example.com",
+        ] {
+            let launched = chrome_flags(typed);
+            assert!(launched.contains(CHROME_PROFILE), "{typed} -> {launched}");
+            assert!(
+                launched.contains(&format!("--remote-debugging-port={CDP_PORT}")),
+                "a window without the port re-attaches and leaves browse with no interface: \
+                 {launched}"
+            );
+            assert!(launched.contains("--no-sandbox"), "{launched}");
+        }
+
+        // The shim covers what the call site cannot see: a name typed into a
+        // shell, and the icon on the desktop.
+        let shim = install_chrome_shim();
+        assert!(shim.contains("/home/user/.local/bin/google-chrome"), "{shim}");
+        assert!(shim.contains("applications/google-chrome.desktop"), "the icon reads this one");
+    }
+
+    #[test]
+    fn a_browser_already_on_the_wrong_profile_is_ended_but_ours_is_left_alone() {
+        // Chrome re-attaches to a running instance, so a window left open on
+        // the old profile would swallow the next sign-in too. The filter has to
+        // be exact: renderers and zygotes are the same binary and do not all
+        // carry the flag, and matching them would close the app's own browser
+        // in the middle of a task.
+        let evict = evict_wrong_profile_browser();
+        assert!(evict.contains(&format!("--user-data-dir={CHROME_PROFILE}")), "{evict}");
+        assert!(evict.contains("--type="), "helper processes must be excluded: {evict}");
+        assert!(evict.contains("pkill"), "{evict}");
+    }
+
+    #[test]
+    fn a_flag_the_caller_already_set_is_not_set_twice() {
+        let once = chrome_flags("google-chrome --no-sandbox --user-data-dir=/tmp/x");
+        assert_eq!(once.matches("--no-sandbox").count(), 1, "{once}");
+        assert_eq!(once.matches("--user-data-dir").count(), 1, "{once}");
+        // And a caller that named its own profile keeps it: only `browse` does
+        // that, and it names this one.
+        assert!(once.contains("--user-data-dir=/tmp/x"), "{once}");
+    }
+
+    #[test]
+    fn a_program_that_is_not_a_browser_is_left_alone() {
+        assert_eq!(
+            chrome_flags("xdg-open /home/user/report.pdf"),
+            "xdg-open /home/user/report.pdf"
+        );
+        assert_eq!(chrome_flags("thunar"), "thunar");
+    }
+
+    #[test]
+    fn the_session_reader_is_pointed_at_the_profile_the_browser_actually_uses() {
+        // These two have to name one directory. When they did not, nothing
+        // failed: the browser wrote its cookies where it was told and the
+        // reader looked somewhere else, so every machine came back signed in to
+        // nothing and no error was raised anywhere. A path is a contract
+        // between two files here, so it is passed in rather than spelled twice.
+        assert!(
+            SESSION_READER.contains("sys.argv[1]"),
+            "the reader must take the profile from its caller, not guess at it"
+        );
+        assert!(
+            !SESSION_READER.contains("expanduser"),
+            "`~` resolves against whoever runs the command, which is not who runs the browser"
+        );
+        assert!(CHROME_PROFILE.starts_with(GUAC_DIR), "the profile lives inside Guaca's directory");
+        assert!(CHROME_PROFILE.starts_with('/'), "an absolute path, for the same reason");
     }
 
     #[test]

--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -23,6 +23,7 @@ pub const OPEN_ON_DESKTOP: &str = "open_on_desktop";
 pub const USE_SCREEN: &str = "use_screen";
 pub const BROWSE: &str = "browse";
 pub const SCHEDULE: &str = "schedule";
+pub const CREATE_AGENT: &str = "create_agent";
 
 /// Tool definitions offered on every agent turn.
 pub fn specs() -> Vec<ToolSpec> {
@@ -232,6 +233,58 @@ pub fn specs() -> Vec<ToolSpec> {
             }),
         },
         ToolSpec {
+            name: CREATE_AGENT.to_string(),
+            // Three failures this description exists to prevent: an agent made
+            // for one afternoon's task, a refusal treated as an obstacle to
+            // route around, and a crew created and then left waiting because
+            // nobody realised a new agent does nothing until it is spoken to.
+            description: "Add an agent to this workspace: a new colleague with its own \
+                          instructions, its own computer and its own memory, which you and \
+                          everyone else can then reach by name with `send_message`. It joins your \
+                          own group and can only ever talk to the agents you can. Create one for a \
+                          role the operator will still need next week; work that ends with this \
+                          conversation belongs to you or to an agent that already exists. The \
+                          operator has to approve it, so this waits for their answer, and their \
+                          answer is final: if they decline, say what you would have created and \
+                          carry on without it. A new agent starts idle and does nothing at all \
+                          until somebody messages it, so send it its first piece of work yourself."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "What it is called, and how it is addressed. Name it for \
+                                        the role, e.g. `Chief of Product`."
+                    },
+                    "instructions": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Its standing instructions, written as if speaking to it: \
+                                        who it is, what it owns, and how it should work. This is \
+                                        all it will know about its job, so write the whole brief \
+                                        rather than a job title."
+                    },
+                    "skills": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Short capability lines. This is what the rest of the crew \
+                                        reads when deciding whether a task is this agent's, so \
+                                        write what it does, not what it is."
+                    },
+                    "notes": {
+                        "type": "string",
+                        "description": "Optional. Seeds its memory file: facts it should start \
+                                        out knowing, in markdown. It maintains this itself \
+                                        afterwards."
+                    }
+                },
+                "required": ["name", "instructions"],
+                "additionalProperties": false
+            }),
+        },
+        ToolSpec {
             name: SEND_MESSAGE.to_string(),
             description: "Send a message to the other agents a piece of work belongs to. Choose \
                           them by fit: the agents whose skills cover this task, and no others. \
@@ -279,6 +332,19 @@ pub enum ToolInvocation {
     UseScreen { action: ScreenAction },
     Browse { action: String, args: serde_json::Value },
     Schedule { action: ScheduleAction },
+    CreateAgent { draft: NewAgent },
+}
+
+/// The agent an agent asked for. Not yet validated, and not yet approved.
+///
+/// No model field: what a new agent costs to run is the operator's decision,
+/// so it inherits its group's model the way an agent created in the UI does.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NewAgent {
+    pub name: String,
+    pub instructions: String,
+    pub skills: Vec<String>,
+    pub notes: String,
 }
 
 /// What an agent can do to its own schedule.
@@ -311,7 +377,7 @@ pub enum ScreenAction {
 pub enum ToolParseError {
     #[error(
         "unknown tool {name:?}. Available tools: directory, send_message, update_notes, \
-         run_command, open_on_desktop, use_screen, browse, schedule."
+         run_command, open_on_desktop, use_screen, browse, schedule, create_agent."
     )]
     UnknownTool { name: String },
     #[error("arguments for {name} were not valid JSON: {detail}")]
@@ -336,6 +402,8 @@ pub enum ToolParseError {
     IncompleteSchedule { needs: String },
     #[error("use_screen {action} needs {needs}")]
     IncompleteScreenAction { action: String, needs: String },
+    #[error("create_agent needs {needs}")]
+    IncompleteAgent { needs: String },
 }
 
 impl ToolParseError {
@@ -394,6 +462,12 @@ impl ToolParseError {
             ToolParseError::MissingText => {
                 "Error: `text` must be a non-empty string containing the message body.".to_string()
             }
+            ToolParseError::IncompleteAgent { needs } => format!(
+                "Error: to create an agent you need {needs}. For example {{\"name\": \"Chief of \
+                 Product\", \"instructions\": \"You own the product roadmap. Decide what gets \
+                 built and in what order, and say why.\", \"skills\": [\"roadmap\", \
+                 \"prioritisation\"]}}."
+            ),
             ToolParseError::MissingContent => {
                 "Error: `content` must be a string holding the complete new notes. To clear your \
                  notes, pass an empty string."
@@ -579,6 +653,44 @@ pub fn parse(call: &ToolCall) -> Result<ToolInvocation, ToolParseError> {
                 _ => Err(ToolParseError::MissingContent),
             }
         }
+        CREATE_AGENT => {
+            let value = call.parsed_arguments().map_err(|e| ToolParseError::BadJson {
+                name: CREATE_AGENT.to_string(),
+                detail: e.to_string(),
+            })?;
+            // Aliases for the same two ideas, because a model that has just been
+            // told to write a colleague's brief reaches for whichever word its
+            // training used. Rejecting a near miss costs a whole turn, and this
+            // is the one tool where the retry also costs the operator a second
+            // permission prompt for the same request.
+            let field = |names: &[&str]| {
+                names
+                    .iter()
+                    .find_map(|name| value.get(*name).and_then(|v| v.as_str()))
+                    .map(str::trim)
+                    .filter(|text| !text.is_empty())
+                    .map(str::to_string)
+            };
+
+            let name =
+                field(&["name", "agent_name", "agent"]).ok_or(ToolParseError::IncompleteAgent {
+                    needs: "a `name` for the agent".to_string(),
+                })?;
+            let instructions = field(&["instructions", "system_prompt", "prompt", "role"]).ok_or(
+                ToolParseError::IncompleteAgent {
+                    needs: "`instructions` saying what the agent is for".to_string(),
+                },
+            )?;
+
+            Ok(ToolInvocation::CreateAgent {
+                draft: NewAgent {
+                    name,
+                    instructions,
+                    skills: normalize_list(value.get("skills")),
+                    notes: field(&["notes"]).unwrap_or_default(),
+                },
+            })
+        }
         SEND_MESSAGE => {
             let value = call.parsed_arguments().map_err(|e| ToolParseError::BadJson {
                 name: SEND_MESSAGE.to_string(),
@@ -588,7 +700,7 @@ pub fn parse(call: &ToolCall) -> Result<ToolInvocation, ToolParseError> {
                 ToolParseError::BadJson { name: SEND_MESSAGE.to_string(), detail: e.to_string() }
             })?;
 
-            let mut to = normalize_recipients(args.to.as_ref());
+            let mut to = normalize_list(args.to.as_ref());
             if to.is_empty() {
                 // `agent: "Chef"` is a common near-miss worth accepting.
                 if let Some(single) =
@@ -614,12 +726,12 @@ pub fn parse(call: &ToolCall) -> Result<ToolInvocation, ToolParseError> {
     }
 }
 
-/// Coerces the several shapes models actually emit into a list of names.
+/// Coerces the several shapes models actually emit into a list of strings.
 ///
 /// Specified as an array of strings. Observed in the wild: a bare string, a
 /// comma-separated string, an array containing objects with a `name` field.
 /// Each is unambiguous, so rejecting them buys nothing but a retry.
-fn normalize_recipients(value: Option<&serde_json::Value>) -> Vec<String> {
+fn normalize_list(value: Option<&serde_json::Value>) -> Vec<String> {
     let mut out = Vec::new();
     match value {
         Some(serde_json::Value::String(one)) => {
@@ -853,9 +965,9 @@ mod tests {
         let specs = specs();
         assert_eq!(
             specs.len(),
-            8,
+            9,
             "directory, run_command, open_on_desktop, use_screen, browse, schedule, \
-             send_message, update_notes"
+             create_agent, send_message, update_notes"
         );
         for spec in &specs {
             assert_eq!(
@@ -1050,6 +1162,100 @@ mod tests {
         assert!(text.contains("do not record the conversation"));
         assert!(text.contains("replaces the file"), "consolidation must be explicit");
         assert!(text.contains("space is limited"));
+    }
+
+    #[test]
+    fn creating_an_agent_takes_a_name_and_a_brief() {
+        // Doubled hashes: the markdown heading in `notes` would otherwise close
+        // an `r#"..."#` literal early.
+        let parsed = parse(&call(
+            CREATE_AGENT,
+            r##"{"name":"  Chief of Product  ","instructions":"You own the roadmap.",
+                 "skills":["roadmap","pricing"],"notes":"# Context\nB2B."}"##,
+        ))
+        .unwrap();
+        assert_eq!(
+            parsed,
+            ToolInvocation::CreateAgent {
+                draft: NewAgent {
+                    name: "Chief of Product".into(),
+                    instructions: "You own the roadmap.".into(),
+                    skills: vec!["roadmap".into(), "pricing".into()],
+                    notes: "# Context\nB2B.".into(),
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn the_brief_is_accepted_under_the_names_a_model_reaches_for() {
+        // A wrong guess here is not just a wasted turn: the retry asks the
+        // operator to approve the same agent a second time.
+        for field in ["instructions", "system_prompt", "prompt", "role"] {
+            let parsed =
+                parse(&call(CREATE_AGENT, &format!(r#"{{"name":"Scout","{field}":"You look."}}"#)));
+            match parsed {
+                Ok(ToolInvocation::CreateAgent { draft }) => {
+                    assert_eq!(draft.instructions, "You look.", "{field} was not read")
+                }
+                other => panic!("{field} gave {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn an_agent_with_no_brief_is_refused_with_a_usable_example() {
+        // A nameless or briefless agent would reach the operator as a request
+        // to approve nothing in particular.
+        for arguments in [r#"{"instructions":"You look."}"#, r#"{"name":"Scout"}"#, "{}"] {
+            let err = parse(&call(CREATE_AGENT, arguments)).unwrap_err();
+            assert!(matches!(err, ToolParseError::IncompleteAgent { .. }), "{arguments}");
+            assert!(
+                err.guidance().contains("instructions"),
+                "the way out has to be in the message"
+            );
+        }
+
+        let blank = parse(&call(CREATE_AGENT, r#"{"name":"  ","instructions":"x"}"#)).unwrap_err();
+        assert!(matches!(blank, ToolParseError::IncompleteAgent { .. }));
+    }
+
+    #[test]
+    fn skills_survive_the_shapes_a_model_sends_them_in() {
+        let parsed = parse(&call(
+            CREATE_AGENT,
+            r#"{"name":"Scout","instructions":"You look.","skills":"research, fact checking"}"#,
+        ));
+        match parsed {
+            Ok(ToolInvocation::CreateAgent { draft }) => {
+                assert_eq!(draft.skills, vec!["research".to_string(), "fact checking".to_string()])
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn creating_an_agent_says_it_needs_permission_and_starts_idle() {
+        // Both were real failures in the conversation this tool came from: an
+        // agent that reported it could not create anyone, and a crew created
+        // and then left waiting for work that was never sent.
+        let spec = description(CREATE_AGENT);
+        assert!(spec.contains("operator has to approve"), "{spec}");
+        assert!(spec.contains("does nothing at all until somebody messages it"), "{spec}");
+        assert!(
+            spec.contains("still need next week"),
+            "without this it creates an agent per task: {spec}"
+        );
+    }
+
+    #[test]
+    fn creating_an_agent_offers_no_choice_of_model() {
+        // What a new agent costs to run is the operator's call, not a field a
+        // model can set on its own behalf.
+        let spec = specs().into_iter().find(|s| s.name == CREATE_AGENT).unwrap();
+        let properties = spec.parameters["properties"].as_object().unwrap();
+        assert!(!properties.contains_key("model"), "{properties:?}");
+        assert!(!properties.contains_key("group_id"), "an agent must not place one elsewhere");
     }
 
     #[test]

--- a/src-tauri/src/runtime/events.rs
+++ b/src-tauri/src/runtime/events.rs
@@ -9,8 +9,9 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use serde::Serialize;
 
+use crate::domain::approval::ApprovalState;
 use crate::domain::envelope::{Envelope, Participant};
-use crate::domain::ids::{AgentId, GroupId, MessageId, RunId};
+use crate::domain::ids::{AgentId, ApprovalId, GroupId, MessageId, RunId};
 
 /// What an agent is doing right now, surfaced as the dot next to its name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -23,6 +24,11 @@ pub enum Activity {
     Queued {
         depth: usize,
     },
+    /// Parked mid-turn on a permission request. Its own state rather than
+    /// `Thinking`, because the difference between a model that is working and
+    /// one that is waiting on the operator is the difference between leaving it
+    /// alone and going to answer it.
+    AwaitingApproval,
     /// Not processing; messages accumulate.
     Paused,
 }
@@ -97,6 +103,21 @@ pub enum UiEvent {
     RunSettled {
         run_id: RunId,
         steps_used: u32,
+    },
+
+    /// An agent is waiting on the operator.
+    ///
+    /// The request itself travels in the transcript, as a part of the message
+    /// that carries it. Only the id is here, because what the UI is missing at
+    /// this point is not the wording but the fact that it is still live.
+    ApprovalRequested {
+        approval_id: ApprovalId,
+        agent_id: AgentId,
+    },
+    /// Answered, timed out, or abandoned by a restart.
+    ApprovalSettled {
+        approval_id: ApprovalId,
+        state: ApprovalState,
     },
 }
 

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -93,13 +93,84 @@ struct ToolResult {
     /// answer a model cannot act on as text.
     image: Option<String>,
 }
+
+/// The placeholder the UI draws while a model call is in flight.
+///
+/// Owns its own id because a retry has to be able to throw one away: text that
+/// arrived before a stream broke is text the operator has already seen, and the
+/// answer that replaces it starts from the beginning. Ending the old one and
+/// opening a new one is what stops the second attempt appending to the first.
+struct Stream {
+    message_id: MessageId,
+    channel_id: AgentId,
+    agent_id: AgentId,
+    run_id: RunId,
+    to: Participant,
+}
+
+impl Stream {
+    fn open(&self, events: &dyn EventSink) {
+        events.emit(UiEvent::StreamStarted {
+            message_id: self.message_id,
+            channel_id: self.channel_id,
+            agent_id: self.agent_id,
+            run_id: self.run_id,
+            to: self.to,
+        });
+    }
+
+    fn close(&self, events: &dyn EventSink) {
+        events.emit(UiEvent::StreamEnded {
+            message_id: self.message_id,
+            channel_id: self.channel_id,
+        });
+    }
+
+    /// Discards whatever was drawn and starts again under a new id.
+    fn reopen(&mut self, events: &dyn EventSink) {
+        self.close(events);
+        self.message_id = MessageId::new();
+        self.open(events);
+    }
+}
+
+/// How many times one model call is attempted before the operator is told.
+///
+/// The failure this exists for is a connection that never opened: a laptop that
+/// changed network, a provider blipping. Three attempts covers that without
+/// turning a real outage into a minute of silence.
+const CALL_ATTEMPTS: usize = 3;
+
+/// Waits between attempts. One entry per retry, so this is `CALL_ATTEMPTS - 1`.
+const CALL_BACKOFF: [Duration; 2] = [Duration::from_secs(1), Duration::from_secs(3)];
+
+/// The longest this will sit on a `Retry-After` before giving the turn back.
+///
+/// A provider is entitled to ask for five minutes; an agent holding its turn
+/// open that long is indistinguishable from one that has hung, so the honest
+/// move is to stop and let the operator decide.
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(20);
+
+/// What the operator said, from the point of view of the parked turn.
+///
+/// A refusal and a silence are separate because they are separate to the agent:
+/// one is an answer to accept and report, the other is a question still hanging
+/// that it should leave with the operator rather than ask again.
+enum Permission {
+    Granted,
+    Refused,
+    Unanswered,
+    /// Nobody was asked, because the request could not be recorded.
+    Failed(String),
+}
 use crate::db::{Store, StoreError};
-use crate::domain::agent::{AgentCard, DirectoryEntry, Lifecycle};
+use crate::domain::agent::{AgentCard, CleanDraft, DirectoryEntry, Lifecycle};
+use crate::domain::approval::{Approval, ApprovalState, Decision, DetailField, ProtectedAction};
 use crate::domain::connector::Connector;
 use crate::domain::envelope::{
     channel_for, Envelope, NoticeKind, Part, Participant, RefusedRecipient, ToolOutcome, Trust,
 };
-use crate::domain::ids::{AgentId, GroupId, MessageId, RunId};
+use crate::domain::ids::{AgentId, ApprovalId, GroupId, MessageId, RunId};
 use crate::domain::now_ms;
 use crate::domain::signin::Signin;
 use crate::llm::openrouter::{ChatMessage, ChatRequest, LlmClient, LlmError, ToolCall};
@@ -131,6 +202,16 @@ const BURST_POLL: Duration = Duration::from_millis(25);
 /// right by the time anyone reads it.
 const SIGNIN_SCAN_EVERY: Duration = Duration::from_secs(120);
 
+/// How long an agent holds its turn open waiting for the operator to answer a
+/// permission request.
+///
+/// The request is on screen in the channel that agent is talking in, so this is
+/// generous rather than urgent: the cost of waiting is one parked actor, and
+/// the cost of giving up too early is an operator who walked to the kitchen
+/// coming back to a request that has already lapsed. What it must not be is
+/// forever, because a turn that never ends is a run that never settles.
+const APPROVAL_WINDOW: Duration = Duration::from_secs(10 * 60);
+
 #[derive(Debug, thiserror::Error)]
 pub enum RuntimeError {
     #[error(transparent)]
@@ -139,6 +220,10 @@ pub enum RuntimeError {
     UnknownAgent(AgentId),
     #[error("{0} has been deleted")]
     AgentTerminated(String),
+    #[error(
+        "the message that failed is no longer in the transcript, so there is nothing to send again"
+    )]
+    NothingToRetry,
 }
 
 struct Inbox {
@@ -162,6 +247,9 @@ struct Inner {
     activity: Mutex<HashMap<AgentId, Activity>>,
     /// Outstanding work per run, used to decide when a cascade has settled.
     inflight: Mutex<HashMap<RunId, usize>>,
+    /// Turns parked on a permission request, by request id. The row in SQLite
+    /// is the record; this is the way back to the agent that is holding.
+    waiting: Mutex<HashMap<ApprovalId, tokio::sync::oneshot::Sender<()>>>,
     /// Per-agent notes on disk.
     workspace: Workspace,
     /// When each machine was last asked what it is signed in to, so browsing
@@ -211,6 +299,7 @@ impl Runtime {
                 inboxes: Mutex::new(HashMap::new()),
                 activity: Mutex::new(HashMap::new()),
                 inflight: Mutex::new(HashMap::new()),
+                waiting: Mutex::new(HashMap::new()),
                 workspace,
                 last_signin_scan: Mutex::new(HashMap::new()),
                 viewer_port: AtomicU16::new(0),
@@ -562,6 +651,39 @@ impl Runtime {
         Ok(run_id)
     }
 
+    /// Puts a turn that failed back on its feet.
+    ///
+    /// Delivers the same envelope again rather than a summary of it: what broke
+    /// was the model call, not the message, so the agent should read exactly
+    /// what it read before.
+    ///
+    /// A new run, because the operator pressing a button is an operator action
+    /// and gets the budget of one. The hop is kept from the original: an agent
+    /// retrying three hops deep must not come back one hop from the top with
+    /// the whole cascade's allowance in front of it.
+    pub fn retry_turn(&self, agent: AgentId, cause: MessageId) -> Result<RunId, RuntimeError> {
+        let card = self.inner.store.get_agent(agent)?.ok_or(RuntimeError::UnknownAgent(agent))?;
+        if card.lifecycle == Lifecycle::Terminated {
+            return Err(RuntimeError::AgentTerminated(card.name));
+        }
+        let original = self.inner.store.get_message(cause)?.ok_or(RuntimeError::NothingToRetry)?;
+
+        let run_id = RunId::new();
+        let envelope = Envelope {
+            id: MessageId::new(),
+            run_id,
+            channel_id: agent,
+            to: Participant::Agent { id: agent },
+            cause: Some(original.id),
+            created_at: now_ms(),
+            ..original
+        };
+
+        self.track_inflight(run_id, 1);
+        self.deliver(envelope)?;
+        Ok(run_id)
+    }
+
     /// Replies this agent is still owed in this run.
     fn awaiting_replies(&self, run: RunId, me: AgentId) -> usize {
         self.inner.guard.lock().run(run).awaiting(me)
@@ -598,26 +720,143 @@ impl Runtime {
         kind: NoticeKind,
         text: String,
     ) {
+        self.record_for(agent, run_id, cause, vec![Part::Notice { kind, text }]);
+    }
+
+    /// Writes something Guaca has to say into an agent's channel.
+    ///
+    /// Written straight to the transcript rather than delivered, so it never
+    /// wakes the agent it is about.
+    fn record_for(
+        &self,
+        agent: AgentId,
+        run_id: RunId,
+        cause: Option<MessageId>,
+        parts: Vec<Part>,
+    ) {
         let envelope = Envelope {
             id: MessageId::new(),
             run_id,
             channel_id: agent,
             from: Participant::System,
             to: Participant::Agent { id: agent },
-            parts: vec![Part::Notice { kind, text }],
+            parts,
             trust: Trust::System,
             hop: 0,
             expects_reply: false,
             cause,
             created_at: now_ms(),
         };
-        // A notice is written straight to the transcript rather than delivered,
-        // so it never wakes the agent it is about.
         if let Err(err) = self.inner.store.append(&envelope) {
-            tracing::error!(%err, "failed to record notice");
+            tracing::error!(%err, "failed to record a system message");
             return;
         }
         self.inner.events.emit(UiEvent::MessageAppended { message: Box::new(envelope) });
+    }
+
+    // ---- asking the operator ---------------------------------------------
+
+    /// Answers a permission request and wakes whatever is waiting on it.
+    ///
+    /// The row is settled first and only from pending, so a second click, or a
+    /// click that arrives as the request times out, is refused here rather than
+    /// overwriting an answer that is already recorded.
+    pub fn decide_approval(
+        &self,
+        id: ApprovalId,
+        decision: Decision,
+    ) -> Result<Approval, RuntimeError> {
+        let approval = self.inner.store.settle_approval(id, decision.into())?;
+        if let Some(waiter) = self.inner.waiting.lock().remove(&id) {
+            let _ = waiter.send(());
+        }
+        self.inner.events.emit(UiEvent::ApprovalSettled { approval_id: id, state: approval.state });
+        Ok(approval)
+    }
+
+    /// Puts a request to the operator and holds the turn until it is answered.
+    ///
+    /// The verdict is read back from the row rather than from the channel the
+    /// answer arrived on. Those two can disagree by microseconds when a click
+    /// lands as the window closes, and the row is the thing the operator can
+    /// see: honouring it means a button that visibly said "allowed" allowed it.
+    async fn ask_operator(
+        &self,
+        card: &AgentCard,
+        run_id: RunId,
+        action: ProtectedAction,
+        summary: String,
+        detail: Vec<DetailField>,
+    ) -> Permission {
+        match self.inner.store.has_standing_grant(card.id, action) {
+            Ok(true) => return Permission::Granted,
+            Ok(false) => {}
+            Err(err) => return Permission::Failed(err.to_string()),
+        }
+
+        let approval = match self.inner.store.create_approval(
+            card.id,
+            card.group_id,
+            run_id,
+            action,
+            &summary,
+            &detail,
+        ) {
+            Ok(approval) => approval,
+            Err(err) => return Permission::Failed(err.to_string()),
+        };
+
+        let (waker, wait) = tokio::sync::oneshot::channel();
+        self.inner.waiting.lock().insert(approval.id, waker);
+
+        self.record_for(
+            card.id,
+            run_id,
+            None,
+            vec![Part::Approval {
+                id: approval.id,
+                action,
+                summary: approval.summary.clone(),
+                detail: approval.detail.clone(),
+            }],
+        );
+        // Parked before the request is announced, so anything that reacts to
+        // the announcement sees an agent that is already waiting rather than
+        // one that still looks like it is thinking.
+        self.set_activity(card.id, Activity::AwaitingApproval);
+        self.inner
+            .events
+            .emit(UiEvent::ApprovalRequested { approval_id: approval.id, agent_id: card.id });
+
+        let woken = tokio::time::timeout(APPROVAL_WINDOW, wait).await.is_ok();
+        self.inner.waiting.lock().remove(&approval.id);
+        self.set_activity(card.id, Activity::Thinking);
+
+        if !woken {
+            // Expiring can lose to an answer landing in this instant, and when
+            // it does that answer stands: `settle_approval` only moves a row out
+            // of pending, so the loser here changes nothing.
+            if let Ok(expired) =
+                self.inner.store.settle_approval(approval.id, ApprovalState::Expired)
+            {
+                self.inner.events.emit(UiEvent::ApprovalSettled {
+                    approval_id: approval.id,
+                    state: expired.state,
+                });
+            }
+        }
+
+        match self.inner.store.get_approval(approval.id) {
+            Ok(Some(settled)) => match settled.state {
+                ApprovalState::Allow | ApprovalState::AlwaysAllow => Permission::Granted,
+                ApprovalState::Deny => Permission::Refused,
+                ApprovalState::Pending | ApprovalState::Expired => Permission::Unanswered,
+            },
+            // The request cannot be read back, so nothing can be said about
+            // what the operator wanted. Refusing to act is the only safe end.
+            Ok(None) => Permission::Unanswered,
+            Err(err) => Permission::Failed(err.to_string()),
+        }
     }
 
     // ---- one agent turn --------------------------------------------------
@@ -720,14 +959,14 @@ impl Runtime {
             _ => (agent_id, Participant::Human),
         };
 
-        let stream_id = MessageId::new();
-        self.inner.events.emit(UiEvent::StreamStarted {
-            message_id: stream_id,
+        let mut stream = Stream {
+            message_id: MessageId::new(),
             channel_id: out_channel,
             agent_id,
             run_id,
             to: stream_to,
-        });
+        };
+        stream.open(&*self.inner.events);
 
         let config = self.config();
         let mut collected_text = String::new();
@@ -767,18 +1006,7 @@ impl Runtime {
                 temperature: None,
             };
 
-            let events = self.inner.events.clone();
-            let completion = self
-                .inner
-                .llm
-                .stream_chat(&inference, &request, |token| {
-                    events.emit(UiEvent::StreamDelta {
-                        message_id: stream_id,
-                        channel_id: out_channel,
-                        text: token.to_string(),
-                    });
-                })
-                .await;
+            let completion = self.stream_with_retries(&inference, &request, &mut stream).await;
 
             let completion = match completion {
                 Ok(completion) => completion,
@@ -832,9 +1060,7 @@ impl Runtime {
             }
         }
 
-        self.inner
-            .events
-            .emit(UiEvent::StreamEnded { message_id: stream_id, channel_id: out_channel });
+        stream.close(&*self.inner.events);
 
         if hit_tool_ceiling {
             tool_parts.push(Part::Notice {
@@ -880,6 +1106,69 @@ impl Runtime {
         }
 
         self.finish_turn(agent_id, run_id, batch.len());
+    }
+
+    /// One model call, attempted more than once when the failure is the kind
+    /// that fixes itself.
+    ///
+    /// The budget is not touched here. A call is one call however many times
+    /// the network dropped it, and reserving a step per attempt would bill a
+    /// run for requests that never reached a provider.
+    async fn stream_with_retries(
+        &self,
+        inference: &InferenceConfig,
+        request: &ChatRequest,
+        stream: &mut Stream,
+    ) -> Result<crate::llm::openrouter::Completion, LlmError> {
+        let mut last: Option<LlmError> = None;
+
+        for attempt in 0..CALL_ATTEMPTS {
+            if let Some(err) = &last {
+                let wait = match err {
+                    // A provider that says when to come back is worth obeying,
+                    // up to the point where waiting is worse than stopping.
+                    LlmError::RateLimited { retry_after_secs: Some(secs), .. } => {
+                        Duration::from_secs(*secs).min(MAX_RETRY_AFTER)
+                    }
+                    _ => CALL_BACKOFF[(attempt - 1).min(CALL_BACKOFF.len() - 1)],
+                };
+                tracing::warn!(
+                    attempt,
+                    error = %err,
+                    wait_ms = wait.as_millis() as u64,
+                    "retrying a model call"
+                );
+                tokio::time::sleep(wait).await;
+                // Anything already on screen belongs to the attempt that broke.
+                stream.reopen(&*self.inner.events);
+            }
+
+            let events = self.inner.events.clone();
+            let message_id = stream.message_id;
+            let channel_id = stream.channel_id;
+            let result = self
+                .inner
+                .llm
+                .stream_chat(inference, request, |token| {
+                    events.emit(UiEvent::StreamDelta {
+                        message_id,
+                        channel_id,
+                        text: token.to_string(),
+                    });
+                })
+                .await;
+
+            match result {
+                Ok(completion) => return Ok(completion),
+                Err(err) if err.is_transient() => last = Some(err),
+                // A rejected key or an unknown model answers the same way every
+                // time. Retrying it wastes the operator's time to reach the
+                // message they needed to read immediately.
+                Err(err) => return Err(err),
+            }
+        }
+
+        Err(last.expect("the loop only ends here after a failure"))
     }
 
     fn finish_turn(&self, agent_id: AgentId, run_id: RunId, consumed: usize) {
@@ -1077,9 +1366,17 @@ impl Runtime {
             return self.use_screen(card, action, arguments).await;
         }
 
+        if let ToolInvocation::CreateAgent { draft } = invocation {
+            let (rendered, part) = self.create_agent_for(card, run_id, draft, arguments).await;
+            return (rendered, part, None);
+        }
+
         let (rendered, part) = match invocation {
-            // Handled above, where it can answer with a picture.
-            ToolInvocation::UseScreen { .. } => unreachable!("taken by the branch above"),
+            // Both handled above: one answers with a picture, the other has to
+            // stop and ask the operator.
+            ToolInvocation::UseScreen { .. } | ToolInvocation::CreateAgent { .. } => {
+                unreachable!("taken by the branches above")
+            }
             ToolInvocation::Directory => {
                 let roster = self.roster_excluding(card.id);
                 let payload =
@@ -1139,6 +1436,7 @@ impl Runtime {
             }
 
             ToolInvocation::RunCommand { command } => {
+                let used = self.credentials_named_in(card, &command);
                 let outcome = match self.ensure_computer(card).await {
                     Ok((client, sandbox)) => {
                         client.run(&sandbox.id, &sandbox.envd_token, &command).await
@@ -1148,7 +1446,8 @@ impl Runtime {
                 let (rendered, outcome) = match outcome {
                     Ok(output) => {
                         let summary = format!(
-                            "exit {}, {} bytes out",
+                            "{}exit {}, {} bytes out",
+                            used,
                             output.exit_code,
                             output.stdout.len() + output.stderr.len()
                         );
@@ -1277,6 +1576,232 @@ impl Runtime {
         };
 
         (rendered, part, None)
+    }
+
+    /// Adding an agent to the workspace, if the operator says so.
+    ///
+    /// Split out because it is the only tool that stops mid-turn and waits for
+    /// a person. Everything that can be decided without them is decided first:
+    /// a request that would fail anyway is refused here rather than after the
+    /// operator has approved it, since an approval spent on an agent that then
+    /// could not be created is worse than no question at all.
+    async fn create_agent_for(
+        &self,
+        card: &AgentCard,
+        run_id: RunId,
+        draft: tools::NewAgent,
+        arguments: serde_json::Value,
+    ) -> (String, Part) {
+        let failed = |message: String, error: String, arguments: serde_json::Value| {
+            (
+                message,
+                Part::ToolCall {
+                    name: tools::CREATE_AGENT.to_string(),
+                    arguments,
+                    outcome: ToolOutcome::Failed { error },
+                },
+            )
+        };
+
+        let roster = self.inner.store.list_agents().unwrap_or_default();
+        let crew: Vec<AgentCard> = roster
+            .into_iter()
+            .filter(|a| a.group_id == card.group_id && a.lifecycle != Lifecycle::Terminated)
+            .collect();
+
+        // Checked before the operator is asked. Coming back to say the name was
+        // taken after they pressed Allow spends their attention on nothing.
+        if crew.iter().any(|a| a.name.eq_ignore_ascii_case(draft.name.trim())) {
+            return failed(
+                format!(
+                    "Error: there is already an agent called {}. Nothing was created and the \
+                     operator was not asked. Use a different name, or message the one that \
+                     exists.",
+                    draft.name.trim()
+                ),
+                "duplicate name".to_string(),
+                arguments,
+            );
+        }
+
+        let (avatar, color) = crate::domain::agent::suggest_look(&draft.name, &crew);
+        let proposed = crate::domain::agent::AgentDraft {
+            // Its own group, never a parameter: the group wall is what stops an
+            // agent reaching agents it was not meant to, and an agent that could
+            // place a new one on the other side of that wall could walk through
+            // it by proxy.
+            group_id: Some(card.group_id),
+            name: draft.name.clone(),
+            avatar,
+            color,
+            // Blank means inherit, which is how an agent created in the UI
+            // starts too. What a new agent costs to run stays the operator's.
+            model: String::new(),
+            system_prompt: draft.instructions.clone(),
+            skills: draft.skills.clone(),
+        };
+
+        let clean = match proposed.validate() {
+            Ok(clean) => clean,
+            Err(err) => {
+                return failed(
+                    format!("Error: that agent could not be created ({err})."),
+                    err.to_string(),
+                    arguments,
+                )
+            }
+        };
+
+        let notes = draft.notes.trim().to_string();
+        let mut detail = vec![
+            DetailField::new("Name", &clean.name),
+            DetailField::new(
+                "Skills",
+                if clean.skills.is_empty() {
+                    "none stated".to_string()
+                } else {
+                    clean.skills.join(", ")
+                },
+            ),
+            DetailField::new("Instructions", &clean.system_prompt),
+        ];
+        if !notes.is_empty() {
+            detail.push(DetailField::new("Starting notes", &notes));
+        }
+
+        let permission = self
+            .ask_operator(
+                card,
+                run_id,
+                ProtectedAction::CreateAgent,
+                format!("{} wants to create an agent called {}", card.name, clean.name),
+                detail,
+            )
+            .await;
+
+        match permission {
+            Permission::Granted => self.add_agent(&clean, &notes, arguments),
+            Permission::Refused => (
+                format!(
+                    "The operator said no to creating {}, so it does not exist. That is their \
+                     decision to make and it is final for this request: do not ask again. Carry \
+                     on with the agents you have, and say what you would have given this one to \
+                     do if it matters.",
+                    clean.name
+                ),
+                Part::ToolCall {
+                    name: tools::CREATE_AGENT.to_string(),
+                    arguments,
+                    outcome: ToolOutcome::Refused { reason: "the operator declined".to_string() },
+                },
+            ),
+            Permission::Unanswered => (
+                format!(
+                    "Nobody answered the request to create {}, so nothing was created. The \
+                     operator is away rather than opposed. Finish what you can without it and \
+                     tell them plainly what you wanted to add and why, so they can decide when \
+                     they are back.",
+                    clean.name
+                ),
+                Part::ToolCall {
+                    name: tools::CREATE_AGENT.to_string(),
+                    arguments,
+                    outcome: ToolOutcome::Refused {
+                        reason: "the operator did not answer".to_string(),
+                    },
+                },
+            ),
+            Permission::Failed(err) => failed(
+                format!(
+                    "Error: the operator could not be asked about creating {} ({err}), so nothing \
+                     was created. Tell them what you were trying to add.",
+                    clean.name
+                ),
+                err,
+                arguments,
+            ),
+        }
+    }
+
+    /// The half of creating an agent that happens once permission is in hand.
+    fn add_agent(
+        &self,
+        clean: &CleanDraft,
+        notes: &str,
+        arguments: serde_json::Value,
+    ) -> (String, Part) {
+        let card = match self.inner.store.create_agent(clean) {
+            Ok(card) => card,
+            Err(err) => {
+                return (
+                    format!("Error: {} could not be created ({err}).", clean.name),
+                    Part::ToolCall {
+                        name: tools::CREATE_AGENT.to_string(),
+                        arguments,
+                        outcome: ToolOutcome::Failed { error: err.to_string() },
+                    },
+                )
+            }
+        };
+
+        // Seeded before the agent is running, so its first turn already has
+        // them. A failure here costs the notes, not the agent.
+        if !notes.is_empty() {
+            if let Err(err) = self.inner.workspace.write(card.id, &card.name, notes) {
+                tracing::warn!(%err, agent = %card.name, "could not seed the new agent's notes");
+            }
+        }
+
+        self.start_agent(card.id);
+        self.inner.events.emit(UiEvent::AgentsChanged);
+
+        (
+            format!(
+                "Created {name}. It is in the workspace now and every agent here can reach it by \
+                 name. It is idle and will stay idle until something arrives for it, so if the \
+                 work is ready, send it.",
+                name = card.name
+            ),
+            Part::ToolCall {
+                name: tools::CREATE_AGENT.to_string(),
+                arguments,
+                outcome: ToolOutcome::Ok { summary: format!("created {}", card.name) },
+            },
+        )
+    }
+
+    /// Which of the group's credentials a command reaches for, as a prefix for
+    /// the line the operator reads.
+    ///
+    /// The transcript is where an operator finds out what their tokens were
+    /// used for, and until now it did not say: a credential went into the
+    /// environment of every command and nothing distinguished the command that
+    /// spent it. This reports the variables the command names, which is what
+    /// can honestly be known from here — whether the process then used it is
+    /// between the process and the service.
+    ///
+    /// Names only. The value is not in this string and could not be: nothing on
+    /// this side of the boundary holds one.
+    fn credentials_named_in(&self, card: &AgentCard, command: &str) -> String {
+        let named: Vec<String> = self
+            .inner
+            .store
+            .group_connectors(card.group_id)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|connector| {
+                !connector.env_var.is_empty()
+                    && (command.contains(&format!("${}", connector.env_var))
+                        || command.contains(&format!("${{{}}}", connector.env_var)))
+            })
+            .map(|connector| format!("{} (${})", connector.service, connector.env_var))
+            .collect();
+
+        if named.is_empty() {
+            String::new()
+        } else {
+            format!("used {} · ", named.join(", "))
+        }
     }
 
     /// Looking at, and acting on, the screen.

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -221,7 +221,8 @@ pub fn system_prompt(
     if roster.is_empty() {
         out.push_str(
             "You are currently the only agent in the workspace. `send_message` has no valid \
-             recipients until another agent is created.\n",
+             recipients until there is somebody to send to, and `create_agent` is how one \
+             appears.\n",
         );
     } else {
         out.push_str("One human operator, plus these agents:\n");
@@ -280,6 +281,26 @@ pub fn system_prompt(
          wait for a reply, and never call `send_message` again just to check for one.\n\
          - Guaca limits how far a chain of agent messages can travel. If a send is refused, the \
          refusal explains why. Accept it and report back rather than retrying.\n",
+    );
+
+    // Said in the prompt as well as in the tool schema, because an agent asked
+    // for something the crew has nobody for reasons about the crew here, before
+    // it has any reason to go looking at a tool list. Asked to staff ten roles,
+    // one with this tool available still replied that it could not create
+    // agents from this interface.
+    out.push_str(
+        "\n## Growing the crew\n\
+         `create_agent` adds a colleague: its own instructions, its own computer, its own memory, \
+         reachable by name the moment it exists. Reach for it when the workspace is missing a \
+         role, not when you are missing an afternoon's work: a task belongs to you or to an agent \
+         already here.\n\
+         - The operator approves every one, and the request waits for them. Their answer settles \
+         it. If they decline, say what you would have created and carry on without it.\n\
+         - A new agent is idle and stays idle until something reaches it. Creating one is not \
+         delegating to it; send it the first piece of work yourself.\n\
+         - You are never unable to create an agent. If the crew has nobody for a role the \
+         operator needs, propose it or create it rather than reporting that the workspace will \
+         not let you.\n",
     );
 
     out.push_str("\n## Your reply\n");
@@ -841,9 +862,31 @@ mod tests {
     }
 
     #[test]
-    fn a_lone_agent_is_told_it_has_no_one_to_message() {
+    fn a_lone_agent_is_told_it_has_no_one_to_message_and_how_that_changes() {
         let prompt = prompt_for(&card("Manager"), &[], "", ReplyMode::ToOperator);
         assert!(prompt.contains("only agent in the workspace"));
+        assert!(
+            prompt.contains("`create_agent` is how one appears"),
+            "an agent alone in a workspace is exactly the one that needs to know: {prompt}"
+        );
+    }
+
+    #[test]
+    fn an_agent_is_told_it_can_staff_the_workspace_and_on_what_terms() {
+        // The failure this exists to stop: asked to fill ten roles, an agent
+        // with this tool available replied that it could not create agents from
+        // this interface. A tool schema alone did not reach the answer.
+        let prompt = prompt_for(&card("Manager"), &[entry("Chef", &[])], "", ReplyMode::ToOperator);
+        assert!(prompt.contains("create_agent"), "the tool has to be named, not just offered");
+        assert!(prompt.contains("operator approves every one"), "{prompt}");
+        assert!(
+            prompt.contains("never unable to create an agent"),
+            "the exact wrong answer has to be ruled out by name: {prompt}"
+        );
+        assert!(
+            prompt.contains("Creating one is not delegating to it"),
+            "a crew created and then left waiting is the other half of the failure: {prompt}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/sessions.py
+++ b/src-tauri/src/sessions.py
@@ -20,10 +20,16 @@ import json
 import os
 import shutil
 import sqlite3
+import sys
 import tempfile
 import urllib.parse
 
-PROFILE = os.path.expanduser("~/.guac/chrome/Default")
+# Passed in rather than spelled here. The launcher already names this directory
+# absolutely, and a second copy of it written as `~` is a copy that resolves
+# against whatever user the command daemon happens to run as: agree with the
+# launcher on every machine, or agree with it only on the ones where those two
+# users match, silently reporting an empty jar everywhere else.
+PROFILE = sys.argv[1]
 
 
 def rows(name, query):

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -19,13 +19,14 @@ use axum::Router;
 use guac_lib::config::{AppConfig, InferenceConfig};
 use guac_lib::db::Store;
 use guac_lib::domain::agent::Lifecycle;
+use guac_lib::domain::approval::Decision;
 use guac_lib::domain::connector::CleanConnector;
 use guac_lib::domain::envelope::{Part, Participant};
 use guac_lib::domain::group::CleanGroup;
 use guac_lib::domain::now_ms;
 use guac_lib::domain::signin::Signin;
 use guac_lib::llm::openrouter::LlmClient;
-use guac_lib::runtime::events::{RecordingSink, UiEvent};
+use guac_lib::runtime::events::{Activity, RecordingSink, UiEvent};
 use guac_lib::runtime::guard::GuardLimits;
 use guac_lib::runtime::Runtime;
 use guac_lib::workspace::Workspace;
@@ -1123,4 +1124,270 @@ async fn the_directory_says_which_peer_is_signed_in_to_what() {
         listing.contains("LinkedIn"),
         "the directory has to say what a peer is signed in to: {listing}"
     );
+}
+
+// ---- adding an agent -----------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_agent_cannot_add_a_colleague_without_the_operator_saying_so() {
+    // The whole point of the mechanism: the turn stops, nothing exists yet, and
+    // a person decides. An agent that could staff its own workspace could spend
+    // the operator's money in a shape they never chose.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Say("Chief of Product is set up.".into())
+        } else {
+            Script::Hire {
+                name: "Chief of Product".into(),
+                instructions: "You own the roadmap.".into(),
+                notes: "# Context\nB2B services, founder-led sales.".into(),
+            }
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "Create a chief of product.").unwrap();
+
+    let request = h.awaited_request().await;
+    assert!(
+        h.agent_named("Chief of Product").is_none(),
+        "an agent existed before anybody was asked about it"
+    );
+    assert_eq!(
+        h.runtime.activity_snapshot().get(&h.id("Manager")),
+        Some(&Activity::AwaitingApproval),
+        "a parked agent has to be distinguishable from a thinking one"
+    );
+
+    h.runtime.decide_approval(request, Decision::Allow).unwrap();
+    h.settle(run).await;
+
+    let hired = h.agent_named("Chief of Product").expect("the operator allowed it");
+    let manager = h.runtime.store().get_agent(h.id("Manager")).unwrap().unwrap();
+    assert_eq!(hired.group_id, manager.group_id, "a new agent lands inside its maker's wall");
+    assert!(hired.model.is_empty(), "what it costs to run stays the operator's decision");
+    assert!(hired.lifecycle.accepts_work(), "and it is running, not queued behind a start");
+    assert_eq!(hired.system_prompt, "You own the roadmap.");
+    assert!(
+        h.runtime.workspace().read(hired.id).contains("founder-led sales"),
+        "an agent handed starting notes has to open with them, not find an empty file"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_refusal_reaches_the_model_as_a_decision_rather_than_a_failure() {
+    // A refusal worded as an error gets retried. This one has to read as
+    // settled, or the next turn asks the operator the same question again.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Say("Understood, no new agent.".into())
+        } else {
+            Script::Hire {
+                name: "Scout".into(),
+                instructions: "You look things up.".into(),
+                notes: String::new(),
+            }
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "Create a scout.").unwrap();
+
+    let request = h.awaited_request().await;
+    h.runtime.decide_approval(request, Decision::Deny).unwrap();
+    h.settle(run).await;
+
+    assert!(h.agent_named("Scout").is_none(), "a denial has to mean nothing was created");
+
+    let told = tool_results(&stub).join("\n");
+    assert!(told.contains("said no"), "the model has to be told what happened: {told}");
+    assert!(told.contains("do not ask again"), "and that it is settled: {told}");
+
+    // The operator still gets an answer rather than a dead turn.
+    let said = h.channel_texts("Manager");
+    assert!(said.iter().any(|t| t.contains("no new agent")), "{said:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn always_allow_means_the_same_agent_is_not_asked_twice() {
+    // The second request is the one that must not appear. Asking again after
+    // "always" is how a permission prompt becomes something to click through.
+    let hires = Arc::new(AtomicUsize::new(0));
+    let counter = hires.clone();
+    let stub = serve(move |body| {
+        if has_tool_result(body) {
+            Script::Say("Done.".into())
+        } else {
+            let nth = counter.fetch_add(1, Ordering::SeqCst);
+            Script::Hire {
+                name: format!("Scout {nth}"),
+                instructions: "You look things up.".into(),
+                notes: String::new(),
+            }
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+
+    let first = h.runtime.send_from_human(h.id("Manager"), "Create a scout.").unwrap();
+    let request = h.awaited_request().await;
+    h.runtime.decide_approval(request, Decision::AlwaysAllow).unwrap();
+    h.settle(first).await;
+
+    let second = h.runtime.send_from_human(h.id("Manager"), "Create another scout.").unwrap();
+    h.settle(second).await;
+
+    assert!(h.agent_named("Scout 0").is_some(), "the approved one");
+    assert!(h.agent_named("Scout 1").is_some(), "and the one that needed no asking");
+    assert_eq!(
+        h.sink.count_of(|e| matches!(e, UiEvent::ApprovalRequested { .. })),
+        1,
+        "the operator answered once and should not have been asked again"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_name_already_taken_is_refused_without_troubling_the_operator() {
+    // Approving a create that then fails on a duplicate name spends the
+    // operator's attention on nothing at all.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Say("There is already a Chef.".into())
+        } else {
+            Script::Hire {
+                name: "Chef".into(),
+                instructions: "You cook.".into(),
+                notes: String::new(),
+            }
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager", "Chef"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "Create a chef.").unwrap();
+    h.settle(run).await;
+
+    assert_eq!(
+        h.sink.count_of(|e| matches!(e, UiEvent::ApprovalRequested { .. })),
+        0,
+        "nobody should have been asked"
+    );
+    let told = tool_results(&stub).join("\n");
+    assert!(told.contains("already an agent called Chef"), "{told}");
+}
+
+// ---- surviving a bad connection ------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_connection_that_drops_once_is_retried_rather_than_reported() {
+    // The failure an operator actually hits: a laptop changes network, one
+    // request never lands, and an agent that would have answered fine reports
+    // that it could not reach the endpoint. Retrying is what the operator would
+    // have done, so the runtime does it first.
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let counter = attempts.clone();
+    let stub = serve(move |_body| {
+        if counter.fetch_add(1, Ordering::SeqCst) == 0 {
+            Script::Unavailable
+        } else {
+            Script::Say("Answered on the second attempt.".into())
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "hello").unwrap();
+    h.settle(run).await;
+
+    assert!(attempts.load(Ordering::SeqCst) >= 2, "the failed call was never tried again");
+    let said = h.channel_texts("Manager");
+    assert!(said.iter().any(|t| t.contains("second attempt")), "{said:?}");
+    assert!(
+        !said.iter().any(|t| t.contains("could not reach")),
+        "a failure the runtime recovered from must not reach the operator: {said:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_call_that_keeps_failing_is_reported_with_the_message_to_send_again() {
+    // Once retries are spent the operator has to be told, and told next to the
+    // thing that failed, or the only way back is to retype what they asked.
+    let stub = serve(|_body| Script::Unavailable).await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "what is the plan?").unwrap();
+    h.settle(run).await;
+
+    let failure = h
+        .runtime
+        .store()
+        .channel_messages(h.id("Manager"), 50)
+        .unwrap()
+        .into_iter()
+        .find(|m| {
+            m.parts.iter().any(|p| {
+                matches!(
+                    p,
+                    Part::Notice {
+                        kind: guac_lib::domain::envelope::NoticeKind::UpstreamError,
+                        ..
+                    }
+                )
+            })
+        })
+        .expect("the operator has to be told the call failed");
+
+    let cause = failure.cause.expect("the notice must name what to send again");
+    assert_eq!(
+        h.runtime.store().get_message(cause).unwrap().unwrap().plain_text(),
+        "what is the plan?",
+        "retrying has to re-deliver the message the turn was answering"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn retrying_delivers_the_same_message_again_under_a_fresh_budget() {
+    let stub = serve(|_body| Script::Say("Answered.".into())).await;
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+
+    let first = h.runtime.send_from_human(h.id("Manager"), "the question").unwrap();
+    h.settle(first).await;
+
+    let original = h
+        .runtime
+        .store()
+        .channel_messages(h.id("Manager"), 50)
+        .unwrap()
+        .into_iter()
+        .find(|m| m.plain_text() == "the question")
+        .unwrap();
+
+    let again = h.runtime.retry_turn(h.id("Manager"), original.id).unwrap();
+    assert_ne!(again, first, "a retry is the operator acting, so it gets a run of its own");
+    h.settle(again).await;
+
+    let asked = h
+        .runtime
+        .store()
+        .channel_messages(h.id("Manager"), 50)
+        .unwrap()
+        .into_iter()
+        .filter(|m| m.plain_text() == "the question")
+        .count();
+    assert_eq!(asked, 2, "the agent has to read what it read before, not a summary of it");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn retrying_something_that_is_no_longer_there_says_so() {
+    let stub = serve(|_body| Script::Say("hi".into())).await;
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+
+    let gone = guac_lib::domain::ids::MessageId::new();
+    assert!(matches!(
+        h.runtime.retry_turn(h.id("Manager"), gone),
+        Err(guac_lib::runtime::RuntimeError::NothingToRetry)
+    ));
 }

--- a/src-tauri/tests/connectors.rs
+++ b/src-tauri/tests/connectors.rs
@@ -1,0 +1,169 @@
+//! What a credential actually reaches, against the real service.
+//!
+//! The scripted suites prove the plumbing: a secret goes into the environment
+//! of a sandbox command and never anywhere else. They cannot prove the thing an
+//! operator cares about, which is that an agent handed a key can do the work the
+//! key is for. That needs the real machine and the real API, so it costs money
+//! and lives behind `#[ignore]`.
+//!
+//! Run with `./scripts/connectors.sh`.
+//!
+//! The credential is read from the app's own database and put into the sandbox
+//! the way the runtime puts it there. It is never printed, never asserted on,
+//! and never written to the sandbox's disk: if one of these tests fails, the
+//! output says which step failed and not what the token was.
+
+use std::collections::BTreeMap;
+
+use guac_lib::db::Store;
+use guac_lib::e2b::E2bClient;
+
+/// Two real documents, and something in each that OCR has to come back with.
+///
+/// arXiv because the papers are stable, public, and already cited by this
+/// project: `docs/PROTOCOL.md` argues from both of them.
+const DOCUMENTS: [(&str, &str, &str); 2] = [
+    ("beyond-browsing.pdf", "https://arxiv.org/pdf/2410.16464", "Beyond Browsing"),
+    ("attention.pdf", "https://arxiv.org/pdf/1706.03762", "Attention Is All You Need"),
+];
+
+/// One local file, read by Mistral OCR: upload, sign, read.
+///
+/// Written as shell rather than as Rust HTTP calls on purpose. This is the
+/// sequence an agent will run through `run_command`, in the same login shell,
+/// reaching the credential by the same variable name, so what passes here is
+/// what an agent can do rather than something only the test can.
+///
+/// `DOCUMENT` is replaced with the file name. Not a `format!`: the body is
+/// mostly braces and escaping every one of them makes it unreadable and
+/// unpasteable into a terminal, which is where it was worked out.
+const OCR_ONE_FILE: &str = r#"set -e
+file_id=$(curl -sS --max-time 120 https://api.mistral.ai/v1/files \
+  -H "Authorization: Bearer $MISTRAL_API_KEY" \
+  -F purpose=ocr -F file=@$HOME/docs/DOCUMENT \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+signed=$(curl -sS --max-time 120 "https://api.mistral.ai/v1/files/$file_id/url?expiry=1" \
+  -H "Authorization: Bearer $MISTRAL_API_KEY" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["url"])')
+python3 -c 'import json,sys; print(json.dumps({"model":"mistral-ocr-4-1","document":{"type":"document_url","document_url":sys.argv[1]},"pages":[0]}))' "$signed" > /tmp/ocr.json
+curl -sS --max-time 300 https://api.mistral.ai/v1/ocr \
+  -H "Authorization: Bearer $MISTRAL_API_KEY" -H 'Content-Type: application/json' \
+  --data @/tmp/ocr.json \
+  | python3 -c 'import json,sys; d=json.load(sys.stdin); print("\n".join(p.get("markdown","") for p in d.get("pages",[])) or json.dumps(d)[:400])'"#;
+
+fn app_dir() -> Option<std::path::PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(std::path::PathBuf::from(home).join("Library/Application Support/com.madebywelch.guac"))
+}
+
+fn configured() -> Option<guac_lib::config::AppConfig> {
+    let raw = std::fs::read_to_string(app_dir()?.join("config.json")).ok()?;
+    let config: guac_lib::config::AppConfig = serde_json::from_str(&raw).ok()?;
+    (!config.e2b.api_key.trim().is_empty()).then_some(config)
+}
+
+/// The group environment holding `var`, exactly as the runtime would build it.
+///
+/// Whichever group the operator put the credential in: it is one workspace and
+/// the test should not care which crew holds the key.
+fn credentials_holding(var: &str) -> Option<BTreeMap<String, String>> {
+    let store = Store::open(&app_dir()?.join("guac.db")).ok()?;
+    store
+        .list_groups()
+        .ok()?
+        .into_iter()
+        .filter_map(|group| store.connector_env(group.id).ok())
+        .find(|env| env.contains_key(var))
+}
+
+/// A machine with the group's credentials in its environment.
+struct Machine {
+    client: E2bClient,
+    id: String,
+    token: String,
+}
+
+impl Machine {
+    async fn start(env: BTreeMap<String, String>, key: &str) -> Machine {
+        let client = E2bClient::new(key).expect("an E2B key is configured").with_env(env);
+        let sandbox = client.create("connector-test", 300).await.expect("a machine to work on");
+        Machine { client, id: sandbox.id, token: sandbox.envd_token }
+    }
+
+    async fn run(&self, command: &str) -> String {
+        let out = self
+            .client
+            .run(&self.id, &self.token, command)
+            .await
+            .unwrap_or_else(|err| panic!("could not run on the machine: {err}"));
+        assert_eq!(
+            out.exit_code, 0,
+            "command failed: {command}\nstdout: {}\nstderr: {}",
+            out.stdout, out.stderr
+        );
+        out.stdout
+    }
+
+    /// Never left running. A sandbox nobody holds a reference to bills exactly
+    /// like a used one, and a failing assertion takes the rest of the test with
+    /// it, so this is called before anything that can panic.
+    async fn release(&self) {
+        if let Err(err) = self.client.kill(&self.id).await {
+            eprintln!("could not release {}: {err}", self.id);
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live: costs money, needs the E2B and Mistral keys the app is configured with"]
+async fn an_agent_can_read_a_folder_of_documents_it_downloaded() {
+    // The whole path an operator asked for, end to end: a machine with the
+    // group's credentials in its environment downloads a folder of PDFs and
+    // turns them into text with Mistral OCR. Everything here is what an agent
+    // would do with `run_command`, in the same shell, with the same variable.
+    let Some(config) = configured() else {
+        eprintln!("no E2B key configured; skipping");
+        return;
+    };
+    let Some(env) = credentials_holding("MISTRAL_API_KEY") else {
+        eprintln!("no Mistral credential in any group; add one and run this again");
+        return;
+    };
+
+    let machine = Machine::start(env, &config.e2b.api_key).await;
+
+    // 1. The folder. Downloaded the way an agent would, with the tool it has.
+    let mut downloaded = String::new();
+    for (name, url) in DOCUMENTS.map(|(name, url, _)| (name, url)) {
+        machine
+            .run(&format!("mkdir -p ~/docs && curl -sSL --max-time 120 -o ~/docs/{name} {url}"))
+            .await;
+        downloaded = machine.run("ls -1 ~/docs && du -sh ~/docs | cut -f1").await;
+    }
+    assert!(downloaded.contains("beyond-browsing.pdf"), "the folder is not there: {downloaded}");
+
+    // 2. The credential reaches the shell under the name the catalog promised,
+    // and only as a name: what is asserted is that it is set, never its value.
+    let present = machine.run("test -n \"$MISTRAL_API_KEY\" && echo set || echo missing").await;
+    assert_eq!(present.trim(), "set", "the credential never reached the machine's environment");
+
+    // 3. OCR, per file: upload, sign, read. This is the sequence the catalog
+    // note tells an agent about, run exactly as written there.
+    let mut text = String::new();
+    for (name, _, expected) in DOCUMENTS {
+        let extracted = machine.run(&OCR_ONE_FILE.replace("DOCUMENT", name)).await;
+
+        println!("--- {name} ---\n{}\n", extracted.chars().take(600).collect::<String>());
+        assert!(
+            extracted.to_lowercase().contains(&expected.to_lowercase()),
+            "OCR did not return the text on page one of {name}. Expected {expected:?} in:\n{extracted}"
+        );
+        text.push_str(&extracted);
+    }
+
+    machine.release().await;
+
+    // The value must not have travelled with the result. Cheap to check and the
+    // one mistake in this flow that would matter.
+    assert!(!text.contains("MISTRAL_API_KEY="), "the environment leaked into the output");
+}

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -45,6 +45,15 @@ pub enum Script {
     Directory,
     /// Emit an `update_notes` tool call.
     Notes(String),
+    /// Emit a `create_agent` tool call.
+    Hire { name: String, instructions: String, notes: String },
+    /// Answer with a 503.
+    ///
+    /// Stands in for every failure worth retrying: a provider having a bad
+    /// minute, a request that timed out, a connection that never opened. They
+    /// arrive as different `LlmError`s and all answer `is_transient`, which is
+    /// the only thing the retry loop asks them.
+    Unavailable,
 }
 
 pub fn frame(value: serde_json::Value) -> String {
@@ -94,6 +103,20 @@ pub fn render(script: &Script) -> String {
                 serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
             ));
         }
+        Script::Hire { name, instructions, notes } => {
+            let args =
+                serde_json::json!({ "name": name, "instructions": instructions, "notes": notes })
+                    .to_string();
+            body.push_str(&frame(serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                {"index":0,"id":"call_hire","type":"function",
+                 "function":{"name":"create_agent","arguments": args}}
+            ]}}]})));
+            body.push_str(&frame(
+                serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
+            ));
+        }
+        // Never rendered: the server answers it with a status, not a body.
+        Script::Unavailable => {}
         Script::Directory => {
             body.push_str(&frame(serde_json::json!({"choices":[{"delta":{"tool_calls":[
                 {"index":0,"id":"call_dir","type":"function",
@@ -163,6 +186,13 @@ where
                 call_counter.fetch_add(1, Ordering::SeqCst);
                 recorder.lock().push(body.0.clone());
                 let script = decide(&body.0);
+                if matches!(script, Script::Unavailable) {
+                    return (
+                        axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                        "the model provider is having a moment",
+                    )
+                        .into_response();
+                }
                 ([("content-type", "text/event-stream")], render(&script)).into_response()
             }
         }),
@@ -319,6 +349,35 @@ impl Harness {
             assert!(Instant::now() < deadline, "timed out waiting for {what}");
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
+    }
+
+    /// Waits for an agent to park on a permission request, and returns it.
+    ///
+    /// Polling the event sink rather than the store because the request the
+    /// test wants to answer is the one the UI would be drawing, and a turn is
+    /// holding its line open until somebody does.
+    pub async fn awaited_request(&self) -> guac_lib::domain::ids::ApprovalId {
+        let deadline = Instant::now() + Duration::from_secs(20);
+        loop {
+            let asked = self.sink.snapshot().into_iter().find_map(|event| match event {
+                UiEvent::ApprovalRequested { approval_id, .. } => Some(approval_id),
+                _ => None,
+            });
+            if let Some(id) = asked {
+                return id;
+            }
+            assert!(Instant::now() < deadline, "no permission request arrived");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    pub fn agent_named(&self, name: &str) -> Option<guac_lib::domain::agent::AgentCard> {
+        self.runtime
+            .store()
+            .list_agents()
+            .unwrap()
+            .into_iter()
+            .find(|card| card.name == name && card.lifecycle != Lifecycle::Terminated)
     }
 
     pub fn pause(&self, name: &str) {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -53,6 +53,7 @@ vi.mock("./lib/ipc", () => ({
     ],
     agentActivity: async () => ({}),
     usageSummary: async () => [],
+    approvalStates: async () => ({}),
     agentLastActive: () => agentLastActive(),
     getSettings: () => getSettings(),
     channelMessages: async () => [],

--- a/src/components/AgentEditor.tsx
+++ b/src/components/AgentEditor.tsx
@@ -11,6 +11,7 @@ import {
 import { api } from "../lib/ipc";
 import { useStore } from "../lib/store";
 import { type AgentCard, type AgentDraft, errorMessage } from "../lib/types";
+import { GrantList } from "./GrantList";
 import { RoutineList } from "./RoutineList";
 import { SigninList } from "./SigninList";
 
@@ -283,6 +284,8 @@ export function AgentEditor({ agent, onClose }: Props) {
         )}
 
         {agent && <SigninList agent={agent} />}
+
+        {agent && <GrantList agent={agent} />}
 
         {agent && <RoutineList agentId={agent.id} />}
 

--- a/src/components/ApprovalRequest.test.tsx
+++ b/src/components/ApprovalRequest.test.tsx
@@ -1,0 +1,135 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useStore } from "../lib/store";
+import type { AgentCard, ApprovalState, Envelope, Part } from "../lib/types";
+import { MessageItem } from "./MessageItem";
+
+const decideApproval = vi.fn<(id: string, decision: string) => Promise<unknown>>();
+const approvalStates = vi.fn(async () => ({}));
+
+vi.mock("../lib/ipc", () => ({
+  api: {
+    decideApproval: (id: string, decision: string) => decideApproval(id, decision),
+    approvalStates: () => approvalStates(),
+  },
+}));
+
+const MANAGER: AgentCard = {
+  id: "manager",
+  groupId: "g1",
+  sandboxId: null,
+  name: "Manager",
+  avatar: "avocado",
+  color: "#c7d96b",
+  model: "",
+  systemPrompt: "",
+  skills: [],
+  lifecycle: "active",
+  version: 1,
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+const REQUEST: Extract<Part, { type: "approval" }> = {
+  type: "approval",
+  id: "ap1",
+  action: "createAgent",
+  summary: "Manager wants to create an agent called Chief of Product",
+  detail: [
+    { label: "Name", value: "Chief of Product" },
+    { label: "Instructions", value: "You own the roadmap." },
+  ],
+};
+
+/** The envelope the runtime writes: Guaca, in the asking agent's channel. */
+function asking(): Envelope {
+  return {
+    id: "m1",
+    runId: "r1",
+    channelId: MANAGER.id,
+    from: { kind: "system" },
+    to: { kind: "agent", id: MANAGER.id },
+    parts: [REQUEST],
+    trust: "system",
+    hop: 0,
+    expectsReply: false,
+    cause: null,
+    createdAt: 0,
+  };
+}
+
+function draw(state: ApprovalState | undefined) {
+  useStore.setState({ approvals: state ? { [REQUEST.id]: state } : {}, banner: null });
+  return render(
+    <MessageItem
+      message={asking()}
+      lookups={{ byId: (id) => (id === MANAGER.id ? MANAGER : undefined), byName: () => undefined }}
+      continued={false}
+      feed={false}
+    />,
+  );
+}
+
+describe("a request for permission", () => {
+  beforeEach(() => {
+    decideApproval.mockReset();
+    decideApproval.mockResolvedValue(undefined);
+    approvalStates.mockClear();
+  });
+
+  it("shows what was asked for, not just that something was", () => {
+    // The operator is deciding whether an agent should exist. A summary alone
+    // would have them approving a name with the instructions out of sight.
+    draw("pending");
+    expect(screen.getByText(REQUEST.summary)).toBeTruthy();
+    expect(screen.getByText("You own the roadmap.")).toBeTruthy();
+    expect(screen.getByText(/Manager is waiting on you/)).toBeTruthy();
+  });
+
+  it("sends the answer the operator chose", () => {
+    draw("pending");
+    fireEvent.click(screen.getByRole("button", { name: "Always allow" }));
+    expect(decideApproval).toHaveBeenCalledWith("ap1", "alwaysAllow");
+  });
+
+  it("says who a standing allow is for", () => {
+    // "Always" reads as a workspace setting. It is one agent being let off one
+    // question, and the operator has to know that before clicking it.
+    draw("pending");
+    expect(screen.getByText(/Always allow is for Manager only/)).toBeTruthy();
+  });
+
+  it.each([
+    ["allow", /You allowed this\./],
+    ["alwaysAllow", /said not to ask again/],
+    ["deny", /You declined/],
+    ["expired", /Nobody answered/],
+  ] as const)("draws no buttons once it is %s", (state, said) => {
+    draw(state);
+    expect(screen.queryByRole("button", { name: "Allow" })).toBeNull();
+    expect(screen.getByText(said)).toBeTruthy();
+    expect(screen.getByText(REQUEST.summary)).toBeTruthy();
+  });
+
+  it("offers no decision for a request it has never heard of", () => {
+    // Older than the window the store loads, so nothing is waiting on it.
+    // Buttons here would offer an answer that reaches nobody.
+    draw(undefined);
+    expect(screen.queryByRole("button", { name: "Allow" })).toBeNull();
+  });
+
+  it("takes the server's answer when a decision is refused", async () => {
+    // The turn timed out while this was on screen, or it was answered in
+    // another window. Arguing with the store would leave live buttons on a
+    // request that is already settled.
+    decideApproval.mockRejectedValue({ kind: "alreadyAnswered", message: "already answered" });
+    draw("pending");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Deny" }));
+    });
+
+    expect(approvalStates).toHaveBeenCalled();
+    expect(useStore.getState().banner?.text).toContain("already answered");
+  });
+});

--- a/src/components/ApprovalRequest.tsx
+++ b/src/components/ApprovalRequest.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+
+import { AgentAvatar } from "../avatars/AgentAvatar";
+import { api } from "../lib/ipc";
+import { useStore } from "../lib/store";
+import { type AgentCard, type Decision, errorMessage, type Part } from "../lib/types";
+
+type ApprovalPart = Extract<Part, { type: "approval" }>;
+
+interface Props {
+  part: ApprovalPart;
+  /** The agent that asked. Undefined once it has been deleted. */
+  agent: AgentCard | undefined;
+}
+
+/** What the operator is told after the fact, per outcome. */
+const SETTLED: Record<string, string> = {
+  allow: "You allowed this.",
+  alwaysAllow: "You allowed this, and said not to ask again.",
+  deny: "You declined.",
+  expired: "Nobody answered, so nothing happened.",
+};
+
+/**
+ * An agent asking the operator for permission, in the channel it asked from.
+ *
+ * The agent is parked mid-turn while this is on screen, which is why it is a
+ * card in the transcript rather than a dialog: the operator can read what led
+ * to the request before answering it, and a request nobody answers lapses on
+ * its own rather than blocking the window.
+ *
+ * Every value here is what a model asked for, so all of it is rendered as
+ * text. An agent that could format its own request could draw a button.
+ */
+export function ApprovalRequest({ part, agent }: Props) {
+  // A request the store has never heard of is older than the window it loads,
+  // so it cannot still be live. Drawing live buttons for one would offer the
+  // operator a decision that no longer reaches anybody.
+  const state = useStore((s) => s.approvals[part.id]) ?? "expired";
+  const refreshApprovals = useStore((s) => s.refreshApprovals);
+  const setBanner = useStore((s) => s.setBanner);
+  const [deciding, setDeciding] = useState<Decision | null>(null);
+
+  const asker = agent?.name ?? "A deleted agent";
+
+  const answer = (decision: Decision) => {
+    setDeciding(decision);
+    void api
+      .decideApproval(part.id, decision)
+      .catch((error) => {
+        // Answered somewhere else, or lapsed while this was on screen. The
+        // server's copy is the truth, so take it rather than arguing.
+        setBanner({ tone: "error", text: errorMessage(error) });
+        void refreshApprovals();
+      })
+      .finally(() => setDeciding(null));
+  };
+
+  return (
+    <div className="ask" data-state={state}>
+      <div className="ask__head">
+        <AgentAvatar
+          avatar={agent?.avatar ?? "blank"}
+          color={agent?.color ?? "#8aa0a6"}
+          size="sm"
+          seed={agent?.id ?? part.id}
+        />
+        <div>
+          <p className="ask__summary">{part.summary}</p>
+          <p className="ask__note">
+            {state === "pending"
+              ? `${asker} is waiting on you. Nothing has been created yet.`
+              : (SETTLED[state] ?? "This request is no longer live.")}
+          </p>
+        </div>
+      </div>
+
+      <dl className="ask__detail">
+        {part.detail.map((field) => (
+          <div key={`${part.id}:${field.label}`}>
+            <dt>{field.label}</dt>
+            <dd>{field.value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      {state === "pending" && (
+        <div className="ask__actions">
+          <button
+            type="button"
+            className="btn btn--primary"
+            disabled={deciding !== null}
+            onClick={() => answer("allow")}
+          >
+            Allow
+          </button>
+          <button
+            type="button"
+            className="btn"
+            disabled={deciding !== null}
+            title={`Stop asking when ${asker} does this`}
+            onClick={() => answer("alwaysAllow")}
+          >
+            Always allow
+          </button>
+          <button
+            type="button"
+            className="btn btn--ghost"
+            disabled={deciding !== null}
+            onClick={() => answer("deny")}
+          >
+            Deny
+          </button>
+          {/* The scope of the middle button, said in full. "Always" reads as a
+              setting for the workspace, and it is not: it is one agent being
+              let off one question. */}
+          <span className="ask__scope">Always allow is for {asker} only.</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/GrantList.tsx
+++ b/src/components/GrantList.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+
+import { api } from "../lib/ipc";
+import { type AgentCard, errorMessage, type ProtectedAction } from "../lib/types";
+
+interface Props {
+  agent: AgentCard;
+}
+
+/** What each standing grant lets the agent do, in the operator's words. */
+const PHRASE: Record<ProtectedAction, string> = {
+  createAgent: "Adds agents to this workspace without asking.",
+};
+
+/**
+ * Standing permissions, and the way to take one back.
+ *
+ * A grant is created by clicking "Always allow" on a request in the transcript,
+ * which is a decision made in one second about every future request. This is
+ * where that decision stops being permanent. A permission that could only ever
+ * be given would make the middle button on every request a thing to think hard
+ * about, which is the opposite of what it is for.
+ *
+ * Nothing is drawn when there are none: an empty panel here would advertise a
+ * mechanism most agents never touch.
+ */
+export function GrantList({ agent }: Props) {
+  const [grants, setGrants] = useState<ProtectedAction[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<ProtectedAction | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void api
+      .agentGrants(agent.id)
+      .then((found) => {
+        if (!cancelled) setGrants(found);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [agent.id]);
+
+  const revoke = async (action: ProtectedAction) => {
+    setBusy(action);
+    setError(null);
+    try {
+      setGrants(await api.revokeGrant(agent.id, action));
+    } catch (caught) {
+      setError(errorMessage(caught));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (grants.length === 0) return null;
+
+  return (
+    <div className="connectors">
+      <div className="routines__head">
+        <span className="field__label">Standing permission</span>
+      </div>
+
+      {grants.map((action) => (
+        <div className="connector" key={action}>
+          <div className="connector__row">
+            <strong className="connector__service">{PHRASE[action]}</strong>
+            <button
+              type="button"
+              className="btn btn--ghost btn--small"
+              style={{ marginLeft: "auto" }}
+              disabled={busy !== null}
+              onClick={() => void revoke(action)}
+            >
+              {busy === action ? "Removing…" : "Ask me again"}
+            </button>
+          </div>
+        </div>
+      ))}
+
+      {error && (
+        <div className="banner banner--error" style={{ margin: "0.4rem 0 0" }}>
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/MessageItem.test.tsx
+++ b/src/components/MessageItem.test.tsx
@@ -4,7 +4,13 @@ import { describe, expect, it, vi } from "vitest";
 import type { AgentCard, Envelope, Part } from "../lib/types";
 import { type Lookups, MessageItem } from "./MessageItem";
 
-vi.mock("../lib/ipc", () => ({ openExternal: vi.fn() }));
+const retryTurn = vi.fn<(agentId: string, messageId: string) => Promise<string>>(
+  async () => "run-2",
+);
+vi.mock("../lib/ipc", () => ({
+  openExternal: vi.fn(),
+  api: { retryTurn: (agentId: string, messageId: string) => retryTurn(agentId, messageId) },
+}));
 
 function card(id: string, name: string): AgentCard {
   return {
@@ -254,5 +260,95 @@ describe("an agent's own record of what it did", () => {
   it("surfaces a guard stop as a centred notice", () => {
     show(record({ type: "notice", kind: "guardStop", text: "hop limit (8) reached" }));
     expect(screen.getByText("hop limit (8) reached")).toBeTruthy();
+  });
+});
+
+describe("a failed turn", () => {
+  /** What the runtime writes once its own retries are spent. */
+  function failure(cause: string | null): Envelope {
+    return envelope({
+      id: "notice-1",
+      from: { kind: "system" },
+      to: { kind: "agent", id: "manager" },
+      trust: "system",
+      expectsReply: false,
+      cause,
+      parts: [
+        {
+          type: "notice",
+          kind: "upstreamError",
+          text: "Manager could not reply: could not reach the inference endpoint",
+        },
+      ],
+    });
+  }
+
+  it("offers to send the message again, and says which", () => {
+    retryTurn.mockClear();
+    render(
+      <MessageItem
+        message={failure("m-original")}
+        lookups={lookups}
+        continued={false}
+        feed={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(retryTurn).toHaveBeenCalledWith("manager", "m-original");
+    // And it will not fire twice on a double click: a second run is a second
+    // model call, billed.
+    expect((screen.getByRole("button", { name: "Sent again" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it("offers nothing when there is nothing to send again", () => {
+    render(
+      <MessageItem message={failure(null)} lookups={lookups} continued={false} feed={false} />,
+    );
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+  });
+
+  it("does not offer a retry for a limit that would be hit again", () => {
+    // The guard refused this on purpose. A button here would spend the same
+    // budget to reach the same refusal.
+    const stopped = envelope({
+      from: { kind: "system" },
+      to: { kind: "agent", id: "manager" },
+      cause: "m-original",
+      parts: [{ type: "notice", kind: "guardStop", text: "this conversation used its budget" }],
+    });
+    render(<MessageItem message={stopped} lookups={lookups} continued={false} feed={false} />);
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+  });
+});
+
+describe("a command that used a credential", () => {
+  it("says so in the transcript, by name, with no value anywhere", () => {
+    // The operator's audit trail for their own tokens. Before this, a
+    // credential went into the environment of every command and nothing
+    // distinguished the command that spent it.
+    const used = envelope({
+      from: { kind: "agent", id: "manager" },
+      to: { kind: "system" },
+      parts: [
+        {
+          type: "toolCall",
+          name: "run_command",
+          arguments: { command: 'curl -H "Authorization: Bearer $MISTRAL_API_KEY" ...' },
+          outcome: {
+            status: "ok",
+            summary: "used Mistral ($MISTRAL_API_KEY) · exit 0, 812 bytes out",
+          },
+        },
+      ],
+    });
+    const { container } = render(
+      <MessageItem message={used} lookups={lookups} continued={false} feed={false} />,
+    );
+
+    expect(container.textContent).toContain("used Mistral ($MISTRAL_API_KEY)");
+    expect(container.textContent).toContain("Manager used run_command");
   });
 });

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -1,6 +1,17 @@
 import { AgentAvatar } from "../avatars/AgentAvatar";
+import { api } from "../lib/ipc";
+import { useStore } from "../lib/store";
 import { sendBody, sendRecipients } from "../lib/toolArgs";
-import type { AgentCard, AgentId, Envelope, Part, Participant } from "../lib/types";
+import {
+  type AgentCard,
+  type AgentId,
+  type Envelope,
+  errorMessage,
+  type MessageId,
+  type Part,
+  type Participant,
+} from "../lib/types";
+import { ApprovalRequest } from "./ApprovalRequest";
 import { Markdown } from "./Markdown";
 import { NoticeRow, toPeer, WireRow } from "./WireRow";
 
@@ -40,6 +51,18 @@ function keyed(message: Envelope) {
   return message.parts.map((part, position) => ({ part, key: `${message.id}:${position}` }));
 }
 
+/**
+ * Sends a failed turn's message again.
+ *
+ * Imperative rather than a prop threaded through every message: this is one
+ * button on one kind of notice, and the store is reachable without a hook.
+ */
+function onRetry(agentId: AgentId, messageId: MessageId) {
+  void api.retryTurn(agentId, messageId).catch((error) => {
+    useStore.getState().setBanner({ tone: "error", text: errorMessage(error) });
+  });
+}
+
 function plainBody(message: Envelope): string {
   return message.parts
     .filter((p): p is Extract<Part, { type: "text" }> => p.type === "text")
@@ -62,6 +85,15 @@ function plainBody(message: Envelope): string {
  */
 export function MessageItem({ message, lookups, continued, feed }: Props) {
   const { from, to } = message;
+
+  // Ahead of everything else: a request for permission is addressed to the
+  // operator whoever the envelope says it is from, and it is the one thing in a
+  // transcript they are expected to act on rather than read.
+  const asking = message.parts.find((part) => part.type === "approval");
+  if (asking) {
+    const askerId = to.kind === "agent" ? to.id : message.channelId;
+    return <ApprovalRequest part={asking} agent={lookups.byId(askerId)} />;
+  }
 
   if (from.kind === "agent" && to.kind === "agent") {
     return (
@@ -111,7 +143,9 @@ function ActivityRecord({ message, lookups }: { message: Envelope; lookups: Look
               ? "checked who is available"
               : part.name === "update_notes"
                 ? "updated its notes"
-                : `used ${part.name}`;
+                : part.name === "create_agent"
+                  ? "asked to add an agent"
+                  : `used ${part.name}`;
           return (
             <div className="wire wire--quiet" key={key}>
               <span className="wire__quiet-text">
@@ -206,7 +240,18 @@ function ChatBubble({
         )}
 
         {notices.map(({ part, key }) => (
-          <NoticeRow key={key} kind={part.kind} text={part.text} />
+          <NoticeRow
+            key={key}
+            kind={part.kind}
+            text={part.text}
+            // Only where there is something to send again: the notice records
+            // which message the turn was answering when the call failed.
+            onRetry={
+              part.kind === "upstreamError" && message.cause
+                ? () => onRetry(message.channelId, message.cause as MessageId)
+                : undefined
+            }
+          />
         ))}
 
         {texts.map(({ part, key }) => (

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useStore } from "../lib/store";
+import type { Group } from "../lib/types";
+import { Sidebar } from "./Sidebar";
+
+vi.mock("../lib/ipc", () => ({
+  api: {
+    listAgents: async () => [],
+    listGroups: async () => [],
+  },
+}));
+
+const MODEL = "anthropic/claude-opus-4-1-20250805";
+
+function group(name: string, defaultModel: string | null): Group {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    name,
+    agentCount: 0,
+    createdAt: 0,
+    baseUrl: null,
+    defaultModel,
+    apiKeySet: false,
+    apiKeyHint: "",
+  };
+}
+
+function draw(g: Group) {
+  useStore.setState({
+    agents: [],
+    groups: [g],
+    activity: {},
+    lastActive: {},
+    usage: { [g.id]: { prompt: 900_000, completion: 900_000, calls: 400, cost: 123.45 } },
+    pulse: {},
+    pulses: [],
+    selected: null,
+  });
+  return render(
+    <Sidebar
+      onNewAgent={vi.fn()}
+      onEditAgent={vi.fn()}
+      onNewGroup={vi.fn()}
+      onEditGroup={vi.fn()}
+      onOpenSettings={vi.fn()}
+    />,
+  );
+}
+
+describe("group header", () => {
+  beforeEach(() => {
+    useStore.setState({ groups: [], agents: [] });
+  });
+
+  it("does not draw the pinned model in the rail at all", () => {
+    // The rail is 15.5rem. A model id beside the name left one letter of
+    // "everyone" and an ellipsis; on a line of its own it cost a whole row per
+    // group to say something the gear already shows.
+    const { container } = draw(group("everyone", MODEL));
+
+    expect(container.querySelector(".rail__group-head")?.textContent).toContain("everyone");
+    expect(screen.queryByText(MODEL)).toBeNull();
+  });
+});

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -115,6 +115,11 @@ export function Sidebar({
         return { text: "typing", kind: "thinking" };
       case "queued":
         return { text: `${state.depth} queued`, kind: "queued" };
+      // The one state the operator is the fix for. It reads as an instruction
+      // rather than a status because the agent is parked until they act, and
+      // the request itself is in a channel they may not have open.
+      case "awaitingApproval":
+        return { text: "needs you", kind: "asking" };
       case "paused":
         return { text: "paused", kind: "paused" };
       default: {
@@ -222,23 +227,19 @@ export function Sidebar({
               <div key={group.id} className="rail__group">
                 <div className="rail__group-head">
                   <span className="rail__group-name">{group.name}</span>
-                  {group.defaultModel && (
-                    <span className="rail__group-pin" title={`Runs on ${group.defaultModel}`}>
-                      {group.defaultModel}
-                    </span>
-                  )}
-                  <span style={{ flex: 1 }} />
-                  <TokenMeter groupId={group.id} />
-                  <span className="rail__group-count">{members.length}</span>
-                  <button
-                    type="button"
-                    className="rail__gear"
-                    onClick={() => onEditGroup(group)}
-                    title={`${group.name} settings`}
-                    aria-label={`${group.name} settings`}
-                  >
-                    ⚙
-                  </button>
+                  <span className="rail__group-tail">
+                    <TokenMeter groupId={group.id} />
+                    <span className="rail__group-count">{members.length}</span>
+                    <button
+                      type="button"
+                      className="rail__gear"
+                      onClick={() => onEditGroup(group)}
+                      title={`${group.name} settings`}
+                      aria-label={`${group.name} settings`}
+                    >
+                      ⚙
+                    </button>
+                  </span>
                 </div>
                 {members.map(row)}
                 {members.length === 0 && <p className="rail__empty">No agents in here.</p>}

--- a/src/components/WireRow.tsx
+++ b/src/components/WireRow.tsx
@@ -210,13 +210,44 @@ export function WritingRow({ from, to }: { from: WirePeer; to: WirePeer }) {
   );
 }
 
-/** A centred system line: guard stops, upstream failures, lifecycle notes. */
-export function NoticeRow({ kind, text }: { kind: string; text: string }) {
+/**
+ * A centred system line: guard stops, upstream failures, lifecycle notes.
+ *
+ * `onRetry` is offered only where trying again could plausibly work. The
+ * runtime has already retried a failed call several times by the time one of
+ * these is written, so this is the operator's attempt, not the first one: a
+ * button on a guard stop would only spend the same budget to hit the same
+ * limit.
+ */
+export function NoticeRow({
+  kind,
+  text,
+  onRetry,
+}: {
+  kind: string;
+  text: string;
+  onRetry?: () => void;
+}) {
+  const [tried, setTried] = useState(false);
+
   return (
     <div className="wire wire--notice">
       <span className={kind === "upstreamError" ? "chip chip--error" : "chip chip--guard"}>
         <span aria-hidden="true">{kind === "upstreamError" ? "!" : "◆"}</span>
         <span style={{ whiteSpace: "normal" }}>{text}</span>
+        {onRetry && (
+          <button
+            type="button"
+            className="chip__action"
+            disabled={tried}
+            onClick={() => {
+              setTried(true);
+              onRetry();
+            }}
+          >
+            {tried ? "Sent again" : "Try again"}
+          </button>
+        )}
       </span>
     </div>
   );

--- a/src/lib/connectorCatalog.test.ts
+++ b/src/lib/connectorCatalog.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { CATALOG, entryFor } from "./connectorCatalog";
+
+/**
+ * The catalog is data, and every field of it is a promise the Rust side has to
+ * be able to keep. A tile whose variable name or note the backend rejects looks
+ * fine in the grid and fails at the moment the operator pastes a token in,
+ * which is the worst place to find out.
+ */
+
+/** `ConnectorError::BadEnvVar` in `domain/connector.rs`. */
+const ENV_VAR = /^[A-Za-z_][A-Za-z0-9_]*$/;
+/** `MAX_NOTE_LEN` in `domain/connector.rs`. */
+const MAX_NOTE = 240;
+
+describe("the connector catalog", () => {
+  it("names a variable the backend will accept", () => {
+    for (const entry of CATALOG) {
+      expect(entry.envVar, `${entry.service} claims ${entry.envVar}`).toMatch(ENV_VAR);
+    }
+  });
+
+  it("keeps every note inside what a connector can store", () => {
+    // A note is copied onto the credential when the tile is used, and the
+    // backend refuses one over this length. It is also read by every agent in
+    // the group on every turn, so the cap is a budget rather than a formality.
+    for (const entry of CATALOG) {
+      expect(entry.note?.length ?? 0, `${entry.service}'s note`).toBeLessThanOrEqual(MAX_NOTE);
+    }
+  });
+
+  it("never gives two services the same variable", () => {
+    // One variable per group is a unique index in SQLite. Two tiles sharing a
+    // name would make the second one unaddable, and the error would name an
+    // index rather than the tile that caused it.
+    const vars = CATALOG.map((entry) => entry.envVar);
+    expect(new Set(vars).size).toBe(vars.length);
+
+    const services = CATALOG.map((entry) => entry.service);
+    expect(new Set(services).size).toBe(services.length);
+  });
+
+  it("gives every entry a colour and something to draw", () => {
+    for (const entry of CATALOG) {
+      expect(entry.color, entry.service).toMatch(/^#[0-9a-f]{6}$/);
+      expect(entry.mark.length, entry.service).toBeGreaterThan(0);
+    }
+  });
+
+  it("offers Mistral, and says the part of it that is not guessable", () => {
+    // An agent holding this key would reach for chat completions. The OCR call
+    // is a different endpoint, a different model id, and wants the file
+    // uploaded first, so the note carries all three.
+    const mistral = entryFor("Mistral");
+    expect(mistral?.envVar).toBe("MISTRAL_API_KEY");
+    expect(mistral?.note).toContain("mistral-ocr-4-1");
+    expect(mistral?.note).toContain("/v1/ocr");
+    expect(mistral?.note).toContain("/v1/files");
+  });
+});

--- a/src/lib/connectorCatalog.ts
+++ b/src/lib/connectorCatalog.ts
@@ -89,6 +89,20 @@ export const CATALOG: CatalogEntry[] = [
     color: "#10a37f",
   },
   {
+    service: "Mistral",
+    envVar: "MISTRAL_API_KEY",
+    where: "console.mistral.ai → API Keys",
+    path: "M17.143 3.429v3.428h-3.429v3.429h-3.428V6.857H6.857V3.43H3.43v13.714H0v3.428h10.286v-3.428H6.857v-3.429h3.429v3.429h3.429v-3.429h3.428v3.429h-3.428v3.428H24v-3.428h-3.43V3.429z",
+    mark: "M",
+    color: "#fa520f",
+    // The key reaches chat and embeddings, which any model knows how to call.
+    // OCR is the part nobody guesses right: it is its own endpoint, it wants a
+    // file that has been uploaded first, and the model id is not the one an
+    // agent would reach for. Three details are cheaper here than three failed
+    // attempts on a service that bills by the page.
+    note: "OCR reads documents: upload to /v1/files, then POST /v1/ocr with model mistral-ocr-4-1. Billed per page.",
+  },
+  {
     service: "Slack",
     envVar: "SLACK_BOT_TOKEN",
     where: "api.slack.com → Your apps → OAuth & Permissions",

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -15,16 +15,22 @@ import type {
   AgentCard,
   AgentDraft,
   AgentId,
+  Approval,
+  ApprovalId,
+  ApprovalState,
   Computer,
   Connector,
   ConnectorDraft,
   ConnectorId,
+  Decision,
   Envelope,
   Group,
   GroupDraft,
   GroupId,
   GroupReset,
   GroupUsage,
+  MessageId,
+  ProtectedAction,
   Routine,
   RoutineDraft,
   RoutineId,
@@ -68,6 +74,23 @@ export const api = {
    */
   scanAgentSignins: (id: AgentId) => invoke<Signin[]>("scan_agent_signins", { id }),
 
+  /**
+   * What every recent permission request came to, keyed by id. The requests
+   * themselves arrive in the transcript; this is the half that changes.
+   */
+  approvalStates: () => invoke<Record<ApprovalId, ApprovalState>>("approval_states"),
+
+  /** Refused if it was already answered or has lapsed. */
+  decideApproval: (id: ApprovalId, decision: Decision) =>
+    invoke<Approval>("decide_approval", { id, decision }),
+
+  /** What this agent no longer has to ask about. */
+  agentGrants: (id: AgentId) => invoke<ProtectedAction[]>("agent_grants", { id }),
+
+  /** Takes one back, and returns what is left. */
+  revokeGrant: (id: AgentId, action: ProtectedAction) =>
+    invoke<ProtectedAction[]>("revoke_grant", { id, action }),
+
   listGroups: () => invoke<Group[]>("list_groups"),
 
   createGroup: (draft: GroupDraft) => invoke<Group>("create_group", { draft }),
@@ -108,6 +131,13 @@ export const api = {
   sendMessage: (agentId: AgentId, text: string) => invoke<RunId>("send_message", { agentId, text }),
 
   clearChannel: (channelId: AgentId) => invoke<number>("clear_channel", { channelId }),
+
+  /**
+   * Sends the message a failed turn was answering again, as a new run. The
+   * runtime already retried the call itself; this is the operator's turn.
+   */
+  retryTurn: (agentId: AgentId, messageId: MessageId) =>
+    invoke<RunId>("retry_turn", { agentId, messageId }),
   /** Resets a whole group: transcripts, routines, notes and spend. */
   clearGroup: (groupId: GroupId) => invoke<GroupReset>("clear_group", { groupId }),
   agentRoutines: (id: AgentId) => invoke<Routine[]>("agent_routines", { id }),

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -14,6 +14,8 @@ import type {
   Activity,
   AgentCard,
   AgentId,
+  ApprovalId,
+  ApprovalState,
   Envelope,
   Group,
   GroupId,
@@ -67,6 +69,12 @@ interface State {
    */
   pulse: Record<GroupId, { at: number; tokens: number }[] | undefined>;
 
+  /**
+   * What each permission request came to. The request itself lives in the
+   * transcript, which is immutable; this is the part that moves.
+   */
+  approvals: Record<ApprovalId, ApprovalState | undefined>;
+
   selected: ChannelKey | null;
   messages: Record<ChannelKey, Envelope[] | undefined>;
   streams: Record<MessageId, StreamBuffer | undefined>;
@@ -78,6 +86,7 @@ interface State {
   bootstrap: () => Promise<void>;
   refreshAgents: () => Promise<void>;
   refreshUsage: () => Promise<void>;
+  refreshApprovals: () => Promise<void>;
   select: (key: ChannelKey) => Promise<void>;
   loadChannel: (key: ChannelKey) => Promise<void>;
   applyEvent: (event: UiEvent) => void;
@@ -122,6 +131,7 @@ export const useStore = create<State>((set, get) => ({
   settings: null,
   usage: {},
   pulse: {},
+  approvals: {},
   selected: null,
   messages: {},
   streams: {},
@@ -129,15 +139,16 @@ export const useStore = create<State>((set, get) => ({
   banner: null,
 
   async bootstrap() {
-    const [agents, groups, activity, lastActive, settings, usage] = await Promise.all([
+    const [agents, groups, activity, lastActive, settings, usage, approvals] = await Promise.all([
       api.listAgents(),
       api.listGroups(),
       api.agentActivity(),
       api.agentLastActive(),
       api.getSettings(),
       api.usageSummary(),
+      api.approvalStates(),
     ]);
-    set({ agents, groups, activity, lastActive, settings, usage: byGroup(usage) });
+    set({ agents, groups, activity, lastActive, settings, usage: byGroup(usage), approvals });
 
     const live = agents.filter((a) => a.lifecycle !== "terminated");
     const current = get().selected;
@@ -180,6 +191,14 @@ export const useStore = create<State>((set, get) => ({
 
   async refreshUsage() {
     set({ usage: byGroup(await api.usageSummary()) });
+  },
+
+  /**
+   * Re-reads what every request came to. Used when a decision is refused,
+   * which means this side is holding a stale answer.
+   */
+  async refreshApprovals() {
+    set({ approvals: await api.approvalStates() });
   },
 
   applyEvent(event) {
@@ -337,6 +356,20 @@ export const useStore = create<State>((set, get) => ({
         // grouped sum over a local table, and only when a run has gone quiet.
         void get().refreshUsage();
         break;
+
+      case "approvalRequested": {
+        set((state) => ({
+          approvals: { ...state.approvals, [event.approvalId]: "pending" },
+        }));
+        break;
+      }
+
+      case "approvalSettled": {
+        set((state) => ({
+          approvals: { ...state.approvals, [event.approvalId]: event.state },
+        }));
+        break;
+      }
     }
   },
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,7 +31,51 @@ export type Part =
   | { type: "text"; text: string }
   | { type: "json"; name: string; value: unknown }
   | { type: "notice"; kind: NoticeKind; text: string }
-  | { type: "toolCall"; name: string; arguments: unknown; outcome: ToolOutcome };
+  | { type: "toolCall"; name: string; arguments: unknown; outcome: ToolOutcome }
+  /**
+   * An agent asking the operator for permission. Carries its own wording, so an
+   * old channel still says what was asked; what came of it is read from
+   * {@link Approval} state by `id`.
+   */
+  | {
+      type: "approval";
+      id: ApprovalId;
+      action: ProtectedAction;
+      summary: string;
+      detail: DetailField[];
+    };
+
+export type ApprovalId = string;
+
+/** Something an agent may not do without being told it can. */
+export type ProtectedAction = "createAgent";
+
+/** What the operator can answer. Pending and expired are not answers. */
+export type Decision = "allow" | "alwaysAllow" | "deny";
+
+export type ApprovalState = Decision | "pending" | "expired";
+
+/**
+ * One field of a request. `value` is what the model asked for, so it is
+ * rendered as text and never as markdown.
+ */
+export interface DetailField {
+  label: string;
+  value: string;
+}
+
+export interface Approval {
+  id: ApprovalId;
+  agentId: AgentId;
+  groupId: GroupId;
+  runId: RunId;
+  action: ProtectedAction;
+  summary: string;
+  detail: DetailField[];
+  state: ApprovalState;
+  createdAt: number;
+  decidedAt: number | null;
+}
 
 export interface Envelope {
   id: MessageId;
@@ -179,6 +223,8 @@ export type Activity =
   | { state: "idle" }
   | { state: "thinking" }
   | { state: "queued"; depth: number }
+  /** Parked mid-turn on a permission request. Waiting on a person, not a model. */
+  | { state: "awaitingApproval" }
   | { state: "paused" };
 
 export interface GuardLimits {
@@ -242,7 +288,9 @@ export type UiEvent =
       /** Null when the provider does not price calls. Not the same as free. */
       cost: number | null;
     }
-  | { type: "runSettled"; runId: RunId; stepsUsed: number };
+  | { type: "runSettled"; runId: RunId; stepsUsed: number }
+  | { type: "approvalRequested"; approvalId: ApprovalId; agentId: AgentId }
+  | { type: "approvalSettled"; approvalId: ApprovalId; state: ApprovalState };
 
 /** Tokens spent, as the provider counted them. Never estimated. */
 export interface Tokens {

--- a/src/styles.css
+++ b/src/styles.css
@@ -195,31 +195,28 @@ button {
   gap: 0.45rem;
 }
 
+/* The only part of the header that gives up space. Everything to its right is
+   a fixed-width readout, so the name shrinks to an ellipsis rather than the
+   row overflowing the rail. */
 .rail__group-name {
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-/* Shown only when the group pins a model, because the useful thing to know at
-   a glance is which crews are not on the default. */
-.rail__group-pin {
-  font-size: 0.55rem;
-  letter-spacing: 0.04em;
-  text-transform: none;
-  color: var(--rail-muted);
-  background: var(--rail-raised);
-  border-radius: 0.3rem;
-  padding: 0.05rem 0.3rem;
-  max-width: 6.5rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.rail__group-count {
+.rail__group-tail {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
   margin-left: auto;
+  flex: none;
 }
+
+/* The group's pinned model is not drawn here at all. A model id is longer than
+   the rail is wide, so it took the group name's space on one line and a whole
+   row of its own on two. It lives behind the gear, with the endpoint. */
 
 .rail__gear {
   background: none;
@@ -262,46 +259,23 @@ button {
   background: var(--flesh-soft);
 }
 
+.meter__count,
 .meter__cost {
-  font-family: var(--font-mono);
-  font-size: 0.55rem;
-  color: var(--rail-muted);
-  font-variant-numeric: tabular-nums;
-}
-
-.meter[data-busy] .meter__cost {
-  color: var(--flesh-soft);
-}
-
-.run__cost {
-  margin-left: 0.35rem;
-}
-
-.meter__count {
   font-family: var(--font-mono);
   font-size: 0.55rem;
   letter-spacing: 0.04em;
   color: var(--rail-muted);
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
-.meter[data-busy] .meter__cost {
-  font-family: var(--font-mono);
-  font-size: 0.55rem;
-  color: var(--rail-muted);
-  font-variant-numeric: tabular-nums;
-}
-
+.meter[data-busy] .meter__count,
 .meter[data-busy] .meter__cost {
   color: var(--flesh-soft);
 }
 
 .run__cost {
   margin-left: 0.35rem;
-}
-
-.meter__count {
-  color: var(--flesh-soft);
 }
 
 .rail__group-head:hover .rail__gear,
@@ -470,6 +444,17 @@ button {
 
 .agent-row__meta[data-state="thinking"] {
   color: var(--flesh);
+}
+
+/* Louder than thinking, because it is the only rail state that is asking for
+   something. A parked agent stays parked until the operator answers, and the
+   request is in a channel they may not have open. */
+.agent-row__meta[data-state="asking"] {
+  color: var(--rail-ground);
+  background: var(--flesh);
+  border-radius: 0.3rem;
+  padding: 0.05rem 0.3rem;
+  font-weight: 600;
 }
 
 /* The rail reorders itself as agents talk. Sliding rows into place is legible;
@@ -1266,6 +1251,104 @@ button {
   justify-content: center;
 }
 
+/* ==========================================================================
+   Permission requests
+
+   A card in the transcript rather than a dialog. The agent that asked is parked
+   until it is answered, so this has to be findable later and readable next to
+   whatever led to it, which a modal over the top of the window is not. Live it
+   sits up off the page; answered it settles back into the paper, because it is
+   then a record and not a decision.
+   ========================================================================== */
+.ask {
+  margin: 0.6rem 1.5rem 0.6rem 1.15rem;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius);
+  background: var(--raised);
+  padding: 0.85rem 1rem;
+}
+
+.ask[data-state="pending"] {
+  border-color: color-mix(in oklab, var(--flesh) 45%, var(--edge));
+  box-shadow: 0 0.4rem 1.2rem -0.6rem rgb(24 33 27 / 0.18);
+}
+
+/* Answered, and therefore history. */
+.ask:not([data-state="pending"]) {
+  background: var(--ground);
+  color: var(--muted);
+}
+
+.ask__head {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+}
+
+.ask__summary {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.92rem;
+  color: var(--text);
+}
+
+.ask:not([data-state="pending"]) .ask__summary {
+  font-weight: 500;
+  color: var(--muted);
+}
+
+.ask__note {
+  margin: 0.15rem 0 0;
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.ask__detail {
+  margin: 0.7rem 0 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.ask__detail dt {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+
+/* The model wrote these. They are shown whole, wrapped, and never as markdown;
+   a long brief scrolls rather than pushing the buttons off the screen. */
+.ask__detail dd {
+  margin: 0.1rem 0 0;
+  font-size: 0.84rem;
+  line-height: 1.5;
+  color: var(--text);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-height: 11rem;
+  overflow-y: auto;
+}
+
+.ask:not([data-state="pending"]) .ask__detail dd {
+  color: var(--muted);
+  max-height: 5.5rem;
+}
+
+.ask__actions {
+  margin-top: 0.85rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.ask__scope {
+  flex-basis: 100%;
+  font-size: 0.72rem;
+  color: var(--faint);
+}
+
 .wire-modal__head {
   display: flex;
   align-items: center;
@@ -1295,6 +1378,28 @@ button {
   background: var(--sunken);
   color: var(--muted);
   max-width: 100%;
+}
+
+/* The way out of a failure, on the failure itself. A notice that says only what
+   went wrong leaves the operator to work out what to do about it. */
+.chip__action {
+  margin-left: 0.15rem;
+  padding: 0 0.3rem;
+  border: 1px solid currentColor;
+  border-radius: 0.25rem;
+  background: none;
+  color: inherit;
+  font: inherit;
+  font-size: 0.64rem;
+}
+
+.chip__action:hover:not(:disabled) {
+  background: color-mix(in oklab, currentColor 14%, transparent);
+}
+
+.chip__action:disabled {
+  opacity: 0.55;
+  cursor: default;
 }
 
 .chip--guard {


### PR DESCRIPTION
Agents can add agents, and the operator approves each one.

`create_agent` takes a name, instructions, skills and optional starting notes.
The new agent lands in its maker's group — never a parameter, since an agent
that could place one on the other side of the group wall could walk through it
by proxy — and inherits the group's model, because what a new agent costs to run
stays the operator's decision.

Asked to staff ten roles, a Manager holding this tool replied that it could not
create agents from this interface. The prompt now rules that answer out by name,
along with the two adjacent failures: an agent per task, and a crew created and
then left waiting because creating one is not delegating to it.

## The permission mechanism

`ProtectedAction` is general and has one variant today. A protected call parks
the turn: it writes a request row, puts a card in the channel that agent is
talking in, and waits up to ten minutes while the actor holds its place. The
rail shows that agent as "needs you", because the request is in a channel the
operator may not have open.

Three details are load-bearing:

- **The row is the verdict, not the channel the wakeup arrived on.** A click and
  the turn's own timeout can land in the same instant. `settle_approval` only
  moves a row out of `pending`, and the parked turn reads its answer back from
  the row, so a button that visibly said "allowed" allowed it.
- **A restart expires everything pending.** Nothing holds a parked turn across
  one, so a `pending` row afterwards is a question that can no longer reach
  anybody. Cleared at startup, before the window opens.
- **"Always allow" is scoped to the agent that asked**, and the card says so
  under the buttons. The grant is the decision row itself rather than a second
  table that could disagree with it, and it is revocable from that agent's
  editor: a permission that can only ever be given makes the middle button a
  decision to agonise over.

The wording the operator reads is composed by the runtime from the validated
draft, never by the model. An agent that could write its own request could
describe creating an agent as tidying up.

## Also here, because they came out of using it

- **One Chrome profile per machine, and no way to reach another.** A sign-in
  performed on the screen went to a profile no agent could drive, and detection
  truthfully reported an empty jar with nothing erroring. Every route is now
  shimmed onto the profile `browse` uses: a wrapper first on PATH, a desktop
  entry in the user's own XDG directory, the flags again at the call site, and a
  browser found on another profile is closed when the desktop starts. The
  debugging port travels with the profile, or `browse` loses its remote
  interface — which is the trap that created the second profile in the first
  place.
- **`sessions.py` was looking somewhere the browser never wrote.** It located
  the profile as `~/.guac/chrome` while the launcher spells it absolutely: two
  spellings of one path, one resolving against whoever runs the command. Passed
  in from the constant now, with a test that fails if either side drifts.
- **Failed model calls retry themselves, then hand the operator a button.**
  Three attempts, 1s then 3s, honouring `Retry-After` up to 20s, and only for
  errors `is_transient` admits to. The stream is reopened between attempts so a
  second attempt cannot append to a first one's half-written text, and no second
  step is reserved: a call is one call however many times the network dropped
  it. What survives becomes a notice carrying **Try again**, which re-delivers
  the message the turn was answering as a new run at the original hop. Guard
  stops get no button — that would spend the same budget to hit the same limit.
- **A command that reaches for a credential says so in the transcript**, by
  name. It reports the variables the command names, which is what can honestly
  be known from this side; whether the process used it is between the process
  and the service. No value appears, and none could.
- **Mistral joins the connector catalog**, with the OCR call in its note because
  that is the part an agent will not guess: its own endpoint, its own model id,
  and the file uploaded first.
- **The rail no longer draws a group's pinned model.** It took the group name's
  space on one line and a whole row on two, to say something the gear already
  shows.

## Testing

326 Rust unit, 34 cascade, 247 frontend, all green through `./scripts/ci.sh`.
The cascade suite covers the operator gate, a denial reaching the model as
settled rather than as an error, always-allow not asking twice, a name already
taken refused without troubling the operator at all, and a connection that drops
once being retried rather than reported.

`scripts/connectors.sh` is new and live-gated. It starts a real machine with the
group's credentials in its environment, downloads a folder of PDFs and reads
them with `mistral-ocr-4-1` — the one claim the scripted suites cannot make. Run
against a real key it returns the text of both papers in about ten seconds and
releases the sandbox.

Larger than one change. The five areas interleave in `runtime/mod.rs`,
`commands.rs` and `MessageItem.tsx`, so splitting them into commits that each
build would have meant rebuilding the intermediate states by hand. Say the word
and I will do it properly as separate PRs.
