### PR TITLE
fix: an agent with no computer is not offered one

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -125,6 +125,15 @@ pub struct E2bConfig {
     pub idle_minutes: u32,
 }
 
+impl E2bConfig {
+    /// Whether agents have machines at all. Decided here, by the key, rather
+    /// than by asking a sandbox: a machine that is asleep is still an agent's
+    /// machine, and one that was never possible is not.
+    pub fn is_configured(&self) -> bool {
+        !self.api_key.trim().is_empty()
+    }
+}
+
 pub fn default_idle_minutes() -> u32 {
     15
 }
@@ -192,7 +201,7 @@ impl AppConfig {
     pub fn redacted(&self) -> RedactedConfig {
         RedactedConfig {
             operator_name: self.operator_name.clone(),
-            e2b_key_set: !self.e2b.api_key.trim().is_empty(),
+            e2b_key_set: self.e2b.is_configured(),
             e2b_key_hint: hint_for(&self.e2b.api_key),
             computer_idle_minutes: self.e2b.idle_minutes,
             base_url: self.inference.base_url.clone(),

--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -27,7 +27,21 @@ pub const SCHEDULE: &str = "schedule";
 pub const CREATE_AGENT: &str = "create_agent";
 pub const REQUEST_PERMISSION: &str = "request_permission";
 
-/// Tool definitions offered on every agent turn.
+/// The tools offered on an agent's turn.
+///
+/// The four that need a machine are left off when the workspace has no E2B
+/// key. Offered anyway, an agent spent a model call learning from the error
+/// what the runtime knew before it asked, and a schema on the list is a
+/// standing invitation to try again next turn.
+pub fn offered(has_computer: bool) -> Vec<ToolSpec> {
+    specs().into_iter().filter(|spec| has_computer || !needs_computer(&spec.name)).collect()
+}
+
+fn needs_computer(name: &str) -> bool {
+    matches!(name, RUN_COMMAND | OPEN_ON_DESKTOP | USE_SCREEN | BROWSE)
+}
+
+/// Every tool definition, whether or not this workspace can honour it.
 pub fn specs() -> Vec<ToolSpec> {
     vec![
         ToolSpec {
@@ -1124,6 +1138,23 @@ mod tests {
             "the rule is useless without the alternative: {}",
             spec.description
         );
+    }
+
+    #[test]
+    fn without_a_computer_the_tools_that_need_one_are_not_offered() {
+        // Offered anyway, an agent with no machine spends a model call
+        // learning from the error what the runtime knew before it asked, and
+        // a schema on the list is a standing invitation to try again.
+        let without: Vec<String> = offered(false).into_iter().map(|s| s.name).collect();
+        for tool in [RUN_COMMAND, OPEN_ON_DESKTOP, USE_SCREEN, BROWSE] {
+            assert!(!without.contains(&tool.to_string()), "{tool} needs a machine");
+        }
+        for tool in
+            [DIRECTORY, UPDATE_NOTES, SCHEDULE, SEND_MESSAGE, CREATE_AGENT, REQUEST_PERMISSION]
+        {
+            assert!(without.contains(&tool.to_string()), "{tool} works without one");
+        }
+        assert_eq!(offered(true).len(), specs().len(), "with a machine, everything is offered");
     }
 
     #[test]

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -1246,13 +1246,19 @@ impl Runtime {
         }
 
         let (credentials, signins) = self.reach_of(&card);
+        // Settings are read once for the turn, so the prompt and the tool list
+        // agree: a turn told it has a machine is offered the tools for one, and
+        // a turn told it has none is not.
+        let config = self.config();
+        let has_computer = config.e2b.is_configured();
         #[allow(unused_mut)]
         let mut messages = prompt::build_messages(
             &card,
-            &self.config().operator_name,
+            &config.operator_name,
             &roster,
             &credentials,
             &signins,
+            has_computer,
             &names,
             &notes,
             &history,
@@ -1281,7 +1287,6 @@ impl Runtime {
         };
         stream.open(&*self.inner.events);
 
-        let config = self.config();
         let mut collected_text = String::new();
         // Settings resolve agent over group over app. An agent that names its own
         // model keeps it; otherwise the group's choice applies; otherwise the
@@ -1315,7 +1320,7 @@ impl Runtime {
             let request = ChatRequest {
                 model: model.clone(),
                 messages: messages.clone(),
-                tools: tools::specs(),
+                tools: tools::offered(has_computer),
                 temperature: None,
             };
 

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -40,6 +40,7 @@ pub enum ReplyMode {
     Assigned,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn system_prompt(
     card: &AgentCard,
     // What this agent calls the person it works for. Empty for "the operator".
@@ -51,6 +52,9 @@ pub fn system_prompt(
     // What this agent's own browser turned out to be signed in to. Nobody typed
     // these: they were read off the machine.
     signins: &[Signin],
+    // Whether there is a machine at all. Without an E2B key there is not, and
+    // the section below has to say the opposite of what it says with one.
+    has_computer: bool,
     notes: &str,
     mode: ReplyMode,
 ) -> String {
@@ -82,9 +86,23 @@ pub fn system_prompt(
     // schema does not connect it to what it can do: asked to check the weather,
     // one with a working machine still answered that it had no way to look
     // anything up.
+    //
+    // And stated the other way when there is no machine. The four tools are not
+    // offered then, but an agent told never to say it has no computer will go
+    // on saying it has one, and describe results it had no way to produce.
     out.push_str("\n## Your computer\n");
-    out.push_str(
-        "You have your own Linux machine, and it is not just a shell. It runs a full desktop \
+    if !has_computer {
+        out.push_str(
+            "You do not have one. No E2B key is configured in this workspace, so there is no \
+             machine behind you: no shell, no browser, no screen, and no way to fetch a page or \
+             run code. What you know is what is in this conversation and in your memory. When a \
+             task needs a machine, say so plainly and tell the operator that adding an E2B key \
+             in Settings gives you one; do not describe a result you did not produce. \
+             Everything else described here still works.\n",
+        );
+    } else {
+        out.push_str(
+            "You have your own Linux machine, and it is not just a shell. It runs a full desktop \
          with Google Chrome, Firefox, a file manager and an editor installed, and the operator \
          can watch that screen and take control of it.\n\n\
          - `run_command` runs a shell command on it. The filesystem persists between turns and \
@@ -107,68 +125,75 @@ pub fn system_prompt(
          Never say you have no computer, no browser, or no way to look something up. You have \
          all three. Say what you ran and what it returned rather than presenting a result as \
          something you simply knew.\n",
-    );
+        );
+    }
 
     // Immediately after the computer, because this is a fact about that
     // machine. An agent that is not told this looks at a signed-in browser and
     // reports that it has no access, which is the whole reason any of this
     // exists: the access was never missing, the knowledge was.
-    out.push_str("\n## What you can reach\n");
-    if credentials.is_empty() && signins.is_empty() {
-        out.push_str(
+    //
+    // And left out without a machine: a session lives in a browser and a
+    // credential goes into a shell, so with neither there is nothing to reach.
+    if has_computer {
+        out.push_str("\n## What you can reach\n");
+        if credentials.is_empty() && signins.is_empty() {
+            out.push_str(
             "Your browser is not signed in to anything, and you have been given no credentials. \
              You can still browse the open web. If a task needs an account, say which one and ask \
              the operator to sign you in; you cannot sign yourself in.\n",
         );
-    } else {
-        out.push_str(
+        } else {
+            out.push_str(
             "These accounts are already open to you. They are facts, not offers: go straight to \
              the page or the API you need rather than looking for a way in.\n\n",
         );
 
-        let (certain, likely): (Vec<&Signin>, Vec<&Signin>) =
-            signins.iter().partition(|signin| signin.recognised);
+            let (certain, likely): (Vec<&Signin>, Vec<&Signin>) =
+                signins.iter().partition(|signin| signin.recognised);
 
-        if !certain.is_empty() {
-            out.push_str(
-                "Your browser is signed in to these, so `browse` reaches them as the account \
+            if !certain.is_empty() {
+                out.push_str(
+                    "Your browser is signed in to these, so `browse` reaches them as the account \
                  holder without any sign-in step:\n",
-            );
-            for signin in &certain {
-                out.push_str(&format!("- {}\n", signin.label()));
+                );
+                for signin in &certain {
+                    out.push_str(&format!("- {}\n", signin.label()));
+                }
+                out.push('\n');
             }
-            out.push('\n');
-        }
 
-        // Hedged on purpose. These were matched by a session-shaped cookie on a
-        // site the browser had visited, which is usually right and is sometimes
-        // an anonymous session that every visitor gets. An agent that treats a
-        // guess as a fact reports an account as broken when it was never there.
-        if !likely.is_empty() {
-            out.push_str(
+            // Hedged on purpose. These were matched by a session-shaped cookie on a
+            // site the browser had visited, which is usually right and is sometimes
+            // an anonymous session that every visitor gets. An agent that treats a
+            // guess as a fact reports an account as broken when it was never there.
+            if !likely.is_empty() {
+                out.push_str(
                 "You may also be signed in to these, though it is not certain. Try, and if you \
                  are asked to log in then you are not signed in after all: say so rather than \
                  reporting the site as broken.\n",
             );
-            for signin in &likely {
-                out.push_str(&format!("- {}\n", signin.label()));
-            }
-            out.push('\n');
-        }
-
-        if !credentials.is_empty() {
-            out.push_str("You hold these credentials, already in your shell as that variable:\n");
-            for connector in credentials {
-                out.push_str(&connector.own_line());
+                for signin in &likely {
+                    out.push_str(&format!("- {}\n", signin.label()));
+                }
                 out.push('\n');
             }
-            out.push_str(
-                "Use one by name, for example `curl -H \"Authorization: Bearer $TOKEN\" …`. \
-                 Never print one, never copy one into a message, and never send one to a peer.\n\n",
-            );
-        }
 
-        out.push_str(
+            if !credentials.is_empty() {
+                out.push_str(
+                    "You hold these credentials, already in your shell as that variable:\n",
+                );
+                for connector in credentials {
+                    out.push_str(&connector.own_line());
+                    out.push('\n');
+                }
+                out.push_str(
+                    "Use one by name, for example `curl -H \"Authorization: Bearer $TOKEN\" …`. \
+                 Never print one, never copy one into a message, and never send one to a peer.\n\n",
+                );
+            }
+
+            out.push_str(
             "You are acting as the operator on every one of these. Anything you send, post, buy \
              or delete is done in their name and they cannot take it back, so do the reading \
              freely and stop before anything public or irreversible that they did not ask for.\n\n\
@@ -176,6 +201,7 @@ pub fn system_prompt(
              to sign in, do not ask anyone for a password, and do not accept one if it is \
              offered: only the operator can sign you in, at the real site, on your screen.\n",
         );
+        }
     }
     // The route out of "I cannot do that". Said even when this agent has
     // nothing, because that is exactly when it matters.
@@ -321,9 +347,9 @@ pub fn system_prompt(
     // it has any reason to go looking at a tool list. Asked to staff ten roles,
     // one with this tool available still replied that it could not create
     // agents from this interface.
-    out.push_str(
+    out.push_str(&format!(
         "\n## Growing the crew\n\
-         `create_agent` adds a colleague: its own instructions, its own computer, its own memory, \
+         `create_agent` adds a colleague: its own instructions, {computer}its own memory, \
          reachable by name the moment it exists. Reach for it when the workspace is missing a \
          role, not when you are missing an afternoon's work: a task belongs to you or to an agent \
          already here.\n\
@@ -334,7 +360,8 @@ pub fn system_prompt(
          - You are never unable to create an agent. If the crew has nobody for a role the \
          operator needs, propose it or create it rather than reporting that the workspace will \
          not let you.\n",
-    );
+        computer = if has_computer { "its own computer, " } else { "" },
+    ));
 
     out.push_str("\n## Your reply\n");
     out.push_str(match mode {
@@ -441,6 +468,7 @@ pub fn build_messages(
     roster: &[DirectoryEntry],
     credentials: &[Connector],
     signins: &[Signin],
+    has_computer: bool,
     names: &NameTable,
     notes: &str,
     history: &[Envelope],
@@ -453,6 +481,7 @@ pub fn build_messages(
         roster,
         credentials,
         signins,
+        has_computer,
         notes,
         mode,
     ))];
@@ -491,7 +520,7 @@ mod tests {
         notes: &str,
         mode: ReplyMode,
     ) -> String {
-        system_prompt(card, "", roster, &[], &[], notes, mode)
+        system_prompt(card, "", roster, &[], &[], true, notes, mode)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -504,7 +533,7 @@ mod tests {
         inbound: &[Envelope],
         mode: ReplyMode,
     ) -> Vec<ChatMessage> {
-        build_messages(card, "", roster, &[], &[], names, notes, history, inbound, mode)
+        build_messages(card, "", roster, &[], &[], true, names, notes, history, inbound, mode)
     }
 
     /// The body of one `##` section, so a test can assert where something is
@@ -679,6 +708,46 @@ mod tests {
     }
 
     #[test]
+    fn an_agent_without_a_computer_is_told_so_rather_than_the_opposite() {
+        // The README says that without an E2B key the computer tools are not
+        // offered. The prompt went on saying "never say you have no computer"
+        // to an agent that had none, and the four tools were still on the
+        // list, so its first act on any real task was to call one and read
+        // back an error the runtime knew before it asked.
+        let prompt =
+            system_prompt(&card("Manager"), "", &[], &[], &[], false, "", ReplyMode::ToOperator);
+        let computer = section(&prompt, "## Your computer");
+        assert!(computer.contains("do not have one"), "said plainly, got: {computer}");
+        for tool in ["`run_command`", "`open_on_desktop`", "`use_screen`", "`browse`"] {
+            assert!(!prompt.contains(tool), "{tool} must not be named: nothing answers to it");
+        }
+        assert!(
+            !prompt.contains("Never say you have no computer"),
+            "the rule for an agent with a machine is the wrong rule for one without"
+        );
+        assert!(
+            computer.contains("E2B") && computer.contains("Settings"),
+            "the way to get one is named, so the agent can tell the operator: {computer}"
+        );
+        assert!(
+            !prompt.contains("## What you can reach"),
+            "accounts are a fact about a machine; without one there is nothing to reach"
+        );
+    }
+
+    #[test]
+    fn an_agent_with_a_computer_reads_exactly_as_it_did_before() {
+        // The change is for the agent without a machine. One with a machine
+        // must still be told it has one, in the words that stopped it saying
+        // otherwise.
+        let prompt = prompt_for(&card("Manager"), &[], "", ReplyMode::ToOperator);
+        let computer = section(&prompt, "## Your computer");
+        assert!(computer.contains("Never say you have no computer"));
+        assert!(!computer.contains("do not have one"));
+        assert!(prompt.contains("## What you can reach"));
+    }
+
+    #[test]
     fn an_agent_is_told_which_accounts_are_already_open_to_it() {
         // The failure the whole feature exists to end: the operator signs the
         // agent's browser in to Gmail, the agent is never told, and it replies
@@ -690,6 +759,7 @@ mod tests {
             &[],
             &[credential("GitHub", "madebywelch", "GITHUB_TOKEN")],
             &[signed_in(c.id, "LinkedIn")],
+            true,
             "",
             ReplyMode::ToOperator,
         );
@@ -716,7 +786,7 @@ mod tests {
         let mut hedged = signed_in(c.id, "intranet.example");
         hedged.recognised = false;
 
-        let prompt = system_prompt(&c, "", &[], &[], &[hedged], "", ReplyMode::ToOperator);
+        let prompt = system_prompt(&c, "", &[], &[], &[hedged], true, "", ReplyMode::ToOperator);
         assert!(prompt.contains("may also be signed in"), "a guess has to read as one");
         assert!(
             !prompt.contains("Your browser is signed in to these"),
@@ -736,7 +806,7 @@ mod tests {
         let c = card("Researcher");
         let mut token = credential("GitHub", "madebywelch", "GITHUB_TOKEN");
         token.secret_hint = "...ter2".into();
-        let prompt = system_prompt(&c, "", &[], &[token], &[], "", ReplyMode::ToOperator);
+        let prompt = system_prompt(&c, "", &[], &[token], &[], true, "", ReplyMode::ToOperator);
 
         assert!(prompt.contains("GITHUB_TOKEN"), "the name is what it needs");
         assert!(!prompt.contains("ghp_"), "no value, not even a hint of one");
@@ -765,6 +835,7 @@ mod tests {
             &[],
             &[],
             &[signed_in(c.id, "LinkedIn")],
+            true,
             "",
             ReplyMode::ToOperator,
         );
@@ -785,7 +856,8 @@ mod tests {
         let mut researcher = entry("Researcher", &["web research"]);
         researcher.reaches = vec!["LinkedIn".into()];
 
-        let prompt = system_prompt(&c, "", &[researcher], &[], &[], "", ReplyMode::ToOperator);
+        let prompt =
+            system_prompt(&c, "", &[researcher], &[], &[], true, "", ReplyMode::ToOperator);
         assert!(prompt.contains("- Researcher (web research) — signed in to LinkedIn"));
         assert!(
             prompt.contains("ask that agent to do the part that needs it"),
@@ -957,13 +1029,21 @@ mod tests {
         // The operator should never have to say "remember my name": it is one
         // fact about the workspace, not something each agent discovers and
         // keeps privately while its peers stay ignorant.
-        let prompt =
-            system_prompt(&card("Manager"), "Robert", &[], &[], &[], "", ReplyMode::ToOperator);
+        let prompt = system_prompt(
+            &card("Manager"),
+            "Robert",
+            &[],
+            &[],
+            &[],
+            true,
+            "",
+            ReplyMode::ToOperator,
+        );
         assert!(prompt.contains("Robert"), "the operator's name belongs in every prompt");
 
         // Unnamed operators read exactly as they did before this existed.
         let anonymous =
-            system_prompt(&card("Manager"), "  ", &[], &[], &[], "", ReplyMode::ToOperator);
+            system_prompt(&card("Manager"), "  ", &[], &[], &[], true, "", ReplyMode::ToOperator);
         assert!(!anonymous.contains("is called"), "no name means no claim about one");
     }
 

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -1250,6 +1250,58 @@ async fn a_one_off_routine_does_not_come_due_twice() {
     );
 }
 
+#[tokio::test]
+async fn an_agent_with_no_e2b_key_is_not_offered_a_computer_and_is_told_it_has_none() {
+    // The README: without an E2B key the computer tools are not offered.
+    // This checks what the model was actually sent, on both sides of the
+    // setting, because the runtime is where the tool list and the prompt are
+    // put together and a unit test on either half cannot see the join.
+    let stub = serve(|_| Script::Say("noted".into())).await;
+    let h = harness(&stub, &["Clerk"], GuardLimits::default());
+    assert!(h.runtime.config().e2b.api_key.is_empty(), "the harness has no E2B key");
+
+    let run = h.runtime.send_from_human(h.id("Clerk"), "hello").unwrap();
+    h.settle(run).await;
+
+    let without = stub.transcript.lock().last().cloned().expect("the model was called");
+    let offered = tool_names(&without);
+    for tool in ["run_command", "open_on_desktop", "use_screen", "browse"] {
+        assert!(!offered.contains(&tool.to_string()), "{tool} offered with nothing behind it");
+    }
+    assert!(offered.contains(&"send_message".to_string()), "the rest are still there: {offered:?}");
+    let prompt = without["messages"][0]["content"].as_str().unwrap_or_default();
+    assert!(prompt.contains("do not have one"), "the prompt says so too: {prompt}");
+
+    // The operator adds a key. The next turn has a machine.
+    let mut config = h.runtime.config();
+    config.e2b.api_key = "e2b_test".into();
+    h.runtime.set_config(config);
+
+    let run = h.runtime.send_from_human(h.id("Clerk"), "hello again").unwrap();
+    h.settle(run).await;
+
+    let with = stub.transcript.lock().last().cloned().unwrap();
+    let offered = tool_names(&with);
+    for tool in ["run_command", "open_on_desktop", "use_screen", "browse"] {
+        assert!(offered.contains(&tool.to_string()), "{tool} must be back: {offered:?}");
+    }
+    let prompt = with["messages"][0]["content"].as_str().unwrap_or_default();
+    assert!(prompt.contains("Never say you have no computer"), "and the prompt says so: {prompt}");
+}
+
+/// The tools a request offered, by name.
+fn tool_names(body: &serde_json::Value) -> Vec<String> {
+    body["tools"]
+        .as_array()
+        .map(|tools| {
+            tools
+                .iter()
+                .filter_map(|t| t["function"]["name"].as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// The system prompt each agent was actually sent, by name.
 fn prompts_by_agent(stub: &harness::Stub) -> HashMap<String, String> {
     let mut out = HashMap::new();
@@ -1281,6 +1333,12 @@ async fn an_agent_is_told_what_its_browser_holds_and_what_its_peers_hold() {
     // tries and hits a login wall.
     let stub = serve(|_| Script::Say("Noted.".into())).await;
     let h = harness(&stub, &["Manager", "Researcher"], GuardLimits::default());
+    // A sign-in lives in a browser and a credential goes into a shell, so what
+    // an agent can reach is only said to one with a machine. Nothing below
+    // starts one; the key only has to be set.
+    let mut config = h.runtime.config();
+    config.e2b.api_key = "e2b_test".into();
+    h.runtime.set_config(config);
 
     let group = h.runtime.store().get_agent(h.id("Manager")).unwrap().unwrap().group_id;
     h.runtime


### PR DESCRIPTION
The README, under Computers:

> Without an E2B key none of this appears, and the other four tools are not
> offered.

The pane is hidden, but the tools were offered: every turn sent all ten
schemas, and every system prompt carried the `## Your computer` section ending
in "Never say you have no computer, no browser, or no way to look something up.
You have all three." So an agent in a workspace with no E2B key was told, in
the strongest words the prompt has, the opposite of the truth. Its first act on
a real task was to call `run_command` and get back "no E2B API key is set", a
model call spent learning what the runtime knew before it asked; and an agent
that has been told never to say it has no machine keeps saying it has one,
which is how results get described that nothing produced. This is the
first-run experience for anyone who has not set up E2B, which is most people
trying the app.

## What changes

**One decision, once per turn.** `E2bConfig::is_configured` (the key is set)
is read where the prompt and the tool list are assembled, so the two agree: a
turn told it has a machine is offered the tools for one, and a turn told it
has none is not. `RedactedConfig::e2b_key_set` uses the same method.

**`tools::offered(has_computer)`** returns `specs()` minus `run_command`,
`open_on_desktop`, `use_screen` and `browse` when there is no machine.
`specs()` still exists as the full list.

**The prompt says so.** Without a machine, `## Your computer` reads:

> You do not have one. No E2B key is configured in this workspace, so there is
> no machine behind you: no shell, no browser, no screen, and no way to fetch a
> page or run code. What you know is what is in this conversation and in your
> memory. When a task needs a machine, say so plainly and tell the operator that
> adding an E2B key in Settings gives you one; do not describe a result you did
> not produce. Everything else described here still works.

`## What you can reach` is left out entirely: a session lives in a browser and
a credential goes into a shell, so with neither there is nothing to reach. And
`create_agent` stops promising the new colleague "its own computer".

**With a machine, nothing changes.** `an_agent_with_a_computer_reads_exactly_as_it_did_before`
pins that the section, the closing rule and the reach section are all still
there.

## Testing

- `an_agent_without_a_computer_is_told_so_rather_than_the_opposite` (prompt):
  says it has none, names none of the four tools, drops the "never say" rule,
  names E2B and Settings, and has no reach section.
- `an_agent_with_a_computer_reads_exactly_as_it_did_before` (prompt).
- `without_a_computer_the_tools_that_need_one_are_not_offered` (tools): the
  four are gone, the six remain, and with a machine `offered(true)` is `specs()`.
- `an_agent_with_no_e2b_key_is_not_offered_a_computer_and_is_told_it_has_none`
  (cascade): reads what the model was actually sent, on both sides of the
  setting, because the runtime is where the tool list and the prompt are put
  together and a unit test on either half cannot see the join. The harness has
  no key; the first turn offers six tools and says "do not have one"; then
  `set_config` adds a key and the next turn offers ten and says "Never say you
  have no computer".
- `an_agent_is_told_what_its_browser_holds_and_what_its_peers_hold` now sets a
  key before inserting sign-ins, since a session presupposes a machine. Nothing
  in it starts one; the key only has to be set.

`./scripts/ci.sh rust` on Rust 1.95: 370 unit, 43 cascade, 10 evals, 10 files,
12 trajectory; clippy clean. Frontend untouched.

**I have not run the live evals.** This is a prompt change and the repo says to
run them for one. There is no Guaca settings file on the machine I worked from,
so they cannot be pointed at a model here. The change is confined to the
no-machine branch, and the with-machine prompt is byte-for-byte what it was
(there is a test for that), so the live scenarios, which run with a machine,
should read the same prompt they read before; but that is a reason to expect
they pass, not evidence that they do. If you can run
`./scripts/evals.sh` on this branch I would like to know what it says.

## What this does not settle

- Under `## Working with peers`, "work that needs an account, a machine or a
  signed-in session you do not have belongs to the agent that has it" is still
  said without a machine, and in that workspace no peer has one either. It
  seemed better to leave the delegation rules alone than to fork them; a peer
  told the same thing will say so, and the hop converges.
- The `create_agent` *tool description* in `tools.rs` still says "its own
  computer". Tool descriptions are static; varying them by configuration felt
  like more machinery than the sentence is worth. The prompt is where the
  agent reads about the crew, and that is fixed.
- The `RUN_COMMAND` etc. dispatch paths are unchanged, so a model that calls
  one it was not offered still gets the same "no E2B API key" error it did
  before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
