### PR TITLE
chore: rust-version says what the lockfile needs

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 description = "Guac: a local, no-auth chat surface where you and your agents talk to each other."
 authors = ["madebywelch"]
 edition = "2021"
-rust-version = "1.82"
+# What the lockfile actually needs, not an aspiration. `time`, `plist` and the
+# `icu` crates declare 1.88, and thirty-odd more are edition 2024, so an older
+# toolchain fails on the first crate it downloads rather than on this line. It
+# also steers `cargo update` toward versions that build here.
+rust-version = "1.88"
 
 [lib]
 name = "guac_lib"


### PR DESCRIPTION
`Cargo.toml` says `rust-version = "1.82"`. The committed lockfile does not
build there. With Cargo 1.84 (Homebrew's current `rust`), `cargo metadata`
fails before compiling anything:

```
error: failed to download `cpufeatures v0.3.0`
Caused by:
  failed to parse manifest at `.../cpufeatures-0.3.0/Cargo.toml`
```

`cpufeatures 0.3.0` is edition 2024, pulled in by `uuid → rand → chacha20`. Past
that, `time 0.3.55`, `plist 1.10`, `darling 0.23` and the `icu` crates declare
`rust-version = "1.88"`, and about thirty-five locked crates are edition 2024.
The Dockerfile uses `rust:1.95` and is fine, so `./scripts/ci.sh` means one
thing in the container and another on a laptop whose Rust matched the stated
minimum.

## The change

`rust-version = "1.88"`, with a comment saying where the number comes from.
That is the highest `rust-version` any locked crate declares (from
`cargo metadata` over the lockfile). Two side effects worth naming:

- Cargo's MSRV-aware resolver reads this field, so a future `cargo update`
  prefers versions that still build at 1.88 rather than silently moving the
  floor again.
- Anyone on an older toolchain now gets "package requires rustc 1.88 or newer"
  pointing at this crate, instead of a manifest parse error deep in the
  registry.

The alternative was pinning `cpufeatures`, `time`, etc. back to keep 1.82 true.
That fights the lockfile on every update for a floor nothing else in the repo
depends on; if 1.82 matters for a reason I could not see, say so and I will do
that instead.

## Testing

- `rustup toolchain install 1.88.0` then
  `cargo +1.88.0 check --manifest-path src-tauri/Cargo.toml --all-targets`:
  passes on a fresh target dir.
- `cargo +1.95.0 metadata` still resolves the lockfile unchanged (`Cargo.lock`
  is not touched by this PR).
- `cargo +1.84.0` still fails, as it should now say it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
