### PR TITLE
fix: an agent's memory is what it is called, and it answers to both words

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,14 @@ crew that is stuck.
 
 ## Memory and routines
 
-Each agent has a notes file it maintains itself with `update_notes`, shown to it
-at the start of every turn. It is the only thing that survives between
+Each agent has a memory file it maintains itself with `update_notes`, shown to
+it at the start of every turn. It is the only thing that survives between
 conversations. You can read and edit it in the agent editor.
+
+Memory and notes are one file under two names: memory is what an agent is told
+it has, notes is what the tool and the files are called. Ask an agent to update
+its memory, to remember something, or to make a note of it, and all three land
+in the same place.
 
 An agent can also keep its own schedule: "check the listings every five hours"
 is a routine, stored as a next-due time rather than a timer, so it survives a
@@ -177,7 +182,7 @@ Everything lives in one directory:
 ~/Library/Application Support/com.madebywelch.guac/
   guac.db        agents, groups, messages, routines, usage
   config.json    settings, written 0600
-  workspace/     one markdown file per agent: its notes
+  workspace/     one markdown file per agent: its memory
 ```
 
 The API key is stored in `config.json` in plaintext. Guaca is a local app with
@@ -186,10 +191,10 @@ honest answer is the OS keychain, and that is a deliberate follow-up rather than
 something faked here.
 
 Deleting an agent is a soft delete: it leaves the rail and can never be messaged
-again, its computer is destroyed and its notes go, but what it already said
+again, its computer is destroyed and its memory goes, but what it already said
 stays readable and its name becomes free to reuse. **Start fresh** on a group
-resets its whole crew (transcripts, routines, notes and spend) while keeping the
-agents themselves.
+resets its whole crew (transcripts, routines, memories and spend) while keeping
+the agents themselves.
 
 ## Working on it
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,7 +119,7 @@ another's instructions by listing peers. There is a test for that too.
 ## A protected action parks the turn that asked for it
 
 Agents can add agents. Every other tool acts on the asking agent's own machine,
-notes or peers; this one changes the workspace and adds something the operator
+memory or peers; this one changes the workspace and adds something the operator
 pays to run, so it stops and asks.
 
 The turn does not return and retry later. It parks: `create_agent` writes a

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -376,8 +376,8 @@ pub async fn delete_agent(state: State<'_, AppState>, id: AgentId) -> Reply<()> 
 
     state.runtime.store().set_lifecycle(id, Lifecycle::Terminated)?;
     state.runtime.stop_agent(id);
-    // The transcript survives a deletion, but the agent's private notes are
-    // its own and go with it.
+    // The transcript survives a deletion, but the agent's private memory is
+    // its own and goes with it.
     state.runtime.workspace().remove(id);
     // Its schedule goes too, or it would keep coming due for an agent that can
     // no longer act on it.
@@ -415,13 +415,13 @@ pub fn agent_activity(state: State<'_, AppState>) -> Reply<HashMap<AgentId, Acti
 
 /// Newest message timestamp per agent, used to order the sidebar by who spoke
 /// most recently. Live updates come from message events; this seeds them.
-/// An agent's notes: a small markdown file it maintains for itself.
+/// An agent's memory: a small markdown file it maintains for itself.
 #[tauri::command]
 pub fn agent_notes(state: State<'_, AppState>, id: AgentId) -> Reply<String> {
     Ok(state.runtime.workspace().read(id))
 }
 
-/// Lets the operator seed or correct an agent's notes by hand.
+/// Lets the operator seed or correct an agent's memory by hand.
 #[tauri::command]
 pub fn set_agent_notes(state: State<'_, AppState>, id: AgentId, content: String) -> Reply<String> {
     let card = state
@@ -598,8 +598,8 @@ pub fn clear_group(state: State<'_, AppState>, group_id: GroupId) -> Reply<Group
         messages: store.delete_group_messages(group_id)?,
         routines: store.delete_group_routines(group_id)?,
         calls: store.delete_group_usage(group_id)?,
-        // Notes are files, not rows. An agent whose transcript, schedule and
-        // spend are gone but which still opens tomorrow believing what it
+        // A memory is a file, not a row. An agent whose transcript, schedule
+        // and spend are gone but which still opens tomorrow believing what it
         // wrote last week has not started fresh.
         notes: agents
             .iter()

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -96,7 +96,7 @@ pub struct AppConfig {
     /// What agents call the person using this app.
     ///
     /// Ambient rather than something each agent discovers and writes into its
-    /// own notes: an operator had to tell one agent their name, that agent
+    /// own memory: an operator had to tell one agent their name, that agent
     /// stored it privately, and every other agent still had no idea who it was
     /// working for. Empty falls back to "the operator", which is what agents
     /// said before this existed.

--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -49,15 +49,17 @@ pub fn specs() -> Vec<ToolSpec> {
             // The description is the whole design. It has to make selective
             // writing and consolidation the obvious reading, because the model
             // has no other signal about what belongs in a durable file.
-            description: "Replace your notes. Your notes are a short markdown file shown to you \
-                          at the start of every turn, so anything kept there you will always \
-                          know. Record only what will still matter in a week: who you are and \
-                          how you work, the operator's standing preferences, decisions that hold \
-                          across conversations, and durable facts. Do not record the \
-                          conversation itself, task-by-task progress, or anything already in the \
-                          messages above. This REPLACES the file entirely, so write out \
-                          everything you want to keep and leave behind what no longer holds; if \
-                          something you believed turned out to be wrong, correct it here rather \
+            description: "Replace your memory. Your memory is a short markdown file, also called \
+                          your notes, shown to you at the start of every turn, so anything kept \
+                          there you will always know. This is the tool for anything asked of your \
+                          memory, in whatever words: remember this, update your memory, make a \
+                          note of that, forget that. Record only what will still matter in a week: \
+                          who you are and how you work, the operator's standing preferences, \
+                          decisions that hold across conversations, and durable facts. Do not \
+                          record the conversation itself, task-by-task progress, or anything \
+                          already in the messages above. This REPLACES the file entirely, so write \
+                          out everything you want to keep and leave behind what no longer holds; \
+                          if something you believed turned out to be wrong, correct it here rather \
                           than adding a contradiction. Space is limited, so choose."
                 .to_string(),
             parameters: serde_json::json!({
@@ -65,7 +67,7 @@ pub fn specs() -> Vec<ToolSpec> {
                 "properties": {
                     "content": {
                         "type": "string",
-                        "description": "The complete new contents of your notes, in markdown."
+                        "description": "The complete new contents of your memory, in markdown."
                     }
                 },
                 "required": ["content"],
@@ -275,9 +277,9 @@ pub fn specs() -> Vec<ToolSpec> {
                     },
                     "notes": {
                         "type": "string",
-                        "description": "Optional. Seeds its memory file: facts it should start \
-                                        out knowing, in markdown. It maintains this itself \
-                                        afterwards."
+                        "description": "Optional. Seeds its memory, the file it is shown every \
+                                        turn: facts it should start out knowing, in markdown. It \
+                                        maintains this itself afterwards."
                     }
                 },
                 "required": ["name", "instructions"],
@@ -414,7 +416,7 @@ impl ToolParseError {
             ToolParseError::UnknownTool { name } => {
                 format!(
                     "Error: no tool named {name:?}. You can call `directory`, `send_message`, \
-                     `update_notes`, or `run_command`."
+                     `update_notes` (your memory), or `run_command`."
                 )
             }
             ToolParseError::BadJson { name, detail } => format!(
@@ -469,8 +471,9 @@ impl ToolParseError {
                  \"prioritisation\"]}}."
             ),
             ToolParseError::MissingContent => {
-                "Error: `content` must be a string holding the complete new notes. To clear your \
-                 notes, pass an empty string."
+                "Error: `content` must be a string holding the complete new contents of your \
+                 memory: everything you want to keep, not only the part you just learned. To \
+                 clear it, pass an empty string."
                     .to_string()
             }
         }
@@ -640,13 +643,21 @@ pub fn parse(call: &ToolCall) -> Result<ToolInvocation, ToolParseError> {
                 _ => Err(ToolParseError::MissingCommand),
             }
         }
-        UPDATE_NOTES => {
+        // Memory is what this file is called everywhere a person reads about
+        // it, and notes is what the tool is called. An agent told to update its
+        // memory reaches for the word it was given, and the name it lands on is
+        // the same file either way, so refusing one spends a turn on spelling.
+        UPDATE_NOTES | "update_memory" | "save_memory" => {
             let value = call.parsed_arguments().map_err(|e| ToolParseError::BadJson {
                 name: UPDATE_NOTES.to_string(),
                 detail: e.to_string(),
             })?;
-            // An empty string is a legitimate instruction: clear the notes.
-            match value.get("content").or_else(|| value.get("notes")) {
+            // An empty string is a legitimate instruction: clear the memory.
+            match value
+                .get("content")
+                .or_else(|| value.get("notes"))
+                .or_else(|| value.get("memory"))
+            {
                 Some(serde_json::Value::String(content)) => {
                     Ok(ToolInvocation::UpdateNotes { content: content.clone() })
                 }
@@ -687,7 +698,7 @@ pub fn parse(call: &ToolCall) -> Result<ToolInvocation, ToolParseError> {
                     name,
                     instructions,
                     skills: normalize_list(value.get("skills")),
-                    notes: field(&["notes"]).unwrap_or_default(),
+                    notes: field(&["notes", "memory"]).unwrap_or_default(),
                 },
             })
         }
@@ -1138,11 +1149,41 @@ mod tests {
     }
 
     #[test]
-    fn update_notes_accepts_the_notes_alias() {
-        assert_eq!(
-            parse(&call(UPDATE_NOTES, r#"{"notes":"kept"}"#)).unwrap(),
-            ToolInvocation::UpdateNotes { content: "kept".into() }
-        );
+    fn the_memory_file_answers_to_both_of_its_names() {
+        // The operator's word for this file is memory; the tool is called
+        // `update_notes`. An agent told to update its memory writes the same
+        // file whichever word it reaches for, so a rejection here would cost a
+        // whole turn to say only that the two words mean one thing.
+        for name in [UPDATE_NOTES, "update_memory", "save_memory"] {
+            assert_eq!(
+                parse(&call(name, r#"{"content":"kept"}"#)).unwrap(),
+                ToolInvocation::UpdateNotes { content: "kept".into() },
+                "{name} did not reach the memory file"
+            );
+        }
+        for field in ["content", "notes", "memory"] {
+            assert_eq!(
+                parse(&call(UPDATE_NOTES, &format!("{{\"{field}\":\"kept\"}}"))).unwrap(),
+                ToolInvocation::UpdateNotes { content: "kept".into() },
+                "{field} was not read"
+            );
+        }
+    }
+
+    #[test]
+    fn a_seeded_memory_is_accepted_under_either_word() {
+        for field in ["notes", "memory"] {
+            let parsed = parse(&call(
+                CREATE_AGENT,
+                &format!(
+                    "{{\"name\":\"Scout\",\"instructions\":\"You look.\",\"{field}\":\"B2B.\"}}"
+                ),
+            ));
+            match parsed {
+                Ok(ToolInvocation::CreateAgent { draft }) => assert_eq!(draft.notes, "B2B."),
+                other => panic!("{field} gave {other:?}"),
+            }
+        }
     }
 
     #[test]
@@ -1153,11 +1194,16 @@ mod tests {
     }
 
     #[test]
-    fn the_notes_tool_asks_for_durable_things_and_forbids_a_transcript_dump() {
+    fn the_memory_tool_asks_for_durable_things_and_forbids_a_transcript_dump() {
         // The description is the only control over what an agent writes, so the
         // selective-write instruction has to survive edits.
         let spec = specs().into_iter().find(|s| s.name == UPDATE_NOTES).unwrap();
         let text = spec.description.to_lowercase();
+        // Both words, because the tool is named for one of them and asked for
+        // in the other: an agent reading only "notes" here has to guess that
+        // the operator's "update your memory" landed on this tool.
+        assert!(text.contains("memory"), "{text}");
+        assert!(text.contains("notes"), "{text}");
         assert!(text.contains("still matter in a week"));
         assert!(text.contains("do not record the conversation"));
         assert!(text.contains("replaces the file"), "consolidation must be explicit");
@@ -1265,6 +1311,11 @@ mod tests {
         assert!(err.guidance().contains("directory"));
         assert!(err.guidance().contains("send_message"));
         assert!(err.guidance().contains("update_notes"));
+        assert!(
+            err.guidance().contains("memory"),
+            "a model that invented a name for its memory has to recognise the real tool in the \
+             list, and the tool is not named for the word it used"
+        );
     }
 
     #[test]

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -1405,15 +1405,15 @@ impl Runtime {
                     Ok(stored) => {
                         let summary = if stored.truncated {
                             format!(
-                                "Notes saved, but they were too long and the end was cut. {} \
-                                 characters kept. Rewrite them shorter, keeping only what will \
+                                "Memory saved, but it was too long and the end was cut. {} \
+                                 characters kept. Write it again shorter, keeping only what will \
                                  still matter next week.",
                                 stored.characters
                             )
                         } else if stored.characters == 0 {
-                            "Notes cleared.".to_string()
+                            "Memory cleared.".to_string()
                         } else {
-                            format!("Notes saved ({} characters).", stored.characters)
+                            format!("Memory saved ({} characters).", stored.characters)
                         };
                         (
                             summary.clone(),
@@ -1425,7 +1425,7 @@ impl Runtime {
                         )
                     }
                     Err(err) => (
-                        format!("Error: your notes could not be saved ({err})."),
+                        format!("Error: your memory could not be saved ({err})."),
                         Part::ToolCall {
                             name: tools::UPDATE_NOTES.to_string(),
                             arguments,
@@ -1666,7 +1666,7 @@ impl Runtime {
             DetailField::new("Instructions", &clean.system_prompt),
         ];
         if !notes.is_empty() {
-            detail.push(DetailField::new("Starting notes", &notes));
+            detail.push(DetailField::new("Starting memory", &notes));
         }
 
         let permission = self
@@ -1745,10 +1745,10 @@ impl Runtime {
         };
 
         // Seeded before the agent is running, so its first turn already has
-        // them. A failure here costs the notes, not the agent.
+        // them. A failure here costs the memory, not the agent.
         if !notes.is_empty() {
             if let Err(err) = self.inner.workspace.write(card.id, &card.name, notes) {
-                tracing::warn!(%err, agent = %card.name, "could not seed the new agent's notes");
+                tracing::warn!(%err, agent = %card.name, "could not seed the new agent's memory");
             }
         }
 

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -197,20 +197,21 @@ pub fn system_prompt(
 
     // Placed before the roster and the rules: an agent's own accumulated
     // understanding of itself should colour how it reads everything after.
-    out.push_str("\n## Your notes\n");
+    out.push_str("\n## Your memory\n");
     out.push_str(
-        "This is your memory. It is a file of your own, it is shown to you at the start of every \
-         turn, and it is the only thing you carry between conversations: everything else you are \
-         reading now is this conversation, and it goes. Keeping it is your job, and nobody else \
-         does it for you.\n\n\
-         `update_notes` replaces the whole file, so send back everything you want to keep, not \
-         just the new part. Write what will still matter next week: how you work, standing \
-         preferences you have been given, decisions that hold across conversations, what you \
-         have learned about the people and agents you work with. Leave out what this \
-         conversation already says.\n\n\
+        "This is your memory, and your notes are the same thing: one file of your own, shown to \
+         you at the start of every turn, and the only thing you carry between conversations. \
+         Everything else you are reading now is this conversation, and it goes. Keeping it is your \
+         job, and nobody else does it for you.\n\n\
+         `update_notes` is how you write it, whichever way you were asked: remember this, update \
+         your memory, make a note of that, forget that. It replaces the whole file, so send back \
+         everything you want to keep, not just the new part. Write what will still matter next \
+         week: how you work, standing preferences you have been given, decisions that hold across \
+         conversations, what you have learned about the people and agents you work with. Leave out \
+         what this conversation already says.\n\n\
          Keep it current. Correct what turns out to be wrong and delete what has gone stale, \
-         because you will act on this as though it were true: a note you have outgrown does more \
-         damage than one you never wrote.\n\n",
+         because you will act on this as though it were true: something you have outgrown does \
+         more damage than something you never wrote down.\n\n",
     );
     if notes.trim().is_empty() {
         out.push_str("It is empty. Nothing has been worth keeping yet.\n");
@@ -842,8 +843,24 @@ mod tests {
     }
 
     #[test]
+    fn memory_and_notes_are_named_as_one_file() {
+        // The operator asks an agent to update its memory; the tool it has is
+        // called `update_notes`. If the prompt only ever uses one of the two
+        // words, the other one arrives as a request the agent has to guess at,
+        // and the guess it makes is a tool that does not exist.
+        let prompt = prompt_for(&card("Manager"), &[], "", ReplyMode::ToOperator);
+        let memory = section(&prompt, "## Your memory");
+        assert!(memory.contains("your notes are the same thing"), "{memory}");
+        assert!(memory.contains("`update_notes`"), "the tool has to be named here: {memory}");
+        assert!(
+            memory.contains("update your memory"),
+            "the operator's own wording has to appear as one of the ways this gets asked: {memory}"
+        );
+    }
+
+    #[test]
     fn every_agent_is_told_its_memory_is_its_own_to_keep() {
-        // An agent that treats its notes as a scratch pad writes one fact and
+        // An agent that treats its memory as a scratch pad writes one fact and
         // never revisits it, so the file rots into something it still acts on.
         let empty = prompt_for(&card("Manager"), &[], "", ReplyMode::ToOperator);
         let held =
@@ -883,7 +900,7 @@ mod tests {
     }
 
     #[test]
-    fn notes_are_always_in_the_prompt() {
+    fn memory_is_always_in_the_prompt() {
         // Always resident means there is no retrieval step that can fail to
         // surface something the agent chose to remember.
         let prompt = prompt_for(
@@ -897,7 +914,7 @@ mod tests {
     }
 
     #[test]
-    fn an_agent_with_no_notes_is_told_what_belongs_there() {
+    fn an_agent_with_an_empty_memory_is_told_what_belongs_there() {
         let prompt = prompt_for(&card("Manager"), &[], "   ", ReplyMode::ToOperator);
         assert!(prompt.contains("It is empty."));
         assert!(prompt.contains("still matter next week"));

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1,8 +1,15 @@
-//! Per-agent notes on disk.
+//! Per-agent memory on disk.
 //!
 //! Each agent owns one small markdown file that it can rewrite, and that is
 //! shown to it at the start of every turn. This is the smallest thing that
 //! deserves the name memory, and the shape is deliberate.
+//!
+//! It is called memory everywhere a person or a model reads about it, and
+//! `notes` everywhere the code names it: the tool is `update_notes`, the
+//! commands are `agent_notes` and `set_agent_notes`, and the files are these.
+//! Renaming the internals would rewrite the IPC contract to no effect, so
+//! instead both words reach the same file at the model boundary, and the
+//! operator's word is the one an agent is told.
 //!
 //! The 2026 survey of agent memory (arXiv 2603.07670) frames memory as a
 //! write-manage-read loop and names the engineering realities that decide

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -520,7 +520,7 @@ async fn an_upstream_failure_is_reported_in_the_channel_rather_than_swallowed() 
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn an_agent_can_write_notes_and_reads_them_back_next_turn() {
+async fn an_agent_can_write_its_memory_and_reads_it_back_next_turn() {
     // The write-manage-read loop, end to end: an agent records something on one
     // turn and finds it in its own prompt on the next.
     let stub = serve(|body| {
@@ -553,7 +553,35 @@ async fn an_agent_can_write_notes_and_reads_them_back_next_turn() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn deleting_an_agent_takes_its_notes_with_it() {
+async fn an_agent_asked_for_its_memory_writes_the_same_file_as_its_notes() {
+    // What the operator calls this file is memory; the tool is `update_notes`.
+    // An agent that takes the operator at their word and calls `update_memory`
+    // has written the right thing to the right place, and refusing it would
+    // spend a turn on the difference between two words for one file.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Say("Remembered.".into())
+        } else {
+            Script::Memory("Operator prefers terse replies.".into())
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "update your memory: be terse").unwrap();
+    h.settle(run).await;
+
+    assert_eq!(
+        h.runtime.workspace().read(h.id("Manager")),
+        "Operator prefers terse replies.",
+        "a memory written under the operator's word for it went nowhere"
+    );
+    let said = h.channel_texts("Manager").join("\n");
+    assert!(said.contains("Remembered."), "the turn should have carried on, got {said}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn deleting_an_agent_takes_its_memory_with_it() {
     let stub = serve(|_| Script::Notes("private".into())).await;
     let h = harness(&stub, &["Manager"], GuardLimits::default());
     let run = h.runtime.send_from_human(h.id("Manager"), "remember something").unwrap();

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -45,6 +45,9 @@ pub enum Script {
     Directory,
     /// Emit an `update_notes` tool call.
     Notes(String),
+    /// The same call under the name a model reaches for when it is asked to
+    /// update its memory rather than its notes.
+    Memory(String),
     /// Emit a `create_agent` tool call.
     Hire { name: String, instructions: String, notes: String },
     /// Answer with a 503.
@@ -93,11 +96,13 @@ pub fn render(script: &Script) -> String {
                 serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
             ));
         }
-        Script::Notes(content) => {
+        Script::Notes(content) | Script::Memory(content) => {
+            let tool =
+                if matches!(script, Script::Memory(_)) { "update_memory" } else { "update_notes" };
             let args = serde_json::json!({ "content": content }).to_string();
             body.push_str(&frame(serde_json::json!({"choices":[{"delta":{"tool_calls":[
                 {"index":0,"id":"call_notes","type":"function",
-                 "function":{"name":"update_notes","arguments": args}}
+                 "function":{"name": tool,"arguments": args}}
             ]}}]})));
             body.push_str(&frame(
                 serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),

--- a/src/components/AgentEditor.tsx
+++ b/src/components/AgentEditor.tsx
@@ -55,10 +55,10 @@ export function AgentEditor({ agent, onClose }: Props) {
     nameRef.current?.focus();
   }, []);
 
-  // Notes live on disk rather than on the card, so they are fetched separately
-  // and only written back when the operator actually edited them. Saving them
-  // unconditionally would clobber anything the agent wrote while this dialog
-  // was open.
+  // An agent's memory lives on disk rather than on the card, so it is fetched
+  // separately and only written back when the operator actually edited it.
+  // Saving it unconditionally would clobber anything the agent wrote while this
+  // dialog was open.
   useEffect(() => {
     if (!agent) return;
     let cancelled = false;
@@ -263,7 +263,7 @@ export function AgentEditor({ agent, onClose }: Props) {
 
         {agent && (
           <label className="field">
-            <span className="field__label">Notes</span>
+            <span className="field__label">Memory</span>
             <textarea
               className="textarea input--mono"
               value={notesLoaded ? notes : "Loading…"}
@@ -277,7 +277,8 @@ export function AgentEditor({ agent, onClose }: Props) {
             />
             <span className="field__hint">
               The agent's own memory, shown to it every turn and rewritten by it with{" "}
-              <code>update_notes</code>. Seed a persona here if you like. Stored as markdown in the
+              <code>update_notes</code>: ask it to remember something, or to update its memory, and
+              this is the file it writes. Seed a persona here if you like. Stored as markdown in the
               workspace folder beside the database.
             </span>
           </label>

--- a/src/components/GroupEditor.tsx
+++ b/src/components/GroupEditor.tsx
@@ -61,8 +61,8 @@ export function GroupEditor({ group, onClose }: Props) {
   /**
    * Start fresh: the crew stays, everything it has accumulated goes.
    *
-   * Transcripts, schedules, notes and spend together, because clearing only
-   * the transcript left agents acting on notes about a conversation that no
+   * Transcripts, schedules, memories and spend together, because clearing only
+   * the transcript left agents acting on a memory of a conversation that no
    * longer existed and keeping appointments nobody could see the reason for.
    */
   const clear = async () => {
@@ -177,8 +177,8 @@ export function GroupEditor({ group, onClose }: Props) {
           <div className="banner" style={{ margin: "0.2rem 0 0.9rem" }}>
             <span>
               Reset: {cleared.messages} message{cleared.messages === 1 ? "" : "s"},{" "}
-              {cleared.routines} routine{cleared.routines === 1 ? "" : "s"}, {cleared.notes} set
-              {cleared.notes === 1 ? "" : "s"} of notes, and {cleared.calls} recorded call
+              {cleared.routines} routine{cleared.routines === 1 ? "" : "s"}, {cleared.notes} memor
+              {cleared.notes === 1 ? "y" : "ies"}, and {cleared.calls} recorded call
               {cleared.calls === 1 ? "" : "s"}.
             </span>
           </div>
@@ -245,7 +245,7 @@ export function GroupEditor({ group, onClose }: Props) {
                 className="btn btn--ghost"
                 disabled={busy}
                 onClick={() => setConfirmClear(true)}
-                title="Resets every agent in this group: transcripts, routines and notes, and the spend counter. The agents and their computers stay."
+                title="Resets every agent in this group: transcripts, routines and memories, and the spend counter. The agents and their computers stay."
               >
                 {cleared === null ? "Start fresh" : "Reset"}
               </button>

--- a/src/components/MessageItem.test.tsx
+++ b/src/components/MessageItem.test.tsx
@@ -229,19 +229,19 @@ describe("an agent's own record of what it did", () => {
     expect(screen.queryByRole("button")).toBeNull();
   });
 
-  it("does not draw a note update as a message to nobody", () => {
+  it("does not draw a memory update as a message to nobody", () => {
     // update_notes has no recipients, so falling through to the send renderer
-    // drew it as "Sent to no one" with the note body as the message.
+    // drew it as "Sent to no one" with the memory body as the message.
     show(
       record({
         type: "toolCall",
         name: "update_notes",
         arguments: { content: "Smith handles verification." },
-        outcome: { status: "ok", summary: "Notes saved (28 characters)." },
+        outcome: { status: "ok", summary: "Memory saved (28 characters)." },
       }),
     );
     expect(screen.queryByText(/no one/)).toBeNull();
-    expect(screen.getByText(/updated its notes/)).toBeTruthy();
+    expect(screen.getByText(/updated its memory/)).toBeTruthy();
   });
 
   it("names an unrecognised tool rather than guessing it was a send", () => {

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -130,9 +130,9 @@ function ActivityRecord({ message, lookups }: { message: Envelope; lookups: Look
 
         // Everything that is not a send is a quiet one-liner. This used to fall
         // through to the send renderer, so `update_notes` — which has no
-        // recipients — was drawn as "Sent to no one" with the note body as the
-        // message. Naming the tools that are not sends is what stops the next
-        // one from doing the same.
+        // recipients — was drawn as "Sent to no one" with the memory body as
+        // the message. Naming the tools that are not sends is what stops the
+        // next one from doing the same.
         if (part.name !== "send_message") {
           const summary =
             part.outcome.status === "ok" || part.outcome.status === "partial"
@@ -142,7 +142,7 @@ function ActivityRecord({ message, lookups }: { message: Envelope; lookups: Look
             part.name === "directory"
               ? "checked who is available"
               : part.name === "update_notes"
-                ? "updated its notes"
+                ? "updated its memory"
                 : part.name === "create_agent"
                   ? "asked to add an agent"
                   : `used ${part.name}`;

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -115,10 +115,10 @@ export const api = {
 
   agentLastActive: () => invoke<Record<AgentId, number>>("agent_last_active"),
 
-  /** An agent's notes: a small markdown file it maintains for itself. */
+  /** An agent's memory: a small markdown file it maintains for itself. */
   agentNotes: (id: AgentId) => invoke<string>("agent_notes", { id }),
 
-  /** Lets the operator seed or correct an agent's notes by hand. */
+  /** Lets the operator seed or correct an agent's memory by hand. */
   setAgentNotes: (id: AgentId, content: string) =>
     invoke<string>("set_agent_notes", { id, content }),
 
@@ -138,7 +138,7 @@ export const api = {
    */
   retryTurn: (agentId: AgentId, messageId: MessageId) =>
     invoke<RunId>("retry_turn", { agentId, messageId }),
-  /** Resets a whole group: transcripts, routines, notes and spend. */
+  /** Resets a whole group: transcripts, routines, memories and spend. */
   clearGroup: (groupId: GroupId) => invoke<GroupReset>("clear_group", { groupId }),
   agentRoutines: (id: AgentId) => invoke<Routine[]>("agent_routines", { id }),
   createRoutine: (agentId: AgentId, draft: RoutineDraft) =>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -314,6 +314,7 @@ export interface RunUsage extends Tokens {
 export interface GroupReset {
   messages: number;
   routines: number;
+  /** Memories wiped. Named for the file on disk, which is `notes`. */
   notes: number;
   calls: number;
 }


### PR DESCRIPTION
The file an agent carries between conversations was called notes to the model and memory to nobody consistently. An operator saying "update your memory" was asking for a tool that does not exist by that name, and nothing in the prompt said the two words meant one file.

**Memory is the word an agent is told.** The prompt section is `## Your memory` and opens with "This is your memory, and your notes are the same thing", then names `update_notes` as how it gets written "whichever way you were asked: remember this, update your memory, make a note of that, forget that". The tool description leads with memory and keeps notes as the stated synonym. Results read back as "Memory saved (28 characters)."

**Notes stays the name in the code.** `update_notes`, `agent_notes`, `set_agent_notes` and the workspace files are unchanged: renaming them rewrites the IPC contract to no effect. The policy is recorded at the top of `workspace.rs`.

**Both words reach the same file at the model boundary.** `update_memory` and `save_memory` parse as the same call, `memory` is read alongside `content` and `notes`, and `create_agent` seeds from either. Same rule the file already applies to `cmd`, `message` and `system_prompt`: an unambiguous near miss costs a turn to refuse and buys nothing. Recovery text follows, so an invented name lands on `update_notes` (your memory).

Operator surface: the agent editor field is **Memory**, the transcript line is "updated its memory", the approval detail is "Starting memory", and group reset counts memories.

Tests that fail without this: the alias parse test, the description test requiring both words, a prompt test requiring both words plus the tool name, and a cascade test driving a real `update_memory` call through the runtime to the file on disk.

`./scripts/ci.sh` passes. The live evals have not been run; the prompt changed, so they are the check CI cannot do.