### PR TITLE
fix: Chrome stops asking for a keyring, and there is only one browser

### DIFF
--- a/src-tauri/src/e2b.rs
+++ b/src-tauri/src/e2b.rs
@@ -902,7 +902,15 @@ fn chrome_flags(program: &str) -> String {
         return program.to_string();
     };
 
-    let mut flags = vec!["--no-sandbox", "--no-first-run"];
+    // `--password-store=basic` keeps Chrome away from the system keyring.
+    // There is no unlocked keyring daemon on these machines, so Chrome asks to
+    // create a keyring password: a modal over the window, which an agent
+    // reading the screen reports as a fresh profile that is not signed in to
+    // anything. It also decides how cookies are encrypted, and a profile
+    // written under one store and reopened under another cannot read its own
+    // jar, which is a session that silently evaporates. Same flag everywhere,
+    // or the profile is only usable by whichever route opened it first.
+    let mut flags = vec!["--no-sandbox", "--no-first-run", "--password-store=basic"];
     let profile = format!("--user-data-dir={CHROME_PROFILE}");
     let port = format!("--remote-debugging-port={CDP_PORT}");
     // Without the port, a window opened here would hold the profile with no
@@ -945,7 +953,8 @@ fn install_chrome_shim() -> String {
          for real in /opt/google/chrome/google-chrome /usr/bin/google-chrome-stable \
          /usr/bin/chromium /usr/bin/chromium-browser; do\n\
          \x20 [ -x \"$real\" ] && exec \"$real\" --no-sandbox --no-first-run \
-         --user-data-dir={CHROME_PROFILE} --remote-debugging-port={CDP_PORT} \"$@\"\n\
+         --password-store=basic --user-data-dir={CHROME_PROFILE} \
+         --remote-debugging-port={CDP_PORT} \"$@\"\n\
          done\n\
          echo 'no chrome on this machine' >&2\n\
          exit 127\n"
@@ -1118,6 +1127,15 @@ mod tests {
                  {launched}"
             );
             assert!(launched.contains("--no-sandbox"), "{launched}");
+            // Observed: Chrome opened on the screen, asked to create a system
+            // keyring password, and the agent driving it reported that the
+            // profile was fresh and Gmail unavailable. The flag also fixes how
+            // the cookie jar is encrypted, so a session survives being reopened
+            // by a different route.
+            assert!(
+                launched.contains("--password-store=basic"),
+                "without this Chrome blocks on a keyring prompt: {launched}"
+            );
         }
 
         // The shim covers what the call site cannot see: a name typed into a
@@ -1125,6 +1143,20 @@ mod tests {
         let shim = install_chrome_shim();
         assert!(shim.contains("/home/user/.local/bin/google-chrome"), "{shim}");
         assert!(shim.contains("applications/google-chrome.desktop"), "the icon reads this one");
+
+        // What actually lands on the machine, rather than what the command
+        // looks like: the wrapper and the desktop entry travel base64'd.
+        let written: String = shim
+            .split_whitespace()
+            .filter(|token| token.len() > 40)
+            .map(decode)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(written.contains("exec"), "the wrapper should have decoded: {written}");
+        // The operator's own click has to land on the same store as an agent's
+        // launch, or one of them writes a cookie jar the other cannot read.
+        assert!(written.contains("--password-store=basic"), "{written}");
+        assert!(written.contains(CHROME_PROFILE), "{written}");
     }
 
     #[test]

--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -101,11 +101,14 @@ pub fn specs() -> Vec<ToolSpec> {
             name: OPEN_ON_DESKTOP.to_string(),
             description: "Open a program on your computer's screen, where the operator can watch \
                           it and take over. Your machine runs a full Linux desktop with \
-                          google-chrome, firefox-esr, a file manager and an editor installed. \
-                          Use this whenever you are asked to visit a site, look at a page, or do \
-                          anything a person would do in a window: `run_command` fetches text, \
-                          this shows the real thing on screen. The program keeps running after \
-                          this returns."
+                          google-chrome, a file manager and an editor installed. Use this \
+                          whenever you are asked to visit a site, look at a page, or do anything \
+                          a person would do in a window: `run_command` fetches text, this shows \
+                          the real thing on screen. The program keeps running after this \
+                          returns. For the web, open `google-chrome` and nothing else. It is the \
+                          one browser `browse` drives and the one holding whatever accounts you \
+                          are signed in to, so another browser on the screen is a window that \
+                          knows none of your accounts and that your other tools cannot see."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -168,7 +171,10 @@ pub fn specs() -> Vec<ToolSpec> {
                           gives you the page's text and a numbered list of everything you can \
                           use; `click` and `type` take one of those numbers. Read again after \
                           anything that changes the page, because the numbers are renumbered \
-                          each time. The operator watches this happen on screen."
+                          each time. The operator watches this happen on screen. This drives \
+                          Chrome, which is also the browser holding your accounts: if you have \
+                          another browser open, this is not looking at it, and clicking by \
+                          coordinates with `use_screen` may not be either."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -1106,6 +1112,31 @@ mod tests {
         assert_eq!(
             parse(&call(SCHEDULE, "{}")),
             Ok(ToolInvocation::Schedule { action: ScheduleAction::List })
+        );
+    }
+
+    #[test]
+    fn the_desktop_tool_offers_one_browser_because_only_one_is_wired_up() {
+        // Observed: an agent asked to send mail opened firefox, drove it with
+        // `use_screen`, and read the page with `browse`, which was looking at
+        // Chrome the whole time. It then reported the account missing. Only
+        // Chrome is on the profile the accounts live on and the only one
+        // `browse` can drive, so it is the only one worth naming.
+        let desktop = specs().into_iter().find(|s| s.name == OPEN_ON_DESKTOP).unwrap();
+        assert!(!desktop.description.contains("firefox"), "{}", desktop.description);
+        assert!(desktop.description.contains("google-chrome"), "{}", desktop.description);
+        assert!(
+            desktop.description.contains("knows none of your accounts"),
+            "the reason has to travel with the rule: {}",
+            desktop.description
+        );
+
+        let browse = specs().into_iter().find(|s| s.name == BROWSE).unwrap();
+        assert!(
+            browse.description.contains("drives\n                          Chrome")
+                || browse.description.contains("drives Chrome"),
+            "browse has to say which browser it is on: {}",
+            browse.description
         );
     }
 

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -85,7 +85,7 @@ pub fn system_prompt(
     out.push_str("\n## Your computer\n");
     out.push_str(
         "You have your own Linux machine, and it is not just a shell. It runs a full desktop \
-         with Google Chrome, Firefox, a file manager and an editor installed, and the operator \
+         with Google Chrome, a file manager and an editor installed, and the operator \
          can watch that screen and take control of it.\n\n\
          - `run_command` runs a shell command on it. The filesystem persists between turns and \
            the internet works, so anything you do not already know you can go and find out \
@@ -94,7 +94,11 @@ pub fn system_prompt(
            visit a site, look at a page, or do anything a person would do in a window, for \
            example `google-chrome https://example.com`. The operator sees exactly what you \
            opened.\n\
-         - `browse` is how you use the web. The browser tells you exactly where every link, \
+         - `browse` is how you use the web, and it drives Chrome: the one browser on this \
+           machine, holding whatever accounts you are signed in to. Do not open another one. \
+           A second browser knows none of those accounts, `browse` cannot see it, and you \
+           would be reading one window while clicking another. The browser tells you exactly \
+           where every link, \
            button and field is, so prefer it over looking at pixels for anything on a web \
            page: `read` gives you the text and a numbered list of what you can use, then \
            `click` and `type` take those numbers. It is what you want for signing in, \
@@ -1060,6 +1064,23 @@ mod tests {
         assert!(
             note.contains("Nothing means nothing"),
             "an agent will narrate its own silence unless told not to"
+        );
+    }
+
+    #[test]
+    fn only_one_browser_is_offered_because_only_one_holds_the_accounts() {
+        // Observed: told to send mail, an agent opened firefox, drove it by
+        // coordinates, and read the page with `browse`, which was on Chrome the
+        // whole time. It then reported the account missing. The accounts live
+        // on Chrome's profile and `browse` drives only Chrome, so a second
+        // browser is a window that knows nothing and that half its tools cannot
+        // see.
+        let prompt = prompt_for(&card("Outreach"), &[], "", ReplyMode::ToOperator);
+        assert!(!prompt.contains("Firefox"), "{prompt}");
+        assert!(prompt.contains("Do not open another one"), "{prompt}");
+        assert!(
+            prompt.contains("reading one window while clicking another"),
+            "the reason has to be there, or it reads as an arbitrary rule: {prompt}"
         );
     }
 


### PR DESCRIPTION
An agent asked to send an email opened Firefox, then Chrome, then Chrome again,
and reported that Gmail was unavailable because Chrome had launched a fresh
profile and asked to create a system keyring password. Two causes.

## Chrome was asking for a keyring

Nothing on these machines unlocks one, so Chrome offers to create it. That modal
is what the agent saw and reported as a profile signed in to nothing.

The same setting decides how the cookie jar is encrypted. A profile written
under one password store and reopened under another cannot read its own cookies,
so a session evaporates with nothing reporting an error, which is the shape of
half the confusion here. `--password-store=basic` now goes on every route, the
call site and the shim both: a flag on one of them produces exactly the split
the shim exists to prevent.

## The tools offered a browser nothing drives

`open_on_desktop` advertised `firefox-esr`. The agent opened it, drove it by
coordinates with `use_screen`, and read the page with `browse`, which was on
Chrome the whole time. It was reading one window and clicking another, and its
conclusion followed: the account was missing from the window it was clicking and
present on the profile it could not see.

Chrome is the only browser on the accounts and the only one `browse` speaks to,
so it is the only one named now, with the reason attached in both the tool
description and the prompt rather than stated as a rule.

## Testing

Four tests, three of them pinning wording since wording is the change. The shim
test now decodes what actually lands on the machine rather than asserting
against the base64 that carries it, which is why it caught that the flag had to
be added in two places rather than one.

`./scripts/ci.sh`: 259 frontend, 443 Rust.

## What this does not settle

Whether the operator's signed-in Chrome and the agent's are the same profile at
all. Four agents hold sandboxes, each with its own disk, and a session belongs
to one agent. The detection table currently reports exactly one sign-in in the
whole workspace, YouTube on Outreach's machine, and no Gmail anywhere. If the
Chrome the operator is looking at belongs to a different agent, these fixes will
not put Gmail in Outreach's hands.
