### PR TITLE
feat: a model's reasoning is shown while it works, and never kept

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,19 @@ then it has an address. One file failing does not refuse the four beside it.
 size and the type on a message are read off the disk, never taken from the
 webview. A staged file that is never sent stays, like every other file here.
 
+**A model's reasoning is shown and never kept, and the placeholder is what
+makes that true.** `ReasoningDelta` names a message id and no channel: the
+webview files it under the agent that opened that stream and drops it when the
+stream ends, so nothing else has to remember to clear it and a retry that
+reopens under a new id throws away the half-formed thought of the attempt that
+broke. It is carried apart from the text from the wire onwards, as
+`Token::Reasoning`, because a single `&str` callback made the two the same
+thing by the time anything could tell them apart, and the answer is the only
+half that may be persisted, hashed by the guard or replayed into a prompt. It
+is also its own slice in the store rather than a field on the stream buffer:
+written there, every thought would re-render and re-parse the markdown of every
+live bubble for text that is in none of them.
+
 **Every event is an IPC hop and a render, so tokens are coalesced before they
 leave.** A model writes faster than a screen refreshes. One event per token
 spent the operator's main thread on work no eye could resolve, and with five

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -169,6 +169,42 @@ Two rules keep it honest:
 What survives all three becomes a notice carrying the `cause` of the turn, which
 is what the operator's "Try again" sends again, as a new run at the original hop.
 
+## A thought is shown and never kept
+
+A turn can spend a minute working through tool results before it writes a word.
+For that minute the operator had a pulsing avatar and the sentence "Manager is
+working", which says a turn is alive and nothing about what it is doing. Where
+the provider publishes the model's own working, that is what the line above the
+composer now shows: the line it is on, replaced as it writes.
+
+Three things keep it from becoming a fourth kind of message.
+
+- **It is carried apart from the text, from the wire onwards.** `Token::Text`
+  and `Token::Reasoning` reach the runtime as separate fragments, and only the
+  first is accumulated. Reasoning is never persisted, never included in the
+  content hash the loop guard compares, and never sent back to a model. Nothing
+  downstream of `stream_chat` holds it, so there is no path by which it could
+  be. Two spellings are read (`reasoning`, `reasoning_content`) because two
+  conventions exist, and a frame carrying both is one thought, not two.
+- **It is addressed to the placeholder, which is what makes it ephemeral for
+  free.** `ReasoningDelta` names a message id and no channel. The webview files
+  it under the agent that opened that stream and drops it when the stream ends,
+  so a thought cannot outlive the turn that had it, and a retry that reopens
+  under a new id discards the half-formed thought of the attempt that broke.
+  The agent is the right key rather than the channel: a turn writing to a peer
+  streams into the peer's channel, while the operator watching it work is
+  reading its own.
+- **It is buffered on the same clock as the text, and stored beside it rather
+  than in it.** Reasoning arrives as fast as an answer and costs the same IPC
+  hop and render, so `Pen` coalesces both to 16ms. In the store it is its own
+  slice: written into the stream buffer, every token would re-render and
+  re-parse the markdown of every live bubble for text that is in none of them.
+  `ChannelView.perf.test.tsx` counts that.
+
+Only the newest line is kept, because there is nowhere to scroll back to. Models
+that publish nothing (Anthropic's, over OpenRouter, unless thinking is asked for)
+leave the line exactly as it was.
+
 ## Trust is a property of the envelope, and it is restated in words
 
 The survey's "tool poisoning" (MCP) and "task injection" (A2A) describe the same

--- a/src-tauri/src/llm/mod.rs
+++ b/src-tauri/src/llm/mod.rs
@@ -2,4 +2,4 @@ pub mod openrouter;
 pub mod sse;
 pub mod tools;
 
-pub use openrouter::{ChatMessage, ChatRequest, Completion, LlmClient, LlmError, ToolCall};
+pub use openrouter::{ChatMessage, ChatRequest, Completion, LlmClient, LlmError, Token, ToolCall};

--- a/src-tauri/src/llm/openrouter.rs
+++ b/src-tauri/src/llm/openrouter.rs
@@ -186,6 +186,21 @@ pub struct ToolCall {
     pub arguments: String,
 }
 
+/// One fragment of a streamed response, as it arrives.
+///
+/// Reasoning is carried apart from the answer rather than concatenated into it.
+/// It is shown while a turn is running and then dropped: never persisted, never
+/// hashed, never sent back to a model. With a single `&str` callback the two
+/// were the same thing by the time anyone could tell them apart, and the only
+/// way back would be parsing prose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Token<'a> {
+    /// Part of what the model is saying.
+    Text(&'a str),
+    /// Part of how it got there, when the provider publishes any.
+    Reasoning(&'a str),
+}
+
 impl ToolCall {
     /// Parses the argument string, tolerating an empty one.
     ///
@@ -368,8 +383,30 @@ struct StreamChoice {
 struct Delta {
     #[serde(default)]
     content: Option<String>,
+    /// The model's own working, when it publishes any.
+    ///
+    /// Two spellings because two conventions exist: OpenRouter says
+    /// `reasoning`, and the OpenAI-compatible servers that followed DeepSeek
+    /// say `reasoning_content`. Reading only one of them shows a thinking model
+    /// thinking on one endpoint and working in silence on the next. A provider
+    /// that sends both sends the same words twice, which is why they are
+    /// coalesced rather than concatenated.
+    #[serde(default)]
+    reasoning: Option<String>,
+    #[serde(default)]
+    reasoning_content: Option<String>,
     #[serde(default)]
     tool_calls: Vec<DeltaToolCall>,
+}
+
+impl Delta {
+    /// Whichever spelling of the reasoning this frame used, if either.
+    fn thinking(&self) -> Option<&str> {
+        [self.reasoning.as_deref(), self.reasoning_content.as_deref()]
+            .into_iter()
+            .flatten()
+            .find(|fragment| !fragment.is_empty())
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -459,10 +496,10 @@ impl LlmClient {
         Ok(Self { http })
     }
 
-    /// Streams a completion, calling `on_token` for each text fragment.
+    /// Streams a completion, calling `on_token` for each fragment.
     ///
     /// `on_token` runs on the caller's task and must not block; it exists so
-    /// the UI can render text as it arrives rather than after the turn ends.
+    /// the UI can render a turn as it happens rather than after it ends.
     pub async fn stream_chat<F>(
         &self,
         cfg: &InferenceConfig,
@@ -470,7 +507,7 @@ impl LlmClient {
         mut on_token: F,
     ) -> Result<Completion, LlmError>
     where
-        F: FnMut(&str),
+        F: FnMut(Token<'_>),
     {
         if !cfg.is_ready() {
             return Err(LlmError::NotConfigured);
@@ -532,7 +569,7 @@ impl LlmClient {
         on_token: &mut F,
     ) -> Result<Completion, LlmError>
     where
-        F: FnMut(&str),
+        F: FnMut(Token<'_>),
     {
         let mut decoder = SseDecoder::new();
         let mut accumulator = ToolCallAccumulator::default();
@@ -588,9 +625,15 @@ impl LlmClient {
                 }
 
                 for choice in parsed.choices {
+                    // Ahead of the text, and accumulated nowhere: a model
+                    // reasons its way to what it then says, and nothing
+                    // downstream of this call is allowed to keep the reasoning.
+                    if let Some(fragment) = choice.delta.thinking() {
+                        on_token(Token::Reasoning(fragment));
+                    }
                     if let Some(fragment) = choice.delta.content {
                         if !fragment.is_empty() {
-                            on_token(&fragment);
+                            on_token(Token::Text(&fragment));
                             content.push_str(&fragment);
                         }
                     }
@@ -694,6 +737,19 @@ mod tests {
         serde_json::json!({ "choices": [{ "delta": { "content": content } }] }).to_string()
     }
 
+    /// A reasoning frame, spelled the way the endpoint under test spells it.
+    fn thinking_frame(field: &str, content: &str) -> String {
+        serde_json::json!({ "choices": [{ "delta": { field: content } }] }).to_string()
+    }
+
+    /// Everything a stream reported, tagged, in arrival order.
+    fn collect<'a>(tokens: &'a mut Vec<(&'static str, String)>) -> impl FnMut(Token<'_>) + 'a {
+        |token| match token {
+            Token::Text(text) => tokens.push(("text", text.to_string())),
+            Token::Reasoning(text) => tokens.push(("reasoning", text.to_string())),
+        }
+    }
+
     #[tokio::test]
     async fn streams_text_and_reports_tokens_in_order() {
         let (base, _) = stub(|_| {
@@ -703,13 +759,100 @@ mod tests {
 
         let client = LlmClient::new().unwrap();
         let mut tokens = Vec::new();
-        let completion = client
-            .stream_chat(&cfg(base), &request(), |t| tokens.push(t.to_string()))
-            .await
-            .unwrap();
+        let completion =
+            client.stream_chat(&cfg(base), &request(), collect(&mut tokens)).await.unwrap();
 
         assert_eq!(completion.content, "Hello, world");
-        assert_eq!(tokens, vec!["Hel", "lo, ", "world"], "tokens must surface incrementally");
+        assert_eq!(
+            tokens,
+            vec![("text", "Hel".into()), ("text", "lo, ".into()), ("text", "world".into())],
+            "tokens must surface incrementally"
+        );
+    }
+
+    #[tokio::test]
+    async fn reasoning_surfaces_apart_from_the_answer_and_never_joins_it() {
+        // A model that publishes its working writes it before the answer, in
+        // frames of the same shape. Concatenating the two would put the
+        // thinking in the transcript, in the prompt of every later turn, and in
+        // the fingerprint the loop guard compares.
+        let (base, _) = stub(|_| {
+            sse(&[
+                &thinking_frame("reasoning", "17 times 20 is 340"),
+                &thinking_frame("reasoning", ", plus 51"),
+                &text_frame("391"),
+                "[DONE]",
+            ])
+        })
+        .await;
+
+        let client = LlmClient::new().unwrap();
+        let mut tokens = Vec::new();
+        let completion =
+            client.stream_chat(&cfg(base), &request(), collect(&mut tokens)).await.unwrap();
+
+        assert_eq!(
+            tokens,
+            vec![
+                ("reasoning", "17 times 20 is 340".into()),
+                ("reasoning", ", plus 51".into()),
+                ("text", "391".into()),
+            ]
+        );
+        assert_eq!(completion.content, "391", "reasoning is not part of what was said");
+    }
+
+    #[tokio::test]
+    async fn reasoning_is_read_under_either_spelling() {
+        // OpenRouter says `reasoning`; the servers that followed DeepSeek say
+        // `reasoning_content`. An operator pointing Guaca at a local endpoint
+        // should not lose the line under the composer.
+        for field in ["reasoning", "reasoning_content"] {
+            let frame = thinking_frame(field, "weighing it up");
+            let (base, _) = stub(move |_| sse(&[&frame, &text_frame("yes"), "[DONE]"])).await;
+
+            let client = LlmClient::new().unwrap();
+            let mut tokens = Vec::new();
+            client.stream_chat(&cfg(base), &request(), collect(&mut tokens)).await.unwrap();
+            assert_eq!(
+                tokens.first(),
+                Some(&("reasoning", "weighing it up".to_string())),
+                "{field} was not read"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_frame_carrying_both_spellings_reports_the_thought_once() {
+        // A provider that fills both fields is saying the same thing twice.
+        // Passing both through doubles every word on screen.
+        let frame = serde_json::json!({"choices":[{"delta":{
+            "reasoning": "checking the total",
+            "reasoning_content": "checking the total",
+        }}]})
+        .to_string();
+        let (base, _) = stub(move |_| sse(&[&frame, &text_frame("done"), "[DONE]"])).await;
+
+        let client = LlmClient::new().unwrap();
+        let mut tokens = Vec::new();
+        client.stream_chat(&cfg(base), &request(), collect(&mut tokens)).await.unwrap();
+        assert_eq!(
+            tokens,
+            vec![("reasoning", "checking the total".into()), ("text", "done".into())]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_stream_that_only_ever_reasoned_is_still_truncated() {
+        // Thinking is not an answer. A stream cut off after its reasoning has
+        // produced nothing to say, and reporting it as an empty success is how
+        // an agent goes silent with no explanation.
+        let (base, _) =
+            stub(|_| sse(&[&thinking_frame("reasoning", "still working it out")])).await;
+
+        let client = LlmClient::new().unwrap();
+        let err = client.stream_chat(&cfg(base), &request(), |_| {}).await.unwrap_err();
+        assert!(matches!(err, LlmError::Truncated), "got {err:?}");
     }
 
     #[tokio::test]

--- a/src-tauri/src/runtime/events.rs
+++ b/src-tauri/src/runtime/events.rs
@@ -67,6 +67,19 @@ pub enum UiEvent {
         channel_id: AgentId,
         text: String,
     },
+    /// Part of the model's own working, for as long as the turn lasts.
+    ///
+    /// Addressed to the placeholder rather than to a channel, and that is what
+    /// makes it ephemeral for free: the UI files it under the agent that opened
+    /// the stream and drops the lot when the stream ends, so a thought cannot
+    /// outlive the turn that had it. Nothing here is persisted, and no channel
+    /// id is carried because a thought is not filed anywhere: a turn writing to
+    /// a peer streams into that peer's channel, while the operator watching
+    /// this agent work is reading its own.
+    ReasoningDelta {
+        message_id: MessageId,
+        text: String,
+    },
     /// The placeholder is replaced by the persisted message that follows.
     StreamEnded {
         message_id: MessageId,
@@ -162,6 +175,20 @@ impl RecordingSink {
             .collect()
     }
 
+    /// The same for the reasoning that ran alongside it.
+    pub fn streamed_reasoning(&self, message_id: MessageId) -> String {
+        self.events
+            .lock()
+            .iter()
+            .filter_map(|e| match e {
+                UiEvent::ReasoningDelta { message_id: id, text } if *id == message_id => {
+                    Some(text.as_str())
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
     pub fn appended_messages(&self) -> Vec<Envelope> {
         self.events
             .lock()
@@ -229,6 +256,24 @@ mod tests {
 
         assert_eq!(sink.streamed_text(id), "Hello, world");
         assert_eq!(sink.streamed_text(other), "NOISE");
+    }
+
+    #[test]
+    fn a_thought_and_the_text_beside_it_are_kept_apart() {
+        // They share a placeholder and arrive interleaved. A sink that mixed
+        // them would put the model's working into the assertion that says what
+        // the operator watched appear.
+        let sink = RecordingSink::new();
+        let id = MessageId::new();
+        sink.emit(UiEvent::ReasoningDelta { message_id: id, text: "weighing it up".into() });
+        sink.emit(UiEvent::StreamDelta {
+            message_id: id,
+            channel_id: AgentId::new(),
+            text: "Yes.".into(),
+        });
+
+        assert_eq!(sink.streamed_text(id), "Yes.");
+        assert_eq!(sink.streamed_reasoning(id), "weighing it up");
     }
 
     #[test]

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -177,7 +177,7 @@ use crate::domain::now_ms;
 use crate::domain::routine::{Routine, RunKind};
 use crate::domain::signin::Signin;
 use crate::files::FileStore;
-use crate::llm::openrouter::{ChatMessage, ChatRequest, LlmClient, LlmError, ToolCall};
+use crate::llm::openrouter::{ChatMessage, ChatRequest, LlmClient, LlmError, Token, ToolCall};
 use crate::llm::tools::{self, Delivery, ToolInvocation};
 use crate::workspace::Workspace;
 use events::{Activity, EventSink, UiEvent};
@@ -2978,35 +2978,61 @@ const PEN_FLUSH: Duration = Duration::from_millis(16);
 /// sentence held back waiting for a buffer to fill, and a fast one must not
 /// flood. Whatever is unflushed when the call ends is written by `flush`, so
 /// no token is ever dropped.
+///
+/// Reasoning is held in its own buffer and flushed on the same clock. It is
+/// produced at the same rate as the text and costs the same IPC hop and render,
+/// so a thinking model streaming its working uncoalesced is the freeze this
+/// whole arrangement exists to prevent, arriving through a second door.
 struct Pen {
     events: Arc<dyn EventSink>,
     message_id: MessageId,
     channel_id: AgentId,
     held: String,
+    thought: String,
     last: Instant,
 }
 
 impl Pen {
     fn new(events: Arc<dyn EventSink>, message_id: MessageId, channel_id: AgentId) -> Self {
-        Self { events, message_id, channel_id, held: String::new(), last: Instant::now() }
+        Self {
+            events,
+            message_id,
+            channel_id,
+            held: String::new(),
+            thought: String::new(),
+            last: Instant::now(),
+        }
     }
 
-    fn write(&mut self, token: &str) {
-        self.held.push_str(token);
+    fn write(&mut self, token: Token<'_>) {
+        match token {
+            Token::Text(text) => self.held.push_str(text),
+            Token::Reasoning(text) => self.thought.push_str(text),
+        }
         if self.last.elapsed() >= PEN_FLUSH {
             self.flush();
         }
     }
 
     fn flush(&mut self) {
-        if self.held.is_empty() {
+        if self.held.is_empty() && self.thought.is_empty() {
             return;
         }
-        self.events.emit(UiEvent::StreamDelta {
-            message_id: self.message_id,
-            channel_id: self.channel_id,
-            text: std::mem::take(&mut self.held),
-        });
+        // The thought first, in the order it was written: it is what led to the
+        // sentence in the same flush.
+        if !self.thought.is_empty() {
+            self.events.emit(UiEvent::ReasoningDelta {
+                message_id: self.message_id,
+                text: std::mem::take(&mut self.thought),
+            });
+        }
+        if !self.held.is_empty() {
+            self.events.emit(UiEvent::StreamDelta {
+                message_id: self.message_id,
+                channel_id: self.channel_id,
+                text: std::mem::take(&mut self.held),
+            });
+        }
         self.last = Instant::now();
     }
 }

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -660,6 +660,77 @@ async fn streamed_text_matches_the_persisted_message() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_model_that_thinks_out_loud_is_watched_without_being_recorded() {
+    // The whole of the feature: an operator can see what a turn is doing while
+    // it does it, and nothing about it survives the turn. Reasoning that leaked
+    // into the message would be replayed into every later prompt, hashed by the
+    // loop guard, and read back by a peer as something the agent had said.
+    let stub = serve(|_| Script::Thinking {
+        about: "They want the total, so 17 times 23.".into(),
+        say: "391.".into(),
+    })
+    .await;
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "what is 17 times 23").unwrap();
+    h.settle(run).await;
+
+    let stream_id = h
+        .sink
+        .snapshot()
+        .into_iter()
+        .find_map(|e| match e {
+            UiEvent::StreamStarted { message_id, .. } => Some(message_id),
+            _ => None,
+        })
+        .expect("a stream should have started");
+
+    assert_eq!(
+        h.sink.streamed_reasoning(stream_id),
+        "They want the total, so 17 times 23.",
+        "the operator should have seen it working"
+    );
+    assert_eq!(h.sink.streamed_text(stream_id), "391.");
+
+    // And the transcript holds the answer alone.
+    let persisted = h.channel_texts("Manager").pop().unwrap();
+    assert_eq!(persisted, "391.");
+    assert!(!persisted.contains("17 times 23"), "reasoning reached the transcript: {persisted}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_thought_is_coalesced_on_the_same_clock_as_the_text() {
+    // Reasoning is produced as fast as text and costs the same IPC hop and
+    // render. A thinking model streaming its working one token at a time is
+    // the freeze the pen exists to prevent, arriving through a second door.
+    let thinking = "weighing the options carefully. ".repeat(40);
+    let expected = thinking.clone();
+    let stub =
+        serve(move |_| Script::Thinking { about: thinking.clone(), say: "Yes.".into() }).await;
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "decide").unwrap();
+    h.settle(run).await;
+
+    let deltas = h.sink.count_of(|e| matches!(e, UiEvent::ReasoningDelta { .. }));
+    assert!(
+        deltas <= 12,
+        "{deltas} events for reasoning the provider sent in {} pieces",
+        expected.len().div_ceil(9)
+    );
+
+    let stream_id = h
+        .sink
+        .snapshot()
+        .into_iter()
+        .find_map(|e| match e {
+            UiEvent::StreamStarted { message_id, .. } => Some(message_id),
+            _ => None,
+        })
+        .expect("a stream should have started");
+    // Coalesced, not truncated: the tail is flushed when the call ends.
+    assert_eq!(h.sink.streamed_reasoning(stream_id), expected);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn a_long_reply_reaches_the_window_in_far_fewer_events_than_tokens() {
     // Every event is an IPC hop and a re-render in the operator's window, and a
     // model writes faster than a screen refreshes. Emitting one per token spent

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -41,6 +41,9 @@ use guac_lib::workspace::Workspace;
 pub enum Script {
     /// Emit plain text.
     Say(String),
+    /// Publish some working, then say something. What a reasoning model sends:
+    /// the thinking arrives first, in frames of the same shape as the text.
+    Thinking { about: String, say: String },
     /// Emit a `send_message` tool call, declared as a courtesy: what a model
     /// sends when it is being polite, and what most of these scenarios play.
     SendTo { recipients: Vec<String>, text: String },
@@ -90,6 +93,23 @@ pub fn render(script: &Script) -> String {
             // Split into fragments so the streaming path is exercised, not
             // just a single-chunk happy case.
             for piece in text.as_bytes().chunks(7) {
+                let piece = String::from_utf8_lossy(piece).to_string();
+                body.push_str(&frame(
+                    serde_json::json!({"choices":[{"delta":{"content": piece}}]}),
+                ));
+            }
+            body.push_str(&frame(
+                serde_json::json!({"choices":[{"delta":{},"finish_reason":"stop"}]}),
+            ));
+        }
+        Script::Thinking { about, say } => {
+            for piece in about.as_bytes().chunks(9) {
+                let piece = String::from_utf8_lossy(piece).to_string();
+                body.push_str(&frame(
+                    serde_json::json!({"choices":[{"delta":{"reasoning": piece}}]}),
+                ));
+            }
+            for piece in say.as_bytes().chunks(7) {
                 let piece = String::from_utf8_lossy(piece).to_string();
                 body.push_str(&frame(
                     serde_json::json!({"choices":[{"delta":{"content": piece}}]}),

--- a/src/components/ChannelView.perf.test.tsx
+++ b/src/components/ChannelView.perf.test.tsx
@@ -19,6 +19,7 @@ import { ChannelView } from "./ChannelView";
  */
 
 let rendersOfMessages = 0;
+let rendersOfBubbles = 0;
 let latestBubble = "";
 
 vi.mock("./MessageItem", () => ({
@@ -27,6 +28,7 @@ vi.mock("./MessageItem", () => ({
     return <div />;
   },
   StreamingMessage: ({ text }: { text: string }) => {
+    rendersOfBubbles += 1;
     latestBubble = text;
     return <div>{text}</div>;
   },
@@ -106,12 +108,14 @@ function stream(messageId: string, channelId: string, agentId: string, tokens: n
 describe("ChannelView under streaming load", () => {
   beforeEach(() => {
     rendersOfMessages = 0;
+    rendersOfBubbles = 0;
     latestBubble = "";
     useStore.setState({
       agents: [agent(AGENT, "Manager"), agent(OTHER, "Chef")],
       messages: { [AGENT]: Array.from({ length: 30 }, (_, i) => message(i)) },
       streams: {},
-      activity: {},
+      reasoning: {},
+      activity: { [AGENT]: { state: "thinking" } },
     });
   });
 
@@ -155,5 +159,29 @@ describe("ChannelView under streaming load", () => {
     await feed(stream("00000000-0000-4000-8000-0000000000d2", OTHER, OTHER, 200));
 
     expect(rendersOfMessages).toBe(0);
+  });
+
+  it("does not re-render the transcript or a bubble for a thought", async () => {
+    // Reasoning arrives as fast as text and is drawn in one line above the
+    // composer. Held in the stream buffer it would re-render, and re-parse the
+    // markdown of, every bubble on screen for text that is in none of them.
+    const id = "00000000-0000-4000-8000-0000000000d3";
+    draw();
+    await feed(stream(id, AGENT, AGENT, 1));
+    const bubbles = rendersOfBubbles;
+
+    await feed(
+      Array.from({ length: 200 }, () => ({
+        type: "reasoningDelta" as const,
+        messageId: id as MessageId,
+        text: "thinking ",
+      })),
+    );
+
+    expect(rendersOfMessages).toBe(0);
+    expect(rendersOfBubbles).toBe(bubbles);
+
+    // And the line itself kept up, which is the point of drawing it at all.
+    expect(useStore.getState().reasoning[AGENT]?.endsWith("thinking ")).toBe(true);
   });
 });

--- a/src/components/ChannelView.test.tsx
+++ b/src/components/ChannelView.test.tsx
@@ -97,6 +97,7 @@ function open(messages: Envelope[]) {
     agents: [card(MANAGER, "Manager"), card(CHEF, "Chef")],
     messages: { [MANAGER]: messages },
     streams: {},
+    reasoning: {},
     activity: {},
     lastActive: {},
     banner: null,
@@ -236,6 +237,36 @@ describe("while an agent is working", () => {
 
     doing({ state: "idle" });
     expect(screen.queryByText("Manager is working")).toBeNull();
+  });
+
+  it("shows what it is thinking, and stops when the thought is dropped", () => {
+    // The complaint this answers: a pulsing avatar says a turn is alive and
+    // nothing says what it is doing, through a wait that can run to a minute
+    // of tool calls.
+    open([envelope({})]);
+    doing({ state: "thinking" });
+
+    act(() => useStore.setState({ reasoning: { [MANAGER]: "**Checking**\n\nthe totals now" } }));
+    expect(screen.getByText("the totals now")).toBeTruthy();
+    expect(screen.queryByText("Manager is working")).toBeNull();
+    // And it stops being a live region while it holds a line that is replaced
+    // several times a second, or a screen reader reads out every half sentence
+    // of it over whatever else it was saying.
+    expect(screen.queryByRole("status")).toBeNull();
+
+    // The runtime clears it when the stream ends, and the line goes back to
+    // saying only that the turn is still going.
+    act(() => useStore.setState({ reasoning: {} }));
+    expect(screen.getByRole("status").textContent).toContain("Manager is working");
+  });
+
+  it("draws another agent's thinking in that agent's channel and not this one", () => {
+    open([envelope({})]);
+    doing({ state: "thinking" });
+    act(() => useStore.setState({ reasoning: { [CHEF]: "not this channel" } }));
+
+    expect(screen.queryByText("not this channel")).toBeNull();
+    expect(screen.getByText("Manager is working")).toBeTruthy();
   });
 
   it("counts unread work as working, and waiting on a person as not", () => {

--- a/src/components/ChannelView.tsx
+++ b/src/components/ChannelView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { AgentAvatar } from "../avatars/AgentAvatar";
 import { api } from "../lib/ipc";
+import { thoughtLine } from "../lib/reasoning";
 import { ACTIVITY_CHANNEL, type ChannelKey, useAgentLookup, useStore } from "../lib/store";
 import { rowStandsFor, toPeer, transcriptRows } from "../lib/transcript";
 import { type Activity, type AgentCard, type AgentId, errorMessage } from "../lib/types";
@@ -253,21 +254,34 @@ export function ChannelView({ channel, onOpenMenu }: Props) {
 }
 
 /**
- * That the agent is still going, above the box you would type into.
+ * That the agent is still going, above the box you would type into, and what
+ * it is thinking while it goes.
  *
  * The sidebar already says "typing" beside the name, but the operator watching
  * a channel is looking at the bottom of it, waiting. A silent gap between
  * sending and the first token is the moment the app looks broken, and it is a
  * long one: a turn can spend several model calls on tool results before a word
- * is written for anybody to read.
+ * is written for anybody to read. A pulse says the turn is alive; it does not
+ * say what it is doing, and those are different questions when the wait is
+ * thirty seconds.
  *
- * The name is revealed on hover rather than sat there permanently. Whose
- * channel this is has been established four times over by the time you reach
- * the bottom of it, so the still frame is one moving character and the
- * sentence is there for the moment you want it. It stays in the accessibility
- * tree either way, which is why this is opacity rather than a mount.
+ * So when the model publishes its working, the line shows the line it is on.
+ * Which means it is only ever one line: the thinking is gone the moment the
+ * turn ends and there is nowhere to scroll back to, so anything but the
+ * newest words would be chrome pointing at something the operator cannot
+ * reach. Where the model publishes nothing, this is the sentence it always
+ * was, revealed on hover, because whose channel this is has been established
+ * four times over by the time you reach the bottom of it. It stays in the
+ * accessibility tree either way, which is why that is opacity rather than a
+ * mount.
+ *
+ * Subscribed here rather than in the parent for the same reason `LiveStreams`
+ * is: the thought changes every sixteen milliseconds and the transcript above
+ * it does not.
  */
 function WorkingNote({ agent, state }: { agent: AgentCard; state: Activity | undefined }) {
+  const thought = thoughtLine(useStore((s) => s.reasoning[agent.id]));
+
   // Queued counts: the agent has work it has not read yet, and to the operator
   // that is the same thing as working. Awaiting approval does not: it is
   // waiting on a person, and the request itself is in this channel saying so.
@@ -275,7 +289,15 @@ function WorkingNote({ agent, state }: { agent: AgentCard; state: Activity | und
   if (!working) return null;
 
   return (
-    <div className="working" role="status">
+    // A sentence that appears once is a status worth announcing; a line
+    // replaced several times a second is not. So this is a live region for
+    // exactly as long as it holds the sentence, which is from the moment the
+    // turn starts until the model publishes its first thought.
+    <div
+      className="working"
+      role={thought ? undefined : "status"}
+      data-thinking={thought ? "true" : undefined}
+    >
       <AgentAvatar
         avatar={agent.avatar}
         color={agent.color}
@@ -284,7 +306,7 @@ function WorkingNote({ agent, state }: { agent: AgentCard; state: Activity | und
         activity={{ state: "thinking" }}
         title={`${agent.name} is working`}
       />
-      <span className="working__label">{agent.name} is working</span>
+      <span className="working__label">{thought || `${agent.name} is working`}</span>
     </div>
   );
 }

--- a/src/lib/reasoning.test.ts
+++ b/src/lib/reasoning.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { keepThought, thoughtLine } from "./reasoning";
+
+describe("keeping a thought", () => {
+  it("appends what arrives", () => {
+    expect(keepThought(undefined, "I need")).toBe("I need");
+    expect(keepThought("I need", " the total")).toBe("I need the total");
+  });
+
+  it("keeps the end rather than the beginning", () => {
+    // The head is the first thing the model thought and never changes again.
+    const long = "a".repeat(300);
+    const held = keepThought(long, "END");
+    expect(held.endsWith("END")).toBe(true);
+    expect(held.length).toBeLessThanOrEqual(240);
+  });
+
+  it("keeps the newlines, because they are where a line starts", () => {
+    // Reduced to the last line on the way in, "Checking totals\n\n" plus "Now
+    // the sum" concatenated into one run-on line with no boundary left to find.
+    const held = keepThought(keepThought("", "Checking totals\n\n"), "Now the sum");
+    expect(thoughtLine(held)).toBe("Now the sum");
+  });
+});
+
+describe("the line drawn from it", () => {
+  it("is the last line with anything on it", () => {
+    expect(thoughtLine("first thought\n\nsecond thought")).toBe("second thought");
+  });
+
+  it("holds the previous line while the next one is still blank", () => {
+    // A delta that is only a paragraph break must not blank the line.
+    expect(thoughtLine("Checking totals\n\n")).toBe("Checking totals");
+  });
+
+  it("takes the marks off a heading rather than drawing them", () => {
+    expect(thoughtLine("**Checking the totals**")).toBe("Checking the totals");
+    expect(thoughtLine("## Weighing it up")).toBe("Weighing it up");
+    expect(thoughtLine("running `update_notes` next")).toBe("running update_notes next");
+  });
+
+  it("leaves an identifier alone", () => {
+    // Stripping every markdown character would have made this "updatenotes".
+    expect(thoughtLine("call update_notes with the whole file")).toBe(
+      "call update_notes with the whole file",
+    );
+  });
+
+  it("scrolls a long line from the right, marked once however long it gets", () => {
+    const line = `${"word ".repeat(60)}newest`;
+    const shown = thoughtLine(line);
+    expect(shown.endsWith("newest")).toBe(true);
+    expect(shown.startsWith("…")).toBe(true);
+    // Re-truncating an already-truncated line must not stack ellipses.
+    expect(shown.match(/…/g)).toHaveLength(1);
+  });
+
+  it("is empty when there is nothing to say", () => {
+    expect(thoughtLine(undefined)).toBe("");
+    expect(thoughtLine("\n\n  \n")).toBe("");
+  });
+});

--- a/src/lib/reasoning.ts
+++ b/src/lib/reasoning.ts
@@ -1,0 +1,59 @@
+/**
+ * What a turn shows of its own thinking.
+ *
+ * A model that publishes its working produces it as fast as it writes an
+ * answer, and none of it is kept: the runtime addresses it to the placeholder
+ * rather than to a channel, and the store drops it when the stream ends. So the
+ * only question here is how much of it is worth holding while it runs.
+ *
+ * The answer is a tail. A turn that reasons for two minutes writes tens of
+ * kilobytes into a slice that is rewritten every sixteen milliseconds, and
+ * nobody reads any of it except the last line: the one line under the composer
+ * is there to say what is happening *now*. Keeping the head instead would
+ * freeze that line on the first thing the model thought.
+ */
+
+/**
+ * Raw reasoning held per agent. Comfortably more than one line, so the line
+ * being written survives the paragraph before it being forgotten.
+ */
+const KEPT = 240;
+
+/** Characters of that line drawn at once, before it starts scrolling. */
+const SHOWN = 100;
+
+/**
+ * Adds what just arrived, keeping the end.
+ *
+ * Raw, newlines and all: the paragraph boundaries are what tell the line where
+ * it starts, and a reduction that dropped them ran the end of one thought into
+ * the beginning of the next.
+ */
+export function keepThought(held: string | undefined, arriving: string): string {
+  const next = (held ?? "") + arriving;
+  return next.length > KEPT ? next.slice(-KEPT) : next;
+}
+
+/**
+ * The one line to draw, as the model would have written it.
+ *
+ * Reasoning arrives as prose with markdown section headings in it. This is a
+ * single muted line of chrome, not a document, so the marks come off rather
+ * than get rendered: `**Checking the totals**` is a heading everywhere except
+ * here, where it is four characters of noise.
+ */
+export function thoughtLine(held: string | undefined): string {
+  const lines = (held ?? "").split("\n").map(plain).filter(Boolean);
+  const line = lines[lines.length - 1] ?? "";
+  // Truncated from the front, so the newest words keep arriving on the right.
+  // The other way round, the line stops changing the moment it is full.
+  return line.length > SHOWN ? `…${line.slice(-SHOWN)}` : line;
+}
+
+function plain(line: string): string {
+  return line
+    .replace(/\*\*/g, "")
+    .replace(/`/g, "")
+    .replace(/^#{1,6}\s*/, "")
+    .trim();
+}

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -80,6 +80,7 @@ function reset(messages: Record<string, Envelope[] | undefined> = {}) {
     selected: "chef",
     messages,
     streams: {},
+    reasoning: {},
     pulses: [],
     usage: {},
     pulse: {},
@@ -258,6 +259,57 @@ describe("streaming", () => {
     apply(started);
     apply({ type: "streamEnded", messageId: "s1", channelId: "chef" });
     expect(useStore.getState().streams.s1).toBeUndefined();
+  });
+});
+
+describe("what an agent is thinking", () => {
+  const started: UiEvent = {
+    type: "streamStarted",
+    messageId: "s1",
+    channelId: "manager",
+    agentId: "chef",
+    runId: "r1",
+    to: { kind: "agent", id: "manager" },
+  };
+
+  it("is filed under the agent doing the thinking, not the channel it writes to", () => {
+    // Chef answering Manager streams into Manager's channel. The operator
+    // watching Chef work is reading Chef's.
+    apply(started);
+    apply({ type: "reasoningDelta", messageId: "s1", text: "weighing it up" });
+    expect(useStore.getState().reasoning.chef).toBe("weighing it up");
+    expect(useStore.getState().reasoning.manager).toBeUndefined();
+  });
+
+  it("is dropped when the turn ends", () => {
+    // The whole contract: it is visible while it happens and gone afterwards.
+    apply(started);
+    apply({ type: "reasoningDelta", messageId: "s1", text: "weighing it up" });
+    apply({ type: "streamEnded", messageId: "s1", channelId: "manager" });
+    expect(useStore.getState().reasoning.chef).toBeUndefined();
+  });
+
+  it("is dropped when a failed call reopens under a new id", () => {
+    // Anything already thought belongs to the attempt that broke, exactly like
+    // the text that was already on screen.
+    apply(started);
+    apply({ type: "reasoningDelta", messageId: "s1", text: "half a thought" });
+    apply({ type: "streamEnded", messageId: "s1", channelId: "manager" });
+    apply({ ...started, messageId: "s2" });
+    expect(useStore.getState().reasoning.chef).toBeUndefined();
+  });
+
+  it("ignores a thought for a stream that never started", () => {
+    apply({ type: "reasoningDelta", messageId: "ghost", text: "x" });
+    expect(useStore.getState().reasoning).toEqual({});
+  });
+
+  it("never lands in the transcript", () => {
+    // It is not something anybody said, so no channel may hold it.
+    apply(started);
+    apply({ type: "reasoningDelta", messageId: "s1", text: "weighing it up" });
+    expect(JSON.stringify(useStore.getState().messages)).not.toContain("weighing");
+    expect(useStore.getState().streams.s1?.text).toBe("");
   });
 });
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -10,6 +10,7 @@ import { useCallback, useMemo } from "react";
 import { create } from "zustand";
 
 import { api } from "./ipc";
+import { keepThought } from "./reasoning";
 import type {
   Activity,
   AgentCard,
@@ -78,6 +79,18 @@ interface State {
   selected: ChannelKey | null;
   messages: Record<ChannelKey, Envelope[] | undefined>;
   streams: Record<MessageId, StreamBuffer | undefined>;
+  /**
+   * What each agent is thinking, while it is thinking it.
+   *
+   * Kept apart from `streams` rather than folded into the buffer, and that is
+   * not tidiness: the component drawing the live bubbles subscribes to
+   * `streams`, so a thought written into one would re-render and re-parse the
+   * markdown of every bubble on screen for text that is not in any of them.
+   * Keyed by agent because that is who is thinking; a turn writing to a peer
+   * streams into the peer's channel while the operator watching it work is
+   * reading its own.
+   */
+  reasoning: Record<AgentId, string | undefined>;
   pulses: Pulse[];
 
   /**
@@ -145,6 +158,7 @@ export const useStore = create<State>((set, get) => ({
   selected: null,
   messages: {},
   streams: {},
+  reasoning: {},
   pulses: [],
   focused: null,
   banner: null,
@@ -278,17 +292,25 @@ export const useStore = create<State>((set, get) => ({
       }
 
       case "streamStarted": {
-        set((state) => ({
-          streams: {
-            ...state.streams,
-            [event.messageId]: {
-              channelId: event.channelId,
-              agentId: event.agentId,
-              text: "",
-              to: event.to,
+        set((state) => {
+          // Whatever this agent was thinking belonged to the attempt this one
+          // replaces. A failed call reopens under a new id, and its half-formed
+          // last thought is not what the retry is doing.
+          const reasoning = { ...state.reasoning };
+          delete reasoning[event.agentId];
+          return {
+            reasoning,
+            streams: {
+              ...state.streams,
+              [event.messageId]: {
+                channelId: event.channelId,
+                agentId: event.agentId,
+                text: "",
+                to: event.to,
+              },
             },
-          },
-        }));
+          };
+        });
         break;
       }
 
@@ -306,11 +328,35 @@ export const useStore = create<State>((set, get) => ({
         break;
       }
 
+      case "reasoningDelta": {
+        set((state) => {
+          // The stream is what says whose thought this is, and whether anything
+          // is still waiting for it. A delta for a placeholder that has already
+          // gone is dropped, exactly as its text would be.
+          const stream = state.streams[event.messageId];
+          if (!stream) return state;
+          return {
+            reasoning: {
+              ...state.reasoning,
+              [stream.agentId]: keepThought(state.reasoning[stream.agentId], event.text),
+            },
+          };
+        });
+        break;
+      }
+
       case "streamEnded": {
         set((state) => {
           const streams = { ...state.streams };
+          const ending = streams[event.messageId];
           delete streams[event.messageId];
-          return { streams };
+          if (!ending) return { streams };
+
+          // The turn is over, so the thinking goes with it. This is the whole
+          // of what makes it ephemeral: nothing else ever clears it.
+          const reasoning = { ...state.reasoning };
+          delete reasoning[ending.agentId];
+          return { streams, reasoning };
         });
         break;
       }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -309,6 +309,13 @@ export type UiEvent =
       to: Participant;
     }
   | { type: "streamDelta"; messageId: MessageId; channelId: AgentId; text: string }
+  /**
+   * Part of the model's working, for as long as the turn lasts.
+   *
+   * Addressed to the placeholder and to nothing else: the agent it belongs to
+   * is read from the stream it names, and it goes when that stream ends.
+   */
+  | { type: "reasoningDelta"; messageId: MessageId; text: string }
   | { type: "streamEnded"; messageId: MessageId; channelId: AgentId }
   | { type: "activityChanged"; agentId: AgentId; activity: Activity }
   | { type: "channelsCleared"; agents: AgentId[] }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1652,6 +1652,11 @@ button {
    The name is revealed on hover: whose channel this is has been established
    several times over by the time you reach the bottom of it, so the resting
    state is one moving character.
+
+   A thought is not. When the model publishes what it is working through, that
+   line is the reason to look here at all, so it is shown without being asked
+   for. One line, clipped at the pane: it is replaced several times a second
+   and wrapping it would push the composer around the screen.
    ========================================================================== */
 
 .working {
@@ -1673,11 +1678,24 @@ button {
   transform: translateX(-0.3rem);
   transition: opacity 160ms ease, transform 160ms ease;
   pointer-events: none;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.working:hover .working__label {
+.working:hover .working__label,
+.working[data-thinking] .working__label {
   opacity: 1;
   transform: none;
+}
+
+/* Lighter than the answer it is on the way to, and italic so a glance can tell
+   the two apart without reading either: this is the only text in the pane that
+   is not something anybody said. */
+.working[data-thinking] .working__label {
+  font-style: italic;
+  opacity: 0.75;
 }
 
 /* The pulse is what carries "still going" when the label is hidden. It rides


### PR DESCRIPTION
An agent mid-turn showed a pulsing avatar and the sentence "Manager is
working", which says the turn is alive and nothing about what it is doing. That
gap is a long one: a turn can spend a minute working through tool results
before it writes a word anybody can read. Where the provider publishes the
model's own working, the line above the composer now shows the line it is on,
replaced as it writes and gone the moment the turn ends.

It is carried apart from the answer from the wire onwards. `Token::Reasoning`
and `Token::Text` arrive as separate fragments and only the second is
accumulated, so reasoning cannot reach the transcript, the content hash the
loop guard compares, or the prompt of any later turn; a single `&str` callback
made the two the same thing by the time anything could tell them apart. Both
spellings are read, `reasoning` and `reasoning_content`, because two
conventions exist and an operator pointing Guaca at a local endpoint should not
lose the line. A frame carrying both is one thought rather than two.

`ReasoningDelta` names a message id and no channel, and that is what makes it
ephemeral without any new bookkeeping: the webview files it under the agent
that opened that stream and drops it when the stream ends, so nothing else has
to remember to clear it, and a retry that reopens under a new id throws away
the half-formed thought of the attempt that broke. The agent is the right key
rather than the channel, because a turn writing to a peer streams into the
peer's channel while the operator watching it work is reading its own. In the
store it is its own slice rather than a field on the stream buffer: written
there, every thought would re-render and re-parse the markdown of every live
bubble for text that is in none of them, which the perf test measures at 201
renders in place of one. `Pen` coalesces it on the same 16ms clock as the
text, since reasoning is produced as fast as an answer and costs the same IPC
hop.

Only the newest line is kept, because the thinking is gone when the turn ends
and there is nowhere to scroll back to. The note also stops being a live region
while it holds one: a line replaced several times a second is not a status to
announce. Nothing is asked of the provider, so a model that publishes nothing
leaves the line exactly as it was and no call costs more than it did.

