### PR TITLE
fix: a peer message lands in the row that announced it

### DIFF
--- a/src/components/ChannelView.tsx
+++ b/src/components/ChannelView.tsx
@@ -358,14 +358,11 @@ function LiveStreams({
 
         // A message bound for a peer will settle into a collapsed row, so it is
         // announced rather than streamed. Only text meant for the operator is
-        // worth watching arrive.
+        // worth watching arrive. The writer is the peer: this stream is filed
+        // in the recipient's channel, which is the one being looked at.
         if (buffer.to.kind === "agent") {
           return (
-            <WritingRow
-              key={id}
-              from={toPeer(lookups.byId(buffer.agentId), buffer.agentId)}
-              to={toPeer(lookups.byId(buffer.to.id), buffer.to.id)}
-            />
+            <WritingRow key={id} peer={toPeer(lookups.byId(buffer.agentId), buffer.agentId)} />
           );
         }
         return buffer.text.length > 0 ? (

--- a/src/components/WireRow.test.tsx
+++ b/src/components/WireRow.test.tsx
@@ -1,6 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
-import { why } from "./WireRow";
+import type { WirePeer } from "../lib/transcript";
+import { PeerBurstRow, WritingRow, why } from "./WireRow";
+
+const GOV: WirePeer = {
+  id: "gov",
+  name: "Government Procurement",
+  color: "#c7d96b",
+  avatar: "plain",
+};
+const REV: WirePeer = { id: "rev", name: "Revenue Operations", color: "#8bbf6a", avatar: "plain" };
 
 describe("why", () => {
   it("keeps what happened and drops the instructions to the model", () => {
@@ -16,5 +26,60 @@ describe("why", () => {
   it("survives a reason that is one sentence, or none of the expected shape", () => {
     expect(why("Refused: no agent named Ghost exists")).toBe("no agent named Ghost exists");
     expect(why("something went wrong")).toBe("something went wrong");
+  });
+});
+
+describe("a peer message arriving", () => {
+  /** What a chip says and what it is wearing, ignoring the live-only dots. */
+  const chips = (root: HTMLElement) =>
+    [...root.querySelectorAll(".wire__chip")].map((chip) => ({
+      label: chip.querySelector(".wire__label")?.textContent,
+      // The size class, so a chip that grew or lost its face fails here.
+      avatar: chip.querySelector(".avatar")?.className,
+    }));
+
+  it("is announced as the chip it settles into", () => {
+    // One message landing must not read as two events. The live row was a
+    // sentence with an arrow and no avatar, and the settled row a chip with an
+    // avatar and different words, so a message arriving moved, renamed itself
+    // and grew a face in one frame.
+    const live = render(<WritingRow peer={GOV} />);
+    const settled = render(
+      <PeerBurstRow
+        peers={[{ peer: GOV, agentId: "gov", sent: 0, received: 1 }]}
+        onOpen={vi.fn()}
+      />,
+    );
+
+    expect(chips(live.container)).toEqual(chips(settled.container));
+    expect(chips(live.container)).toEqual([
+      { label: "Message from Government Procurement", avatar: "avatar avatar--xs" },
+    ]);
+    expect(live.container.querySelector(".wire__dots")).not.toBeNull();
+    expect(settled.container.querySelector(".wire__dots")).toBeNull();
+  });
+
+  it("keeps a burst in one group, so the rules bracket it rather than wrap into it", () => {
+    // The rules either side of a wire row are `.wire` pseudo-elements. As items
+    // of a wrapping flex row they were laid out with the chips: the left rule
+    // squeezed onto the first line, the right one stranded beside whichever
+    // chip wrapped last. Every chip goes in one child, and `.wire` never wraps.
+    const { container } = render(
+      <PeerBurstRow
+        peers={[
+          { peer: GOV, agentId: "gov", sent: 1, received: 1 },
+          { peer: REV, agentId: "rev", sent: 0, received: 1 },
+        ]}
+        onOpen={vi.fn()}
+      />,
+    );
+
+    const wire = container.querySelector(".wire");
+    expect(wire?.children).toHaveLength(1);
+    expect(wire?.firstElementChild?.className).toBe("wire__chips");
+    expect(chips(container).map((c) => c.label)).toEqual([
+      "2 messages with Government Procurement",
+      "Message from Revenue Operations",
+    ]);
   });
 });

--- a/src/components/WireRow.tsx
+++ b/src/components/WireRow.tsx
@@ -37,6 +37,48 @@ function clockTime(ms: number): string {
 }
 
 /**
+ * The inside of a peer chip.
+ *
+ * Shared rather than written twice because a chip is drawn before the message
+ * arrives and again after it has, and the two have to be the same object to the
+ * eye. An avatar a size out or a label in a different place turns one message
+ * landing into two things happening.
+ */
+function PeerFace({ peer, label }: { peer: WirePeer; label: string }) {
+  return (
+    <>
+      <AgentAvatar avatar={peer.avatar} color={peer.color} size="xs" seed={peer.id} />
+      <span className="wire__label">{label}</span>
+    </>
+  );
+}
+
+/** One peer's share of a burst, and the thread behind it. */
+function PeerChip({ summary, onOpen }: { summary: PeerSummary; onOpen: (peer: AgentId) => void }) {
+  const { peer, agentId } = summary;
+  const face = <PeerFace peer={peer} label={summaryLabel(summary)} />;
+  const style = { "--accent": peer.color } as React.CSSProperties;
+
+  // An unresolved name has no thread to open. It still gets a chip: an agent
+  // that wrote to a name nobody can find is worth seeing.
+  return agentId ? (
+    <button
+      type="button"
+      className="wire__chip wire__chip--open"
+      style={style}
+      title={`Read the conversation with ${peer.name}`}
+      onClick={() => onOpen(agentId)}
+    >
+      {face}
+    </button>
+  ) : (
+    <span className="wire__chip" style={style}>
+      {face}
+    </span>
+  );
+}
+
+/**
  * A burst of peer traffic, one chip per peer.
  *
  * Per peer rather than "5 messages with 2 agents", for the same reason a
@@ -44,6 +86,10 @@ function clockTime(ms: number): string {
  * hides the thing the operator opened the channel to find out. It also means
  * every chip has exactly one thread behind it, so a click never has to ask
  * which conversation was meant.
+ *
+ * The chips are one child rather than several, so the rules either side of the
+ * row bracket the group instead of joining it: as siblings in a wrapping row
+ * they were laid out with the chips and ended up inside the burst.
  */
 export function PeerBurstRow({
   peers,
@@ -53,41 +99,12 @@ export function PeerBurstRow({
   onOpen: (peer: AgentId) => void;
 }) {
   return (
-    <div className="wire wire--burst">
-      {peers.map((summary) => {
-        const { agentId } = summary;
-        const face = (
-          <>
-            <AgentAvatar
-              avatar={summary.peer.avatar}
-              color={summary.peer.color}
-              size="xs"
-              seed={summary.peer.id}
-            />
-            <span className="wire__label">{summaryLabel(summary)}</span>
-          </>
-        );
-        const style = { "--accent": summary.peer.color } as React.CSSProperties;
-
-        // An unresolved name has no thread to open. It still gets a chip: an
-        // agent that wrote to a name nobody can find is worth seeing.
-        return agentId ? (
-          <button
-            key={summary.peer.id}
-            type="button"
-            className="wire__chip wire__chip--open"
-            style={style}
-            title={`Read the conversation with ${summary.peer.name}`}
-            onClick={() => onOpen(agentId)}
-          >
-            {face}
-          </button>
-        ) : (
-          <span key={summary.peer.id} className="wire__chip" style={style}>
-            {face}
-          </span>
-        );
-      })}
+    <div className="wire">
+      <div className="wire__chips">
+        {peers.map((summary) => (
+          <PeerChip key={summary.peer.id} summary={summary} onOpen={onOpen} />
+        ))}
+      </div>
     </div>
   );
 }
@@ -224,28 +241,42 @@ export function MessageModal({
 }
 
 /**
- * An agent composing a message to a peer.
+ * A peer composing a message to the agent whose channel this is.
  *
  * Deliberately textless. The finished message collapses into a burst row, so
  * streaming its text into a bubble first means the operator watches a wall of
  * text appear and then vanish, which is worse than never showing it.
+ *
+ * It is the chip that row will draw, with dots, and the words come from the
+ * same function so they cannot drift apart. Written in its own shape instead
+ * (an arrow, a sentence naming both ends) it moved, changed wording and grew an
+ * avatar the instant the message landed, which read as two separate events
+ * rather than one arriving.
+ *
+ * Only the sender is named because only the sender is news: agent-to-agent
+ * traffic is filed under the recipient, so a live peer stream in this channel
+ * is always addressed to the agent whose channel the operator already has open.
  */
-export function WritingRow({ from, to }: { from: WirePeer; to: WirePeer }) {
+export function WritingRow({ peer }: { peer: WirePeer }) {
   return (
     <div className="wire wire--writing">
-      <span className="wire__chip" style={{ "--accent": from.color } as React.CSSProperties}>
-        <span className="wire__arrow" aria-hidden="true">
-          ⇢
+      <div className="wire__chips">
+        <span
+          className="wire__chip"
+          title={`${peer.name} is writing`}
+          style={{ "--accent": peer.color } as React.CSSProperties}
+        >
+          <PeerFace
+            peer={peer}
+            label={summaryLabel({ peer, agentId: null, sent: 0, received: 1 })}
+          />
+          <span className="wire__dots" aria-hidden="true">
+            <i />
+            <i />
+            <i />
+          </span>
         </span>
-        <span className="wire__label">
-          {from.name} is writing to {to.name}
-        </span>
-        <span className="wire__dots" aria-hidden="true">
-          <i />
-          <i />
-          <i />
-        </span>
-      </span>
+      </div>
     </div>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1166,10 +1166,15 @@ button {
   padding: 0.3rem 1.5rem 0.3rem 1.15rem;
 }
 
+/* `min-width` so the bracket survives a row that fills. A burst of four peers
+   is as wide as the column, and rules that shrink to nothing on that row and
+   not on the one above it make two rows of the same kind look like two kinds
+   of row. */
 .wire::before,
 .wire::after {
   content: "";
   flex: 1;
+  min-width: 1.4rem;
   height: 1px;
   background: linear-gradient(to right, transparent, var(--edge), transparent);
 }
@@ -1236,15 +1241,22 @@ button {
   color: var(--pit);
 }
 
-/* A burst: one chip per peer, on one line. Several peers is the common case
-   for a fan-out, and they belong together: it was one moment of the run. */
-.wire--burst {
-  gap: 0.4rem;
+/* A burst: one chip per peer. Several peers is the common case for a fan-out
+   and they belong together, so they wrap among themselves rather than in the
+   row. As flex items of a wrapping `.wire` the two rules joined the wrap flow:
+   the left one was squeezed to a stub on the first line and the right one was
+   stranded beside whichever chip wrapped last, which drew one moment of the
+   run as two ragged rows pointing at nothing. */
+.wire__chips {
+  display: flex;
+  align-items: center;
   flex-wrap: wrap;
   justify-content: center;
+  gap: 0.4rem;
+  min-width: 0;
 }
 
-.wire--burst .wire__chip {
+.wire__chips .wire__chip {
   max-width: 100%;
 }
 
@@ -1697,7 +1709,19 @@ button {
   opacity: 0.5;
 }
 
+.wire--writing .wire__chip {
+  position: relative;
+}
+
+/* Outside the pill, so the live chip is the exact box of the settled one. As a
+   flex item the dots made it a dozen pixels wider, and a centred row slid
+   sideways the instant the message landed. The thing worth noticing there is
+   the message, not the row moving. */
 .wire__dots {
+  position: absolute;
+  left: 100%;
+  inset-block: 0;
+  margin-left: 0.4rem;
   display: inline-flex;
   gap: 2px;
   align-items: center;


### PR DESCRIPTION
Watching an agent write to a peer read as two events: the live row was a sentence with an arrow naming both ends and no avatar, while the row it settles into is a chip with the peer's face and different words, so a message arriving moved sideways, renamed itself and grew a face. The live row is now that chip with dots, and its words come from `summaryLabel` so the two cannot drift apart; naming both ends was redundant because `channel_for` files agent-to-agent traffic under the recipient, so a live peer stream is always addressed to the agent whose channel is already open. The dots sit outside the pill, since as a flex item they made the live chip a dozen pixels wider than the settled one and slid a centred row sideways on arrival.

Separately, a burst of three or more came apart: the rules either side of a wire row are `.wire` pseudo-elements and `.wire--burst` set `flex-wrap` on that same flex row, so they were laid out with the chips (left rule squeezed to a stub, right one stranded beside whichever chip wrapped last), and the chips now sit in one child that wraps among themselves with the rules keeping a `min-width`. Two new tests cover both halves and each fails against the old markup; the layout itself was checked in a browser against the real stylesheet at two column widths, which is not something jsdom can see.