### PR TITLE
fix: a blank key is a local server, not a missing one

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -789,7 +789,7 @@ mod tests {
     fn a_patch_can_supply_a_key_that_was_never_saved() {
         // The Test connection path: the operator has typed a key but not saved.
         let mut config = AppConfig::default();
-        assert!(!config.inference.is_ready(), "no key stored yet");
+        assert!(config.inference.api_key.is_empty(), "no key stored yet");
 
         apply_patch(
             &mut config,
@@ -797,8 +797,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(config.inference.api_key, "sk-typed", "whitespace is trimmed");
-        assert!(config.inference.is_ready(), "the typed key must be usable without saving");
+        assert_eq!(
+            config.inference.api_key, "sk-typed",
+            "whitespace is trimmed, and the typed key is what the probe will send"
+        );
     }
 
     #[test]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -67,8 +67,12 @@ impl InferenceConfig {
         format!("{}/chat/completions", self.base_url.trim_end_matches('/'))
     }
 
+    /// Whether there is somewhere to send a request. A key is not part of it:
+    /// a local llama.cpp or LM Studio server takes none, and the README tells
+    /// the operator to leave it blank. Whether the endpoint wants one is the
+    /// endpoint's answer to give, and a 401 says so in words.
     pub fn is_ready(&self) -> bool {
-        !self.api_key.trim().is_empty() && !self.base_url.trim().is_empty()
+        !self.base_url.trim().is_empty()
     }
 }
 
@@ -316,6 +320,22 @@ mod tests {
         assert_eq!(cfg.chat_completions_url(), "https://openrouter.ai/api/v1/chat/completions");
         cfg.base_url = "https://openrouter.ai/api/v1/".into();
         assert_eq!(cfg.chat_completions_url(), "https://openrouter.ai/api/v1/chat/completions");
+    }
+
+    #[test]
+    fn a_local_endpoint_is_ready_without_a_key() {
+        // The README tells an operator with a llama.cpp or LM Studio server to
+        // leave the key blank. Ready means there is somewhere to send the
+        // request; whether that place wants a key is its answer to give.
+        let cfg = InferenceConfig {
+            base_url: "http://localhost:8080/v1".into(),
+            api_key: String::new(),
+            ..Default::default()
+        };
+        assert!(cfg.is_ready());
+
+        let blank = InferenceConfig { base_url: "  ".into(), ..Default::default() };
+        assert!(!blank.is_ready(), "nowhere to send it is the one thing that is not ready");
     }
 
     #[test]

--- a/src-tauri/src/llm/openrouter.rs
+++ b/src-tauri/src/llm/openrouter.rs
@@ -244,10 +244,15 @@ impl Completion {
 /// "it didn't work" take an hour to diagnose.
 #[derive(Debug, thiserror::Error)]
 pub enum LlmError {
-    #[error("no API key is configured. Open Settings and paste an OpenRouter key.")]
+    #[error("no inference endpoint is configured. Open Settings and set one.")]
     NotConfigured,
     #[error("the inference endpoint rejected the API key (HTTP {status}): {message}")]
     Auth { status: u16, message: String },
+    #[error(
+        "the inference endpoint wants an API key and none is set (HTTP {status}): {message}. \
+         Open Settings and paste one."
+    )]
+    KeyRequired { status: u16, message: String },
     #[error("rate limited by the inference endpoint: {message}")]
     RateLimited { message: String, retry_after_secs: Option<u64> },
     #[error("model {model:?} was rejected: {message}")]
@@ -282,8 +287,9 @@ impl LlmError {
     /// Short form for the transcript chip.
     pub fn headline(&self) -> String {
         match self {
-            LlmError::NotConfigured => "no API key configured".into(),
+            LlmError::NotConfigured => "no endpoint configured".into(),
             LlmError::Auth { .. } => "API key rejected".into(),
+            LlmError::KeyRequired { .. } => "API key needed".into(),
             LlmError::RateLimited { .. } => "rate limited".into(),
             LlmError::ModelRejected { model, .. } => format!("model {model} unavailable"),
             LlmError::Upstream { status, .. } => format!("upstream HTTP {status}"),
@@ -328,9 +334,19 @@ fn extract_message(body: &str) -> String {
     }
 }
 
-fn classify_status(status: u16, body: &str, model: &str, retry_after: Option<u64>) -> LlmError {
+fn classify_status(
+    status: u16,
+    body: &str,
+    model: &str,
+    key_set: bool,
+    retry_after: Option<u64>,
+) -> LlmError {
     let message = extract_message(body);
     match status {
+        // A server that wants a key answers a keyless request the same way it
+        // answers a wrong one. The operator who never entered a key needs to
+        // be told to, not that theirs was refused.
+        401 | 403 if !key_set => LlmError::KeyRequired { status, message },
         401 | 403 => LlmError::Auth { status, message },
         429 => LlmError::RateLimited { message, retry_after_secs: retry_after },
         // OpenRouter reports an unknown or unavailable model as a 400 or 404.
@@ -489,10 +505,15 @@ impl LlmClient {
             temperature: request.temperature,
         };
 
-        let response = self
-            .http
-            .post(&url)
-            .bearer_auth(cfg.api_key.trim())
+        // A blank key sends no header at all rather than `Bearer ` with
+        // nothing after it, which a strict server rejects. That is the local
+        // server case: llama.cpp and LM Studio want nothing here.
+        let key = cfg.api_key.trim();
+        let mut builder = self.http.post(&url);
+        if !key.is_empty() {
+            builder = builder.bearer_auth(key);
+        }
+        let response = builder
             // OpenRouter uses these for attribution and leaderboard ranking.
             // Other OpenAI-compatible servers ignore them.
             .header("HTTP-Referer", &cfg.referer)
@@ -518,7 +539,13 @@ impl LlmClient {
                 .and_then(|v| v.to_str().ok())
                 .and_then(|v| v.parse::<u64>().ok());
             let text = response.text().await.unwrap_or_default();
-            return Err(classify_status(status.as_u16(), &text, &request.model, retry_after));
+            return Err(classify_status(
+                status.as_u16(),
+                &text,
+                &request.model,
+                !key.is_empty(),
+                retry_after,
+            ));
         }
 
         self.consume_stream(response, &url, timeout, &mut on_token).await
@@ -897,13 +924,78 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_missing_key_fails_before_any_network_call() {
+    async fn a_missing_endpoint_fails_before_any_network_call() {
         let client = LlmClient::new().unwrap();
-        let mut config = cfg("http://127.0.0.1:1/v1".into());
-        config.api_key = "   ".into();
+        let config = cfg("   ".into());
         let err = client.stream_chat(&config, &request(), |_| {}).await.unwrap_err();
         assert!(matches!(err, LlmError::NotConfigured));
-        assert!(!err.is_transient(), "a missing key will not fix itself on retry");
+        assert!(!err.is_transient(), "a missing endpoint will not fix itself on retry");
+        assert!(
+            err.to_string().contains("endpoint"),
+            "the operator is told what is missing, got {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_blank_key_reaches_a_local_server_and_sends_no_authorization_header() {
+        // The README says to leave the key blank for a llama.cpp or LM Studio
+        // server that does not want one. Refusing before the network made that
+        // path a lie, and `Bearer ` with nothing after it is a header a strict
+        // server rejects, so a blank key has to mean no header at all.
+        let saw_auth = Arc::new(Mutex::new(None));
+        let recorder = saw_auth.clone();
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(move |headers: axum::http::HeaderMap| {
+                let recorder = recorder.clone();
+                async move {
+                    *recorder.lock().unwrap() =
+                        Some(headers.get("authorization").map(|v| v.to_str().unwrap().to_string()));
+                    sse(&[&text_frame("ok"), "[DONE]"])
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let client = LlmClient::new().unwrap();
+        let mut config = cfg(format!("http://{addr}/v1"));
+        config.api_key = "   ".into();
+        let completion = client.stream_chat(&config, &request(), |_| {}).await.unwrap();
+
+        assert_eq!(completion.content, "ok");
+        assert_eq!(
+            *saw_auth.lock().unwrap(),
+            Some(None),
+            "the request went out, and carried no Authorization header"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_401_with_no_key_set_says_to_add_one_rather_than_that_it_was_rejected() {
+        // A server that wants a key answers a keyless request the same way it
+        // answers a wrong one. "Rejected the API key" is the wrong story for an
+        // operator who never entered one; what they need is to be told to.
+        let (base, _) = stub(|_| {
+            (
+                axum::http::StatusCode::UNAUTHORIZED,
+                axum::Json(serde_json::json!({"error": {"message": "No auth credentials found"}})),
+            )
+                .into_response()
+        })
+        .await;
+
+        let client = LlmClient::new().unwrap();
+        let mut config = cfg(base);
+        config.api_key = String::new();
+        let err = client.stream_chat(&config, &request(), |_| {}).await.unwrap_err();
+        assert!(matches!(err, LlmError::KeyRequired { status: 401, .. }), "got {err:?}");
+        assert!(!err.is_transient(), "asking again without a key gets the same answer");
+        let text = err.to_string();
+        assert!(text.contains("none is set"), "says what happened, got {text}");
+        assert!(text.contains("Settings"), "says what to do about it, got {text}");
+        assert!(text.contains("No auth credentials"), "and keeps the server's own words");
     }
 
     #[tokio::test]

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -175,6 +175,34 @@ describe("App", () => {
     expect(await screen.findByText(/Add an API key/i)).toBeTruthy();
   });
 
+  it("does not ask for a key when the endpoint is a local server", async () => {
+    // The README says to leave the key blank for a llama.cpp or LM Studio
+    // server. A banner insisting on one is the app contradicting its own
+    // instructions on the operator's first run.
+    getSettings.mockResolvedValue({
+      operatorName: "",
+      baseUrl: "http://localhost:1234/v1",
+      defaultModel: "local/model",
+      apiKeySet: false,
+      e2bKeySet: false,
+      e2bKeyHint: "",
+      computerIdleMinutes: 15,
+      apiKeyHint: "",
+      requestTimeoutSecs: 120,
+      limits: {
+        maxHops: 4,
+        maxStepsPerRun: 40,
+        maxFanoutPerCall: 8,
+        maxSendsPerPair: 3,
+        maxToolRounds: 24,
+      },
+    });
+    listAgents.mockResolvedValue([agent("Manager")]);
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("Manager")).toBeTruthy());
+    expect(screen.queryByText(/Add an API key/i)).toBeNull();
+  });
+
   it("still renders the rail when startup fails", async () => {
     // A failed bootstrap must degrade to a usable window with an error, not to
     // a blank one.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,7 +121,11 @@ export default function App() {
     }
   };
 
-  const needsKey = ready && settings !== null && !settings.apiKeySet;
+  // Only the endpoint the app ships with is known to want a key. A local
+  // server is told to leave it blank, and a banner insisting on one there is
+  // the app contradicting its own README on the operator's first run.
+  const needsKey =
+    ready && settings !== null && !settings.apiKeySet && settings.baseUrl.includes("openrouter.ai");
 
   return (
     <div className="app">

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -182,7 +182,7 @@ export function SettingsDialog({ onClose }: Props) {
           />
           <span className="field__hint">
             Stored on this machine in a file only your user account can read. Leave blank to keep
-            the current key.
+            the current key. A local server that takes no key needs none here.
           </span>
         </label>
 


### PR DESCRIPTION
The README says:

> The endpoint is configurable, so a local llama.cpp or LM Studio server works
> without a code change. Point **Inference endpoint** at it and leave the key
> blank if it does not need one.

The client did not agree. `InferenceConfig::is_ready` wanted a non-empty key,
`stream_chat` returned `NotConfigured` before touching the network, and a test
(`a_missing_key_fails_before_any_network_call`) pinned that. The first-run
banner insisted on a key too, whatever the endpoint was. So the local-server
path in the README could not be walked.

## What changes

**Ready means there is somewhere to send the request.** `is_ready` checks the
endpoint only. A key is not part of it; whether the endpoint wants one is the
endpoint's answer to give.

**A blank key sends no `Authorization` header at all**, rather than `Bearer `
with nothing after it, which a strict server rejects. llama.cpp and LM Studio
want nothing there.

**A 401 with no key set is its own error.** A server that wants a key answers a
keyless request the same way it answers a wrong one, and "the inference
endpoint rejected the API key" is the wrong story for an operator who never
entered one. `LlmError::KeyRequired` says what happened and what to do:

> the inference endpoint wants an API key and none is set (HTTP 401): No auth
> credentials found. Open Settings and paste one.

The chip reads "API key needed". A 401 *with* a key set is still `Auth`, as
before.

**`NotConfigured` keeps its one remaining meaning**, a blank endpoint, and its
message says that instead of asking for a key.

**The banner asks for a key only on the endpoint the app ships with**, which is
the one known to want one. On `http://localhost:1234/v1` it stays out of the
way; Test connection and the new error cover the case where a custom endpoint
turns out to want a key after all. The settings hint under the key field says a
local server needs none.

## Testing

- `a_blank_key_reaches_a_local_server_and_sends_no_authorization_header`: a
  header-aware stub; the request goes out, the reply comes back, and there was
  no `Authorization` header on it.
- `a_401_with_no_key_set_says_to_add_one_rather_than_that_it_was_rejected`:
  the new error, its wording, and that it is not retried.
- `a_missing_endpoint_fails_before_any_network_call` replaces the test that
  pinned the old refusal, and checks the message now names the endpoint.
- `a_local_endpoint_is_ready_without_a_key` in `config.rs`.
- `does not ask for a key when the endpoint is a local server` in
  `App.test.tsx`; the existing "prompts for a key when none is configured"
  still passes on the OpenRouter default.
- `a_patch_can_supply_a_key_that_was_never_saved` asserted `is_ready` flipping
  on the key; it now asserts the key itself, which is what it was about.

`./scripts/ci.sh` on Rust 1.95: 260 frontend, 370 unit, 42 cascade, 10 evals,
10 files, 12 trajectory; clippy clean.

## What this does not settle

- Whether the banner should key off the host at all. The alternative was to
  ship a flag from the backend saying "this endpoint is known to want a key",
  which is the same string comparison one layer down; the frontend already has
  `baseUrl`, so it compares there.
- Clearing a stored key from the settings dialog: a blank field means "keep",
  as before, so an operator moving from OpenRouter to a local server keeps
  sending the old key. Local servers ignore it, so this only matters for
  tidiness, and it seemed like a separate change.
- I have not run this against a live llama.cpp; the stub asserts the header is
  absent, which is what those servers care about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
