### PR TITLE
fix: a schedule that cannot be read waits for the next tick

### DIFF
--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -873,13 +873,15 @@ impl Runtime {
         self.inner.handle.spawn(async move {
             loop {
                 let now = now_ms();
-                let due = match runtime.inner.store.due_routines(now) {
-                    Ok(due) => due,
-                    Err(err) => {
-                        tracing::warn!(%err, "could not read the schedule");
-                        continue;
-                    }
-                };
+                // A read that fails waits for the next tick like one that
+                // succeeds. Skipping straight to the next attempt turned a
+                // database that stayed broken into a hot loop of synchronous
+                // SQLite calls, with a warning written as fast as the disk
+                // could refuse.
+                let due = runtime.inner.store.due_routines(now).unwrap_or_else(|err| {
+                    tracing::warn!(%err, "could not read the schedule; trying again next tick");
+                    Vec::new()
+                });
 
                 for routine in due {
                     // Recorded as run before it is run. A routine that fails on

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -1250,6 +1250,39 @@ async fn a_one_off_routine_does_not_come_due_twice() {
     );
 }
 
+#[test]
+fn a_schedule_that_cannot_be_read_does_not_starve_the_runtime() {
+    // A store error on the schedule used to skip the sleep at the bottom of the
+    // scheduler's loop, so a database that stayed broken turned the tick into
+    // a hot loop: one worker pinned on synchronous SQLite calls and a warning
+    // written as fast as it could be. On a single-threaded runtime that task
+    // never yields, so this runs the runtime on its own thread and gives it a
+    // deadline; a hang here is the bug, and a hang is not a test failure
+    // unless something is watching the clock.
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async {
+            let stub = serve(|_| Script::Say("unused".into())).await;
+            let h = harness(&stub, &["Watcher"], GuardLimits::default());
+            h.runtime.store().conn().unwrap().execute_batch("DROP TABLE routines").unwrap();
+
+            h.runtime.start_scheduler();
+
+            // The scheduler is the only other task on this runtime. If it
+            // does not sleep between failed reads, this never returns.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        });
+        let _ = done_tx.send(());
+    });
+
+    assert!(
+        done_rx.recv_timeout(Duration::from_secs(10)).is_ok(),
+        "the scheduler kept the runtime to itself: a schedule it cannot read has to wait for \
+         the next tick like a schedule it can"
+    );
+}
+
 /// The system prompt each agent was actually sent, by name.
 fn prompts_by_agent(stub: &harness::Stub) -> HashMap<String, String> {
     let mut out = HashMap::new();


### PR DESCRIPTION
The scheduler's loop had one path that skipped the sleep at the bottom. When
`due_routines` returned an error it hit `continue` and went straight back to the
top, so a database that stayed broken (a locked file, a table missing after a
bad migration, a disk that went away) turned the twenty-second tick into a hot
loop: one worker pinned on synchronous SQLite calls, and "could not read the
schedule" written as fast as the disk could refuse.

## The fix

A failed read falls through to the same sleep as a successful one, and the
warning says it will try again next tick, so the log reads as a wait rather
than a stop.

```rust
let due = runtime.inner.store.due_routines(now).unwrap_or_else(|err| {
    tracing::warn!(%err, "could not read the schedule; trying again next tick");
    Vec::new()
});
```

## Testing

One new cascade test, `a_schedule_that_cannot_be_read_does_not_starve_the_runtime`.
It drops the `routines` table out from under a real runtime, starts the
scheduler, and then asks the runtime for 100ms of sleep. The runtime is built
on its own single-threaded executor on its own thread, behind a ten-second
deadline: on one thread the spinning task never yields, so the symptom of the
bug is a hang, and a hang is only a test failure if something is watching the
clock. It fails on `main` in 10s and passes here in 0.12s.

`./scripts/ci.sh rust` on Rust 1.95: 367 unit, 43 cascade, 10 evals, 10 files,
12 trajectory; clippy clean.

## What this does not settle

Whether twenty seconds is the right wait for an error, as opposed to a
successful tick. It seemed wrong to invent a second interval for a case that
has only ever been seen in a test; if the schedule is unreadable the operator
has bigger problems than a routine firing late.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
