### PR TITLE
feat: a file in a chat is shown, not just named

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,39 @@ file formats than this runtime ever will. When placing fails the model is told
 so in words, since an agent that hears nothing describes a document it never
 read.
 
+**A preview reads the bytes over a URL, which is the exception that keeps the
+rule.** The webview has to draw a file to show one, and the reason bytes stay
+out of IPC is that IPC is where the transcript travels in bulk. So they do not
+go that way: `guacfile://localhost/{digest}/{name}` is answered out of the store
+by `app.rs`, fetched once by the one element drawing it and only while that
+element is on screen. A digest arrives from the webview there and is joined onto
+a path, so anything that is not 64 hex characters is refused before the join,
+not after. The name in the URL picks the type of the answer and nothing else:
+the bytes are found by content, and renaming a file cannot turn it into another
+one. If you add a way for the renderer to get at a file, it goes through this
+scheme, and the CSP has to name it or the element silently draws nothing.
+
+**WebKit will not take a custom scheme in a frame, so a document is copied into
+one.** An `img` and a `fetch` on `guacfile:` are allowed by naming the scheme in
+the CSP; a frame is refused whatever you write there, as a scheme source, as a
+host, or through `default-src`, and it is refused silently: no violation event,
+no console line, just a frame that never asks for anything. A PDF is drawn by
+the webview's own viewer and that viewer only runs in a frame, so `localCopy`
+fetches the document over the scheme as usual and hands the frame a `blob:` URL
+instead. That is the only place in this app where a file's bytes sit in the
+renderer, which is why the copy is made when the frame is near the viewport and
+revoked when it goes. Do not "simplify" it back to a direct `src`: it will pass
+every test in this repo and draw an empty rectangle.
+
+**A dropped file is stored before it is sent, and the send carries a
+reference.** `stage_files` runs on the drop. That is what refuses a 40 MB
+archive while the operator is still holding it rather than failing the message
+they went on to write, and what lets a picture be shown back to them, since by
+then it has an address. One file failing does not refuse the four beside it.
+`send_message` then resolves each digest and name against the store again: the
+size and the type on a message are read off the disk, never taken from the
+webview. A staged file that is never sent stays, like every other file here.
+
 **Every event is an IPC hop and a render, so tokens are coalesced before they
 leave.** A model writes faster than a screen refreshes. One event per token
 spent the operator's main thread on work no eye could resolve, and with five

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -267,6 +267,41 @@ which is where an agent that *produced* a document has it. The operator's end is
 the same pipe: `dragDropEnabled` hands Rust the dropped paths, so the bytes are
 read on the Rust side and never enter the webview.
 
+**A drop is taken into the store before anything is sent.** `stage_files` runs
+on the drop, which is what lets the app refuse a 40 MB archive while the
+operator is still holding it rather than failing the message they went on to
+write, and lets it show a picture back to them, since by then it has an address.
+One file failing does not refuse the rest of the drop. What the send then
+carries is a digest and a name, and the runtime resolves both against its own
+store: the size and the type on the message are read off the disk, not taken
+from the webview.
+
+**The webview reads a file over a URL, not over IPC.** `guacfile://localhost/
+{digest}/{name}` is answered out of the file store by `app.rs`, so a preview is
+fetched once, by the one element drawing it, only while that element is on
+screen, and the webview caches and ranges it. Handing the same bytes back over
+IPC would give up exactly what content-addressing them bought: IPC is where the
+transcript travels, in bulk. The scheme is also narrower than Tauri's asset
+protocol, which opens a scoped part of the disk; nothing is addressable here but
+a digest this app stored, and a digest that is not 64 hex characters is refused
+before it is ever joined onto a path. The name in the URL decides the type of
+the answer and nothing else.
+
+A transcript draws what it can of a file rather than naming it: a picture, a
+document's first page in the webview's own viewer, the first lines of anything
+textual, and for the rest a row saying what it is. Each opens a full view, and
+each offers a copy into the downloads folder, whose path is said out loud
+because a file saved somewhere the operator has to go looking for has not really
+been saved.
+
+One exception, and it is WebKit's. A custom scheme is allowed in an `img` and a
+`fetch` if the CSP names it, and refused in a frame however it is named, with no
+violation event and no console line to say so. A PDF is drawn by the webview's
+own viewer and that viewer only runs in a frame, so a document is fetched over
+the scheme like everything else and handed to the frame as a `blob:` URL. That
+is the one place a file's bytes sit in the renderer: the copy is made when the
+frame comes near the viewport and revoked when it leaves.
+
 Two limits worth knowing: 25 MB in, and 8 MB onto a machine, because bytes reach
 a sandbox as base64 inside a shell command. A real upload endpoint is the fix
 for the second.

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -6,7 +6,8 @@
 
 use std::sync::Arc;
 
-use tauri::{Emitter, Manager};
+use tauri::http::{Request, Response};
+use tauri::{Emitter, Manager, UriSchemeContext};
 
 use crate::commands::{self, AppState};
 use crate::config;
@@ -33,6 +34,76 @@ impl EventSink for TauriSink {
     }
 }
 
+/// The scheme a preview is addressed on: `guacfile://localhost/{digest}/{name}`.
+///
+/// Its own scheme rather than a command returning bytes. A transcript crosses
+/// IPC in bulk, forty messages into a prompt and hundreds into the activity
+/// view, which is the whole reason a document is a digest in an envelope rather
+/// than the document; handing those same bytes back over the same channel to
+/// draw a thumbnail would give it up. A URL is fetched once, by one element,
+/// only while it is on screen, and the webview caches and ranges it.
+///
+/// It is also narrower than the asset protocol, which would open a scoped part
+/// of the disk. Nothing is addressable here but a digest this app stored.
+const FILE_SCHEME: &str = "guacfile";
+
+/// Serves one stored file to the webview.
+fn serve_file(
+    context: UriSchemeContext<'_, tauri::Wry>,
+    request: Request<Vec<u8>>,
+) -> Response<Vec<u8>> {
+    let refuse = |status: u16, why: &str| {
+        Response::builder()
+            .status(status)
+            .header("content-type", "text/plain; charset=utf-8")
+            .body(why.as_bytes().to_vec())
+            .expect("a refusal is a valid response")
+    };
+
+    // A request can in principle arrive before `setup` has managed the state,
+    // and a window that asks too early should be told to come back rather than
+    // take the app down with it.
+    let Some(state) = context.app_handle().try_state::<AppState>() else {
+        return refuse(503, "The file store is not open yet.");
+    };
+
+    let range = request.headers().get("range").and_then(|value| value.to_str().ok());
+    let target = request.uri().path().trim_start_matches('/');
+    match state.runtime.files().serve(target, range) {
+        Ok(served) => {
+            // A preview that comes up blank is either a request that never
+            // happened, which means the CSP, or one that was answered wrongly.
+            // The two look identical on screen and nowhere else.
+            tracing::debug!(
+                target,
+                range,
+                served.status,
+                bytes = served.body.len(),
+                "served a file"
+            );
+            let mut response = Response::builder()
+                .status(served.status)
+                .header("content-type", served.mime)
+                // Said even on a whole-file answer: a PDF viewer asks for the
+                // tail first, and one that is told ranges are unavailable
+                // re-reads the document from the start for every page.
+                .header("accept-ranges", "bytes")
+                // The bytes are on this machine already and addressed by their
+                // own content, so nothing they could be revalidated against
+                // will ever have changed.
+                .header("cache-control", "private, max-age=31536000, immutable");
+            if let Some(content_range) = served.content_range {
+                response = response.header("content-range", content_range);
+            }
+            response.body(served.body).expect("a stored file is a valid response")
+        }
+        Err(err) => {
+            tracing::debug!(%err, target, "refused a file the webview asked for");
+            refuse(404, "No file here with that content.")
+        }
+    }
+}
+
 pub fn run() {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -51,6 +122,7 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .register_uri_scheme_protocol(FILE_SCHEME, serve_file)
         .setup(move |app| {
             let data_dir = app.path().app_data_dir()?;
             let config_dir = app.path().app_config_dir()?;
@@ -128,7 +200,18 @@ pub fn run() {
                 "guac ready"
             );
 
-            app.manage(AppState { runtime, config_path });
+            // Where a saved attachment lands. The operating system's own
+            // downloads folder is the one place a person already knows to look;
+            // the home directory is the fallback for a machine that has no such
+            // folder, and the app's own data directory is where a copy goes
+            // rather than nowhere.
+            let downloads = app
+                .path()
+                .download_dir()
+                .or_else(|_| app.path().home_dir())
+                .unwrap_or_else(|_| data_dir.clone());
+
+            app.manage(AppState { runtime, config_path, downloads });
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -164,6 +247,8 @@ pub fn run() {
             commands::pair_messages,
             commands::conversation_flow,
             commands::search,
+            commands::stage_files,
+            commands::save_file,
             commands::send_message,
             commands::retry_turn,
             commands::clear_channel,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -14,6 +14,7 @@ use tauri::State;
 use crate::config::{self, AppConfig, RedactedConfig};
 use crate::domain::agent::{copy_name, AgentCard, AgentDraft, Lifecycle};
 use crate::domain::approval::{Approval, ApprovalState, Decision, ProtectedAction};
+use crate::domain::attachment::Attachment;
 use crate::domain::connector::{Connector, ConnectorDraft};
 use crate::domain::envelope::Envelope;
 use crate::domain::group::{Group, GroupDraft};
@@ -31,6 +32,10 @@ use crate::runtime::Runtime;
 pub struct AppState {
     pub runtime: Runtime,
     pub config_path: PathBuf,
+    /// Where a saved copy of an attachment lands. Resolved once at startup:
+    /// the operating system's own downloads folder is the one place a person
+    /// already knows to look.
+    pub downloads: PathBuf,
 }
 
 /// A structured error the UI can render as more than a toast.
@@ -552,37 +557,99 @@ pub fn search(state: State<'_, AppState>, query: String, limit: Option<u32>) -> 
     Ok(state.runtime.store().search(query.trim(), limit.unwrap_or(20).min(100))?)
 }
 
-/// Sends the operator's message, with anything they dropped on the window.
+/// What became of a drop.
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Staged {
+    pub attached: Vec<Attachment>,
+    /// One line per file that could not be taken, saying which and why.
+    pub refused: Vec<String>,
+}
+
+/// Takes what the operator dropped on the window into the store, there and then.
 ///
-/// `files` are paths on the operator's own disk, never bytes: the webview hands
-/// over what was dropped and this side reads it, so a document never crosses
-/// IPC and never sits in the renderer's memory.
+/// On the drop rather than on the send, for two reasons they feel. A file too
+/// big to send is refused while they are still holding it, instead of failing a
+/// message they have since written; and a picture that is already stored has an
+/// address, so it can be shown back to them before it goes. What is staged and
+/// never sent is the same leftover as a file whose message was deleted, and the
+/// store has always kept those.
+///
+/// `paths` are on the operator's own disk, never bytes: this side reads them,
+/// so a document never crosses IPC and never sits in the renderer's memory.
+#[tauri::command]
+pub fn stage_files(state: State<'_, AppState>, paths: Vec<String>) -> Reply<Staged> {
+    let mut staged = Staged::default();
+    for path in &paths {
+        match state.runtime.files().take(std::path::Path::new(path)) {
+            Ok(file) => staged.attached.push(file),
+            // One file out of five failing does not refuse the other four. The
+            // operator picked all of them deliberately, and the one that cannot
+            // go is named so they know which it was.
+            Err(err) => staged.refused.push(err.to_string()),
+        }
+    }
+    Ok(staged)
+}
+
+/// A file the operator has already dropped, as the webview refers to it.
+///
+/// Two fields and no more: which bytes, and what to call them. Everything else
+/// about an attachment is worked out on this side.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileRef {
+    pub digest: String,
+    pub name: String,
+}
+
+/// Sends the operator's message, with anything they attached to it.
+///
+/// The files are already in the store by now: `stage_files` put them there when
+/// they were dropped. This resolves each one again rather than trusting what
+/// came back over IPC, so a message carries a file the operator actually has.
 #[tauri::command]
 pub fn send_message(
     state: State<'_, AppState>,
     agent_id: AgentId,
     text: String,
-    files: Option<Vec<String>>,
+    files: Option<Vec<FileRef>>,
 ) -> Reply<RunId> {
     let trimmed = text.trim();
-    let paths = files.unwrap_or_default();
+    let files = files.unwrap_or_default();
     // A file on its own is a message. "Here, read this" with the document
     // attached is the most natural way to send one, and rejecting it as empty
     // would be the app arguing with the operator.
-    if trimmed.is_empty() && paths.is_empty() {
+    if trimmed.is_empty() && files.is_empty() {
         return Err(CommandError::new("validation", "message must not be empty"));
     }
 
     let mut attached = Vec::new();
-    for path in &paths {
-        match state.runtime.files().take(std::path::Path::new(path)) {
+    for file in &files {
+        match state.runtime.files().reference(&file.digest, &file.name) {
             Ok(file) => attached.push(file),
-            // Named, because the operator picked this file deliberately and a
+            // Named, because the operator attached this file deliberately and a
             // message that quietly went without it is worse than an error.
             Err(err) => return Err(CommandError::new("file", err.to_string())),
         }
     }
     Ok(state.runtime.send_from_human_with(agent_id, trimmed, attached)?)
+}
+
+/// Puts a copy of a stored file where a person can get at it, and says where.
+///
+/// The downloads folder, not a save dialog: the operator asked for the file,
+/// not for a conversation about where to put it. The path goes back so the app
+/// can say where to look, since a copy that lands somewhere unannounced is a
+/// copy they have to go and find.
+#[tauri::command]
+pub fn save_file(state: State<'_, AppState>, digest: String, name: String) -> Reply<String> {
+    let saved = state
+        .runtime
+        .files()
+        .save_copy(&digest, &name, &state.downloads)
+        .map_err(|err| CommandError::new("file", err.to_string()))?;
+    Ok(saved.display().to_string())
 }
 
 /// Sends a failed turn's message again, as a new run.

--- a/src-tauri/src/files.rs
+++ b/src-tauri/src/files.rs
@@ -27,6 +27,10 @@ pub enum FileError {
     TooBig { name: String, bytes: u64, max: u64 },
     #[error("a file must have a name")]
     Unnamed,
+    // Dropping a folder is a thing people do, and the reason it cannot work is
+    // not something they should have to infer from a read error.
+    #[error("{name} is a folder. Attach the files inside it instead")]
+    IsFolder { name: String },
     #[error("no file here with that content")]
     Unknown,
     #[error("could not use the file store at {path}: {source}")]
@@ -91,7 +95,11 @@ impl FileStore {
             .ok_or(FileError::Unnamed)?;
         // Checked before reading rather than after: the point of a limit is not
         // to load a gigabyte into memory and then object to it.
-        let size = fs::metadata(source).map_err(|e| FileError::io(source, e))?.len();
+        let about = fs::metadata(source).map_err(|e| FileError::io(source, e))?;
+        if about.is_dir() {
+            return Err(FileError::IsFolder { name });
+        }
+        let size = about.len();
         if size > MAX_FILE_BYTES {
             return Err(FileError::TooBig { name, bytes: size, max: MAX_FILE_BYTES });
         }
@@ -99,12 +107,69 @@ impl FileStore {
         self.put(&name, &bytes)
     }
 
+    /// What a message should carry for a file that is already stored.
+    ///
+    /// Everything but "which bytes" and "what to call it" is worked out here
+    /// rather than taken from the caller. The webview holds a reference to a
+    /// file it was shown, not authority over what that file is, so the size
+    /// comes off the disk and the type comes off the name.
+    pub fn reference(&self, digest: &str, name: &str) -> Result<Attachment, FileError> {
+        let name = clean_name(name).ok_or(FileError::Unnamed)?;
+        let path = self.stored(digest).ok_or(FileError::Unknown)?;
+        let bytes = fs::metadata(&path).map_err(|e| FileError::io(&path, e))?.len();
+        Ok(Attachment {
+            digest: digest.to_string(),
+            name: name.clone(),
+            mime: mime_for(&name),
+            bytes,
+        })
+    }
+
     pub fn read(&self, digest: &str) -> Result<Vec<u8>, FileError> {
-        let path = self.path(digest);
-        if !path.exists() {
-            return Err(FileError::Unknown);
-        }
+        let path = self.stored(digest).ok_or(FileError::Unknown)?;
         fs::read(&path).map_err(|e| FileError::io(&path, e))
+    }
+
+    /// Answers the webview's request for one stored file.
+    ///
+    /// `target` is the path of a preview URL, still percent-encoded:
+    /// `{digest}/{name}`. The name only decides the type that goes back, and a
+    /// caller that renames a file cannot turn it into a different one, because
+    /// the bytes are addressed by their content and nothing else.
+    ///
+    /// Ranges are answered because a webview's own PDF viewer asks for them.
+    pub fn serve(&self, target: &str, range: Option<&str>) -> Result<Served, FileError> {
+        let target = decode(target);
+        let (digest, name) = target.split_once('/').unwrap_or((target.as_str(), ""));
+        let bytes = self.read(digest)?;
+        let mime = mime_for(name);
+
+        match parse_range(range.unwrap_or_default(), bytes.len() as u64) {
+            Some((start, end)) => {
+                let total = bytes.len();
+                Ok(Served {
+                    status: 206,
+                    mime,
+                    body: bytes[start as usize..=end as usize].to_vec(),
+                    content_range: Some(format!("bytes {start}-{end}/{total}")),
+                })
+            }
+            None => Ok(Served { status: 200, mime, body: bytes, content_range: None }),
+        }
+    }
+
+    /// Writes a copy of a stored file where a person can get at it.
+    ///
+    /// Never overwrites. Saving the same document twice means the operator
+    /// wants a second copy or has lost the first, and neither is a reason for
+    /// this app to destroy a file it did not write.
+    pub fn save_copy(&self, digest: &str, name: &str, into: &Path) -> Result<PathBuf, FileError> {
+        let name = clean_name(name).ok_or(FileError::Unnamed)?;
+        let bytes = self.read(digest)?;
+        fs::create_dir_all(into).map_err(|e| FileError::io(into, e))?;
+        let path = free_path(into, &name, digest);
+        fs::write(&path, &bytes).map_err(|e| FileError::io(&path, e))?;
+        Ok(path)
     }
 
     /// The text of a file, for a prompt, cut at `limit` characters.
@@ -127,6 +192,100 @@ impl FileStore {
         let (prefix, rest) = digest.split_at(2.min(digest.len()));
         self.root.join(prefix).join(rest)
     }
+
+    /// Where a stored file is, or `None` when nothing is stored there.
+    ///
+    /// The gate on every read. A digest now arrives from the webview asking for
+    /// a preview, and it is joined onto a directory: anything that is not the
+    /// 64 hex characters of a SHA-256 is refused before that join rather than
+    /// after it, so nothing that means something to a path ever reaches one.
+    fn stored(&self, digest: &str) -> Option<PathBuf> {
+        if digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return None;
+        }
+        let path = self.path(digest);
+        path.exists().then_some(path)
+    }
+}
+
+/// One stored file, on its way to the webview.
+///
+/// A preview is bytes, and bytes do not travel over IPC in this app: the
+/// webview reads a file over a URL scheme of its own instead, and this is what
+/// that scheme hands back. `app.rs` turns it into an HTTP response.
+#[derive(Debug, PartialEq)]
+pub struct Served {
+    pub status: u16,
+    pub mime: String,
+    /// The whole file, or the slice a range asked for.
+    pub body: Vec<u8>,
+    /// `content-range`, on a partial answer only.
+    pub content_range: Option<String>,
+}
+
+/// The range a webview asks for: `bytes=first-last`, with either end implied.
+///
+/// Anything else, a range past the end included, is `None` and gets the whole
+/// file. That is a legal answer to a range request and a better one than an
+/// error, which a picture cannot show and a PDF viewer gives up on.
+fn parse_range(header: &str, total: u64) -> Option<(u64, u64)> {
+    if total == 0 {
+        return None;
+    }
+    let spec = header.trim().strip_prefix("bytes=")?.split(',').next()?.trim();
+    let (first, last) = spec.split_once('-')?;
+    let (start, end) = match (first.trim(), last.trim()) {
+        // A suffix range: the last n bytes, however many there turn out to be.
+        ("", n) => (total.saturating_sub(n.parse::<u64>().ok()?), total - 1),
+        (s, "") => (s.parse().ok()?, total - 1),
+        (s, e) => (s.parse().ok()?, e.parse::<u64>().ok()?.min(total - 1)),
+    };
+    (start <= end && start < total).then_some((start, end))
+}
+
+/// Percent-decoding, for the one thing that arrives encoded: the name in a
+/// preview URL, which holds spaces and brackets often enough to matter.
+fn decode(raw: &str) -> String {
+    let bytes = raw.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut at = 0;
+    while at < bytes.len() {
+        let pair = (at + 2 < bytes.len()).then(|| &raw[at + 1..at + 3]);
+        match (bytes[at], pair.and_then(|p| u8::from_str_radix(p, 16).ok())) {
+            (b'%', Some(byte)) => {
+                out.push(byte);
+                at += 3;
+            }
+            (byte, _) => {
+                out.push(byte);
+                at += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// `brief.pdf`, then `brief (2).pdf`, then `brief (3).pdf`.
+///
+/// The digest is the last resort rather than the first, because a person
+/// looking in their downloads folder should see the name they know. Two files
+/// that reach the same digest-suffixed name hold the same bytes by definition,
+/// so the one write that can land on an existing file cannot lose anything.
+fn free_path(dir: &Path, name: &str, digest: &str) -> PathBuf {
+    let first = dir.join(name);
+    if !first.exists() {
+        return first;
+    }
+    let (stem, extension) = match name.rsplit_once('.') {
+        Some((stem, extension)) if !stem.is_empty() => (stem, format!(".{extension}")),
+        _ => (name, String::new()),
+    };
+    (2..100)
+        .map(|n| dir.join(format!("{stem} ({n}){extension}")))
+        .find(|candidate| !candidate.exists())
+        .unwrap_or_else(|| {
+            dir.join(format!("{stem} ({}){extension}", &digest[..8.min(digest.len())]))
+        })
 }
 
 /// The name as it will be shown and as it will land on a machine.
@@ -213,6 +372,142 @@ mod tests {
     fn reading_something_that_was_never_stored_says_so_rather_than_panicking() {
         let (files, _dir) = store();
         assert!(matches!(files.read(&"a".repeat(64)), Err(FileError::Unknown)));
+    }
+
+    #[test]
+    fn a_folder_is_refused_with_something_a_person_can_do_about_it() {
+        // People drop folders. "Is a directory (os error 21)" is a true answer
+        // and a useless one.
+        let (files, dir) = store();
+        let err = files.take(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("folder"), "{err}");
+        assert!(err.to_string().contains("files inside"), "{err}");
+    }
+
+    #[test]
+    fn a_preview_gets_the_bytes_and_the_type_the_name_implies() {
+        let (files, _dir) = store();
+        let stored = files.put("brief.pdf", b"%PDF-1.7 not really").unwrap();
+
+        let served = files.serve(&format!("{}/brief.pdf", stored.digest), None).unwrap();
+        assert_eq!(served.status, 200);
+        assert_eq!(served.mime, "application/pdf");
+        assert_eq!(served.body, b"%PDF-1.7 not really");
+        assert_eq!(served.content_range, None);
+    }
+
+    #[test]
+    fn a_name_with_spaces_arrives_encoded_and_is_still_the_same_file() {
+        // The webview builds the URL with `encodeURIComponent`, so the
+        // separator and every space in the name reach this side as escapes.
+        let (files, _dir) = store();
+        let stored = files.put("last quarter (final).pdf", b"x").unwrap();
+
+        let served = files
+            .serve(&format!("{}%2Flast%20quarter%20(final).pdf", stored.digest), None)
+            .unwrap();
+        assert_eq!(served.mime, "application/pdf");
+        assert_eq!(served.body, b"x");
+    }
+
+    #[test]
+    fn a_digest_that_is_not_a_digest_never_reaches_the_filesystem() {
+        // This one arrives from the webview, and it is joined onto a path.
+        let (files, dir) = store();
+        std::fs::write(dir.path().join("secret"), b"private").unwrap();
+
+        for target in
+            ["../../secret/x.txt", "..%2F..%2Fsecret%2Fx.txt", "/etc/passwd/x.txt", "a/x.txt", ""]
+        {
+            assert!(
+                matches!(files.serve(target, None), Err(FileError::Unknown)),
+                "{target} was not refused"
+            );
+        }
+    }
+
+    #[test]
+    fn a_range_gets_the_slice_it_asked_for_and_says_which_slice_it_is() {
+        // A webview's own PDF viewer asks in ranges, and a viewer handed the
+        // whole file for every range request re-reads it once per page.
+        let (files, _dir) = store();
+        let stored = files.put("doc.pdf", b"0123456789").unwrap();
+        let target = format!("{}/doc.pdf", stored.digest);
+
+        let served = files.serve(&target, Some("bytes=2-5")).unwrap();
+        assert_eq!(served.status, 206);
+        assert_eq!(served.body, b"2345");
+        assert_eq!(served.content_range.as_deref(), Some("bytes 2-5/10"));
+
+        let open_ended = files.serve(&target, Some("bytes=7-")).unwrap();
+        assert_eq!(open_ended.body, b"789");
+        assert_eq!(open_ended.content_range.as_deref(), Some("bytes 7-9/10"));
+
+        // The tail, which is where a PDF keeps the table it opens with.
+        let suffix = files.serve(&target, Some("bytes=-3")).unwrap();
+        assert_eq!(suffix.body, b"789");
+        assert_eq!(suffix.content_range.as_deref(), Some("bytes 7-9/10"));
+    }
+
+    #[test]
+    fn a_range_that_makes_no_sense_gets_the_whole_file_rather_than_an_error() {
+        // Ignoring a range is a legal answer and a picture can show it. An
+        // error is a broken image icon.
+        let (files, _dir) = store();
+        let stored = files.put("doc.pdf", b"0123456789").unwrap();
+        let target = format!("{}/doc.pdf", stored.digest);
+
+        for header in ["bytes=50-60", "bytes=9-2", "items=0-1", "bytes=x-y", "", "bytes=-"] {
+            let served = files.serve(&target, Some(header)).unwrap();
+            assert_eq!(served.status, 200, "{header} should have been answered in full");
+            assert_eq!(served.body.len(), 10, "{header}");
+        }
+
+        // Past the end but overlapping is still a slice, not a refusal.
+        let clamped = files.serve(&target, Some("bytes=8-99")).unwrap();
+        assert_eq!(clamped.body, b"89");
+        assert_eq!(clamped.content_range.as_deref(), Some("bytes 8-9/10"));
+    }
+
+    #[test]
+    fn a_reference_takes_the_bytes_and_the_name_and_works_out_the_rest() {
+        // The webview holds a reference to a file it was shown, not authority
+        // over what that file is.
+        let (files, _dir) = store();
+        let stored = files.put("sheet.csv", b"a,b,c").unwrap();
+
+        let referenced = files.reference(&stored.digest, "../sheet.csv").unwrap();
+        assert_eq!(referenced.name, "sheet.csv", "a name is cleaned wherever it comes from");
+        assert_eq!(referenced.mime, "text/csv", "the type follows the name, not the caller");
+        assert_eq!(referenced.bytes, 5, "and the size comes off the disk");
+
+        assert!(matches!(files.reference(&"b".repeat(64), "ghost.txt"), Err(FileError::Unknown)));
+    }
+
+    #[test]
+    fn a_saved_copy_keeps_its_name_and_never_overwrites_one_already_there() {
+        let (files, dir) = store();
+        let stored = files.put("brief.pdf", b"first").unwrap();
+        let downloads = dir.path().join("Downloads");
+
+        let first = files.save_copy(&stored.digest, "brief.pdf", &downloads).unwrap();
+        assert_eq!(first.file_name().unwrap(), "brief.pdf");
+        assert_eq!(std::fs::read(&first).unwrap(), b"first");
+
+        let again = files.save_copy(&stored.digest, "brief.pdf", &downloads).unwrap();
+        assert_eq!(again.file_name().unwrap(), "brief (2).pdf");
+        assert!(first.exists(), "the first copy is still there");
+    }
+
+    #[test]
+    fn saving_something_that_is_not_stored_says_so_before_it_writes_anything() {
+        let (files, dir) = store();
+        let downloads = dir.path().join("Downloads");
+        assert!(matches!(
+            files.save_copy(&"c".repeat(64), "ghost.pdf", &downloads),
+            Err(FileError::Unknown)
+        ));
+        assert!(!downloads.join("ghost.pdf").exists());
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data: asset: http://asset.localhost; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost; frame-src http://127.0.0.1:* http://localhost:*"
+      "csp": "default-src 'self'; img-src 'self' data: guacfile: http://guacfile.localhost; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost guacfile: http://guacfile.localhost; frame-src http://127.0.0.1:* http://localhost:* blob:"
     }
   },
   "bundle": {

--- a/src/components/Composer.test.tsx
+++ b/src/components/Composer.test.tsx
@@ -1,13 +1,34 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { Attachment, Staged } from "../lib/types";
 import { Composer } from "./Composer";
 
 /** The drop handlers the component registered, so a test can fire one. */
 let dropped: ((paths: string[]) => void) | null = null;
 let over: ((inside: boolean) => void) | null = null;
 
+/** What the runtime says came of a drop. Set per test where it matters. */
+let staging: (paths: string[]) => Promise<Staged> = async (paths) => ({
+  attached: paths.map(stored),
+  refused: [],
+});
+
+/** A file as the store would hand it back: named, typed, and addressed. */
+function stored(path: string): Attachment {
+  const name = path.split("/").pop() ?? path;
+  return {
+    // Content addressing, faked by the name: two copies of one document in
+    // different folders are one attachment, which is the case worth testing.
+    digest: `digest-of-${name}`,
+    name,
+    mime: name.endsWith(".png") ? "image/png" : "text/plain",
+    bytes: 12,
+  };
+}
+
 vi.mock("../lib/ipc", () => ({
+  api: { stageFiles: (paths: string[]) => staging(paths) },
   onFileDrop: async (handlers: {
     dropped: (paths: string[]) => void;
     over: (inside: boolean) => void;
@@ -24,6 +45,7 @@ describe("Composer", () => {
   beforeEach(() => {
     dropped = null;
     over = null;
+    staging = async (paths) => ({ attached: paths.map(stored), refused: [] });
   });
 
   async function draw(onSend = vi.fn(async () => {})) {
@@ -44,7 +66,7 @@ describe("Composer", () => {
     await type("have a look");
     await click("Send");
 
-    expect(onSend).toHaveBeenCalledWith("have a look", ["/Users/robert/Documents/proposal.docx"]);
+    expect(onSend).toHaveBeenCalledWith("have a look", [stored("proposal.docx")]);
   });
 
   it("lets a file be sent with nothing typed", async () => {
@@ -56,7 +78,7 @@ describe("Composer", () => {
     await drop(["/tmp/agenda.txt"]);
     await click("Send");
 
-    expect(onSend).toHaveBeenCalledWith("", ["/tmp/agenda.txt"]);
+    expect(onSend).toHaveBeenCalledWith("", [stored("agenda.txt")]);
   });
 
   it("drops the attachments once they have gone", async () => {
@@ -70,23 +92,25 @@ describe("Composer", () => {
 
   it("keeps them when the send fails, so nothing has to be found again", async () => {
     const onSend = vi.fn(async () => {
-      throw new Error("the file was too big");
+      throw new Error("that agent has been deleted");
     });
     render(<Composer placeholder="Message Manager" onSend={onSend} />);
     await waitFor(() => expect(dropped).not.toBeNull());
 
-    await drop(["/tmp/enormous.zip"]);
+    await drop(["/tmp/notes.md"]);
     await type("here");
     await click("Send");
 
-    await waitFor(() => expect(screen.getByText("enormous.zip")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("notes.md")).toBeTruthy());
     expect((screen.getByRole("combobox") as HTMLTextAreaElement).value).toBe("here");
   });
 
-  it("takes one copy of a file dropped twice", async () => {
+  it("takes one copy of a document dropped twice from two places", async () => {
+    // By content, not by path. A second drop is a person making sure, and one
+    // document saved in two folders is still one document.
     await draw();
     await drop(["/tmp/same.md"]);
-    await drop(["/tmp/same.md"]);
+    await drop(["/Users/robert/Desktop/same.md"]);
 
     expect(screen.getAllByText("same.md")).toHaveLength(1);
   });
@@ -98,7 +122,45 @@ describe("Composer", () => {
 
     expect(screen.queryByText("wrong.md")).toBeNull();
     await click("Send");
-    expect(onSend).toHaveBeenCalledWith("", ["/tmp/right.md"]);
+    expect(onSend).toHaveBeenCalledWith("", [stored("right.md")]);
+  });
+
+  it("names the file it could not take and keeps the ones it could", async () => {
+    // Refused on the drop rather than on the send: the operator is still
+    // holding the file, and one document over the limit must not cost them the
+    // message they have written or the four attachments beside it.
+    staging = async () => ({
+      attached: [stored("/tmp/brief.md")],
+      refused: ["enormous.zip is 40000000 bytes, and the limit is 26214400"],
+    });
+    const onSend = await draw();
+    await drop(["/tmp/brief.md", "/tmp/enormous.zip"]);
+
+    expect(screen.getByText(/enormous.zip is 40000000 bytes/)).toBeTruthy();
+    expect(screen.getByText("brief.md")).toBeTruthy();
+
+    await click("Send");
+    expect(onSend).toHaveBeenCalledWith("", [stored("brief.md")]);
+  });
+
+  it("says so when the drop itself failed", async () => {
+    staging = async () => {
+      throw new Error("could not use the file store");
+    };
+    await draw();
+    await drop(["/tmp/anything.md"]);
+
+    await waitFor(() => expect(screen.getByText(/could not use the file store/)).toBeTruthy());
+  });
+
+  it("shows a dropped picture rather than only its name", async () => {
+    // Three screenshots dropped together are three copies of one long
+    // timestamped name, and nothing else to tell them apart.
+    await draw();
+    await drop(["/tmp/shot.png"]);
+
+    const thumbnail = document.querySelector(".chip__thumb") as HTMLImageElement | null;
+    expect(thumbnail?.getAttribute("src")).toContain("digest-of-shot.png");
   });
 
   it("says where a dragged file will land while it is over the window", async () => {

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -1,20 +1,17 @@
 import { useEffect, useRef, useState } from "react";
 
 import { AgentAvatar } from "../avatars/AgentAvatar";
-import { onFileDrop } from "../lib/ipc";
+import { fileUrl, previewKind, readableSize } from "../lib/files";
+import { api, onFileDrop } from "../lib/ipc";
 import { applyMention, matchMentions, mentionAt } from "../lib/mentions";
 import { useLiveAgents } from "../lib/store";
+import { type Attachment, errorMessage } from "../lib/types";
 
 interface Props {
   placeholder: string;
   disabled?: boolean;
   disabledReason?: string;
-  onSend: (text: string, files: string[]) => Promise<void>;
-}
-
-/** The last segment of a path, which is what a person calls the file. */
-function basename(path: string): string {
-  return path.split(/[/\\]/).pop() || path;
+  onSend: (text: string, files: Attachment[]) => Promise<void>;
 }
 
 export function Composer({ placeholder, disabled, disabledReason, onSend }: Props) {
@@ -23,21 +20,40 @@ export function Composer({ placeholder, disabled, disabledReason, onSend }: Prop
   const [caret, setCaret] = useState(0);
   const [highlighted, setHighlighted] = useState(0);
   const [dismissed, setDismissed] = useState(false);
-  const [files, setFiles] = useState<string[]>([]);
+  const [files, setFiles] = useState<Attachment[]>([]);
+  /** What was dropped and could not be taken, in the words the runtime used. */
+  const [refused, setRefused] = useState<string[]>([]);
   const [dragging, setDragging] = useState(false);
   const ref = useRef<HTMLTextAreaElement>(null);
 
   // Dropping anywhere on the window attaches to whatever channel is open,
   // because the alternative is a small target the operator has to aim at while
   // holding a file.
+  //
+  // The file is taken into the store on the drop rather than on the send, so a
+  // document too big to go is refused while they are still holding it and a
+  // picture can be shown back to them before it goes.
   useEffect(() => {
     if (disabled) return;
     const stopping = onFileDrop({
       over: setDragging,
-      dropped: (paths) =>
-        // Same file twice is one attachment: a second drop of the same
-        // document is a person making sure, not a request to send it twice.
-        setFiles((held) => [...held, ...paths.filter((p) => !held.includes(p))]),
+      dropped: (paths) => {
+        void api
+          .stageFiles(paths)
+          .then((staged) => {
+            // The same file twice is one attachment, by content rather than by
+            // path: a second drop is a person making sure, and one document
+            // saved in two places is still one document.
+            setFiles((held) => [
+              ...held,
+              ...staged.attached.filter(
+                (file) => !held.some((have) => have.digest === file.digest),
+              ),
+            ]);
+            setRefused(staged.refused);
+          })
+          .catch((error) => setRefused([errorMessage(error)]));
+      },
     });
     return () => {
       void stopping.then((stop) => stop());
@@ -89,6 +105,7 @@ export function Composer({ placeholder, disabled, disabledReason, onSend }: Prop
     // leaving the draft in place makes it look like nothing happened.
     setText("");
     setFiles([]);
+    setRefused([]);
     try {
       await onSend(body, files);
     } catch {
@@ -138,14 +155,43 @@ export function Composer({ placeholder, disabled, disabledReason, onSend }: Prop
     <div className="composer" data-dragging={dragging || undefined}>
       {files.length > 0 && (
         <ul className="composer__files" aria-label="Attached files">
-          {files.map((path) => (
-            <li key={path} className="chip">
-              <span className="chip__name">{basename(path)}</span>
+          {files.map((file) => (
+            <li key={file.digest} className="chip">
+              {previewKind(file.mime) === "image" && (
+                // The picture rather than its name: an operator who has dropped
+                // three screenshots cannot tell them apart from
+                // `Screenshot 2026-08-17 at 14.02.11.png` three times over.
+                <img className="chip__thumb" src={fileUrl(file)} alt="" />
+              )}
+              <span className="chip__name">{file.name}</span>
+              <span className="chip__size">{readableSize(file.bytes)}</span>
               <button
                 type="button"
                 className="chip__remove"
-                aria-label={`Remove ${basename(path)}`}
-                onClick={() => setFiles((held) => held.filter((p) => p !== path))}
+                aria-label={`Remove ${file.name}`}
+                onClick={() =>
+                  setFiles((held) => held.filter((have) => have.digest !== file.digest))
+                }
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {refused.length > 0 && (
+        // Said where the attachments are, not as a banner over the app: the
+        // operator is looking at what they just dropped, and the one that did
+        // not arrive belongs beside the ones that did.
+        <ul className="composer__refused" aria-label="Files that could not be attached">
+          {refused.map((why) => (
+            <li key={why} className="chip chip--error">
+              <span className="chip__text">{why}</span>
+              <button
+                type="button"
+                className="chip__remove"
+                aria-label={`Dismiss: ${why}`}
+                onClick={() => setRefused((held) => held.filter((line) => line !== why))}
               >
                 ×
               </button>

--- a/src/components/FileCard.test.tsx
+++ b/src/components/FileCard.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Attachment } from "../lib/types";
+import { FileCard } from "./FileCard";
+
+const saveFile = vi.fn(async (_digest: string, _name: string) => "/Users/robert/Downloads/x");
+const setBanner = vi.fn();
+
+vi.mock("../lib/ipc", () => ({
+  api: { saveFile: (digest: string, name: string) => saveFile(digest, name) },
+}));
+
+vi.mock("../lib/store", () => ({
+  useStore: { getState: () => ({ setBanner }) },
+}));
+
+/**
+ * A stored file. The digest follows the name, so two files in this suite are
+ * two files to the read cache, as they would be anywhere else.
+ */
+function file(name: string, mime: string, bytes = 2048): Attachment {
+  return { digest: name.padEnd(64, "0").slice(0, 64), name, mime, bytes };
+}
+
+const fetched = vi.fn();
+const made: string[] = [];
+const revoked: string[] = [];
+
+describe("FileCard", () => {
+  beforeEach(() => {
+    saveFile.mockClear();
+    setBanner.mockClear();
+    fetched.mockReset();
+    fetched.mockResolvedValue({
+      ok: true,
+      status: 206,
+      text: async () => "first line\nsecond",
+      blob: async () => new Blob(["%PDF-1.7"]),
+    });
+    globalThis.fetch = fetched as unknown as typeof fetch;
+
+    // jsdom has no object URLs. A document is handed to its frame as one,
+    // because WebKit will not take a custom scheme there.
+    made.length = 0;
+    revoked.length = 0;
+    URL.createObjectURL = vi.fn(() => {
+      const url = `blob:guaca/${made.length}`;
+      made.push(url);
+      return url;
+    });
+    URL.revokeObjectURL = vi.fn((url: string) => void revoked.push(url));
+  });
+
+  it("draws a picture rather than naming one", async () => {
+    render(<FileCard file={file("shot.png", "image/png")} />);
+
+    const drawn = screen.getByAltText("shot.png") as HTMLImageElement;
+    const stored = file("shot.png", "image/png");
+    expect(drawn.src).toContain(encodeURIComponent(`${stored.digest}/shot.png`));
+    // Three hundred messages open with a channel and the operator is looking
+    // at the last few.
+    expect(drawn.getAttribute("loading")).toBe("lazy");
+    expect(screen.getByText("2 KB")).toBeTruthy();
+  });
+
+  it("gives a document its first page, in a frame that does not take the click", async () => {
+    const { unmount } = render(<FileCard file={file("brief.pdf", "application/pdf")} />);
+
+    const page = (await screen.findByTitle("brief.pdf")) as HTMLIFrameElement;
+    // A copy of the document, not its address: WebKit refuses a custom scheme
+    // as a frame source whatever the CSP says, and a document's own viewer only
+    // runs in a frame. The bytes still arrive over the scheme.
+    expect(page.src).toBe(made[0]);
+    expect(fetched.mock.calls[0]?.[0]).toContain(encodeURIComponent("brief.pdf"));
+    // Focus and clicks belong to the button behind it, which is what opens the
+    // document. A frame that swallowed either would strand the file.
+    expect(page.getAttribute("tabindex")).toBe("-1");
+
+    // The one place a file's bytes sit in the renderer, and a transcript
+    // scrolls past a lot of documents.
+    unmount();
+    expect(revoked).toEqual([made[0]]);
+  });
+
+  it("says a document could not be read rather than leaving a grey box", async () => {
+    fetched.mockResolvedValue({ ok: false, status: 404, blob: async () => new Blob([]) });
+    render(<FileCard file={file("missing.pdf", "application/pdf")} />);
+
+    await waitFor(() => expect(screen.getByText(/could not be read/)).toBeTruthy());
+  });
+
+  it("reads the first lines of a text file into the transcript", async () => {
+    render(<FileCard file={file("notes.md", "text/markdown")} />);
+
+    await waitFor(() => expect(screen.getByText(/first line/)).toBeTruthy());
+    const asked = fetched.mock.calls[0] ?? [];
+    expect(asked[0]).toContain("guacfile:");
+    expect(asked[1].headers.Range).toBe("bytes=0-2047");
+  });
+
+  it("names anything it cannot draw and offers no preview it does not have", () => {
+    render(<FileCard file={file("archive.zip", "application/zip")} />);
+
+    expect(screen.getByText("archive.zip")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Open archive.zip" })).toBeNull();
+  });
+
+  it("opens the full view on the name, whatever the file is", async () => {
+    render(<FileCard file={file("archive.zip", "application/zip")} />);
+    fireEvent.click(screen.getByRole("button", { name: "archive.zip" }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.getAttribute("aria-label")).toBe("archive.zip");
+    // Clicking a file that cannot be shown has to leave the operator somewhere
+    // better than where they were.
+    expect(screen.getByText(/Save a copy/)).toBeTruthy();
+  });
+
+  it("closes the full view on Escape", () => {
+    render(<FileCard file={file("shot.png", "image/png")} />);
+    fireEvent.click(screen.getByRole("button", { name: "Open shot.png" }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("saves a copy and says where it went", async () => {
+    saveFile.mockResolvedValue("/Users/robert/Downloads/brief.pdf");
+    render(<FileCard file={file("brief.pdf", "application/pdf")} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(saveFile).toHaveBeenCalledWith(
+        file("brief.pdf", "application/pdf").digest,
+        "brief.pdf",
+      ),
+    );
+    // A file saved somewhere the operator has to go looking for has not really
+    // been saved.
+    expect(setBanner).toHaveBeenCalledWith({
+      tone: "ok",
+      text: "Saved to /Users/robert/Downloads/brief.pdf",
+    });
+  });
+
+  it("says why a copy could not be saved", async () => {
+    saveFile.mockRejectedValue({ kind: "file", message: "no file here with that content" });
+    render(<FileCard file={file("brief.pdf", "application/pdf")} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(setBanner).toHaveBeenCalledWith({
+        tone: "error",
+        text: "no file here with that content",
+      }),
+    );
+  });
+
+  it("says a text file could not be read rather than showing an empty box", async () => {
+    fetched.mockRejectedValue(new Error("gone"));
+    render(<FileCard file={file("unreadable.md", "text/markdown")} />);
+
+    await waitFor(() => expect(screen.getByText(/could not be read/)).toBeTruthy());
+  });
+});

--- a/src/components/FileCard.tsx
+++ b/src/components/FileCard.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useRef, useState } from "react";
+
+import {
+  fileUrl,
+  localCopy,
+  PREVIEW_BYTES,
+  previewKind,
+  readableSize,
+  readFileText,
+  SNIPPET_BYTES,
+} from "../lib/files";
+import { api } from "../lib/ipc";
+import { useStore } from "../lib/store";
+import { type Attachment, errorMessage } from "../lib/types";
+
+/**
+ * A file on a message.
+ *
+ * Shown rather than named, because a document that arrives as a filename is a
+ * document the operator has to open something else to read. A picture is drawn,
+ * a PDF gets its first page, a text file gets its first lines, and anything
+ * this cannot draw says so and offers the one thing that always works. All four
+ * open a full view on a click.
+ *
+ * The bytes come over `guacfile:` rather than IPC: see `lib/files.ts`.
+ */
+export function FileCard({ file }: { file: Attachment }) {
+  const [open, setOpen] = useState(false);
+  const kind = previewKind(file.mime);
+
+  return (
+    <>
+      <div className="file" data-kind={kind}>
+        {kind !== "none" && (
+          <button
+            type="button"
+            className="file__view"
+            aria-label={`Open ${file.name}`}
+            onClick={() => setOpen(true)}
+          >
+            <Thumbnail file={file} />
+          </button>
+        )}
+        <div className="file__foot">
+          <button type="button" className="file__name" onClick={() => setOpen(true)}>
+            {file.name}
+          </button>
+          <span className="file__size">{readableSize(file.bytes)}</span>
+          <SaveButton file={file} />
+        </div>
+      </div>
+      {open && <FilePreview file={file} onClose={() => setOpen(false)} />}
+    </>
+  );
+}
+
+/**
+ * As much of a file as belongs in a transcript.
+ *
+ * Bounded in height on purpose: a transcript is a conversation, and a document
+ * that takes the whole pane has stopped being a message and become a reader.
+ * The full view is one click away and is where the reading happens.
+ */
+function Thumbnail({ file }: { file: Attachment }) {
+  switch (previewKind(file.mime)) {
+    case "image":
+      // Lazily, because a channel opens with three hundred messages in it and
+      // the operator is looking at the last few.
+      return <img className="file__image" src={fileUrl(file)} alt={file.name} loading="lazy" />;
+    case "pdf":
+      return <Page file={file} />;
+    case "text":
+      return <Snippet file={file} limit={SNIPPET_BYTES} />;
+    default:
+      return null;
+  }
+}
+
+/**
+ * The first page of a document, drawn by the webview's own viewer.
+ *
+ * A frame, and only once it is nearly on screen. Each one is a renderer of its
+ * own holding a copy of the document, so mounting one per file the moment a
+ * channel opens spends both on pages nobody has scrolled to. It takes no
+ * clicks: the button behind it opens the full view, and a frame that swallowed
+ * the click would leave a document whose one obvious way in does nothing.
+ */
+function Page({ file }: { file: Attachment }) {
+  const [frame, near] = useNearViewport<HTMLDivElement>();
+  const copy = useLocalCopy(file, near);
+
+  return (
+    <div className="file__page" ref={frame}>
+      {copy.url && (
+        <iframe className="file__frame" src={copy.url} title={file.name} tabIndex={-1} />
+      )}
+      {copy.failed && <p className="hint">This document could not be read.</p>}
+    </div>
+  );
+}
+
+/**
+ * A copy of a whole file the frame can be pointed at, while it is wanted.
+ *
+ * Revoked on the way out, because this is the one place a file's bytes sit in
+ * the renderer and a transcript scrolls past a lot of documents. `when` is what
+ * keeps it to the ones on screen.
+ */
+function useLocalCopy(file: Attachment, when: boolean) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    if (!when) return;
+    let live = true;
+    let made: string | null = null;
+    localCopy(file)
+      .then((copy) => {
+        // A copy nobody is waiting for any more is revoked here rather than in
+        // the cleanup, which has already run and seen no url to release.
+        if (!live) return URL.revokeObjectURL(copy);
+        made = copy;
+        setUrl(copy);
+      })
+      .catch(() => live && setFailed(true));
+    return () => {
+      live = false;
+      if (made) URL.revokeObjectURL(made);
+      setUrl(null);
+    };
+  }, [file, when]);
+
+  return { url, failed };
+}
+
+/**
+ * The first lines of a text file, as text.
+ *
+ * `sayTrimmed` where the operator would otherwise believe they have read the
+ * whole thing. Under a message the cut is plain from the shape of it; in the
+ * full view it is not, and a preview that quietly stops is a lie.
+ */
+function Snippet({
+  file,
+  limit,
+  sayTrimmed,
+}: {
+  file: Attachment;
+  limit: number;
+  sayTrimmed?: boolean;
+}) {
+  const [read, setRead] = useState<{ text: string; trimmed: boolean } | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    readFileText(file, limit)
+      .then((got) => live && setRead(got))
+      .catch(() => live && setFailed(true));
+    return () => {
+      live = false;
+    };
+  }, [file, limit]);
+
+  if (failed) return <p className="hint">This file could not be read.</p>;
+  return (
+    <>
+      <pre className="file__text">{read?.text ?? ""}</pre>
+      {sayTrimmed && read?.trimmed && (
+        <p className="hint">The first {readableSize(limit)}. Save a copy to read the rest.</p>
+      )}
+    </>
+  );
+}
+
+/**
+ * The file, as big as the window will allow.
+ *
+ * The same four shapes as the strip with the bounds taken off. A file with no
+ * preview lands here too: the operator clicked something, and an explanation
+ * with a way forward beats nothing happening.
+ */
+export function FilePreview({ file, onClose }: { file: Attachment; onClose: () => void }) {
+  const kind = previewKind(file.mime);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div className="scrim">
+      <button type="button" className="scrim__close" aria-label="Close dialog" onClick={onClose} />
+      <div className="dialog dialog--file" role="dialog" aria-modal="true" aria-label={file.name}>
+        <div className="file-view__head">
+          <h2 className="dialog__title" style={{ margin: 0 }}>
+            {file.name}
+          </h2>
+          <span className="hint">{readableSize(file.bytes)}</span>
+          <div className="file-view__actions">
+            <SaveButton file={file} />
+            <button type="button" className="btn btn--ghost" onClick={onClose}>
+              Close
+            </button>
+          </div>
+        </div>
+
+        <div className="file-view__body" data-kind={kind}>
+          {kind === "image" ? (
+            <img className="file-view__image" src={fileUrl(file)} alt={file.name} />
+          ) : kind === "pdf" ? (
+            <Document file={file} />
+          ) : kind === "text" ? (
+            <Snippet file={file} limit={PREVIEW_BYTES} sayTrimmed />
+          ) : (
+            <p className="hint">
+              Nothing here can show this kind of file. Save a copy and open it with something that
+              can.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** The whole document, in the full view. */
+function Document({ file }: { file: Attachment }) {
+  const copy = useLocalCopy(file, true);
+
+  if (copy.failed) return <p className="hint">This document could not be read.</p>;
+  return copy.url ? (
+    <iframe className="file-view__frame" src={copy.url} title={file.name} />
+  ) : (
+    <p className="hint">Opening…</p>
+  );
+}
+
+/**
+ * Puts a copy where a person can get at it.
+ *
+ * The path comes back and is said out loud: a file saved somewhere the operator
+ * has to go looking for has not really been saved. Imperative on the store, as
+ * the retry button is, because this is one button on a component that is
+ * rendered once per file in a transcript and holds no other state.
+ */
+function SaveButton({ file }: { file: Attachment }) {
+  const [saving, setSaving] = useState(false);
+
+  return (
+    <button
+      type="button"
+      className="btn btn--ghost btn--small"
+      disabled={saving}
+      onClick={() => {
+        setSaving(true);
+        void api
+          .saveFile(file.digest, file.name)
+          .then((path) => useStore.getState().setBanner({ tone: "ok", text: `Saved to ${path}` }))
+          .catch((error) =>
+            useStore.getState().setBanner({ tone: "error", text: errorMessage(error) }),
+          )
+          .finally(() => setSaving(false));
+      }}
+    >
+      {saving ? "Saving…" : "Save"}
+    </button>
+  );
+}
+
+/**
+ * Whether a node has come near the window yet.
+ *
+ * The margin is generous because the point is to have mounted before the
+ * operator arrives rather than as they arrive: a frame that starts loading once
+ * it is already on screen is a grey rectangle they watch fill in.
+ */
+function useNearViewport<T extends HTMLElement>() {
+  const ref = useRef<T>(null);
+  const [near, setNear] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || near) return;
+    const watching = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) setNear(true);
+      },
+      { rootMargin: "400px" },
+    );
+    watching.observe(node);
+    return () => watching.disconnect();
+  }, [near]);
+
+  return [ref, near] as const;
+}

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -14,6 +14,7 @@ import {
   type Participant,
 } from "../lib/types";
 import { ApprovalRequest } from "./ApprovalRequest";
+import { FileCard } from "./FileCard";
 import { Markdown } from "./Markdown";
 import { NoticeRow } from "./WireRow";
 
@@ -222,32 +223,10 @@ function ChatBubble({
         ))}
 
         {files.map(({ part, key }) => (
-          <FileRow key={key} file={part} />
+          <FileCard key={key} file={part} />
         ))}
       </div>
     </article>
-  );
-}
-
-/** Sizes the way a person says them, matching what the agent is told. */
-function readableSize(bytes: number): string {
-  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  if (bytes >= 1024) return `${Math.ceil(bytes / 1024)} KB`;
-  return `${bytes} bytes`;
-}
-
-/**
- * A file on a message.
- *
- * Named and sized, and that is all: the operator dropped it or watched an agent
- * send it, so what matters here is that it went, not a preview of it.
- */
-function FileRow({ file }: { file: Extract<Part, { type: "file" }> }) {
-  return (
-    <div className="file" title={file.mime}>
-      <span className="file__name">{file.name}</span>
-      <span className="file__size">{readableSize(file.bytes)}</span>
-    </div>
   );
 }
 

--- a/src/lib/files.test.ts
+++ b/src/lib/files.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fileUrl, previewKind, readableSize, readFileText } from "./files";
+import type { Attachment } from "./types";
+
+/**
+ * A stored file. The digest follows the name so that two different files in
+ * this suite are two different files to the read cache, as they would be.
+ */
+function file(name: string, mime: string, bytes = 10): Attachment {
+  return { digest: name.padEnd(64, "0").slice(0, 64), name, mime, bytes };
+}
+
+describe("previewKind", () => {
+  it("draws pictures, documents and text, and says so for nothing else", () => {
+    expect(previewKind("image/png")).toBe("image");
+    expect(previewKind("image/webp")).toBe("image");
+    expect(previewKind("application/pdf")).toBe("pdf");
+    expect(previewKind("text/markdown")).toBe("text");
+    expect(previewKind("application/json")).toBe("text");
+  });
+
+  it("refuses to guess at anything else", () => {
+    // The same rule the runtime follows deciding what to show a model: a file
+    // that is only mostly text renders as a screen of replacement characters,
+    // and a row saying what it is serves the operator better.
+    for (const mime of [
+      "application/zip",
+      "application/octet-stream",
+      "application/vnd.ms-excel",
+      "application/msword",
+    ]) {
+      expect(previewKind(mime), mime).toBe("none");
+    }
+  });
+});
+
+describe("fileUrl", () => {
+  it("addresses the bytes by digest and carries the name for its type", () => {
+    // The name is not what finds the file. Two agents sending one document
+    // under different names are one set of bytes at one address.
+    const stored = file("brief.pdf", "application/pdf");
+    const url = fileUrl(stored);
+    expect(url).toContain("guacfile:");
+    expect(decodeURIComponent(url)).toContain(`${stored.digest}/brief.pdf`);
+  });
+
+  it("escapes a name, since a person's file is called what they called it", () => {
+    const url = fileUrl(file("last quarter (final).pdf", "application/pdf"));
+    expect(url).not.toContain(" ");
+    expect(decodeURIComponent(url)).toContain("last quarter (final).pdf");
+  });
+});
+
+describe("readableSize", () => {
+  it("says sizes the way a person does, matching what an agent is told", () => {
+    expect(readableSize(512)).toBe("512 bytes");
+    expect(readableSize(2048)).toBe("2 KB");
+    expect(readableSize(1024 * 1024 * 1.5)).toBe("1.5 MB");
+  });
+});
+
+describe("readFileText", () => {
+  const fetched = vi.fn();
+
+  beforeEach(() => {
+    fetched.mockReset();
+    globalThis.fetch = fetched as unknown as typeof fetch;
+  });
+
+  function answers(body: string, status = 206) {
+    fetched.mockResolvedValue({ ok: status === 200, status, text: async () => body });
+  }
+
+  it("asks for the front of the file rather than all of it", async () => {
+    // A log nobody meant to attach is 20 MB, and the operator asked for a
+    // glance at it, not for it to be in the renderer.
+    answers("hello");
+    await readFileText(file("big.log", "text/plain", 20_000_000), 2048);
+
+    const asked = fetched.mock.calls[0] ?? [];
+    expect(asked[1].headers.Range).toBe("bytes=0-2047");
+  });
+
+  it("cuts the answer itself, because a range is a request and not a promise", async () => {
+    answers("0123456789");
+    const read = await readFileText(file("notes.md", "text/markdown", 10), 4);
+
+    expect(read.text).toBe("0123");
+    expect(read.trimmed).toBe(true);
+  });
+
+  it("says when it read the whole thing", async () => {
+    answers("short", 200);
+    const read = await readFileText(file("notes.md", "text/markdown", 5), 2048);
+
+    expect(read.text).toBe("short");
+    expect(read.trimmed).toBe(false);
+  });
+
+  it("fails by name when the file cannot be read", async () => {
+    fetched.mockResolvedValue({ ok: false, status: 404, text: async () => "" });
+    await expect(readFileText(file("gone.txt", "text/plain"), 2048)).rejects.toThrow("gone.txt");
+  });
+
+  it("reads one file once, however many times the transcript redraws it", async () => {
+    // A channel reload hands every message new objects, so this runs again for
+    // every message that arrives, and a range request is the one kind the
+    // webview's own cache does not hold.
+    answers("cached");
+    const twice = file("stable.md", "text/markdown");
+
+    await readFileText(twice, 2048);
+    await readFileText(twice, 2048);
+
+    expect(fetched).toHaveBeenCalledTimes(1);
+    // A different length is a different read, since it can be cut differently.
+    await readFileText(twice, 64);
+    expect(fetched).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,0 +1,141 @@
+/**
+ * How the webview gets at a file, and what it can show of one.
+ *
+ * The bytes never cross IPC: a transcript does, in bulk, which is the whole
+ * reason a message carries a digest rather than a document. They come over
+ * `guacfile:` instead, a scheme `app.rs` answers out of the file store, so a
+ * picture is fetched once by the element drawing it and only while that element
+ * is on screen.
+ */
+
+import { convertFileSrc } from "@tauri-apps/api/core";
+
+import type { Attachment } from "./types";
+
+/** The scheme `app.rs` registers. */
+const SCHEME = "guacfile";
+
+/** How much of a text file the strip under a message reads. */
+export const SNIPPET_BYTES = 2048;
+
+/**
+ * And how much the full view reads.
+ *
+ * A cap rather than the whole file, because "preview" is a promise about how
+ * long this takes. A log nobody meant to attach is 20 MB, and the operator
+ * asked to glance at it, not to load it.
+ */
+export const PREVIEW_BYTES = 256 * 1024;
+
+/** What can be drawn of a file, decided by its type and nothing else. */
+export type PreviewKind = "image" | "pdf" | "text" | "none";
+
+/**
+ * Which of the four a file is.
+ *
+ * By type, never by sniffing the bytes, which is the same rule the runtime
+ * follows when it decides what to show a model. A file that is only mostly text
+ * renders as a screenful of replacement characters, and the operator is better
+ * served by a row saying what it is and a button that saves it.
+ */
+export function previewKind(mime: string): PreviewKind {
+  if (mime.startsWith("image/")) return "image";
+  if (mime === "application/pdf") return "pdf";
+  if (mime.startsWith("text/") || mime === "application/json") return "text";
+  return "none";
+}
+
+/**
+ * Where the bytes of a stored file are, as a URL.
+ *
+ * The name travels with the digest because the type is worked out from it on
+ * the other side: the same function that typed the file when it arrived. It is
+ * not what finds the file. Two agents sending the same document under different
+ * names are one set of bytes at one address.
+ */
+export function fileUrl(file: Pick<Attachment, "digest" | "name">): string {
+  return convertFileSrc(`${file.digest}/${file.name}`, SCHEME);
+}
+
+/** Sizes the way a person says them, matching what an agent is told. */
+export function readableSize(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${Math.ceil(bytes / 1024)} KB`;
+  return `${bytes} bytes`;
+}
+
+/**
+ * Fetches a whole file and returns a URL a frame will accept.
+ *
+ * WebKit refuses a custom scheme as a frame source whatever the CSP says: not
+ * as `guacfile:`, not as a host, not through `default-src`. An image and a
+ * `fetch` are allowed, a frame is not, and a document's own viewer only runs in
+ * a frame. So the bytes are fetched over the scheme as usual and handed on as a
+ * blob, which is a source WebKit does accept.
+ *
+ * The caller owns what comes back and must revoke it: this is the one place in
+ * the app where a file's bytes sit in the renderer, and they sit there for
+ * exactly as long as something is drawing them.
+ */
+export async function localCopy(file: Attachment): Promise<string> {
+  const response = await fetch(fileUrl(file));
+  if (!response.ok) throw new Error(`could not read ${file.name}`);
+  return URL.createObjectURL(await response.blob());
+}
+
+/** What was read of a text file, and whether that was all of it. */
+export interface FileText {
+  text: string;
+  trimmed: boolean;
+}
+
+/**
+ * What has already been read, by content and length.
+ *
+ * A channel reloads whenever anything happens in it and hands the transcript
+ * fresh objects each time, so a snippet that is not remembered is read again
+ * for every message that arrives, and a range request is the one kind the
+ * webview's own cache does not hold. Keyed by digest, which is only safe
+ * because of what a digest is: the bytes behind one cannot change.
+ *
+ * Bounded because the full view reads a quarter of a megabyte at a time and a
+ * session is long. The oldest goes, which is the least likely to be on screen.
+ */
+const READ = new Map<string, Promise<FileText>>();
+const READ_LIMIT = 64;
+
+/**
+ * Reads the front of a text file.
+ *
+ * Asked for as a range, so a 20 MB log costs the two kilobytes on screen rather
+ * than 20 MB in the renderer. The slice is applied again on this side: a range
+ * is a request, not a guarantee, and the answer to one a server declines to
+ * honour is the whole file.
+ */
+export function readFileText(file: Attachment, limit: number): Promise<FileText> {
+  const key = `${file.digest}:${limit}`;
+  const held = READ.get(key);
+  if (held) return held;
+
+  // The promise rather than its result, because the readers of one file arrive
+  // together: a channel reload remounts every message at once, and a cache
+  // that only fills on completion misses all of them.
+  const reading = read(file, limit);
+  reading.catch(() => READ.delete(key));
+
+  if (READ.size >= READ_LIMIT) READ.delete(READ.keys().next().value as string);
+  READ.set(key, reading);
+  return reading;
+}
+
+async function read(file: Attachment, limit: number): Promise<FileText> {
+  const response = await fetch(fileUrl(file), { headers: { Range: `bytes=0-${limit - 1}` } });
+  if (!response.ok && response.status !== 206) {
+    throw new Error(`could not read ${file.name}`);
+  }
+  const text = await response.text();
+  // Against the file's own size rather than the text's: a character can be
+  // several bytes, so a cut made at a byte count says nothing about the length
+  // of what came back.
+  return { text: text.slice(0, limit), trimmed: file.bytes > limit || text.length > limit };
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -18,6 +18,7 @@ import type {
   Approval,
   ApprovalId,
   ApprovalState,
+  Attachment,
   Computer,
   Connector,
   ConnectorDraft,
@@ -41,6 +42,7 @@ import type {
   Settings,
   SettingsPatch,
   Signin,
+  Staged,
   UiEvent,
 } from "./types";
 
@@ -164,9 +166,32 @@ export const api = {
    */
   search: (query: string, limit?: number) => invoke<SearchHits>("search", { query, limit }),
 
-  /** `files` are absolute paths from a drop; the bytes never cross IPC. */
-  sendMessage: (agentId: AgentId, text: string, files: string[] = []) =>
-    invoke<RunId>("send_message", { agentId, text, files }),
+  /**
+   * Takes dropped files into the store, before anything is sent.
+   *
+   * `paths` are absolute paths from a drop; the bytes never cross IPC, and what
+   * comes back is what a message would carry. A file that could not be taken is
+   * named in `refused` rather than failing the drop, so one document over the
+   * limit does not cost the operator the four beside it.
+   */
+  stageFiles: (paths: string[]) => invoke<Staged>("stage_files", { paths }),
+
+  /** Copies a file out to the downloads folder, and says where it landed. */
+  saveFile: (digest: string, name: string) => invoke<string>("save_file", { digest, name }),
+
+  /**
+   * Sends what the operator typed, with the files they attached.
+   *
+   * Only the digest and the name go over: the runtime resolves both against
+   * its own store, so the size and the type on the message are read off the
+   * disk rather than taken from here.
+   */
+  sendMessage: (agentId: AgentId, text: string, files: Attachment[] = []) =>
+    invoke<RunId>("send_message", {
+      agentId,
+      text,
+      files: files.map(({ digest, name }) => ({ digest, name })),
+    }),
 
   clearChannel: (channelId: AgentId) => invoke<number>("clear_channel", { channelId }),
 

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -10,6 +10,7 @@
  * everything is scored by the same function.
  */
 
+import { readableSize } from "./files";
 import { describeTrigger, routineTitle } from "./routine";
 import { relativeTime } from "./time";
 import type {
@@ -142,13 +143,6 @@ function bestOf(query: string, fields: [text: string, weight: number][]): number
 function firstLine(text: string, cap = 120): string {
   const line = text.replace(/\s+/g, " ").trim();
   return line.length > cap ? `${line.slice(0, cap - 1)}…` : line;
-}
-
-/** Sizes the way a person says them, matching what the transcript shows. */
-export function readableSize(bytes: number): string {
-  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  if (bytes >= 1024) return `${Math.ceil(bytes / 1024)} KB`;
-  return `${bytes} bytes`;
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,17 +30,34 @@ export type ToolOutcome =
 /** Whether a message carries work or is a courtesy. */
 export type Intent = "work" | "courtesy";
 
+/**
+ * A file, as everything that refers to one refers to it.
+ *
+ * The bytes are not here and never cross IPC. They sit once in the runtime's
+ * file store addressed by `digest`, which is the SHA-256 of the contents, and
+ * the webview reads them over the `guacfile:` scheme when it has to draw one.
+ * See `lib/files.ts`.
+ */
+export interface Attachment {
+  digest: string;
+  name: string;
+  mime: string;
+  bytes: number;
+}
+
+/** What became of a drop: what was taken, and what could not be. */
+export interface Staged {
+  attached: Attachment[];
+  /** One line per refused file, saying which it was and why. */
+  refused: string[];
+}
+
 export type Part =
   | { type: "text"; text: string }
   | { type: "json"; name: string; value: unknown }
   | { type: "notice"; kind: NoticeKind; text: string }
   | { type: "toolCall"; name: string; arguments: unknown; outcome: ToolOutcome }
-  /**
-   * A file the message carries. The bytes stay in the runtime's file store and
-   * are addressed by `digest`; a transcript is read in bulk, so a document is
-   * never inlined into one.
-   */
-  | { type: "file"; digest: string; name: string; mime: string; bytes: number }
+  | ({ type: "file" } & Attachment)
   /**
    * An agent asking the operator for permission. Carries its own wording, so an
    * old channel still says what was asked; what came of it is read from
@@ -413,7 +430,7 @@ export interface MessageHit {
 
 /** One attachment, and the message that carried it. Unique by digest. */
 export interface FileHit {
-  file: { digest: string; name: string; mime: string; bytes: number };
+  file: Attachment;
   messageId: MessageId;
   channelId: AgentId;
   from: Participant;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1616,6 +1616,33 @@ button {
   max-width: 16rem;
 }
 
+.chip__size {
+  color: var(--faint);
+  flex: none;
+}
+
+/* The picture, not its name. Three screenshots dropped together are three
+   copies of `Screenshot 2026-08-17 at 14.02.11.png` and nothing else. */
+.chip__thumb {
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 0.2rem;
+  object-fit: cover;
+  flex: none;
+}
+
+/* What could not be attached, beside what could. The operator is looking at
+   the drop they just made, not at the top of the window. */
+.composer__refused {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.3rem;
+  margin: 0;
+  padding: 0.55rem 0.65rem 0;
+}
+
 .chip__remove {
   border: none;
   background: none;
@@ -1632,32 +1659,185 @@ button {
   color: var(--alarm);
 }
 
-/* A file on a message. Named and sized: it is a record of what went, not a
-   preview of it. */
+/* ==========================================================================
+   A file on a message
+
+   Shown, not just named. A document that arrives as a filename is a document
+   the operator has to open something else to read, and the thing they wanted
+   was usually one glance. The strip is bounded in height on purpose: a
+   transcript is a conversation, and a preview that takes the pane has stopped
+   being a message and become a reader. The full view is one click away.
+   ========================================================================== */
+
 .file {
   display: inline-flex;
-  align-items: baseline;
-  gap: 0.5rem;
+  flex-direction: column;
+  align-items: stretch;
   margin-top: 0.35rem;
-  padding: 0.35rem 0.6rem;
   border: 1px solid var(--edge);
   border-radius: var(--radius-sm);
   background: var(--sunken);
+  overflow: hidden;
+  max-width: min(28rem, 100%);
+}
+
+/* Nothing to draw: the row is the whole card, so it keeps the shape the
+   transcript had before previews existed. */
+.file[data-kind="none"] {
   max-width: 100%;
 }
 
+.file__view {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  border-bottom: 1px solid var(--edge);
+  background: var(--raised);
+  cursor: zoom-in;
+  text-align: left;
+}
+
+.file__image {
+  display: block;
+  max-width: 100%;
+  max-height: 17rem;
+  object-fit: contain;
+  margin: 0 auto;
+}
+
+/* The frame is inert. The button behind it is what opens the document, and a
+   frame that took the click would leave the one obvious way in doing nothing. */
+.file__page {
+  height: 15rem;
+  overflow: hidden;
+  background: var(--raised);
+}
+
+.file__frame {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  pointer-events: none;
+}
+
+/* Cut by height rather than by character count, and faded at the cut so the
+   eye reads "there is more" without a line of prose saying it. */
+.file__text {
+  margin: 0;
+  padding: 0.6rem 0.7rem;
+  max-height: 9rem;
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
+  mask-image: linear-gradient(to bottom, #000 70%, transparent);
+}
+
+.file__foot {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.5rem 0.35rem 0.6rem;
+  min-width: 0;
+}
+
 .file__name {
+  border: 0;
+  background: none;
+  padding: 0;
+  color: inherit;
   font-family: var(--font-mono);
   font-size: 0.72rem;
+  text-align: left;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  cursor: pointer;
+}
+
+.file__name:hover {
+  text-decoration: underline;
 }
 
 .file__size {
   font-size: 0.66rem;
   color: var(--muted);
   flex: none;
+}
+
+.file__foot .btn {
+  margin-left: auto;
+  flex: none;
+}
+
+/* The full view. Wider than an ordinary dialog because the whole point of it
+   is that the bounds are off. */
+.dialog--file {
+  width: min(64rem, 100%);
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 3rem);
+}
+
+.file-view__head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  margin-bottom: 0.9rem;
+  min-width: 0;
+}
+
+.file-view__head .dialog__title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-view__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-left: auto;
+  flex: none;
+}
+
+.file-view__body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  overflow: auto;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  background: var(--ground);
+}
+
+.file-view__body[data-kind="text"] {
+  flex-direction: column;
+  padding: 0.35rem 0.5rem;
+}
+
+/* No mask and no height cap in here: this is the reading view. */
+.file-view__body .file__text {
+  max-height: none;
+  mask-image: none;
+  font-size: 0.75rem;
+}
+
+.file-view__image {
+  margin: auto;
+  max-width: 100%;
+  max-height: calc(100vh - 12rem);
+  object-fit: contain;
+}
+
+.file-view__frame {
+  width: 100%;
+  height: calc(100vh - 12rem);
+  border: 0;
 }
 
 /* The typeahead sits above the box it belongs to, so a long list grows away

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -20,6 +20,38 @@ if (typeof Element.prototype.scrollIntoView !== "function") {
   Element.prototype.scrollIntoView = function scrollIntoView() {};
 }
 
+// For the same reason nothing is ever on screen here, so anything that waits to
+// be scrolled to would wait forever. Everything is reported visible, which is
+// as true as anything else in a window with no dimensions.
+if (!("IntersectionObserver" in globalThis)) {
+  class IntersectionObserverStub {
+    constructor(private readonly notify: IntersectionObserverCallback) {}
+    observe(target: Element) {
+      this.notify(
+        [{ target, isIntersecting: true } as IntersectionObserverEntry],
+        this as unknown as IntersectionObserver,
+      );
+    }
+    unobserve() {}
+    disconnect() {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+  }
+  (globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
+    IntersectionObserverStub;
+}
+
+// Tauri injects this into the real webview before the app loads. Only the URL
+// builder is needed: `lib/files.ts` addresses a stored file with it, and every
+// command goes through a mock.
+if (!("__TAURI_INTERNALS__" in globalThis)) {
+  (globalThis as unknown as { __TAURI_INTERNALS__: unknown }).__TAURI_INTERNALS__ = {
+    convertFileSrc: (path: string, protocol: string) =>
+      `${protocol}://localhost/${encodeURIComponent(path)}`,
+  };
+}
+
 // jsdom hands back a `localStorage` object with no methods on it here, so a
 // component that stores a preference throws rather than storing one. Real
 // WKWebView has the whole thing; this is enough of it to assert against.


### PR DESCRIPTION
A file on a message was a name and a size; it is now drawn, as a picture inline, a PDF's first page in the webview's own viewer, a text file's first lines, or a row for anything that cannot be drawn, each opening a full view and offering a copy into the downloads folder. The bytes reach the renderer over a `guacfile://localhost/{digest}/{name}` scheme answered out of the file store rather than over IPC, which is where a transcript travels in bulk; a digest that is not 64 hex characters is refused before it is joined onto a path, and ranges are answered because a PDF viewer asks in them. WebKit refuses a custom scheme in a frame however the CSP names it, and does so silently, so a document is fetched over the scheme as usual and its frame is handed a `blob:` URL, made when the frame nears the viewport and revoked when it leaves. Dropping a file now stores it before anything is sent: an oversize file is refused while the operator is still holding it rather than failing the message they went on to write, one bad file does not refuse the four beside it, and the send carries a digest and a name that the runtime resolves against its own store. Covered by unit tests either side of IPC and by a run against the real webview, which is what caught both the frame refusal and a text snippet being re-read on every channel reload.