### PR TITLE
feat: a channel is read without a name and a clock over every message

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,18 @@ channel only summarises, in `lib/transcript.ts`. A refusal never folds into that
 summary: it is the runtime stopping a message rather than a message. See
 `docs/ARCHITECTURE.md`.
 
+**A channel names nobody, and that is not a missing feature.** It has two
+participants: the agent it is named after, at the top of the pane, and the
+person reading it. A name and a clock over every message is two lines of chrome
+carrying one fact, and four replies written inside the same minute drew four of
+them. The portrait says which agent and the side of the column says whether the
+words are yours. `named` is how the pair's own thread asks for the names back,
+because there both participants are agents and neither is the reader. The clock
+went with them: it is a hover on the row, and `transcriptRows` draws one line
+where the silence ran past half an hour, which is the only place a time ever
+changed what the operator understood. That line also ends whatever burst was
+open, because two exchanges three hours apart are two things that happened.
+
 **A repeat is a shape, not a number of seconds.** `every weekday` and `every
 month` cannot be gaps, and `every day` should not be one: a day is 23 or 25
 hours twice a year, so a daily nine o'clock routine stored as 86400 seconds

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ export default function App() {
   const applyEvent = useStore((s) => s.applyEvent);
   const refreshAgents = useStore((s) => s.refreshAgents);
   const select = useStore((s) => s.select);
+  const loadChannel = useStore((s) => s.loadChannel);
 
   const [editing, setEditing] = useState<AgentCard | "new" | null>(null);
   const [editingGroup, setEditingGroup] = useState<Group | "new" | null>(null);
@@ -223,7 +224,7 @@ export default function App() {
         ) : (
           <ChannelView
             channel={selected ?? ACTIVITY_CHANNEL}
-            onEditAgent={(agent) => setEditing(agent)}
+            onOpenMenu={(agent, at) => setMenu({ agent, ...at })}
           />
         )}
       </main>
@@ -238,11 +239,23 @@ export default function App() {
           onClose={() => setMenu(null)}
           onEditProfile={(agent) => setEditing(agent)}
           onTogglePin={(agent) => void onAgent(() => api.setAgentPinned(agent.id, !agent.pinned))}
+          onTogglePause={(agent) =>
+            void onAgent(() => api.setAgentPaused(agent.id, agent.lifecycle !== "paused"))
+          }
           onDuplicate={(agent) =>
             void onAgent(async () => {
               const copy = await api.duplicateAgent(agent.id);
               await refreshAgents();
               await select(copy.id);
+            })
+          }
+          // The runtime announces the clear and the store re-reads whatever is
+          // open, but only once the event has been round-tripped. Reading here
+          // as well is what makes the click look like it did something.
+          onClearHistory={(agent) =>
+            void onAgent(async () => {
+              await api.clearChannel(agent.id);
+              await loadChannel(agent.id);
             })
           }
         />

--- a/src/components/AgentMenu.test.tsx
+++ b/src/components/AgentMenu.test.tsx
@@ -29,18 +29,32 @@ function open(agent: AgentCard, at = { x: 40, y: 40 }) {
     onClose: vi.fn(),
     onEditProfile: vi.fn(),
     onTogglePin: vi.fn(),
+    onTogglePause: vi.fn(),
     onDuplicate: vi.fn(),
+    onClearHistory: vi.fn(),
   };
   render(<AgentMenu target={{ agent, ...at }} {...handlers} />);
   return handlers;
 }
 
 describe("AgentMenu", () => {
-  it("offers the three things you do to an agent without opening it", () => {
+  it("offers everything you do to an agent, from either place it opens", () => {
     open(card());
-    expect(screen.getByRole("button", { name: "Edit profile" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Pin to top" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Duplicate" })).toBeTruthy();
+    for (const name of ["Pause", "Edit profile", "Pin to top", "Duplicate", "Clear history…"]) {
+      expect(screen.getByRole("button", { name })).toBeTruthy();
+    }
+  });
+
+  it("says resume on an agent that is already paused", () => {
+    open(card({ lifecycle: "paused" }));
+    expect(screen.getByRole("button", { name: "Resume" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Pause" })).toBeNull();
+  });
+
+  it("names the model, which is what you come here to check", () => {
+    // It used to sit under the agent's name over every message it ever wrote.
+    open(card({ model: "openai/gpt-5.6-terra" }));
+    expect(screen.getByText("openai/gpt-5.6-terra")).toBeTruthy();
   });
 
   it("says unpin on an agent that is already pinned", () => {
@@ -67,6 +81,20 @@ describe("AgentMenu", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Close menu" }));
     expect(handlers.onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("asks twice before deleting a history, without closing in between", () => {
+    // The first click is the operator finding the item, not deciding anything.
+    // Closing on it would mean the decision is taken in a menu they have to
+    // open again, having already seen the word "clear" act like a button.
+    const handlers = open(card());
+    fireEvent.click(screen.getByRole("button", { name: "Clear history…" }));
+    expect(handlers.onClearHistory).not.toHaveBeenCalled();
+    expect(handlers.onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete this history" }));
+    expect(handlers.onClearHistory).toHaveBeenCalledTimes(1);
+    expect(handlers.onClose).toHaveBeenCalledTimes(1);
   });
 
   it("stays inside the window when opened near an edge", () => {

--- a/src/components/AgentMenu.tsx
+++ b/src/components/AgentMenu.tsx
@@ -13,24 +13,51 @@ interface Props {
   onClose: () => void;
   onEditProfile: (agent: AgentCard) => void;
   onTogglePin: (agent: AgentCard) => void;
+  onTogglePause: (agent: AgentCard) => void;
   onDuplicate: (agent: AgentCard) => void;
+  onClearHistory: (agent: AgentCard) => void;
 }
 
 /** Roughly what the menu measures. Only used to keep it inside the window. */
 const MARGIN = 8;
 
 /**
- * What you can do to an agent without opening it.
+ * Everything you can do to an agent, in the one place.
+ *
+ * Reached by right-clicking its row in the rail and by the button beside its
+ * name, because those are two ways of asking the same question. Pausing and
+ * clearing used to be permanent buttons over the transcript instead: three
+ * controls the operator reads past on every message, two of which are used
+ * once a week and one of which deletes history.
  *
  * Editing a profile lives behind two clicks on purpose: a name and a set of
  * instructions are written once and read often, so the cost of reaching them
- * belongs on the rare action rather than on every right-click. Pinning and
- * duplicating are one click each because they are the ones you actually do.
+ * belongs on the rare action rather than on every right-click.
+ *
+ * The model is written at the top rather than under the agent's name in the
+ * header. It is what you come here to check when a reply looks wrong, and it
+ * is nothing at all the rest of the time.
  */
-export function AgentMenu({ target, onClose, onEditProfile, onTogglePin, onDuplicate }: Props) {
+export function AgentMenu({
+  target,
+  onClose,
+  onEditProfile,
+  onTogglePin,
+  onTogglePause,
+  onDuplicate,
+  onClearHistory,
+}: Props) {
   const { agent } = target;
   const ref = useRef<HTMLDivElement>(null);
   const [at, setAt] = useState({ x: target.x, y: target.y });
+  /**
+   * Clearing, asked twice.
+   *
+   * In the menu rather than in the pane behind it: a confirmation drawn where
+   * the click did not happen is a confirmation the operator has to go and find,
+   * and this menu opens from two places that draw nothing in common.
+   */
+  const [confirming, setConfirming] = useState(false);
 
   // Measured after it is in the tree rather than guessed: the menu is opened
   // by a click that can land anywhere, and one hanging off the bottom of the
@@ -62,10 +89,11 @@ export function AgentMenu({ target, onClose, onEditProfile, onTogglePin, onDupli
     };
   }, [onClose]);
 
-  const item = (label: string, run: () => void) => (
+  const item = (label: string, run: () => void, tone?: "danger") => (
     <button
       type="button"
       className="menu__item"
+      data-tone={tone}
       onClick={() => {
         run();
         onClose();
@@ -96,10 +124,24 @@ export function AgentMenu({ target, onClose, onEditProfile, onTogglePin, onDupli
         aria-label={agent.name}
         style={{ left: at.x, top: at.y }}
       >
-        <p className="menu__head">{agent.name}</p>
+        <p className="menu__head">
+          {agent.name}
+          {agent.model && <span className="menu__model">{agent.model}</span>}
+        </p>
+        {item(agent.lifecycle === "paused" ? "Resume" : "Pause", () => onTogglePause(agent))}
         {item("Edit profile", () => onEditProfile(agent))}
         {item(agent.pinned ? "Unpin" : "Pin to top", () => onTogglePin(agent))}
         {item("Duplicate", () => onDuplicate(agent))}
+        <hr className="menu__rule" />
+        {confirming ? (
+          item("Delete this history", () => onClearHistory(agent), "danger")
+        ) : (
+          // The only item that does not close the menu. Nothing has been
+          // decided yet, and the next click is the one that matters.
+          <button type="button" className="menu__item" onClick={() => setConfirming(true)}>
+            Clear history…
+          </button>
+        )}
       </div>
     </>
   );

--- a/src/components/ChannelView.perf.test.tsx
+++ b/src/components/ChannelView.perf.test.tsx
@@ -116,7 +116,7 @@ describe("ChannelView under streaming load", () => {
   });
 
   function draw() {
-    render(<ChannelView channel={AGENT} onEditAgent={() => {}} />);
+    render(<ChannelView channel={AGENT} onOpenMenu={() => {}} />);
     rendersOfMessages = 0;
   }
 

--- a/src/components/ChannelView.test.tsx
+++ b/src/components/ChannelView.test.tsx
@@ -101,7 +101,7 @@ function open(messages: Envelope[]) {
     lastActive: {},
     banner: null,
   });
-  return render(<ChannelView channel={MANAGER} onEditAgent={() => {}} />);
+  return render(<ChannelView channel={MANAGER} onOpenMenu={() => {}} />);
 }
 
 beforeEach(() => {
@@ -182,6 +182,41 @@ describe("peer traffic in a channel", () => {
 
     expect(screen.getByText(/Not delivered to Chef/)).toBeTruthy();
     expect(screen.getByText("you already sent Chef this exact message in this run")).toBeTruthy();
+  });
+});
+
+describe("who said what", () => {
+  it("does not write the agent's name over every message it sent", () => {
+    // A channel has two participants: the one named at the top of the pane and
+    // the operator reading it. A name and a clock over each of four replies
+    // written in the same minute is eight lines carrying two facts.
+    open([
+      envelope({ parts: [{ type: "text", text: "what is the status" }] }),
+      envelope({
+        from: { kind: "agent", id: MANAGER },
+        to: { kind: "human" },
+        parts: [{ type: "text", text: "all clear" }],
+      }),
+    ]);
+
+    expect(screen.getByText("all clear")).toBeTruthy();
+    // Once, at the top of the pane, and nowhere in the transcript.
+    expect(screen.getAllByText("Manager")).toHaveLength(1);
+    expect(screen.queryByText("You")).toBeNull();
+  });
+
+  it("says when the conversation picked up again, where it did", () => {
+    const morning = envelope({ parts: [{ type: "text", text: "first thing" }] });
+    const afternoon = envelope({
+      createdAt: morning.createdAt + 5 * 60 * 60 * 1000,
+      parts: [{ type: "text", text: "back again" }],
+    });
+
+    const { container } = open([morning, afternoon]);
+    const line = container.querySelector(".when-row time");
+    expect(line?.getAttribute("datetime")).toBe(new Date(afternoon.createdAt).toISOString());
+    // One line for the gap, not one clock per message.
+    expect(container.querySelectorAll(".when-row")).toHaveLength(1);
   });
 });
 

--- a/src/components/ChannelView.tsx
+++ b/src/components/ChannelView.tsx
@@ -6,19 +6,20 @@ import { rowStandsFor, toPeer, transcriptRows } from "../lib/transcript";
 import { type Activity, type AgentCard, type AgentId, errorMessage } from "../lib/types";
 import { ActivityFlow } from "./ActivityFlow";
 import { Composer } from "./Composer";
-import { MessageItem, StreamingMessage } from "./MessageItem";
+import { MessageItem, StreamingMessage, WhenRow } from "./MessageItem";
 import { PairThread } from "./PairThread";
 import { PeerBurstRow, RefusedRow, WritingRow } from "./WireRow";
 
 interface Props {
   channel: ChannelKey;
-  onEditAgent: (agent: AgentCard) => void;
+  /** Where the operator asked for an agent's actions, and on whom. */
+  onOpenMenu: (agent: AgentCard, at: { x: number; y: number }) => void;
 }
 
 /** How long a message arrived at from search stays marked. */
 const FLASH_MS = 1800;
 
-export function ChannelView({ channel, onEditAgent }: Props) {
+export function ChannelView({ channel, onOpenMenu }: Props) {
   const lookups = useAgentLookup();
   const messages = useStore((s) => s.messages[channel]);
   const activity = useStore((s) => s.activity);
@@ -26,8 +27,6 @@ export function ChannelView({ channel, onEditAgent }: Props) {
   const focused = useStore((s) => s.focused);
   const clearFocus = useStore((s) => s.clearFocus);
 
-  const loadChannel = useStore((s) => s.loadChannel);
-  const [confirmClear, setConfirmClear] = useState(false);
   /** The peer whose thread is open over this channel, if any. */
   const [reading, setReading] = useState<AgentId | null>(null);
 
@@ -72,11 +71,9 @@ export function ChannelView({ channel, onEditAgent }: Props) {
     if (node && pinnedToBottom.current) node.scrollTop = node.scrollHeight;
   }, [messages]);
 
-  // A channel switch abandons any half-confirmed destructive action, and any
-  // thread opened off the old channel: a conversation between two other agents
-  // is not what you asked for by clicking a third.
+  // A channel switch abandons any thread opened off the old one: a conversation
+  // between two other agents is not what you asked for by clicking a third.
   useLayoutEffect(() => {
-    setConfirmClear(false);
     setReading(null);
   }, [channel]);
 
@@ -156,64 +153,24 @@ export function ChannelView({ channel, onEditAgent }: Props) {
               size="sm"
             />
             <h1 className="pane__title">{agent.name}</h1>
-            <p className="pane__subtitle">
-              {agent.model}
-              {agent.skills.length > 0 && ` · ${agent.skills.join(", ")}`}
-            </p>
-            <div style={{ marginLeft: "auto", display: "flex", gap: "0.25rem" }}>
-              {confirmClear ? (
-                <>
-                  <button
-                    type="button"
-                    className="btn btn--danger"
-                    onClick={() => {
-                      setConfirmClear(false);
-                      void api
-                        .clearChannel(agent.id)
-                        .then(() => loadChannel(agent.id))
-                        .catch((error) => setBanner({ tone: "error", text: errorMessage(error) }));
-                    }}
-                  >
-                    Delete this history
-                  </button>
-                  <button
-                    type="button"
-                    className="btn btn--ghost"
-                    onClick={() => setConfirmClear(false)}
-                  >
-                    Keep
-                  </button>
-                </>
-              ) : (
-                <>
-                  <button
-                    type="button"
-                    className="btn btn--ghost"
-                    onClick={() => {
-                      void api
-                        .setAgentPaused(agent.id, !paused)
-                        .catch((error) => setBanner({ tone: "error", text: errorMessage(error) }));
-                    }}
-                  >
-                    {paused ? "Resume" : "Pause"}
-                  </button>
-                  <button
-                    type="button"
-                    className="btn btn--ghost"
-                    onClick={() => setConfirmClear(true)}
-                  >
-                    Clear
-                  </button>
-                  <button
-                    type="button"
-                    className="btn btn--ghost"
-                    onClick={() => onEditAgent(agent)}
-                  >
-                    Edit
-                  </button>
-                </>
-              )}
-            </div>
+            {/* The one thing about an agent that changes what this pane does.
+                Everything else it is set up with is edited rarely and read
+                behind the menu, rather than sitting over every message. */}
+            {paused && <span className="pane__flag">Paused</span>}
+            <button
+              type="button"
+              className="pane__more"
+              aria-label={`Actions for ${agent.name}`}
+              title={`Actions for ${agent.name}`}
+              onClick={(event) => {
+                // Under the button it came from. The menu measures itself and
+                // slides back inside the window if it does not fit there.
+                const box = event.currentTarget.getBoundingClientRect();
+                onOpenMenu(agent, { x: box.left, y: box.bottom + 4 });
+              }}
+            >
+              ⋯
+            </button>
           </>
         ) : (
           <h1 className="pane__title">Channel unavailable</h1>
@@ -250,11 +207,17 @@ export function ChannelView({ channel, onEditAgent }: Props) {
                     <PeerBurstRow peers={row.peers} onOpen={setReading} />
                   ) : row.kind === "refused" ? (
                     <RefusedRow peer={row.peer} at={row.at} body={row.body} reason={row.reason} />
+                  ) : row.kind === "when" ? (
+                    <WhenRow at={row.at} />
                   ) : (
+                    // Two participants, one of them named at the top of the
+                    // pane and the other reading this. Nothing here needs
+                    // telling whose words it is looking at.
                     <MessageItem
                       message={row.message}
                       lookups={lookups}
                       continued={row.continued}
+                      named={false}
                     />
                   )}
                 </div>

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -134,6 +134,8 @@ export function Composer({ placeholder, disabled, disabledReason, onSend }: Prop
     setCaret(event.currentTarget.selectionStart ?? 0);
   };
 
+  const hint = showing ? "↑↓ to choose · Enter to insert" : dragging ? "Drop to attach" : null;
+
   return (
     <div className="composer" data-dragging={dragging || undefined}>
       {files.length > 0 && (
@@ -196,45 +198,50 @@ export function Composer({ placeholder, disabled, disabledReason, onSend }: Prop
         </div>
       )}
 
-      <textarea
-        ref={ref}
-        className="composer__input"
-        rows={1}
-        value={text}
-        placeholder={disabled ? (disabledReason ?? placeholder) : placeholder}
-        disabled={disabled}
-        onChange={(event) => {
-          setText(event.target.value);
-          setCaret(event.target.selectionStart ?? 0);
-          setDismissed(false);
-          setHighlighted(0);
-        }}
-        onKeyUp={track}
-        onClick={track}
-        onKeyDown={onKeyDown}
-        role="combobox"
-        aria-expanded={showing}
-        aria-controls={showing ? "mention-list" : undefined}
-        aria-activedescendant={showing ? `mention-${selected}` : undefined}
-        aria-autocomplete="list"
-      />
-      <div className="composer__foot">
-        <span className="hint">
-          {showing
-            ? "↑↓ to choose · Enter to insert"
-            : dragging
-              ? "Drop to attach"
-              : "Enter to send · @ to tag an agent · drop a file to attach it"}
-        </span>
+      <div className="composer__row">
+        <textarea
+          ref={ref}
+          className="composer__input"
+          rows={1}
+          value={text}
+          placeholder={disabled ? (disabledReason ?? placeholder) : placeholder}
+          disabled={disabled}
+          onChange={(event) => {
+            setText(event.target.value);
+            setCaret(event.target.selectionStart ?? 0);
+            setDismissed(false);
+            setHighlighted(0);
+          }}
+          onKeyUp={track}
+          onClick={track}
+          onKeyDown={onKeyDown}
+          role="combobox"
+          aria-expanded={showing}
+          aria-controls={showing ? "mention-list" : undefined}
+          aria-activedescendant={showing ? `mention-${selected}` : undefined}
+          aria-autocomplete="list"
+        />
         <button
           type="button"
-          className="btn btn--primary"
+          className="composer__send"
+          aria-label="Send"
+          title="Send"
           onClick={() => void submit()}
           disabled={disabled || sending || (text.trim().length === 0 && files.length === 0)}
         >
-          Send
+          <span aria-hidden="true">↑</span>
         </button>
       </div>
+
+      {/* Only when there is something to say. What used to live here
+          permanently was three facts that announce themselves: the typeahead
+          appears when you type @, the drop target says so while a file is over
+          the window, and Enter sends in every chat box ever written. */}
+      {hint && (
+        <div className="composer__foot">
+          <span className="hint">{hint}</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/MessageItem.test.tsx
+++ b/src/components/MessageItem.test.tsx
@@ -65,7 +65,6 @@ describe("messages addressed to the operator", () => {
   it("renders what you said as a bubble, with no avatar", () => {
     const { container } = show(envelope({}));
     expect(screen.getByText("hello there")).toBeTruthy();
-    expect(screen.getByText("You")).toBeTruthy();
     // You know who you are; the avatars exist to tell the agents apart.
     expect(container.querySelector(".avatar")).toBeNull();
   });
@@ -80,6 +79,55 @@ describe("messages addressed to the operator", () => {
     );
     expect(screen.getByText("on it")).toBeTruthy();
     expect(container.querySelector(".avatar")).toBeTruthy();
+  });
+});
+
+describe("naming the author", () => {
+  const reply = envelope({
+    from: { kind: "agent", id: "manager" },
+    to: { kind: "human" },
+    parts: [{ type: "text", text: "on it" }],
+  });
+
+  it("writes it out where two agents look alike in a list", () => {
+    // The pair's own thread. Neither participant is the person reading, and
+    // one column of text with two authors in it is unreadable without names.
+    render(<MessageItem message={reply} lookups={lookups} continued={false} named />);
+    expect(screen.getByText("Manager")).toBeTruthy();
+  });
+
+  it("leaves it out where the channel has already answered the question", () => {
+    // An agent's own channel has two participants: the one named at the top of
+    // the pane, and the operator. A name over every message is the loudest
+    // thing on the page and the one that says least.
+    const { container } = render(
+      <MessageItem message={reply} lookups={lookups} continued={false} named={false} />,
+    );
+    expect(screen.queryByText("Manager")).toBeNull();
+    // The portrait still says which agent, and it is one glyph rather than a
+    // line of display type over every paragraph.
+    expect(container.querySelector(".avatar")).toBeTruthy();
+  });
+
+  it("keeps your own message unmistakable without naming you either", () => {
+    const { container } = render(
+      <MessageItem message={envelope({})} lookups={lookups} continued={false} named={false} />,
+    );
+    expect(screen.queryByText("You")).toBeNull();
+    expect(container.querySelector(".msg[data-operator='true']")).toBeTruthy();
+    expect(container.querySelector(".avatar")).toBeNull();
+  });
+
+  it("still carries the time, out of the way", () => {
+    // Off the header and onto the row itself: every message has one and almost
+    // none of them are worth a line. It is a hover, and the transcript draws a
+    // line of its own wherever the gap was long enough to matter.
+    const { container } = render(
+      <MessageItem message={reply} lookups={lookups} continued={false} named={false} />,
+    );
+    const at = container.querySelector("time.msg__at");
+    expect(at).toBeTruthy();
+    expect(at?.getAttribute("datetime")).toBe(new Date(reply.createdAt).toISOString());
   });
 });
 

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -3,6 +3,7 @@ import { memo } from "react";
 import { AgentAvatar } from "../avatars/AgentAvatar";
 import { api } from "../lib/ipc";
 import { useStore } from "../lib/store";
+import { whenLabel } from "../lib/time";
 import { type Lookups, toPeer } from "../lib/transcript";
 import {
   type AgentCard,
@@ -22,6 +23,18 @@ interface Props {
   lookups: Lookups;
   /** Hides the avatar and header when the previous message had the same author. */
   continued: boolean;
+  /**
+   * Whether the author has to be written out.
+   *
+   * False in an agent's own channel, where there are exactly two participants:
+   * the channel is named after one of them and the operator is the other, so a
+   * name over every message is the loudest thing on the page and the one that
+   * says least. The portrait and the side of the column it sits on carry it.
+   *
+   * True in a pair's thread, where both participants are agents and look alike
+   * in a list.
+   */
+  named?: boolean;
 }
 
 const HUMAN = { id: "human", name: "You", color: "#5b665e", avatar: "plain" };
@@ -38,6 +51,21 @@ function identity(participant: Participant, byId: Lookups["byId"]) {
 
 function clockTime(ms: number): string {
   return new Date(ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+/**
+ * When a stretch of conversation started, drawn between two of them.
+ *
+ * The transcript's clock, moved off every message and onto the few places it
+ * changes anything. What it replaces was a time above four consecutive
+ * messages written in the same minute.
+ */
+export function WhenRow({ at }: { at: number }) {
+  return (
+    <div className="when-row">
+      <time dateTime={new Date(at).toISOString()}>{whenLabel(at, Date.now())}</time>
+    </div>
+  );
 }
 
 /** Keys tied to the message id. A persisted message is immutable. */
@@ -76,7 +104,12 @@ function onRetry(agentId: AgentId, messageId: MessageId) {
  * themselves never change, so an entry that is already on screen is already
  * correct.
  */
-export const MessageItem = memo(function MessageItem({ message, lookups, continued }: Props) {
+export const MessageItem = memo(function MessageItem({
+  message,
+  lookups,
+  continued,
+  named = true,
+}: Props) {
   const { from, to } = message;
 
   // Ahead of everything else: a request for permission is addressed to the
@@ -92,7 +125,7 @@ export const MessageItem = memo(function MessageItem({ message, lookups, continu
     return <ActivityRecord message={message} lookups={lookups} />;
   }
 
-  return <ChatBubble message={message} byId={lookups.byId} continued={continued} />;
+  return <ChatBubble message={message} byId={lookups.byId} continued={continued} named={named} />;
 });
 
 /**
@@ -152,10 +185,12 @@ function ChatBubble({
   message,
   byId,
   continued,
+  named,
 }: {
   message: Envelope;
   byId: Lookups["byId"];
   continued: boolean;
+  named: boolean;
 }) {
   const author = identity(message.from, byId);
   // The operator does not need a portrait of themselves in their own log; the
@@ -178,27 +213,26 @@ function ChatBubble({
       className={continued ? "msg msg--continued" : "msg"}
       data-operator={isOperator ? "true" : undefined}
     >
-      <div>
-        {!continued && !isOperator && (
-          <AgentAvatar
-            avatar={author.avatar}
-            color={author.color}
-            size="sm"
-            seed={author.id}
-            title={author.name}
-          />
-        )}
-      </div>
+      {!isOperator && (
+        <div className="msg__gutter">
+          {!continued && (
+            <AgentAvatar
+              avatar={author.avatar}
+              color={author.color}
+              size="sm"
+              seed={author.id}
+              title={author.name}
+            />
+          )}
+        </div>
+      )}
 
-      <div style={{ minWidth: 0 }}>
-        {!continued && (
+      <div className="msg__body">
+        {named && !continued && (
           <div className="msg__head">
             <span className="msg__author" style={{ color: author.color }}>
               {author.name}
             </span>
-            <time className="msg__time" dateTime={new Date(message.createdAt).toISOString()}>
-              {clockTime(message.createdAt)}
-            </time>
           </div>
         )}
 
@@ -225,6 +259,14 @@ function ChatBubble({
           <FileRow key={key} file={part} />
         ))}
       </div>
+
+      {/* Out of the flow, and revealed by the pointer. Every message has a time
+          and almost none of them are worth a line: four in a row are usually
+          the same minute. Asking for one is a hover; noticing that an hour
+          passed is the line the transcript draws by itself. */}
+      <time className="msg__at" dateTime={new Date(message.createdAt).toISOString()}>
+        {clockTime(message.createdAt)}
+      </time>
     </article>
   );
 }
@@ -251,29 +293,28 @@ function FileRow({ file }: { file: Extract<Part, { type: "file" }> }) {
   );
 }
 
-/** The in-progress bubble shown while an agent is composing. */
+/**
+ * The in-progress bubble shown while an agent is composing.
+ *
+ * Only ever drawn in that agent's own channel, so it carries no name and no
+ * clock: the caret is what says this one is still being written, and it will
+ * settle into a bubble of exactly this shape.
+ */
 export function StreamingMessage({ agent, text }: { agent: AgentCard | undefined; text: string }) {
   return (
     <article className="msg">
-      <div>
+      <div className="msg__gutter">
         <AgentAvatar
           avatar={agent?.avatar ?? "plain"}
           color={agent?.color ?? "#c7d96b"}
           size="sm"
           seed={agent?.id}
           activity={{ state: "thinking" }}
+          title={agent?.name}
         />
       </div>
-      <div style={{ minWidth: 0 }}>
-        <div className="msg__head">
-          <span className="msg__author" style={{ color: agent?.color }}>
-            {agent?.name ?? "Agent"}
-          </span>
-          <span className="msg__time">now</span>
-        </div>
-        <div className="md--streaming">
-          <Markdown>{text}</Markdown>
-        </div>
+      <div className="msg__body md--streaming">
+        <Markdown>{text}</Markdown>
       </div>
     </article>
   );

--- a/src/components/TokenMeter.tsx
+++ b/src/components/TokenMeter.tsx
@@ -110,8 +110,16 @@ export function TokenMeter({ groupId }: Props) {
           />
         ))}
       </span>
-      <span className="meter__count">{compact(spent)}</span>
-      {total?.cost != null && <span className="meter__cost">{money(total.cost)}</span>}
+      {/* One number, not two. A group header already carries a name, a
+          sparkline, a headcount and a gear, and tokens and dollars are the
+          same fact twice: the price is the one an operator acts on. The count
+          is what is left when a provider prices nothing, and then it is the
+          only signal there is. Both are in the tooltip either way. */}
+      {total?.cost != null ? (
+        <span className="meter__cost">{money(total.cost)}</span>
+      ) : (
+        <span className="meter__count">{compact(spent)}</span>
+      )}
     </span>
   );
 }

--- a/src/lib/time.test.ts
+++ b/src/lib/time.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { relativeTime } from "./time";
+import { relativeTime, whenLabel } from "./time";
 
 const NOW = 1_700_000_000_000;
 const ago = (ms: number) => relativeTime(NOW - ms, NOW);
@@ -31,5 +31,39 @@ describe("relativeTime", () => {
 
   it("does not go negative when a clock skews forward", () => {
     expect(relativeTime(NOW + 5_000, NOW)).toBe("now");
+  });
+});
+
+describe("whenLabel", () => {
+  /** 2pm on a Wednesday, local, so "yesterday" and "last week" are unambiguous. */
+  const wednesday = new Date(2024, 4, 15, 14, 0).getTime();
+  const day = 86_400_000;
+
+  it("names today and yesterday rather than dating them", () => {
+    expect(whenLabel(wednesday, wednesday)).toMatch(/^Today /);
+    expect(whenLabel(wednesday - day, wednesday)).toMatch(/^Yesterday /);
+  });
+
+  it("names the weekday while the name still means one day", () => {
+    expect(whenLabel(wednesday - 3 * day, wednesday)).toMatch(/^Sunday /);
+  });
+
+  it("dates anything a weekday name would be ambiguous about", () => {
+    // "Tuesday" three weeks back is four different Tuesdays.
+    expect(whenLabel(wednesday - 21 * day, wednesday)).not.toMatch(/day /);
+    expect(whenLabel(wednesday - 21 * day, wednesday)).toMatch(/24/);
+  });
+
+  it("counts calendar days, not multiples of 24 hours", () => {
+    // Eleven at night and one in the morning are two hours apart and two
+    // different days, and an hour ago is never "yesterday".
+    const lateWednesday = new Date(2024, 4, 15, 23, 0).getTime();
+    const earlyThursday = new Date(2024, 4, 16, 1, 0).getTime();
+    expect(whenLabel(lateWednesday, earlyThursday)).toMatch(/^Yesterday /);
+    expect(whenLabel(new Date(2024, 4, 16, 0, 30).getTime(), earlyThursday)).toMatch(/^Today /);
+  });
+
+  it("carries the clock, because a day on its own does not place a message", () => {
+    expect(whenLabel(wednesday, wednesday)).toMatch(/\d{1,2}[:.]\d\d/);
   });
 });

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -22,6 +22,34 @@ export function relativeTime(at: number, now: number): string {
   return `${Math.round(days / 7)}w`;
 }
 
+/** Local midnight, so a day is a day and not a fixed number of milliseconds. */
+function midnight(at: number): number {
+  const day = new Date(at);
+  day.setHours(0, 0, 0, 0);
+  return day.getTime();
+}
+
+/**
+ * When a stretch of conversation picked up again, for the line between two of
+ * them.
+ *
+ * Named while a name is unambiguous and dated once it is not: "Tuesday" means
+ * this week, and three weeks back it means nothing at all. Rounded from two
+ * local midnights rather than divided out of a difference, because a day is 23
+ * or 25 hours twice a year.
+ */
+export function whenLabel(at: number, now: number): string {
+  // A leading zero is for a column of times that have to line up. This is one
+  // time in a sentence, so it is written the way it is said.
+  const clock = new Date(at).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  const days = Math.round((midnight(now) - midnight(at)) / 86_400_000);
+
+  if (days <= 0) return `Today ${clock}`;
+  if (days === 1) return `Yesterday ${clock}`;
+  if (days < 7) return `${new Date(at).toLocaleDateString([], { weekday: "long" })} ${clock}`;
+  return `${new Date(at).toLocaleDateString([], { day: "numeric", month: "short" })} ${clock}`;
+}
+
 /**
  * A clock that ticks slowly, so relative labels stay honest without
  * re-rendering the rail every frame.

--- a/src/lib/transcript.test.ts
+++ b/src/lib/transcript.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { type Lookups, type Row, summaryLabel, transcriptRows } from "./transcript";
+import { type Lookups, type Row, rowStandsFor, summaryLabel, transcriptRows } from "./transcript";
 import type { AgentCard, Envelope, Part } from "./types";
 
 function card(id: string, name: string): AgentCard {
@@ -271,6 +271,65 @@ describe("merging consecutive messages under one header", () => {
     const first = envelope({});
     const second = envelope({ createdAt: first.createdAt + 5 * 60 * 1000 });
     expect(transcriptRows([first, second], lookups)[1]).toMatchObject({ continued: false });
+  });
+});
+
+describe("saying when a conversation picked up again", () => {
+  const hour = 60 * 60 * 1000;
+
+  it("draws nothing between messages of the same sitting", () => {
+    // The clock a transcript used to print over every message. Four replies in
+    // the same minute is four headers carrying one fact between them.
+    const first = envelope({});
+    const rows = transcriptRows(
+      [first, envelope({ createdAt: first.createdAt + 5 * 60 * 1000 })],
+      lookups,
+    );
+    expect(rows.map((row) => row.kind)).toEqual(["message", "message"]);
+  });
+
+  it("draws a line where the silence was long enough to notice", () => {
+    const first = envelope({});
+    const later = envelope({ createdAt: first.createdAt + 3 * hour });
+    const rows = transcriptRows([first, later], lookups);
+
+    expect(rows.map((row) => row.kind)).toEqual(["message", "when", "message"]);
+    // The time it started again, not the time it stopped: the line belongs to
+    // what is under it.
+    expect(rows[1]).toMatchObject({ kind: "when", at: later.createdAt });
+  });
+
+  it("ends the burst it interrupts", () => {
+    // Two exchanges three hours apart are two things that happened. Counted as
+    // one burst they read as a single conversation the operator missed.
+    const first = inbound("chef");
+    const later = inbound("chef");
+    later.createdAt = first.createdAt + 3 * hour;
+
+    const rows = transcriptRows([first, later], lookups);
+    expect(rows.map((row) => row.kind)).toEqual(["peers", "when", "peers"]);
+  });
+
+  it("never trails a transcript with a line nothing follows", () => {
+    // A turn whose every part folded into a burst leaves no row of its own, so
+    // a line pushed the moment the gap is spotted can end up hanging off the
+    // bottom pointing at nothing.
+    const first = envelope({});
+    const quiet = record(send(["Chef"], { status: "ok", summary: "sent" }));
+    quiet.createdAt = first.createdAt + 3 * hour;
+    const rows = transcriptRows([first, quiet], lookups);
+
+    expect(rows[rows.length - 1]?.kind).not.toBe("when");
+    expect(rows.map((row) => row.kind)).toEqual(["message", "when", "peers"]);
+  });
+
+  it("stands for no message, so search never lands on one", () => {
+    const first = envelope({});
+    const rows = transcriptRows(
+      [first, envelope({ createdAt: first.createdAt + 3 * hour })],
+      lookups,
+    );
+    expect(rowStandsFor(rows[1]!)).toEqual([]);
   });
 });
 

--- a/src/lib/transcript.ts
+++ b/src/lib/transcript.ts
@@ -93,10 +93,25 @@ export type Row =
       at: number;
       body: string;
       reason: string;
-    };
+    }
+  /**
+   * When the conversation picked up again, after a gap long enough that the
+   * messages either side of it are not the same sitting.
+   */
+  | { kind: "when"; key: string; at: number };
 
 /** How long a gap can be before a second message from the same author gets its own header. */
 const CONTINUATION_MS = 4 * 60 * 1000;
+
+/**
+ * How long a silence has to be before the transcript says when it ended.
+ *
+ * This is what a per-message clock was for, and a clock on every message is a
+ * column of near-identical numbers down a transcript where four in a row were
+ * written in the same minute. The gaps are the part worth reading: the exact
+ * time of any one message is still a hover away.
+ */
+const QUIET_MS = 30 * 60 * 1000;
 
 /** True when consecutive messages should merge under one header. */
 export function continues(previous: Envelope | undefined, current: Envelope): boolean {
@@ -128,6 +143,23 @@ export function transcriptRows(messages: Envelope[], lookups: Lookups): Row[] {
   let burst: Extract<Row, { kind: "peers" }> | null = null;
   /** The last bubble, for merging a follow-up under one header. */
   let spoken: Envelope | undefined;
+  /** When the last message was, for spotting the silence after it. */
+  let lastAt: number | null = null;
+  /**
+   * A gap that has been earned but not yet drawn.
+   *
+   * Held rather than pushed on sight, because a message does not always produce
+   * a row: a turn whose every part was folded into a burst leaves none. Emitted
+   * immediately before whatever row does come, so the line always has something
+   * underneath it and never trails the transcript.
+   */
+  let gap: { at: number; key: string } | null = null;
+
+  const mark = () => {
+    if (!gap) return;
+    rows.push({ kind: "when", key: `when:${gap.key}`, at: gap.at });
+    gap = null;
+  };
 
   const count = (
     peer: WirePeer,
@@ -143,6 +175,7 @@ export function transcriptRows(messages: Envelope[], lookups: Lookups): Row[] {
   ) => {
     let open = burst;
     if (!open) {
+      mark();
       open = { kind: "peers", key: `peers:${key}`, peers: [], folded: [] };
       rows.push(open);
       burst = open;
@@ -159,12 +192,21 @@ export function transcriptRows(messages: Envelope[], lookups: Lookups): Row[] {
 
   /** Anything that is not peer traffic. Ends the burst it interrupts. */
   const interrupt = (row: Row) => {
+    mark();
     rows.push(row);
     burst = null;
   };
 
   for (const message of messages) {
     const { from, to } = message;
+
+    // A silence long enough to be a break also ends whatever burst was open:
+    // two exchanges three hours apart are two things that happened, not one.
+    if (lastAt !== null && message.createdAt - lastAt >= QUIET_MS) {
+      gap = { at: message.createdAt, key: message.id };
+      burst = null;
+    }
+    lastAt = message.createdAt;
 
     // Ahead of everything else: a permission request is addressed to the
     // operator whoever the envelope says it is from, and it is the one thing
@@ -249,7 +291,7 @@ export function transcriptRows(messages: Envelope[], lookups: Lookups): Row[] {
  */
 export function rowStandsFor(row: Row): MessageId[] {
   if (row.kind === "peers") return row.folded;
-  if (row.kind === "refused") return [];
+  if (row.kind === "refused" || row.kind === "when") return [];
   return [row.message.id];
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -675,6 +675,42 @@ button {
   margin: 0;
 }
 
+/* An agent that will not answer, said once. It replaces a Pause button whose
+   label was the only place this was written down, which meant reading a
+   control to find out a state. */
+.pane__flag {
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--pit);
+  background: var(--pit-soft);
+  border-radius: 99px;
+  padding: 0.14rem 0.45rem;
+  flex: none;
+}
+
+/* Everything you can do to this agent, behind one glyph. Three text buttons
+   over the transcript competed with the title for a row that is read once. */
+.pane__more {
+  margin-left: auto;
+  flex: none;
+  border: 0;
+  background: none;
+  color: var(--faint);
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0.3rem 0.5rem;
+  border-radius: var(--radius-sm);
+  transition: color 120ms ease, background 120ms ease;
+}
+
+.pane__more:hover,
+.pane__more:focus-visible {
+  color: var(--text);
+  background: var(--sunken);
+}
+
 .pane__scroll {
   flex: 1;
   overflow-y: auto;
@@ -687,11 +723,26 @@ button {
   padding: 1.1rem 0 0.6rem;
 }
 
+/* ==========================================================================
+   Messages
+
+   An agent's words are paper: full measure, a portrait in the gutter, nothing
+   over the top of them. Yours are a bubble against the right edge. That is the
+   whole of the attribution in a channel, and it is enough, because a channel
+   has exactly two participants and one of them is you. What it replaces was a
+   name and a clock over every message, which in a run of four replies written
+   in the same minute is four headers carrying one fact between them.
+
+   The pair's own thread still writes the names out: both participants there
+   are agents, and neither of them is the person reading.
+   ========================================================================== */
+
 .msg {
+  position: relative;
   display: grid;
   grid-template-columns: 2.1rem 1fr;
   gap: 0.75rem;
-  padding: 0.35rem 1.5rem 0.35rem 1.15rem;
+  padding: 0.3rem 1.5rem 0.3rem 1.15rem;
 }
 
 .msg:hover {
@@ -700,6 +751,45 @@ button {
 
 .msg--continued {
   padding-top: 0;
+}
+
+.msg__gutter {
+  grid-column: 1;
+}
+
+/* A measure, not the width of the window. Nothing else in the transcript
+   constrains these now that the names and clocks are gone, and on a wide window
+   a paragraph ran a hundred and twenty characters to the line, which is a line
+   the eye loses its place on coming back to the left margin. */
+.msg__body {
+  grid-column: 2;
+  min-width: 0;
+  max-width: 42rem;
+}
+
+/* Yours: no portrait, no gutter, and held off the right edge. Nothing in the
+   log has to say who wrote it, because the side it is on already has. */
+.msg[data-operator="true"] {
+  grid-template-columns: 1fr;
+  justify-items: end;
+  padding-left: 4rem;
+}
+
+.msg[data-operator="true"] .msg__body {
+  grid-column: 1;
+  /* Shorter than an agent's. What you type is a question or an instruction,
+     and a bubble is the wrong shape for anything longer than a few lines. */
+  max-width: min(32rem, 100%);
+  padding: 0.4rem 0.75rem;
+  border-radius: var(--radius);
+  background: var(--flesh-soft);
+}
+
+/* Two of your own in a row are two bubbles with air between them. No tail on
+   either: which one a tail belongs on is a question about the end of a run,
+   and a transcript row does not know it is the last of one. */
+.msg--continued[data-operator="true"] .msg__body {
+  margin-top: 0.15rem;
 }
 
 .msg__head {
@@ -717,17 +807,41 @@ button {
   letter-spacing: -0.003em;
 }
 
-/* Your own messages sit quieter than the agents'. No portrait, and the name
-   recedes: in your own log you are context, not a participant to identify. */
-.msg[data-operator="true"] .msg__author {
-  font-weight: 500;
-  opacity: 0.72;
+/* Out of the flow entirely, so revealing it moves nothing. Every message has a
+   time; almost none of them are worth a line of their own, and the transcript
+   already draws a line wherever the gap was long enough to notice. */
+.msg__at {
+  position: absolute;
+  top: 0.42rem;
+  right: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--faint);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
 }
 
-.msg__time {
+.msg[data-operator="true"] .msg__at {
+  right: auto;
+  left: 1.15rem;
+}
+
+.msg:hover .msg__at {
+  opacity: 1;
+}
+
+/* When a conversation picked up again. The only clock a transcript draws
+   unasked, and it is drawn where the answer changed. */
+.when-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem 0.45rem;
   font-family: var(--font-mono);
-  font-size: 0.66rem;
-  font-variant-numeric: tabular-nums;
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
   color: var(--faint);
 }
 
@@ -1185,26 +1299,29 @@ button {
    `.pane__scroll` computes its `overflow-x` to `auto` because `overflow-y` is
    set, so the whole transcript earned a horizontal scrollbar. It showed up the
    day the column got narrower for the panel beside it. */
+/* Deliberately not a pill. A burst is the quietest thing a channel draws: it
+   says traffic happened and holds the content one click away. Bordered and
+   filled, two of these in a row read as two cards the operator is meant to
+   study, which is the opposite of what collapsing them was for. */
 .wire__chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.42rem;
+  gap: 0.4rem;
   flex: 0 1 auto;
   min-width: 0;
   max-width: 45%;
-  padding: 0.24rem 0.6rem;
+  padding: 0.1rem 0.2rem;
   border-radius: 99px;
-  border: 1px solid var(--edge);
-  background: var(--raised);
+  border: 1px solid transparent;
+  background: none;
   font-family: var(--font-mono);
   font-size: 0.66rem;
   letter-spacing: 0.01em;
-  color: var(--muted);
+  color: var(--faint);
   transition: border-color 130ms ease, color 130ms ease;
 }
 
 .wire__chip:hover {
-  border-color: color-mix(in oklab, var(--accent, var(--flesh)) 55%, var(--edge));
   color: var(--text);
 }
 
@@ -1236,7 +1353,12 @@ button {
   font-variant-numeric: tabular-nums;
 }
 
+/* Louder than ordinary traffic, and on purpose: this is the runtime stopping a
+   message rather than a message, and the reason is on the row rather than
+   behind the click. */
 .wire[data-refused="true"] .wire__chip {
+  padding: 0.24rem 0.6rem;
+  background: var(--raised);
   border-color: color-mix(in oklab, var(--pit) 40%, transparent);
   color: var(--pit);
 }
@@ -1260,9 +1382,12 @@ button {
   max-width: 100%;
 }
 
-/* There is a conversation behind this one. The chip lifts on hover rather
-   than only recolouring, because "click me" is the thing it has to say. */
+/* There is a conversation behind this one. The chip takes on its pill under
+   the pointer rather than wearing one permanently, because "click me" is only
+   worth saying to somebody already pointing at it. */
 .wire__chip--open:hover {
+  padding: 0.1rem 0.5rem;
+  margin: 0 -0.3rem;
   background: color-mix(in oklab, var(--accent, var(--flesh)) 8%, var(--raised));
   border-color: color-mix(in oklab, var(--accent, var(--flesh)) 55%, var(--edge));
   color: var(--text);
@@ -1744,8 +1869,19 @@ button {
   50% { opacity: 1; transform: translateY(-1.5px); }
 }
 
+/* One row: the box and the one control it needs. The box used to be a stack,
+   with a permanent line of instructions and a Send button under it, which is
+   two rows of chrome under every message anybody types. */
+.composer__row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.4rem;
+  padding: 0.3rem 0.35rem 0.3rem 0;
+}
+
 .composer__input {
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   resize: none;
   border: 0;
   background: none;
@@ -1753,7 +1889,7 @@ button {
   font: inherit;
   font-size: 0.925rem;
   line-height: 1.55;
-  padding: 0.72rem 0.85rem 0.25rem;
+  padding: 0.28rem 0.2rem 0.28rem 0.85rem;
   outline: none;
   max-height: 12rem;
 }
@@ -1762,11 +1898,38 @@ button {
   color: var(--faint);
 }
 
+/* Round, in the accent, and the size of the line it sits beside. A word-width
+   button is a label for something nothing else in the row could be. */
+.composer__send {
+  flex: none;
+  width: 1.75rem;
+  height: 1.75rem;
+  margin-bottom: 0.12rem;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  background: var(--flesh);
+  color: var(--ground);
+  font-size: 0.85rem;
+  line-height: 1;
+  transition: background 120ms ease, opacity 120ms ease;
+}
+
+.composer__send:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--flesh) 86%, var(--text));
+}
+
+.composer__send:disabled {
+  background: var(--edge);
+  color: var(--faint);
+  cursor: not-allowed;
+}
+
 .composer__foot {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 0.15rem 0.5rem 0.45rem 0.85rem;
+  padding: 0 0.85rem 0.4rem;
 }
 
 .hint {
@@ -2740,6 +2903,33 @@ button {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Which model is answering. It used to sit under the agent's name over every
+   message; here it is where somebody goes when a reply looks wrong. */
+.menu__model {
+  display: block;
+  margin-top: 0.1rem;
+  text-transform: none;
+  letter-spacing: 0.02em;
+  opacity: 0.8;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.menu__rule {
+  border: 0;
+  border-top: 1px solid var(--edge);
+  margin: 0.25rem 0;
+}
+
+.menu__item[data-tone="danger"] {
+  color: var(--alarm);
+}
+
+.menu__item[data-tone="danger"]:hover,
+.menu__item[data-tone="danger"]:focus-visible {
+  background: color-mix(in oklab, var(--alarm) 10%, transparent);
 }
 
 .menu__item {


### PR DESCRIPTION
A channel has two participants and it was writing both of them over every message with a clock beside them, so four replies inside the same minute drew four headers carrying one fact between them; attribution is now the portrait and the side of the column, your own messages sit in a bubble against the right edge, and `named` keeps the names in the pair's own thread where both participants are agents.

The clock moved to a line drawn wherever the silence ran past half an hour, with any single message's time a hover on its own row, and the text gained a measure now that no chrome is holding it.

The header lost the model id and its three buttons: Pause and Clear history joined Edit profile, Pin and Duplicate in the agent menu, which is now the one action surface for an agent and takes the confirmation for a deletion itself, and a paused agent says so in the header instead of leaving it to be read off a button label.

Peer bursts, the composer and the group meter each dropped what they were saying twice: unbordered chips that take their pill on hover, no permanent line of instructions under the box, and a price or a token count rather than both.
