### PR TITLE
fix: a desktop opens without jolting the panel or announcing its transport

### DIFF
--- a/docs/MACHINES.md
+++ b/docs/MACHINES.md
@@ -10,6 +10,28 @@ one agent while a credential is scoped to the group, and why an observed
 capability that overclaims is worse than none, are in `PROTOCOL.md`,
 *Connectors*. What follows is what will bite you in the code.
 
+## The frame points at this app's page, not at noVNC's
+
+noVNC narrates its own transport. Every time it connects it slides a bar across
+the top of the picture reading "Connected (unencrypted) to" and the desktop's
+name, and connecting is not a rare event: the frame is rebuilt whenever the
+operator opens a different agent's panel. So the bar arrived in the middle of
+ordinary work and read as a stall that had not happened. It is also wrong about
+the hop that matters, which is TLS from `proxy.rs` to E2B.
+
+The address in the frame is `viewer.html`, which `proxy.rs` answers itself
+rather than relaying. That page frames noVNC from the same origin, which is the
+only way to reach into a document this app does not own, and appends one rule:
+`#noVNC_status.noVNC_status_normal` is hidden. Only the normal kind. The same
+bar carries noVNC's errors, those never time out on their own, and they are the
+only notice an operator gets that a desktop stopped answering.
+
+Two things drift quietly if you let them. The options deciding autoconnect,
+scaling and reconnection live in the address, so the page hands its query
+straight on instead of holding a copy of them; and `e2b.rs` builds that address
+from `proxy::VIEWER_DOCUMENT`, so the two halves cannot disagree about which
+page the frame is pointed at.
+
 ## There is one browser on every machine, and one profile in it
 
 Chrome ignores `--remote-debugging-port` when it re-attaches to an existing

--- a/src-tauri/src/e2b.rs
+++ b/src-tauri/src/e2b.rs
@@ -722,9 +722,15 @@ impl E2bClient {
                 // Through the local viewer, never straight at E2B: these
                 // sandboxes refuse public traffic without a header, and the
                 // token that carries it must not reach the webview.
+                //
+                // The page named here is the app's own rather than noVNC's,
+                // which is what lets the frame be rid of noVNC's chrome. It
+                // hands these options straight on, so they are still decided
+                // here.
                 computer.vnc_url = Some(format!(
-                    "http://{VIEWER_HOST}:{viewer_port}/{sandbox}/{VNC_PORT}/vnc.html\
-                     ?autoconnect=1&resize=scale&reconnect=1"
+                    "http://{VIEWER_HOST}:{viewer_port}/{sandbox}/{VNC_PORT}{page}\
+                     ?autoconnect=1&resize=scale&reconnect=1",
+                    page = crate::proxy::VIEWER_DOCUMENT
                 ));
             }
         }

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -37,6 +37,54 @@ const UPSTREAM_SUFFIX: &str = "e2b.app";
 /// either a probe or a mistake, and it should not hold a task forever.
 const HEAD_LIMIT: usize = 32 * 1024;
 
+/// The page the app points its frame at.
+///
+/// Served from here rather than fetched from the machine, which is what lets a
+/// stylesheet reach noVNC without this relay ever having to interpret a
+/// response body. `e2b.rs` builds the address from this same constant, so the
+/// two cannot drift apart.
+pub const VIEWER_DOCUMENT: &str = "/viewer.html";
+
+/// That page.
+///
+/// noVNC is framed from the same origin, which is what lets this reach into it
+/// and turn off the one piece of its chrome an operator should never see: the
+/// bar it slides across the top of the picture on every connect, announcing the
+/// transport. A panel opening is not news, and "unencrypted" is not even true
+/// of the hop that matters: this relay reaches the machine over TLS.
+///
+/// A warning or an error still shows. A desktop that dies quietly is worse than
+/// one that says so.
+///
+/// The options stay in the address so the app keeps deciding them, which is why
+/// the frame's `src` is set here rather than written into the markup.
+const VIEWER_PAGE: &str = r##"<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Computer</title>
+<style>
+  html, body { margin: 0; height: 100%; background: #000; overflow: hidden; }
+  iframe { display: block; width: 100%; height: 100%; border: 0; }
+</style>
+</head>
+<body>
+<iframe id="desktop" title="Desktop"></iframe>
+<script>
+  var frame = document.getElementById("desktop");
+  frame.addEventListener("load", function () {
+    var doc = frame.contentDocument;
+    if (!doc) return;
+    var quiet = doc.createElement("style");
+    quiet.textContent = "#noVNC_status.noVNC_status_normal{display:none!important}";
+    doc.head.appendChild(quiet);
+  });
+  frame.src = "./vnc.html" + location.search;
+</script>
+</body>
+</html>
+"##;
+
 /// Starts the viewer on a loopback port chosen by the OS.
 ///
 /// Bound to 127.0.0.1 deliberately: this holds tokens that reach an agent's
@@ -96,6 +144,13 @@ async fn serve(
         }
     };
 
+    // This app's own page rather than anything on the machine, so it is answered
+    // here. After the token lookup, not before: an address with no machine
+    // behind it should say so rather than paint a frame that never connects.
+    if request.wants_viewer() {
+        return answer(&mut client, VIEWER_PAGE).await;
+    }
+
     let host = format!("{}-{}.{UPSTREAM_SUFFIX}", request.port, request.sandbox);
     let upstream = TcpStream::connect((host.as_str(), 443)).await?;
     let name = ServerName::try_from(host.clone())
@@ -140,6 +195,18 @@ async fn refuse(client: &mut TcpStream, status: &str, message: &str) -> Result<(
     client.write_all(body.as_bytes()).await
 }
 
+async fn answer(client: &mut TcpStream, page: &str) -> Result<(), std::io::Error> {
+    // Not cached: the page ships with the app, and a stale one from an older
+    // build would frame the desktop with last version's rules.
+    let head = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: text/html; charset=utf-8\r\n\
+         content-length: {}\r\ncache-control: no-store\r\nconnection: close\r\n\r\n",
+        page.len()
+    );
+    client.write_all(head.as_bytes()).await?;
+    client.write_all(page.as_bytes()).await
+}
+
 /// The part of a request this needs to understand: which sandbox, which port,
 /// and the head to pass on with two lines changed.
 #[derive(Debug, PartialEq)]
@@ -158,6 +225,13 @@ struct Request {
 }
 
 impl Request {
+    /// Whether this asks for the viewer's own page rather than for something on
+    /// the machine.
+    fn wants_viewer(&self) -> bool {
+        let path = self.path.split('?').next().unwrap_or_default();
+        path == VIEWER_DOCUMENT
+    }
+
     fn parse(head: &[u8]) -> Option<Self> {
         let text = String::from_utf8_lossy(head);
         let (head, body) = text.split_once("\r\n\r\n").unwrap_or((&text, ""));
@@ -313,6 +387,35 @@ mod tests {
         let out = req.rewritten("6080-sbx.e2b.app", "real");
         assert!(!out.contains("forged"));
         assert!(out.contains("real"));
+    }
+
+    #[test]
+    fn the_page_the_app_frames_is_this_app_s_own() {
+        // Answered here rather than fetched from the machine, which is what lets
+        // noVNC's own chrome be turned off without this relay ever having to
+        // edit a response body.
+        assert!(Request::parse(&head("/sbx/6080/viewer.html?autoconnect=1", "\r\n"))
+            .unwrap()
+            .wants_viewer());
+        assert!(!Request::parse(&head("/sbx/6080/vnc.html", "\r\n")).unwrap().wants_viewer());
+        assert!(
+            !Request::parse(&head("/sbx/6080/app/viewer.html", "\r\n")).unwrap().wants_viewer(),
+            "a similar address under the machine's own tree is still the machine's"
+        );
+    }
+
+    #[test]
+    fn the_viewer_page_passes_its_options_on_and_silences_only_the_chatter() {
+        // The app decides autoconnect, scaling and reconnection in the address,
+        // so the page has to hand the query on rather than hold a copy of it.
+        assert!(VIEWER_PAGE.contains(r#""./vnc.html" + location.search"#));
+        // And only noVNC's normal status goes. The same bar carries the only
+        // notice an operator gets that a desktop stopped answering.
+        assert!(VIEWER_PAGE.contains("#noVNC_status.noVNC_status_normal{display:none!important}"));
+        assert!(
+            !VIEWER_PAGE.contains("#noVNC_status{"),
+            "hiding the bar outright would hide the failures it also carries"
+        );
     }
 
     #[test]

--- a/src/components/ComputerScreen.test.tsx
+++ b/src/components/ComputerScreen.test.tsx
@@ -122,6 +122,48 @@ describe("ComputerScreen", () => {
     expect(screen.getByTitle("Cook's computer")).toBe(before);
   });
 
+  it("holds the space the screen had while it covers the window", async () => {
+    // The picture leaves the flow to grow, so something has to stay behind
+    // holding its place. Without it the rest of the panel jumps up the moment
+    // the operator asks for a better look, and back down when they close it.
+    agentComputer.mockResolvedValue(HAS_ONE);
+    const { container } = render(<ComputerScreen agent={card("has-one", "Cook")} />);
+    fireEvent.click(await screen.findByRole("button", { name: /take over/i }));
+
+    const held = container.querySelector(".screen");
+    const stage = screen.getByRole("dialog", { name: "Cook's computer" });
+    expect(held).not.toBe(stage);
+    expect(held?.contains(stage)).toBe(true);
+    expect(held?.getAttribute("data-full")).toBe("true");
+  });
+
+  it("grows out of the picture it came from rather than appearing at full size", async () => {
+    // FLIP: the stage is already covering the window by the time this runs, so
+    // it is put back over the small picture and let go. A change of size that
+    // lands in a single frame reads as a reconnect that never happened.
+    agentComputer.mockResolvedValue(HAS_ONE);
+    render(<ComputerScreen agent={card("has-one", "Cook")} />);
+    const veil = await screen.findByRole("button", { name: /take over/i });
+
+    // jsdom does no layout, so the two measurements the movement is made of are
+    // supplied: the small picture, then the window the stage grew into.
+    const small = { top: 40, left: 100, width: 300, height: 188 } as DOMRect;
+    const whole = { top: 0, left: 0, width: 1200, height: 800 } as DOMRect;
+    const measure = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValueOnce(small)
+      .mockReturnValue(whole);
+    fireEvent.click(veil);
+    measure.mockRestore();
+
+    const stage = screen.getByRole("dialog", { name: "Cook's computer" });
+    expect(stage.style.transform).toBe("translate(100px, 40px) scale(0.25, 0.235)");
+
+    // And then let go, which is what actually plays the movement.
+    await waitFor(() => expect(stage.style.transform).toBe(""));
+    expect(stage.dataset.zooming).toBe("true");
+  });
+
   it("shrinks again on escape, without needing somewhere else to click first", async () => {
     // The desktop swallows key presses once it has focus, so this is listened
     // for on the window rather than on the frame.

--- a/src/components/ComputerScreen.tsx
+++ b/src/components/ComputerScreen.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { api } from "../lib/ipc";
+import { prefersReducedMotion } from "../lib/motion";
 import { useStore } from "../lib/store";
 import { type AgentCard, type Computer, errorMessage } from "../lib/types";
 
@@ -17,8 +18,14 @@ interface Props {
  * screen it accepts input and the operator can take over.
  *
  * Growing is a CSS change and nothing more: the frame keeps its place in the
- * tree and is promoted to fill the window, so opening and closing it never
- * drops the desktop and reconnects to it.
+ * tree and the stage around it is promoted to fill the window, so opening and
+ * closing it never drops the desktop and reconnects to it.
+ *
+ * Two things make that change something to watch rather than something to
+ * flinch at. The stage is not the element holding the screen's place in the
+ * panel, so the panel does not reflow around the gap it leaves; and the stage
+ * is played out of the picture it grew from rather than appearing at full size
+ * in one frame, which is what made a change of size read as a reconnect.
  *
  * There is deliberately no terminal here. A shell is how the agent works, not
  * how an operator watches it, and a second way in only invited the two to
@@ -40,6 +47,16 @@ export function ComputerScreen({ agent }: Props) {
   // agent's machine into the new panel, so an agent with no computer showed
   // the previous one's screen.
   const showing = useRef(agent.id);
+
+  const stage = useRef<HTMLDivElement>(null);
+  // Where the picture was before it grew. Measured in the click, because by the
+  // time anything can react to the change the stage is already in its new place.
+  const cameFrom = useRef<DOMRect | null>(null);
+
+  const grow = useCallback(() => {
+    cameFrom.current = stage.current?.getBoundingClientRect() ?? null;
+    setFull(true);
+  }, []);
 
   // Nothing at all until there is a key. Offering to give an agent a computer
   // that cannot be made is worse than not mentioning computers.
@@ -95,6 +112,41 @@ export function ComputerScreen({ agent }: Props) {
     return () => window.removeEventListener("keydown", onKey);
   }, [full]);
 
+  // FLIP: the stage is already covering the window, so it is put back over the
+  // small picture it came from and let go. The desktop under it never reloads,
+  // and a change of size that lands in a single frame reads as a reconnect that
+  // did not happen.
+  //
+  // Only on the way up. Coming down, the stage is back inside the panel's
+  // scroller, which clips anything still scaled to the size of the window, and
+  // holding it out of the flow until a transition ended would risk leaving it
+  // there.
+  useLayoutEffect(() => {
+    const node = stage.current;
+    const before = cameFrom.current;
+    cameFrom.current = null;
+    if (!node) return;
+
+    // Anything still playing belongs to the size the stage has just left, so it
+    // stops here rather than finishing in the new one.
+    node.dataset.zooming = "false";
+    node.style.transition = "none";
+    node.style.transform = "";
+    if (!before || prefersReducedMotion()) return;
+
+    const after = node.getBoundingClientRect();
+    if (!before.width || !before.height || !after.width || !after.height) return;
+
+    node.style.transform =
+      `translate(${before.left - after.left}px, ${before.top - after.top}px) ` +
+      `scale(${before.width / after.width}, ${before.height / after.height})`;
+    requestAnimationFrame(() => {
+      node.dataset.zooming = "true";
+      node.style.transition = "";
+      node.style.transform = "";
+    });
+  }, [full]);
+
   const act = async (run: () => Promise<Computer | null>) => {
     const asked = agent.id;
     setBusy(true);
@@ -125,148 +177,152 @@ export function ComputerScreen({ agent }: Props) {
     : {};
 
   return (
-    // The same element in both sizes, which is what keeps the frame below
-    // mounted and the desktop connected across the change.
-    <div className="screen" data-full={full ? "true" : undefined} {...asDialog}>
-      {full && (
-        <div className="screen__bar">
-          <span className="screen__title">{agent.name}'s computer</span>
-          <span className="screen__state" data-state={computer?.state}>
-            {computer?.state}
-          </span>
-          <span style={{ flex: 1 }} />
+    // Two elements, one connection. The outer one stays in the panel and holds
+    // the space the screen had; the inner one is what covers the window. The
+    // frame inside that is the same element in both sizes, which is what keeps
+    // the desktop connected across the change.
+    <div className="screen" data-full={full ? "true" : undefined}>
+      <div className="screen__stage" ref={stage} {...asDialog}>
+        {full && (
+          <div className="screen__bar">
+            <span className="screen__title">{agent.name}'s computer</span>
+            <span className="screen__state" data-state={computer?.state}>
+              {computer?.state}
+            </span>
+            <span style={{ flex: 1 }} />
 
-          {confirming === "sleep" ? (
-            <>
-              <button
-                type="button"
-                className="btn btn--small btn--danger"
-                disabled={busy}
-                onClick={() => void act(() => api.stopAgentComputer(agent.id))}
-              >
-                Sleep it
-              </button>
-              <button
-                type="button"
-                className="btn btn--small btn--ghost"
-                onClick={() => setConfirming(null)}
-              >
-                Keep awake
-              </button>
-            </>
-          ) : confirming === "destroy" ? (
-            <>
-              <button
-                type="button"
-                className="btn btn--small btn--danger"
-                disabled={busy}
-                onClick={() =>
-                  void act(async () => {
-                    await api.deleteAgentComputer(agent.id);
-                    return null;
-                  })
-                }
-              >
-                Destroy it and its disk
-              </button>
-              <button
-                type="button"
-                className="btn btn--small btn--ghost"
-                onClick={() => setConfirming(null)}
-              >
-                Keep
-              </button>
-            </>
-          ) : (
-            <>
-              <button
-                type="button"
-                className="btn btn--small btn--ghost"
-                disabled={busy}
-                onClick={() => setConfirming("sleep")}
-                title="Sleep. The disk is kept, so it wakes signed in."
-              >
-                Sleep
-              </button>
-              <button
-                type="button"
-                className="btn btn--small btn--ghost"
-                disabled={busy}
-                onClick={() => setConfirming("destroy")}
-              >
-                Destroy
-              </button>
-            </>
-          )}
+            {confirming === "sleep" ? (
+              <>
+                <button
+                  type="button"
+                  className="btn btn--small btn--danger"
+                  disabled={busy}
+                  onClick={() => void act(() => api.stopAgentComputer(agent.id))}
+                >
+                  Sleep it
+                </button>
+                <button
+                  type="button"
+                  className="btn btn--small btn--ghost"
+                  onClick={() => setConfirming(null)}
+                >
+                  Keep awake
+                </button>
+              </>
+            ) : confirming === "destroy" ? (
+              <>
+                <button
+                  type="button"
+                  className="btn btn--small btn--danger"
+                  disabled={busy}
+                  onClick={() =>
+                    void act(async () => {
+                      await api.deleteAgentComputer(agent.id);
+                      return null;
+                    })
+                  }
+                >
+                  Destroy it and its disk
+                </button>
+                <button
+                  type="button"
+                  className="btn btn--small btn--ghost"
+                  onClick={() => setConfirming(null)}
+                >
+                  Keep
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className="btn btn--small btn--ghost"
+                  disabled={busy}
+                  onClick={() => setConfirming("sleep")}
+                  title="Sleep. The disk is kept, so it wakes signed in."
+                >
+                  Sleep
+                </button>
+                <button
+                  type="button"
+                  className="btn btn--small btn--ghost"
+                  disabled={busy}
+                  onClick={() => setConfirming("destroy")}
+                >
+                  Destroy
+                </button>
+              </>
+            )}
 
-          <button type="button" className="btn btn--small" onClick={() => setFull(false)}>
-            Close
-          </button>
-        </div>
-      )}
+            <button type="button" className="btn btn--small" onClick={() => setFull(false)}>
+              Close
+            </button>
+          </div>
+        )}
 
-      {live ? (
-        <div className="screen__frame">
-          <iframe
-            // Keyed on the machine alone, never on the size, so growing to fill
-            // the window keeps the same connection.
-            //
-            // Which is also why noVNC's own `view_only` is not used: it is read
-            // once when the connection opens, so switching it would mean
-            // reconnecting. The veil below does that job instead, without
-            // touching the connection.
-            key={computer.sandboxId}
-            title={`${agent.name}'s computer`}
-            src={computer.vncUrl ?? ""}
-          />
-          {!full && (
-            // Swallows clicks aimed at the desktop while it is only meant to be
-            // watched, which is what makes noVNC's own read-only mode
-            // unnecessary and the connection worth keeping.
+        {live ? (
+          <div className="screen__frame">
+            <iframe
+              // Keyed on the machine alone, never on the size, so growing to
+              // fill the window keeps the same connection.
+              //
+              // Which is also why noVNC's own `view_only` is not used: it is
+              // read once when the connection opens, so switching it would mean
+              // reconnecting. The veil below does that job instead, without
+              // touching the connection.
+              key={computer.sandboxId}
+              title={`${agent.name}'s computer`}
+              src={computer.vncUrl ?? ""}
+            />
+            {!full && (
+              // Swallows clicks aimed at the desktop while it is only meant to
+              // be watched, which is what makes noVNC's own read-only mode
+              // unnecessary and the connection worth keeping.
+              <button
+                type="button"
+                className="screen__veil"
+                onClick={grow}
+                title={`Open ${agent.name}'s screen and take over`}
+                aria-label={`Open ${agent.name}'s screen and take over`}
+              />
+            )}
+          </div>
+        ) : (
+          <div className="screen__frame screen__frame--empty">
+            <p className="screen__note">
+              {error ??
+                (busy
+                  ? "Working on it. This takes a few seconds."
+                  : asleep
+                    ? `Asleep. Its disk is kept, so it wakes up where it left off, still signed into
+                       anything it was signed into. It sleeps again after
+                       ${settings?.computerIdleMinutes ?? 15} idle minutes.`
+                    : running
+                      ? "Running, but the desktop is not up yet."
+                      : "No computer yet. Agents get one the first time they use it.")}
+            </p>
             <button
               type="button"
-              className="screen__veil"
-              onClick={() => setFull(true)}
-              title={`Open ${agent.name}'s screen and take over`}
-              aria-label={`Open ${agent.name}'s screen and take over`}
-            />
-          )}
-        </div>
-      ) : (
-        <div className="screen__frame screen__frame--empty">
-          <p className="screen__note">
-            {error ??
-              (busy
-                ? "Working on it. This takes a few seconds."
-                : asleep
-                  ? `Asleep. Its disk is kept, so it wakes up where it left off, still signed into
-                     anything it was signed into. It sleeps again after
-                     ${settings?.computerIdleMinutes ?? 15} idle minutes.`
-                  : running
-                    ? "Running, but the desktop is not up yet."
-                    : "No computer yet. Agents get one the first time they use it.")}
-          </p>
-          <button
-            type="button"
-            className="btn btn--small btn--primary"
-            disabled={busy}
-            onClick={() => void act(() => api.startAgentComputer(agent.id))}
-          >
-            {busy ? "Working…" : asleep ? "Wake" : running ? "Start the desktop" : "Give one"}
-          </button>
-        </div>
-      )}
+              className="btn btn--small btn--primary"
+              disabled={busy}
+              onClick={() => void act(() => api.startAgentComputer(agent.id))}
+            >
+              {busy ? "Working…" : asleep ? "Wake" : running ? "Start the desktop" : "Give one"}
+            </button>
+          </div>
+        )}
+      </div>
 
-      {!full && (
-        <p className="screen__caption">
-          <span>{agent.name}'s screen</span>
-          {computer && (
-            <span className="screen__state" data-state={computer.state}>
-              {computer.state}
-            </span>
-          )}
-        </p>
-      )}
+      {/* Left in place while the stage covers the window: it is out of sight
+          behind it, and it is part of the space the panel is holding open. */}
+      <p className="screen__caption">
+        <span>{agent.name}'s screen</span>
+        {computer && (
+          <span className="screen__state" data-state={computer.state}>
+            {computer.state}
+          </span>
+        )}
+      </p>
     </div>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useLayoutEffect, useRef, useState } from "react";
 
 import { AgentAvatar, type Look } from "../avatars/AgentAvatar";
 import { FLIGHT_MS, roleOf, usePulseChoreography } from "../lib/choreography";
+import { prefersReducedMotion } from "../lib/motion";
 import { ACTIVITY_CHANNEL, useLiveAgents, useStore } from "../lib/store";
 import { relativeTime, useNow } from "../lib/time";
 import type { Activity, AgentCard, AgentId, Group } from "../lib/types";
@@ -16,10 +17,6 @@ interface Props {
   onOpenSearch: () => void;
   /** Where the operator right-clicked, and on whom. */
   onOpenMenu: (agent: AgentCard, at: { x: number; y: number }) => void;
-}
-
-function prefersReducedMotion(): boolean {
-  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 }
 
 /**

--- a/src/lib/choreography.ts
+++ b/src/lib/choreography.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
+import { prefersReducedMotion } from "./motion";
 import type { Pulse } from "./store";
 import type { AgentId } from "./types";
 
@@ -51,10 +52,6 @@ export interface Choreography {
   inFlight: StagedPulse[];
   /** Every message being animated right now, in any phase. */
   staged: StagedPulse[];
-}
-
-function prefersReducedMotion(): boolean {
-  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 }
 
 /**

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,11 @@
+/**
+ * The one question everything animated in this app has to ask.
+ *
+ * Asked at the moment of the movement rather than held in state: the operator
+ * can change the setting while the app is running, and reading it late means
+ * every animation from the next one onwards is right without anything having to
+ * subscribe to it.
+ */
+export function prefersReducedMotion(): boolean {
+  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2676,18 +2676,40 @@ button {
 
 /* --- the screen ----------------------------------------------------------
 
-   One connection, two sizes. Going full screen promotes this same element to
-   fill the window rather than mounting a second one, so the desktop is never
+   One connection, two sizes. Going full screen promotes the stage inside this
+   to fill the window rather than mounting a second one, so the desktop is never
    dropped and reconnected just because the operator wanted a better look. */
 
 .screen {
+  /* Shared with the space held open below, so the picture and the gap it leaves
+     behind cannot disagree about how tall the screen is. */
+  --screen-aspect: 16 / 10;
   margin-bottom: 1.1rem;
+}
+
+/* The stage leaves the flow to cover the window, so this holds the space it had.
+   Without it the panel underneath jumps by the height of the screen the moment
+   the screen opens, and jumps back when it closes. */
+.screen[data-full="true"]::before {
+  content: "";
+  display: block;
+  aspect-ratio: var(--screen-aspect);
+}
+
+/* What grows. The zoom is played from the corner the small picture had, which is
+   also where FLIP puts it back to. */
+.screen__stage {
+  transform-origin: 0 0;
+}
+
+.screen__stage[data-zooming="true"] {
+  transition: transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 .screen__frame {
   position: relative;
   width: 100%;
-  aspect-ratio: 16 / 10;
+  aspect-ratio: var(--screen-aspect);
   overflow: hidden;
   border: 1px solid var(--edge);
   border-radius: var(--radius-sm);
@@ -2755,12 +2777,12 @@ button {
 }
 
 /* Full screen. Fixed rather than a new subtree, which is what keeps the iframe
-   above mounted and the VNC session alive across the change. */
-.screen[data-full="true"] {
+   above mounted and the VNC session alive across the change. The margin stays
+   on the element left behind in the panel, which is still holding the space. */
+.screen[data-full="true"] .screen__stage {
   position: fixed;
   inset: 0;
   z-index: 40;
-  margin: 0;
   display: flex;
   flex-direction: column;
   background: var(--rail-ground);


### PR DESCRIPTION
Two things made opening an agent's desktop feel wrong, and neither of them was the connection.

`.screen` was itself the element that went `position: fixed`, so growing it took the picture out of the inspector's scroller and everything below jumped by the height of the screen, then jumped back on close; the overlay is now a separate `.screen__stage` while `.screen` stays behind holding the space, and growing is a FLIP zoom that `prefers-reduced-motion` skips. noVNC was also sliding a full-width bar across the top of the frame on every connect reading "Connected (unencrypted) to", which is routine rather than rare because the frame is rebuilt whenever a different agent's panel opens, and wrong about the hop that matters, since the relay reaches E2B over TLS. The frame now points at a `viewer.html` that `proxy.rs` answers itself, framing noVNC from the same origin so it can hide `#noVNC_status.noVNC_status_normal` and only that, because the same bar carries noVNC's errors, those never time out, and they are the only notice an operator gets that a desktop stopped answering.

Four new tests, plus two checks in a real engine because jsdom does no layout: the content below the screen moves 0px when it opens, and against real noVNC the normal bar computes to `display: none` while an error still computes to `display: flex`. Nothing ran against a live E2B sandbox, since this machine has no key configured.