### PR TITLE
docs: AGENTS.md routes to the reasoning rather than restating it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,409 +3,121 @@
 Local desktop app. You talk to LLM agents; the agents talk to each other. Tauri
 v2, React + TypeScript front, Rust back.
 
-## Non-obvious things worth knowing before you change something
+This file is the map and the routing table. What is left in it applies wherever
+you are working. The reasoning lives in `docs/`, one file per subsystem, and the
+table below says which one to open before changing something.
 
-**The agent runtime is Rust, not the webview.** Each agent is a `tokio` task
-with an `mpsc` inbox. If you find yourself adding agent logic to `src/`, you are
-in the wrong half of the repo. The frontend renders state and forwards intent.
+## Where things are
 
-**Read `runtime/guard.rs` before touching anything about messaging.** Agents
-messaging each other does not terminate on its own. Five independent limits stop
-it, and each catches a different shape of runaway. Weakening one is not a local
-change.
+```
+src/                  React + TypeScript. A view over the runtime, nothing more.
+  lib/transcript.ts   What a channel shows, and what it collapses. Read first.
+  lib/search.ts       One ranking over hits from SQLite and from the store.
+  lib/ipc.ts          Every call into Rust.
+  components/         One file per surface.
+src-tauri/src/
+  domain/             AgentCard, Envelope, Routine, Connector, Signin, Approval,
+                      Search, ids. No I/O.
+  runtime/
+    guard.rs          The loop guard. Read this one first.
+    mod.rs            Agent actors and the message bus.
+    prompt.rs         Prompt assembly, including the trust boundary.
+    events.rs         Events pushed to the UI.
+  llm/                OpenAI-compatible client, SSE decoding, tool definitions.
+  db/                 SQLite. Plain SQL, numbered migrations.
+  e2b.rs              Sandboxes: the machines agents work on.
+  proxy.rs            Loopback viewer for those machines.
+  browser.py          Drives a machine's Chrome over the DevTools protocol.
+  sessions.py         Reports what that Chrome is signed in to.
+  workspace.rs        Per-agent memory: one markdown file the agent rewrites.
+  files.rs            Attachments, addressed by the SHA-256 of their contents.
+  eval.rs             Reads a run and says whether it communicated sensibly.
+  trajectory.rs       Reads a run's events and says whether the machinery did.
+  config.rs           Operator settings, and the API key the webview never sees.
+  commands.rs         The entire IPC surface.
+  app.rs              The only file that knows Tauri exists.
+```
 
-**`expects_reply` is what makes cascades converge**, not the guard. The guard is
-the backstop. See `docs/ARCHITECTURE.md`.
+The agent runtime lives in Rust, not the webview. Each agent is a `tokio` task
+with its own inbox, so sending is enqueue-and-return and N agents genuinely run
+concurrently. It also means your API key never crosses into the webview. If you
+find yourself adding agent logic to `src/`, you are in the wrong half of the
+repo: the frontend renders state and forwards intent.
 
-**A courtesy to a peer that has already answered is refused; work is not.**
-`send_message` carries an `intent`, and the sender declares it, because a second
-instruction and a thank-you are the same shape on the wire and guessing from the
-shape refused real work. Anything not declared `work`, including a value nobody
-defined, is a courtesy: the permissive half of the parser must not be the half
-that opens the door. `runtime/prompt.rs` says the same thing to the model in the
-mode where it matters, and the two have to agree.
+## Read before you change
 
-**`expects_reply` and `intent` answer different questions, and conflating them
-stopped an agent mid-task.** The first is whether anybody is waiting on your
-words, which is what terminates a cascade. The second is whether you were given
-something to do. An instruction to a peer that has already answered carries work
-and expects no reply, and reading the first as the second put that turn in the
-mode that says nothing is being asked of it and silence is usually right. A real
-send to the operator's own address died there: the agent spent a call, said
-nothing, and looked like it had stopped. `ReplyMode::Assigned` is that
-combination, and its output is still a note. A routine coming due is the other
-way in, and it arrives from neither the operator nor a peer: it matched no arm
-of that match and fell through to the silent mode, so every schedule an agent
-kept was answered by an agent that had just been told nothing was being asked of
-it. Anything carrying work is `Assigned`, whoever sent it.
+| Changing | Read |
+|---|---|
+| Messaging, replies, cascades, hop limits, the guard | `runtime/guard.rs`, then *Cascades terminate because of one asymmetry* and *The five limits* in `docs/ARCHITECTURE.md` |
+| What a turn is told it was asked for: `expects_reply`, `intent`, `ReplyMode` | *Cascades terminate because of one asymmetry*, and `runtime/prompt.rs`, which has to agree with it |
+| Streaming, retries, the budget, when a run settles | *A failed model call is retried*, *A thought is shown and never kept*, *The budget counts model calls* |
+| Permission prompts, parked turns, acting in the operator's name | *A protected action parks the turn that asked for it* |
+| What an agent may do with a page it has just read | *A page that was read this turn cannot quietly press a button* |
+| Attachments, previews, drops | *Files are references, and what a model gets depends on what they are* |
+| SQLite, the pool, migrations | *Storage*, and the two comments in `Store::open` |
+| Schedules and triggers | `docs/ROUTINES.md` |
+| Sandboxes, the browser, sign-ins, credentials | `docs/MACHINES.md`, then *Connectors* in `docs/PROTOCOL.md` |
+| Channels, the rail, search: what the operator sees | `docs/WORKSPACE.md`, then `src/lib/transcript.ts` |
+| A prompt, or anything that changes how much a crew talks | *Three test suites, asking different questions*, then run the live evals |
 
-**Every eval fault but one points at a crew that talks too much, which is why
-the app twice shipped one that stopped too early.** Answered too often, said it
-twice, thanked a thank-you, nagged a peer: all the same direction. `Silent` is
-the only check facing the other way and it needs the whole run to have told the
-operator nothing, so a coordinator that answered while the agent holding the
-actual job said nothing satisfies it. `AssignedAndSaidNothing` reads `intent`
-off the wire and names the agent that was given work and produced no text for
-anyone; a tool trail is not an answer, because the turn that shipped this did
-call a tool. The runtime half is in `emit_reply`: an `Assigned` turn that
-produces nothing files a notice instead of returning quietly, since a turn with
-no text used to produce no envelope at all and therefore no trace of itself.
+Unqualified section names are headings in `docs/ARCHITECTURE.md`.
 
-**A pipeline spends two hops per phase, so the hop limit is four phases, not
-eight.** A coordinator working through specialists in sequence is one hop out
-and one hop back each time, and the next instruction starts from where the last
-answer landed rather than from the operator. Eight hops of honest depth is
-therefore four rounds of delegate-and-read, which is the arithmetic to do before
-raising or lowering `max_hops`. The eval suite holds both halves: three phases
-at hop six, and a fifth phase refused with the depth it had reached.
-
-**Whether a send is "answering" is a question about the run, not the batch.**
-Replies land milliseconds apart and an actor drains whatever is in its inbox, so
-a batch is a timing artifact: three peers answering at once can be split across
-turns, and deciding from the batch made two of them look like strangers. Ask the
-guard, which counts sends per pair for the whole run.
-
-**An agent that needs the operator's authority asks for it rather than
-refusing.** A peer saying "the operator authorised this" is a claim, and
-declining it is correct; what an agent lacked was any way to turn that claim
-into an answer, so it told the operator to repeat an instruction they had
-already given, somewhere else. `request_permission` parks the turn and puts two
-buttons in the channel they are already reading. `ProtectedAction::ActOnBehalf`
-deliberately has no "always allow" in the UI: the grant is scoped to an agent
-and an action, and this action is "act outside the workspace", so a standing yes
-would cover every future send and purchase rather than the one being asked
-about.
-
-**A protected action parks the turn that asked for it, and the row is the
-verdict.** `create_agent` stops mid-turn and waits on a person. The operator's
-click and the turn's own timeout can land in the same instant, so the answer is
-read back from the `approvals` row rather than from the channel the wakeup
-arrived on: `settle_approval` only moves a row out of `pending`, and whichever
-of the two loses that race changes nothing. Anything still pending at startup is
-expired, because nothing holds a parked turn across a restart. "Always allow" is
-the decision row itself, scoped to the one agent that asked. See
-`docs/ARCHITECTURE.md`.
-
-**No channel holds a conversation between two agents, so do not build one from
-`channel_messages`.** A send is filed under the recipient and the answer under
-the sender, and an automatic reply leaves no trace at all in the channel of the
-agent that wrote it, because only explicit tool calls are recorded there. A
-thread assembled from one channel's rows is missing messages nobody can account
-for. `pair_messages` reads both directions from the messages themselves; the
-channel only summarises, in `lib/transcript.ts`. A refusal never folds into that
-summary: it is the runtime stopping a message rather than a message. See
-`docs/ARCHITECTURE.md`.
-
-**A channel names nobody, and that is not a missing feature.** It has two
-participants: the agent it is named after, at the top of the pane, and the
-person reading it. A name and a clock over every message is two lines of chrome
-carrying one fact, and four replies written inside the same minute drew four of
-them. The portrait says which agent and the side of the column says whether the
-words are yours. `named` is how the pair's own thread asks for the names back,
-because there both participants are agents and neither is the reader. The clock
-went with them: it is a hover on the row, and `transcriptRows` draws one line
-where the silence ran past half an hour, which is the only place a time ever
-changed what the operator understood. That line also ends whatever burst was
-open, because two exchanges three hours apart are two things that happened.
-
-**A repeat is a shape, not a number of seconds.** `every weekday` and `every
-month` cannot be gaps, and `every day` should not be one: a day is 23 or 25
-hours twice a year, so a daily nine o'clock routine stored as 86400 seconds
-drifts to eight and stays there. `domain/routine.rs` holds the shape and
-`next_run_at` holds the hour, and the next slot is computed in local time from
-the slot it was due at rather than from the moment it ran, so a machine asleep
-through three of them fires once on waking instead of three times. A gap still
-exists, because an agent scheduling itself works in seconds and nothing shorter
-than a day has an hour to keep.
-
-**A routine's row is one line and its instruction is not in it.** The
-instruction is written to be acted on with no other context, which is several
-sentences, and drawing it as the title made one routine fill the panel. The row
-is a name and a cadence; opening it gives the panel over to that routine. An
-agent naming its own routine is optional, so `routineTitle` cuts the
-instruction down when nobody named it, on a word boundary and after the first
-sentence.
-
-**Switching a routine off and editing one are different actions.** `active`
-has its own command, acts on the click, and does not move `next_run_at`: a
-routine turned back on is due at the slot it was already holding, and the
-scheduler fires an overdue slot once. Parking it behind a Save the operator has
-not pressed means a routine they think they stopped still runs.
-
-**A test run is the scheduler's own path with the schedule left alone.** Same
-delivery, same fresh run, so what the button shows is what Tuesday will do.
-It deliberately does not move `next_run_at` or delete a one-shot, because
-trying a routine out must not spend the only firing it had. It is refused
-while the draft is dirty: firing the saved version while the operator is
-looking at an edited one answers a different question and reads as the edit
-having done nothing. Both kinds are recorded in `routine_runs` and the test is
-marked, because in the transcript the two are identical.
-
-**A trigger is one string in both places it lives.** The column is text and so
-is the wire form, which is why `Trigger` has a hand-written `Serialize`: a
-derived one would hand the webview a tagged object and SQLite `weekdays` for
-the same fact, and only one of the two would be read by the frontend. Text also
-means the trigger after these, a connector event, is a new value rather than a
-new column.
-
-**Pinning is where a row is drawn and nothing else.** It does not bump the card
-version, because the version is how a peer notices a card changed under it and
-nothing a peer can read has. A pinned agent is lifted out of its group in the
-rail and still counted in it, because it is still in it: same wall, same bill,
-same peers. Two rows for one agent would be two nodes in the sidebar's
-`rowRefs`, and the wire would have to pick one to throw a message at.
-
-**A duplicate copies the card and nothing an agent went and did.** Look, model,
-skills and instructions; not the sandbox, the memory, the schedule, the
-accounts or the transcript. Two agents holding one sandbox id is two agents on
-one machine, and a copy that inherited a routine would double a standing
-commitment nobody asked to double.
-
-**Migrations are forward-only and numbered.** One has already run against a real
-database by the time you think of an improvement, and editing it leaves that
-database at the same `user_version` with a different schema. Add another.
-
-**Budget counts model calls, not agent turns.** One turn can make several calls
-working through tool results. Counting turns lets a bounded run bill many times
-over. There is a test named after this.
-
-**A run settles when nothing is outstanding, and an envelope is what is
-outstanding.** `deliver` books one against the run as it queues an envelope,
-and the turn that reads it releases it. Any new path that takes an envelope and
-does not turn it into a turn has to release it too: an agent deleted while
-holding queued work used to take the booking with it, and that run never ended.
-Nothing else decrements.
-
-**A file's bytes never travel in an envelope, and never cross IPC.** A message
-carries a `Part::File` naming the digest; the bytes sit once in `files.rs`,
-addressed by content, and a drop hands Rust the *path* rather than the file.
-Both follow from the same fact: a transcript is read in bulk, forty messages
-into every prompt and hundreds into the activity view. What a model gets depends
-on what the file is: a picture is shown, text is read out, and anything else is
-written to `~/inbox` on the agent's own machine, because a Linux box knows more
-file formats than this runtime ever will. When placing fails the model is told
-so in words, since an agent that hears nothing describes a document it never
-read.
-
-**A preview reads the bytes over a URL, which is the exception that keeps the
-rule.** The webview has to draw a file to show one, and the reason bytes stay
-out of IPC is that IPC is where the transcript travels in bulk. So they do not
-go that way: `guacfile://localhost/{digest}/{name}` is answered out of the store
-by `app.rs`, fetched once by the one element drawing it and only while that
-element is on screen. A digest arrives from the webview there and is joined onto
-a path, so anything that is not 64 hex characters is refused before the join,
-not after. The name in the URL picks the type of the answer and nothing else:
-the bytes are found by content, and renaming a file cannot turn it into another
-one. If you add a way for the renderer to get at a file, it goes through this
-scheme, and the CSP has to name it or the element silently draws nothing.
-
-**WebKit will not take a custom scheme in a frame, so a document is copied into
-one.** An `img` and a `fetch` on `guacfile:` are allowed by naming the scheme in
-the CSP; a frame is refused whatever you write there, as a scheme source, as a
-host, or through `default-src`, and it is refused silently: no violation event,
-no console line, just a frame that never asks for anything. A PDF is drawn by
-the webview's own viewer and that viewer only runs in a frame, so `localCopy`
-fetches the document over the scheme as usual and hands the frame a `blob:` URL
-instead. That is the only place in this app where a file's bytes sit in the
-renderer, which is why the copy is made when the frame is near the viewport and
-revoked when it goes. Do not "simplify" it back to a direct `src`: it will pass
-every test in this repo and draw an empty rectangle.
-
-**A dropped file is stored before it is sent, and the send carries a
-reference.** `stage_files` runs on the drop. That is what refuses a 40 MB
-archive while the operator is still holding it rather than failing the message
-they went on to write, and what lets a picture be shown back to them, since by
-then it has an address. One file failing does not refuse the four beside it.
-`send_message` then resolves each digest and name against the store again: the
-size and the type on a message are read off the disk, never taken from the
-webview. A staged file that is never sent stays, like every other file here.
-
-**A model's reasoning is shown and never kept, and the placeholder is what
-makes that true.** `ReasoningDelta` names a message id and no channel: the
-webview files it under the agent that opened that stream and drops it when the
-stream ends, so nothing else has to remember to clear it and a retry that
-reopens under a new id throws away the half-formed thought of the attempt that
-broke. It is carried apart from the text from the wire onwards, as
-`Token::Reasoning`, because a single `&str` callback made the two the same
-thing by the time anything could tell them apart, and the answer is the only
-half that may be persisted, hashed by the guard or replayed into a prompt. It
-is also its own slice in the store rather than a field on the stream buffer:
-written there, every thought would re-render and re-parse the markdown of every
-live bubble for text that is in none of them.
-
-**Every event is an IPC hop and a render, so tokens are coalesced before they
-leave.** A model writes faster than a screen refreshes. One event per token
-spent the operator's main thread on work no eye could resolve, and with five
-agents answering at once it stopped painting at all, which reads as the window
-freezing and the text arriving in a lump rather than streaming. `Pen` in
-`runtime/mod.rs` buffers to 16ms and flushes when the call ends. On the other
-side, only the component drawing the live bubbles subscribes to `streams`: with
-that subscription in `ChannelView` a single token re-rendered every message in
-the transcript. `ChannelView.perf.test.tsx` counts both.
+## True everywhere
 
 **Anything crossing IPC is camelCase.** `rename_all` on a tagged enum renames
 variants, not fields; you also need `rename_all_fields`. `ipc.contract.test.ts`
 compares the Rust and TypeScript command lists directly, so a rename that only
 lands on one side fails the build rather than at runtime.
 
-**`Store::open` has two SQLite lessons encoded in comments.** Do not reorder the
-pragmas or simplify the migration transaction without reading them.
+**Migrations are forward-only and numbered.** One has already run against a real
+database by the time you think of an improvement, and editing it leaves that
+database at the same `user_version` with a different schema. Add another.
 
-**There is one browser on every machine, and one profile in it.** Chrome
-ignores `--remote-debugging-port` when it re-attaches to an existing profile, so
-`browse` needs a profile it controls, and a sign-in performed on the default one
-was invisible to every agent with nothing reporting an error. The other half is
-the same failure wearing a different name: the template ships a second browser,
-with a binary on `PATH`, a menu entry and an icon on the desktop, and an agent
-told to send mail opened it, drove it by coordinates, and read the page with
-`browse`, which was on Chrome the whole time. Neither is something an agent can
-be asked to remember. A prompt saying "use Chrome" was already there.
+**A secret never reaches a model.** A credential's value and a cookie's value do
+not enter a prompt, a transcript, an event or the webview, and there is no field
+on the types that cross those boundaries for one to arrive in. Keep it that way:
+`docs/MACHINES.md`.
 
-So every route is shimmed onto `google-chrome` and `/home/user/.guac/chrome`: a
-wrapper first on `PATH` with every other browser's name symlinked to it, a
-`.desktop` entry in the user's own XDG directory shadowing each packaged one, a
-launcher on the desktop rewritten in place because it is a file rather than an
-entry anything looks up, and `as_chrome` at the call site, which replaces the
-browser's name as well as adding the flags. The session is started with that
-directory first on `PATH`, since every icon, menu entry and terminal on the
-screen inherits it. Anything still running on another profile or of another kind
-is closed when the desktop starts, the operator's own window included, because a
-sign-in there is one no agent can ever use. If you add a way to open a browser it
-goes through `as_chrome`, and the port goes with the profile or `browse` loses
-its remote interface.
+## What looks like a simplification and is not
 
-**An agent that named another browser is told which one opened.** The rewrite
-is silent on the machine and must not be silent in the turn: handing an agent
-back the name it asked for leaves it describing a window nobody can see and
-reaching for that name again. The flags do not travel with it either, in the
-result or in the transcript, because a model reads its own tool results back and
-copies them.
-
-**Sign-ins are detected, never declared.** The browser is holding the cookies,
-so `domain/signin.rs` asks it rather than asking the operator to keep a list.
-The whole set for an agent is replaced on every scan: a row that outlives the
-logout it should have noticed keeps the crew routing work to a machine that will
-hit a login wall.
-
-**A cookie's presence is not a login, and this is the trap.** A profile that has
-browsed for an hour holds a thousand cookies across three hundred domains, most
-of them durable and `httpOnly`. `google.com` sets `NID` on a browser that has
-never seen an account, and `PHPSESSID` is handed to every anonymous visitor.
-Both were real false positives from a live machine. Detection is therefore a
-signature table plus a rule that needs the browser to have *visited* the site
-and to hold a cookie implying an identity rather than a session. The tests carry
-the real cookie names; do not loosen them without a fresh capture.
-
-**A cookie value must never leave the sandbox.** `browser.py` drops it at the
-only point in the system that sees one, and `CookieMark` has no field it could
-arrive in.
-
-**Everything the app says about page content is wording, except one rule.**
-`WEB_LABEL`, the `[OPERATOR]`/`[AGENT]` labels and the "Message sources" section
-all tell a model that a page is data. An injection is writing aimed at the same
-model arguing the reverse, so where they disagree there was nothing left.
-`needs_consent` in `runtime/mod.rs` is the part that does not depend on the
-model having been convinced: a `click` or `type`, in a turn that has already
-read a page or a screen, on a domain the agent holds a session for, parks the
-turn on the operator. All three conditions are load-bearing and each one alone
-refuses honest work, so read the doc comment before narrowing or widening any of
-them. It is a pure function on purpose, kept apart from the asking, and two of
-its tests exist only to fail a careless rewrite: `notgmail.com` is not a
-`gmail.com` session, and the host in `https://gmail.com@evil.com/` is
-`evil.com`. Reading is never gated, because an agent that cannot read cannot
-report the attack either.
-
-**A failed model call is retried before the operator hears about it, and the
-row the retry reads is the transcript.** `stream_with_retries` re-attempts only
-what `is_transient` admits to, reopens the stream so a second attempt cannot
-append to a first one's half-written text, and never reserves a second step: a
-call is one call however many times the network dropped it. What survives that
-becomes a notice carrying the `cause` of the turn, which is what the operator's
-"Try again" sends again, as a new run at the original hop.
-
-**A credential's secret must never reach the model.** It goes from SQLite into
-the `envs` of one sandbox command and stops there. Not into a prompt, not into
-the transcript, not over IPC, and deliberately not into a dotfile on the sandbox
-either, because that disk survives the sleep this app relies on.
-
-**A session belongs to one agent; a credential belongs to the group.** That is
-physical, not a policy: cookies are on one disk and a token is a string.
-
-**Search happens in two places and is ranked in one.** The workspace is held in
-two places, so it is matched in two: messages, files, links and routines are in
-SQLite and are matched there, while agents and groups are already in the
-webview's store to draw the rail and actions are not stored anywhere at all.
-Reading the transcript into the renderer to search it would copy the database
-across IPC on every keystroke; going to IPC for two agent names would make the
-commonest search the slow one. What must not be split is the ordering: both
-halves arrive in `lib/search.ts` as raw matches and are scored by one function,
-because a list where an agent and a message are ordered by different rules is a
-list you have to read twice. A file and a link are the same rows as the
-messages read from a different angle, which is why one scan produces all three.
-
-**A search hit that opens the wrong part of a channel is a search that failed.**
-A transcript is read as "the newest three hundred", and a hit from last month is
-not in that window. `channel_messages` takes a `through` so the window reaches
-back to the message being opened, bounded at a thousand; past that the operator
-lands in the right channel at its newest end. Anything that jumps to a message
-goes through `openMessage` rather than `select`.
-
-## Where things are
-
-```
-src/                 React + TypeScript. A view over the runtime, nothing more.
-  lib/transcript.ts  What a channel shows, and what it collapses. Read first.
-src-tauri/src/
-  domain/            AgentCard, Envelope, Routine, Connector, Signin, Approval,
-                     Search, ids. No I/O.
-  runtime/
-    guard.rs         The loop guard. Read this one first.
-    mod.rs           Agent actors and the message bus.
-    prompt.rs        Prompt assembly, including the trust boundary.
-    events.rs        Events pushed to the UI.
-  llm/               OpenAI-compatible client, SSE decoding, tool definitions.
-  db/                SQLite. Plain SQL, numbered migrations.
-  e2b.rs             Sandboxes: the machines agents work on.
-  proxy.rs           Loopback viewer for those machines.
-  eval.rs            Reads a run and says whether it communicated sensibly.
-  trajectory.rs      Reads a run's events and says whether the machinery did.
-  files.rs           Attachments, addressed by the SHA-256 of their contents.
-  commands.rs        The entire IPC surface.
-  app.rs             The only file that knows Tauri exists.
-```
-
-The agent runtime lives in Rust, not the webview. Each agent is a `tokio` task
-with its own inbox, so sending is enqueue-and-return and N agents genuinely run
-concurrently. It also means your API key never crosses into the webview.
-
-`docs/ARCHITECTURE.md` covers the design decisions. `docs/PROTOCOL.md` records
-what the agent-interoperability literature contributed and what had to be
-invented.
+- **A thread between two agents is `pair_messages`.** A send is filed under the
+  recipient and the answer under the sender, so a thread assembled from one
+  channel's rows is missing messages nobody can account for.
+- **`FileCard` hands the frame a `blob:` URL on purpose.** WebKit refuses a
+  custom scheme in a frame and says nothing. A direct `guacfile:` `src` passes
+  every test in this repo and draws an empty rectangle.
+- **Only the component drawing the live bubbles subscribes to `streams`.** One
+  level higher, a single token re-renders every message in the transcript.
+- **The sign-in tests carry real cookie names.** A cookie's presence is not a
+  login. Do not loosen them without a fresh capture from a live machine.
+- **All three conditions in `needs_consent` are load-bearing.** Each one alone
+  refuses honest work. Read the doc comment before narrowing or widening any.
+- **An envelope booked against a run is released by whatever consumes it.** A
+  path that takes one without turning it into a turn leaves the run outstanding
+  for the life of the process.
 
 ## Conventions
 
 - Match the surrounding code. Comments explain why, never what.
 - Every guard refusal and every error the operator can hit says what happened
   and what to do about it. Both are read by a model or a human under pressure.
+- Errors an agent reads mid-turn need a way forward, not just a reason. A
+  refusal that only says no gets reworded and retried.
 - New behaviour needs a test that would fail without it. Failure paths first.
 - No dead code, no speculative API surface. The contract test fails on a command
   nothing calls.
-- Errors an agent reads mid-turn need a way forward, not just a reason. A
-  refusal that only says no gets reworded and retried.
 
 ## Ownership
 
 **A person owns every commit, and the tool that helped write it is not a
 co-author.** Whoever commits answers for the change: in review, in the incident,
-and a year later when the reason matters more than the diff. That
-accountability does not divide and does not transfer, so the record must not
-suggest it did. Use whatever tools you like and sign your own work.
+and a year later when the reason matters more than the diff. That accountability
+does not divide and does not transfer, so the record must not suggest it did.
+Use whatever tools you like and sign your own work.
 
 No machine signature anywhere. No `Co-authored-by` trailer naming a model, no
 "Generated with" footer, no session or tool link, in commits, PR titles and
-bodies, issues, comments or code. A name in an author list is a claim that the
-thing behind it can answer a question about the code, and a model on a later
-version cannot answer for this one.
+bodies, issues, comments or code.
 
 **A trailer written on a contributor's branch still reaches `main`.** GitHub's
 squash-merge collects `Co-authored-by` lines out of the commits it squashes and
@@ -424,26 +136,22 @@ the source rather than at the end.
 GUAC_LOG=guac=debug pnpm app
 ```
 
-The Rust suite includes cascade tests that drive the real runtime against a
-scripted OpenAI-compatible server. If you change messaging, they are the ones
-that will catch you.
+Three suites ask three different questions, and a change can pass one while
+failing the next. *Three test suites, asking different questions* in
+`docs/ARCHITECTURE.md` is the long version.
 
-The evals are a second suite asking a different question: not "did the runtime
-do as it was told" but "is the resulting traffic something an operator would
-want to watch". Every cascade defect this app has had passed the first suite and
-failed the second. If you change a prompt, run the live half. CI cannot see a
-prompt that makes agents chattier.
-
-```sh
-./scripts/evals.sh       # live, against the configured model, costs money
-```
-
-The trajectory suite asks the third question, about the machinery rather than
-the talk: every placeholder closed, every parked turn released, every model
-call on the run's bill, nothing filed against a run already reported finished.
-Both other suites read the messages, and a run whose messages are all correct
-can still have left a half-arrived bubble on screen. If you touch streaming,
-settle detection, retries or the budget, this is the one that will catch you.
+- **Cascade tests**, inside the Rust suite, ask whether the runtime did as it
+  was told. They drive the real runtime against a scripted OpenAI-compatible
+  server. If you change messaging, they are the ones that will catch you.
+- **Evals** ask whether the resulting traffic is something an operator would
+  want to watch. Every cascade defect this app has had passed the first suite
+  and failed this one. CI cannot see a prompt that makes agents chattier, so if
+  you change a prompt, run the live half: `./scripts/evals.sh`, which costs
+  money.
+- **Trajectory** asks whether the machinery behaved: every placeholder closed,
+  every parked turn released, every model call on the run's bill, nothing filed
+  against a run already reported finished. If you touch streaming, settle
+  detection, retries or the budget, run it.
 
 ```sh
 cargo test --manifest-path src-tauri/Cargo.toml --test trajectory

--- a/README.md
+++ b/README.md
@@ -253,11 +253,13 @@ the agents themselves.
 GUAC_LOG=guac=debug pnpm app
 ```
 
-`AGENTS.md` is the short version for anyone, human or otherwise, about to change
-something: what is surprising, what will bite, and how to check.
-`docs/ARCHITECTURE.md` is the long version, including why agent conversations
-end rather than going round forever, which is the hardest thing here.
-`docs/PROTOCOL.md` records what the interoperability literature contributed.
+`AGENTS.md` is the map for anyone, human or otherwise, about to change
+something: where everything lives, and which file to read first for the part
+being changed. `docs/ARCHITECTURE.md` is the long version, including why agent
+conversations end rather than going round forever, which is the hardest thing
+here. `docs/ROUTINES.md`, `docs/MACHINES.md` and `docs/WORKSPACE.md` cover the
+subsystems it does not, and `docs/PROTOCOL.md` records what the
+interoperability literature contributed.
 
 ## Status
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,8 @@
 # Architecture
 
 Decisions worth explaining, and the reasoning that would otherwise be lost.
+Routines, machines and the workspace have files of their own beside this one,
+and `AGENTS.md` routes between all four.
 
 ## The runtime lives in Rust, not the webview
 
@@ -108,12 +110,21 @@ combination of work with nobody waiting: do it, then file what you did as a note
 in your own channel. The asymmetry that terminates cascades is untouched, because
 what changed is what the recipient is told, not where its answer goes.
 
+The mode follows the work rather than the sender, and the second incident is
+why. The first version matched on who the message came from, and a routine
+coming due comes from neither the operator nor a peer: it matched no arm of that
+match and fell through to the silent mode, so every schedule an agent kept was
+answered by an agent that had just been told nothing was being asked of it.
+Anything carrying work is `Assigned`, whoever sent it. See `ROUTINES.md`.
+
 The field is trusted, and that is deliberate. A model can label a courtesy as
 work, and then the run pays for one extra turn and hits the same per-pair,
 hop and budget limits as before. The alternative was to keep guessing, and the
 guess was already refusing real work. `courtesy` is the default when nothing is
 declared, so a model that ignores the field gets the old, stricter behaviour
-rather than a door quietly opened.
+rather than a door quietly opened. The rule lives in two places and they have to
+agree: `runtime/prompt.rs` tells the model the same thing, in the mode where it
+matters.
 
 Messages that do not expect a reply are batched: an agent waking to four replies
 reads all four in one turn. Because real replies arrive seconds apart rather
@@ -140,6 +151,13 @@ Settings.
 When a limit is hit the agent is told why, in words it can act on, and the
 reason appears on the transcript chip. Nothing is dropped silently.
 
+**A pipeline spends two hops per phase, so the depth limit is four phases, not
+eight.** A coordinator working through specialists in sequence is one hop out
+and one hop back each time, and the next instruction starts from where the last
+answer landed rather than from the operator. That is the arithmetic to do before
+raising or lowering `max_hops`. The eval suite holds both halves: three phases
+reaching hop six, and a fifth phase refused with the depth it had reached.
+
 ## The budget counts model calls, not turns
 
 An early version reserved one unit of budget per agent turn. A turn can make
@@ -150,11 +168,12 @@ and the test that found it is still there.
 
 ## A failed model call is retried before the operator hears about it
 
-`LlmError::is_transient` decides. Rate limits, timeouts, transport failures and
-5xx are worth another attempt; a rejected key or an unknown model is not,
-because it answers the same way every time and retrying only delays the message
-the operator needs to read. Three attempts, one and three seconds apart, or the
-provider's own `Retry-After` capped at twenty seconds.
+`stream_with_retries` is the loop and `LlmError::is_transient` decides. Rate
+limits, timeouts, transport failures and 5xx are worth another attempt; a
+rejected key or an unknown model is not, because it answers the same way every
+time and retrying only delays the message the operator needs to read. Three
+attempts, one and three seconds apart, or the provider's own `Retry-After`
+capped at twenty seconds.
 
 Two rules keep it honest:
 
@@ -181,11 +200,13 @@ Three things keep it from becoming a fourth kind of message.
 
 - **It is carried apart from the text, from the wire onwards.** `Token::Text`
   and `Token::Reasoning` reach the runtime as separate fragments, and only the
-  first is accumulated. Reasoning is never persisted, never included in the
-  content hash the loop guard compares, and never sent back to a model. Nothing
-  downstream of `stream_chat` holds it, so there is no path by which it could
-  be. Two spellings are read (`reasoning`, `reasoning_content`) because two
-  conventions exist, and a frame carrying both is one thought, not two.
+  first is accumulated. A single `&str` callback was tried and made the two the
+  same thing by the time anything downstream could tell them apart. Reasoning is
+  never persisted, never included in the content hash the loop guard compares,
+  and never sent back to a model. Nothing downstream of `stream_chat` holds it,
+  so there is no path by which it could be. Two spellings are read (`reasoning`,
+  `reasoning_content`) because two conventions exist, and a frame carrying both
+  is one thought, not two.
 - **It is addressed to the placeholder, which is what makes it ephemeral for
   free.** `ReasoningDelta` names a message id and no channel. The webview files
   it under the agent that opened that stream and drops it when the stream ends,
@@ -195,11 +216,17 @@ Three things keep it from becoming a fourth kind of message.
   streams into the peer's channel, while the operator watching it work is
   reading its own.
 - **It is buffered on the same clock as the text, and stored beside it rather
-  than in it.** Reasoning arrives as fast as an answer and costs the same IPC
-  hop and render, so `Pen` coalesces both to 16ms. In the store it is its own
-  slice: written into the stream buffer, every token would re-render and
-  re-parse the markdown of every live bubble for text that is in none of them.
-  `ChannelView.perf.test.tsx` counts that.
+  than in it.** A model writes faster than a screen refreshes, and one event per
+  token spent the operator's main thread on work no eye could resolve: with five
+  agents answering at once the window stopped painting at all, which reads as
+  freezing and the text arriving in a lump rather than streaming. `Pen` in
+  `runtime/mod.rs` buffers text and reasoning alike to 16ms and flushes when the
+  call ends. In the store reasoning is its own slice: written into the stream
+  buffer, every token would re-render and re-parse the markdown of every live
+  bubble for text that is in none of them. The same care applies one level out,
+  where only the component drawing the live bubbles subscribes to `streams`:
+  with that subscription any higher, a single token re-rendered every message in
+  the transcript. `ChannelView.perf.test.tsx` counts both.
 
 Only the newest line is kept, because there is nowhere to scroll back to. Models
 that publish nothing (Anthropic's, over OpenRouter, unless thinking is asked for)
@@ -264,19 +291,21 @@ the question where they are already looking.
 
 Two differences from `create_agent`. The heading is the runtime's but the
 sentence being decided is the agent's own, quoted under it, because only the
-agent can describe what it is about to do. And there is no "always allow": a
-grant is scoped to an agent and an action, and when the action is "act outside
-the workspace" a standing yes covers every future send, submission and purchase.
-Creating an agent is narrow enough to be worth not asking twice; this is not.
+agent can describe what it is about to do. And `ProtectedAction::ActOnBehalf`
+deliberately has no "always allow": a grant is scoped to an agent and an action,
+and when the action is "act outside the workspace" a standing yes covers every
+future send, submission and purchase. Creating an agent is narrow enough to be
+worth not asking twice; this is not.
 
 ## A page that was read this turn cannot quietly press a button
 
 The trust boundary below is words: `Trust` on the envelope, `[OPERATOR]` and
-`[AGENT "x"]` labels, `WEB_LABEL` in front of every page, and a system prompt
-saying a page is data. All of it is aimed at a model, and an injection is a
-piece of writing aimed at the same model, arguing the opposite. Where the two
-disagree the app had no answer, because nothing in the runtime stopped a turn
-that had just read a page from acting on what it said.
+`[AGENT "x"]` labels, `WEB_LABEL` in front of every page, and the *Message
+sources* section of the system prompt saying a page is data. All of it is
+aimed at a model, and an injection is a piece of writing aimed at the same
+model, arguing the opposite. Where the two disagree the app had no answer,
+because nothing in the runtime stopped a turn that had just read a page from
+acting on what it said.
 
 `needs_consent` is the answer, and its whole design is in what it does *not*
 gate. Three conditions have to hold together:
@@ -349,16 +378,16 @@ carries is a digest and a name, and the runtime resolves both against its own
 store: the size and the type on the message are read off the disk, not taken
 from the webview.
 
-**The webview reads a file over a URL, not over IPC.** `guacfile://localhost/
-{digest}/{name}` is answered out of the file store by `app.rs`, so a preview is
-fetched once, by the one element drawing it, only while that element is on
-screen, and the webview caches and ranges it. Handing the same bytes back over
-IPC would give up exactly what content-addressing them bought: IPC is where the
-transcript travels, in bulk. The scheme is also narrower than Tauri's asset
-protocol, which opens a scoped part of the disk; nothing is addressable here but
-a digest this app stored, and a digest that is not 64 hex characters is refused
-before it is ever joined onto a path. The name in the URL decides the type of
-the answer and nothing else.
+**The webview reads a file over a URL, not over IPC.** The scheme is
+`guacfile://localhost/{digest}/{name}`, answered out of the file store by
+`app.rs`, so a preview is fetched once, by the one element drawing it, only
+while that element is on screen, and the webview caches and ranges it. Handing
+the same bytes back over IPC would give up exactly what content-addressing
+them bought: IPC is where the transcript travels, in bulk. The scheme is also
+narrower than Tauri's asset protocol, which opens a scoped part of the disk;
+nothing is addressable here but a digest this app stored, and a digest that is
+not 64 hex characters is refused before it is ever joined onto a path. The
+name in the URL decides the type of the answer and nothing else.
 
 A transcript draws what it can of a file rather than naming it: a picture, a
 document's first page in the webview's own viewer, the first lines of anything
@@ -367,13 +396,18 @@ each offers a copy into the downloads folder, whose path is said out loud
 because a file saved somewhere the operator has to go looking for has not really
 been saved.
 
-One exception, and it is WebKit's. A custom scheme is allowed in an `img` and a
-`fetch` if the CSP names it, and refused in a frame however it is named, with no
-violation event and no console line to say so. A PDF is drawn by the webview's
-own viewer and that viewer only runs in a frame, so a document is fetched over
-the scheme like everything else and handed to the frame as a `blob:` URL. That
-is the one place a file's bytes sit in the renderer: the copy is made when the
-frame comes near the viewport and revoked when it leaves.
+One exception, and it is WebKit's. A custom scheme is allowed in an `img` and
+a `fetch` if the CSP names it, and refused in a frame however it is named, as
+a scheme source, as a host, or through `default-src`, with no violation event
+and no console line to say so. A PDF is drawn by the webview's own viewer and
+that viewer only runs in a frame, so `localCopy` fetches the document over the
+scheme like everything else and hands the frame a `blob:` URL. That is the one
+place a file's bytes sit in the renderer: the copy is made when the frame
+comes near the viewport and revoked when it leaves. Do not simplify it back to
+a direct `src`. It will pass every test in this repo and draw an empty
+rectangle. Any other way the renderer is given to reach a file goes through
+the same scheme, and the CSP has to name it or the element silently asks for
+nothing.
 
 Two limits worth knowing: 25 MB in, and 8 MB onto a machine, because bytes reach
 a sandbox as base64 inside a shell command. A real upload endpoint is the fix
@@ -415,8 +449,9 @@ so an agent deleted with work in its inbox used to take those bookings with it:
 the run never settled, its spend was never reconciled against the store, and the
 entry sat in the in-flight table for the life of the process. The booking is now
 made where an envelope is queued and released wherever one is dropped, which is
-the only pair of places that can be kept in step. The trajectory suite found
-this.
+the only pair of places that can be kept in step. Any new path that takes an
+envelope and does not turn it into a turn has to release it too; nothing else
+decrements. The trajectory suite found this.
 
 ## Why there is no Docker image for the app
 
@@ -485,7 +520,9 @@ the job simply never appeared. `AssignedAndSaidNothing` is that gap: it reads
 `intent` off the wire, and an agent that was handed work and produced no text
 for anyone is named. A tool trail deliberately does not count, because the turn
 that shipped the bug did call a tool and what the operator saw was a channel
-with no words in it.
+with no words in it. The runtime half is in `emit_reply`: an `Assigned` turn
+that produces nothing files a notice instead of returning quietly, since a turn
+with no text produced no envelope at all and therefore left no trace of itself.
 
 Both of those read the messages, and there is a class of defect neither can
 see, because it leaves the messages intact. A placeholder that opens and never

--- a/docs/MACHINES.md
+++ b/docs/MACHINES.md
@@ -1,0 +1,72 @@
+# Machines
+
+An agent can be given a computer: an E2B sandbox with a Linux desktop, a
+browser, and a viewer the operator can watch. `e2b.rs` starts them, `proxy.rs`
+serves the viewer, `browser.py` drives Chrome over the DevTools protocol, and
+`sessions.py` reports what that Chrome is signed in to.
+
+Why an agent is told what it already has access to, why a session is scoped to
+one agent while a credential is scoped to the group, and why an observed
+capability that overclaims is worse than none, are in `PROTOCOL.md`,
+*Connectors*. What follows is what will bite you in the code.
+
+## There is one browser on every machine, and one profile in it
+
+Chrome ignores `--remote-debugging-port` when it re-attaches to an existing
+profile, so `browse` needs a profile it controls, and a sign-in performed on the
+default one was invisible to every agent with nothing reporting an error. The
+other half is the same failure wearing a different name: the template ships a
+second browser, with a binary on `PATH`, a menu entry and an icon on the
+desktop, and an agent told to send mail opened it, drove it by coordinates, and
+read the page with `browse`, which was on Chrome the whole time. Neither is
+something an agent can be asked to remember. A prompt saying "use Chrome" was
+already there.
+
+So every route is shimmed onto `google-chrome` and `/home/user/.guac/chrome`: a
+wrapper first on `PATH` with every other browser's name symlinked to it, a
+`.desktop` entry in the user's own XDG directory shadowing each packaged one, a
+launcher on the desktop rewritten in place because it is a file rather than an
+entry anything looks up, and `as_chrome` at the call site, which replaces the
+browser's name as well as adding the flags. The session is started with that
+directory first on `PATH`, since every icon, menu entry and terminal on the
+screen inherits it. Anything still running on another profile or of another kind
+is closed when the desktop starts, the operator's own window included, because a
+sign-in there is one no agent can ever use.
+
+If you add a way to open a browser it goes through `as_chrome`, and the port
+goes with the profile or `browse` loses its remote interface.
+
+## An agent that named another browser is told which one opened
+
+The rewrite is silent on the machine and must not be silent in the turn:
+handing an agent back the name it asked for leaves it describing a window nobody
+can see and reaching for that name again. The flags do not travel with it
+either, in the result or in the transcript, because a model reads its own tool
+results back and copies them.
+
+## Sign-ins are detected, never declared
+
+The browser is holding the cookies, so `domain/signin.rs` asks it rather than
+asking the operator to keep a list. The whole set for an agent is replaced on
+every scan: a row that outlives the logout it should have noticed keeps the crew
+routing work to a machine that will hit a login wall.
+
+## A cookie's presence is not a login, and this is the trap
+
+A profile that has browsed for an hour holds a thousand cookies across three
+hundred domains, most of them durable and `httpOnly`. `google.com` sets `NID` on
+a browser that has never seen an account, and `PHPSESSID` is handed to every
+anonymous visitor. Both were real false positives from a live machine. Detection
+is therefore a signature table plus a rule that needs the browser to have
+*visited* the site and to hold a cookie implying an identity rather than a
+session. The tests carry the real cookie names, and they are the whole
+defence: do not loosen them without a fresh capture.
+
+## A cookie value must never leave the sandbox
+
+`browser.py` drops it at the only point in the system that sees one, and
+`CookieMark` has no field it could arrive in. The same holds one level up: a
+credential's secret has no field on `Connector`, so it cannot be serialized to
+the webview or rendered into a prompt. It goes from SQLite into the `envs` of
+one sandbox command and stops there, and deliberately not into a dotfile on the
+sandbox either, because that disk survives the sleep this app relies on.

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -1,0 +1,58 @@
+# Routines
+
+A routine is an instruction an agent gives itself when a trigger comes due.
+`domain/routine.rs` holds the shape, the scheduler is in `runtime/mod.rs`, and
+`RoutineList` and `RoutineDetail` draw them.
+
+## A repeat is a shape, not a number of seconds
+
+`every weekday` and `every month` cannot be gaps, and `every day` should not be
+one: a day is 23 or 25 hours twice a year, so a daily nine o'clock routine
+stored as 86400 seconds drifts to eight and stays there. `domain/routine.rs`
+holds the shape and `next_run_at` holds the hour, and the next slot is computed
+in local time from the slot it was due at rather than from the moment it ran, so
+a machine asleep through three of them fires once on waking instead of three
+times. A gap still exists, because an agent scheduling itself works in seconds
+and nothing shorter than a day has an hour to keep.
+
+## A trigger is one string in both places it lives
+
+The column is text and so is the wire form, which is why `Trigger` has a
+hand-written `Serialize`: a derived one would hand the webview a tagged object
+and SQLite `weekdays` for the same fact, and only one of the two would be read
+by the frontend. Text also means the trigger after these, a connector event, is
+a new value rather than a new column.
+
+## Switching a routine off and editing one are different actions
+
+`active` has its own command, acts on the click, and does not move
+`next_run_at`: a routine turned back on is due at the slot it was already
+holding, and the scheduler fires an overdue slot once. Parking it behind a Save
+the operator has not pressed means a routine they think they stopped still runs.
+
+## A test run is the scheduler's own path with the schedule left alone
+
+Same delivery, same fresh run, so what the button shows is what Tuesday will do.
+It deliberately does not move `next_run_at` or delete a one-shot, because trying
+a routine out must not spend the only firing it had. It is refused while the
+draft is dirty: firing the saved version while the operator is looking at an
+edited one answers a different question and reads as the edit having done
+nothing. Both kinds are recorded in `routine_runs` and the test is marked,
+because in the transcript the two are identical.
+
+## A routine's row is one line and its instruction is not in it
+
+The instruction is written to be acted on with no other context, which is
+several sentences, and drawing it as the title made one routine fill the panel.
+The row is a name and a cadence; opening it gives the panel over to that
+routine. An agent naming its own routine is optional, so `routineTitle` cuts the
+instruction down when nobody named it, on a word boundary and after the first
+sentence.
+
+## What a routine delivers is work, and the runtime is what sent it
+
+It arrives from neither the operator nor a peer, which is the case the reply
+mode originally had no arm for: every schedule an agent kept was answered by an
+agent that had just been told nothing was being asked of it. Anything carrying
+work is `ReplyMode::Assigned`, whoever sent it. See *Cascades terminate because
+of one asymmetry* in `ARCHITECTURE.md`.

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -1,0 +1,60 @@
+# The workspace
+
+What the operator sees, and the decisions the webview makes on its own. The
+runtime half is in `ARCHITECTURE.md`; `src/lib/transcript.ts` is the file to
+read first.
+
+## A channel names nobody, and that is not a missing feature
+
+It has two participants: the agent it is named after, at the top of the pane,
+and the person reading it. A name and a clock over every message is two lines of
+chrome carrying one fact, and four replies written inside the same minute drew
+four of them. The portrait says which agent and the side of the column says
+whether the words are yours. `named` on `MessageItem` is where the two views
+part: a channel passes `false`, and the pair's own thread takes the default,
+because there both participants are agents and neither is the reader. The clock
+went with them: it is a hover on the row, and `transcriptRows` draws one line
+where the silence ran past half an hour, which is the only place a time ever
+changed what the operator understood. That line also ends whatever burst was
+open, because two exchanges three hours apart are two things that happened.
+
+What a channel folds and what it must never fold is in *A channel says an
+exchange happened; the pair's thread is what it said*, in `ARCHITECTURE.md`.
+
+## Pinning is where a row is drawn and nothing else
+
+It does not bump the card version, because the version is how a peer notices a
+card changed under it and nothing a peer can read has. A pinned agent is lifted
+out of its group in the rail and still counted in it, because it is still in it:
+same wall, same bill, same peers. Two rows for one agent would be two nodes in
+the sidebar's `rowRefs`, and the wire would have to pick one to throw a message
+at.
+
+## A duplicate copies the card and nothing an agent went and did
+
+Look, model, skills and instructions; not the sandbox, the memory, the schedule,
+the accounts or the transcript. Two agents holding one sandbox id is two agents
+on one machine, and a copy that inherited a routine would double a standing
+commitment nobody asked to double.
+
+## Search happens in two places and is ranked in one
+
+The workspace is held in two places, so it is matched in two: messages, files,
+links and routines are in SQLite and are matched there, while agents and groups
+are already in the webview's store to draw the rail and actions are not stored
+anywhere at all. Reading the transcript into the renderer to search it would
+copy the database across IPC on every keystroke; going to IPC for two agent
+names would make the commonest search the slow one. What must not be split is
+the ordering: both halves arrive in `lib/search.ts` as raw matches and are
+scored by one function, because a list where an agent and a message are ordered
+by different rules is a list you have to read twice. A file and a link are the
+same rows as the messages read from a different angle, which is why one scan
+produces all three.
+
+## A search hit that opens the wrong part of a channel is a search that failed
+
+A transcript is read as "the newest three hundred", and a hit from last month is
+not in that window. `channel_messages` takes a `through` so the window reaches
+back to the message being opened, bounded at a thousand; past that the operator
+lands in the right channel at its newest end. Anything that jumps to a message
+goes through `openMessage` rather than `select`.


### PR DESCRIPTION
`AGENTS.md` is loaded in full every session and had grown to 27KB, about half of it `docs/ARCHITECTURE.md` and `docs/PROTOCOL.md` restated in shorter form. What is left is the map, a table saying which file to open before changing something, three rules that hold wherever you are working, and six things that look like simplifications and are not. The material that existed nowhere else moved into `docs/ROUTINES.md`, `docs/MACHINES.md` and `docs/WORKSPACE.md`, and seven smaller facts went into the `ARCHITECTURE.md` sections that already owned them rather than being appended. Nothing was dropped: of 102 backticked identifiers in the old file, 101 are still in the corpus, and the last is written `[AGENT "x"]` where it survives. Docs only, so CI is untouched, and one pre-existing rendering bug is fixed on the way, where the `guacfile` URL was wrapped inside inline code and drew with a space in the middle of it.