### PR TITLE
feat: the rail is arranged by hand, and lends its top to whoever is working

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ table below says which one to open before changing something.
 ```
 src/                  React + TypeScript. A view over the runtime, nothing more.
   lib/transcript.ts   What a channel shows, and what it collapses. Read first.
+  lib/rail.ts         What order the rail draws agents in, and where a drop lands.
   lib/search.ts       One ranking over hits from SQLite and from the store.
   lib/ipc.ts          Every call into Rust.
   components/         One file per surface.
@@ -58,6 +59,7 @@ repo: the frontend renders state and forwards intent.
 | Schedules and triggers | `docs/ROUTINES.md` |
 | Sandboxes, the browser, sign-ins, credentials | `docs/MACHINES.md`, then *Connectors* in `docs/PROTOCOL.md` |
 | Channels, the rail, search: what the operator sees | `docs/WORKSPACE.md`, then `src/lib/transcript.ts` |
+| The rail's order, dragging a row, groups as places you go inside | *The rail is arranged by hand*, *A drop is one call* and *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/rail.ts` |
 | A prompt, or anything that changes how much a crew talks | *Three test suites, asking different questions*, then run the live evals |
 
 Unqualified section names are headings in `docs/ARCHITECTURE.md`.

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -21,14 +21,114 @@ open, because two exchanges three hours apart are two things that happened.
 What a channel folds and what it must never fold is in *A channel says an
 exchange happened; the pair's thread is what it said*, in `ARCHITECTURE.md`.
 
+## The rail is arranged by hand, and lends the top of a section out
+
+Two orders, not one. `railOrder` on the card is the arrangement: the operator
+drags a row into place and it stays there, which is what makes reaching for one
+a thing you can learn. Activity is a loan on top of it. An agent that is working
+is lifted to the top of its section for exactly as long as it is working, and the
+place goes back the moment it stops. `awaitingApproval` outranks working, because
+it is the one state the operator is the fix for; `paused` scores nothing, because
+it is not work in progress but a row that will not move until somebody moves it,
+and lifting it would hold the top indefinitely. A pinned row never lifts at all:
+being findable in one glance is what a pin is for, and a row that moves when its
+agent gets busy is the thing a pin exists to stop.
+
+Before this, the rail was ordered by who spoke last and by nothing else. That is
+an order nobody chose and one that moves under the hand reaching for it: every
+reply rewrote it, so no arrangement could survive a conversation. Recency did not
+go away, it just stopped being the whole answer: it is what separates two lifted
+rows, and it is still the text in the right-hand column.
+
+`lib/rail.ts` holds all of it, and holds it as pure functions over a list, so the
+same rules order a section, decide where a drop lands, and decide what "one row
+up" means. The rail draws the arrangement itself while a drag is in progress,
+with nobody lifted. Dragging is arranging: a row dropped below a peer that is
+only near the top because it happens to be mid-turn would land somewhere nobody
+aimed at, and the rail would look like it had ignored the gesture the moment that
+turn ended.
+
+## A drop is one call, because a drag is one gesture
+
+`move_agent` takes the group and the row to land in front of, and `None` for the
+end of that group. One command rather than two: a drag can change the crew and
+the place at the same time, and two writes leave a state where the agent has
+joined the group but not landed in it. The runtime renumbers every live row
+densely inside one transaction, because a workspace holds tens of agents and a
+scheme with gaps has a state where the gap is used up that this one does not.
+
+The anchor is a row, not an index. The operator dropped onto something they could
+see, so the position is expressed as the thing they saw; a stale view cannot
+corrupt an arrangement, it can only lose the half of the intent that no longer
+applies. A row that is gone, or has moved to another group, is ignored and the
+agent lands at the end of the group it was dropped into. A row dropped on itself
+asks for nothing and is refused in both halves, because the fallback for an
+anchor that is not there is the end of the group, and a null gesture that reached
+it would move the row to the bottom of the rail.
+
+Which side of the target it lands on is read off two positions rather than
+measured against the pointer. A row's midpoint is geometry a test cannot see and
+a hand cannot aim at; the direction the row travelled says which side it belongs
+on, and dragging down past something and dragging up onto it are exactly what
+those two look like while they are happening.
+
+**Pointer events, not HTML5 drag and drop.** `dragDropEnabled` is what lets a
+dropped document reach Rust without its bytes entering the renderer, and it is
+the same setting that stops `dragstart` firing inside the webview on some
+platforms. A rail that only rearranges on macOS is not a feature. A press
+becomes a drag after five pixels, because a row is a button first.
+
+Everything a drag does is also in the agent's menu: move up, move down, and move
+to a named group. A rail that can only be arranged by dragging cannot be arranged
+from a keyboard at all.
+
+## A group is a place you can be inside
+
+Two views of one rail. In the overview every group has a heading and its members
+under it, which is what it always was. Clicking a group's circle takes the rail
+inside it: one crew, its name and controls given a line of their own, and the
+pins folded to the head of the single list rather than kept in a section of their
+own, because everybody drawn there is in that crew already.
+
+The circles are faces, not names. A crew is recognised by who is in it long
+before its name is read, and four of them have to fit across a rail that is
+15.5rem wide. Four faces tiled in a square rather than a row of overlaps: the
+circle is 38px across and three 1.35rem avatars in a row measure 51px even
+leaning on each other, so a row either overflowed the ring or hid the faces it
+was drawn to show.
+
+Each circle does two jobs, which is why it is a circle and not an item in a menu.
+Clicking it opens the group. Dropping an agent on it puts the agent in the group,
+so the shortest gesture for moving somebody between crews is the one that also
+says which crew, and it is on screen for the whole of the drag. The circle also
+carries whether anyone inside is working and whether anyone is waiting on the
+operator: once the rail is inside one group, the strip is the only place the
+other crews are visible at all.
+
+The strip is absent while there is one group, which is the state most workspaces
+are in. A choice of one is chrome that never changes and a drop target that
+cannot move anybody anywhere.
+
+The group being looked inside is in the store rather than in the sidebar, because
+opening a channel can invalidate it. A search hit or a click on the flow board
+can land on an agent in another crew, and a rail still showing the group you were
+in has the open channel nowhere on it, so `select` lets the focus go.
+
+The pinned section is a flag drawn as a place. It spans groups, so a row dropped
+among the pins keeps its own crew: the alternative is a gesture that says "keep
+this where I can see it" and quietly moves the agent to a different set of peers.
+
 ## Pinning is where a row is drawn and nothing else
 
 It does not bump the card version, because the version is how a peer notices a
-card changed under it and nothing a peer can read has. A pinned agent is lifted
-out of its group in the rail and still counted in it, because it is still in it:
-same wall, same bill, same peers. Two rows for one agent would be two nodes in
-the sidebar's `rowRefs`, and the wire would have to pick one to throw a message
-at.
+card changed under it and nothing a peer can read has. `railOrder` is the same
+kind of fact and is kept the same way, and both live on the agent rather than in
+a preferences blob because they have to die with it: a name is free to reuse the
+moment an agent is deleted, and whoever takes it next must not inherit a pin or a
+place. A pinned agent is lifted out of its group in the rail and still counted in
+it, because it is still in it: same wall, same bill, same peers. Two rows for one
+agent would be two nodes in the sidebar's `rowRefs`, and the wire would have to
+pick one to throw a message at.
 
 ## A duplicate copies the card and nothing an agent went and did
 

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -239,6 +239,7 @@ pub fn run() {
             commands::duplicate_agent,
             commands::set_agent_paused,
             commands::set_agent_pinned,
+            commands::move_agent,
             commands::agent_activity,
             commands::agent_last_active,
             commands::agent_notes,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -426,6 +426,28 @@ pub fn set_agent_pinned(state: State<'_, AppState>, id: AgentId, pinned: bool) -
     Ok(card)
 }
 
+/// Puts an agent where the operator dropped it: which group, and which place.
+///
+/// One call rather than two, because a drag is one gesture that can be both,
+/// and two writes leave a state where the agent has arrived in the group but
+/// not in the place it was dropped.
+///
+/// `before` is the row it lands in front of; `None` is the end of the group.
+/// Nothing about the agent itself changes, so the card version does not move
+/// and no peer is told: an agent's group is enforced on every turn from a fresh
+/// read, so it is in its new crew's directory from the next message onward.
+#[tauri::command]
+pub fn move_agent(
+    state: State<'_, AppState>,
+    id: AgentId,
+    group_id: GroupId,
+    before: Option<AgentId>,
+) -> Reply<AgentCard> {
+    let card = state.runtime.store().move_agent(id, group_id, before)?;
+    state.runtime.emit(UiEvent::AgentsChanged);
+    Ok(card)
+}
+
 /// Makes a second agent from the same card.
 ///
 /// The card and nothing else: a copy starts with the look, the model, the

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -492,6 +492,31 @@ CREATE INDEX messages_pair
     WHERE from_kind = 'agent' AND to_kind = 'agent';
 "#,
     ),
+    (
+        20,
+        r#"
+-- Where the operator put an agent in the rail.
+--
+-- The rail was ordered entirely by who spoke last, which is an order nobody
+-- chose and one that moves under the hand reaching for it. This column is the
+-- arrangement; activity now lends a row the top of its section while it works
+-- and gives the place back. On the agent for the same reason `pinned` is: it is
+-- a fact about that agent and has to die with it.
+--
+-- Backfilled in creation order, so an upgrade draws the rail it drew before,
+-- and distinct from the start, so the first drag has somewhere to land. Ties
+-- are still legal and are broken by `created_at`; a dense renumber on every
+-- move keeps them rare rather than impossible.
+ALTER TABLE agents ADD COLUMN rail_order INTEGER NOT NULL DEFAULT 0;
+
+UPDATE agents SET rail_order = (
+    SELECT COUNT(*)
+      FROM agents AS earlier
+     WHERE earlier.created_at < agents.created_at
+        OR (earlier.created_at = agents.created_at AND earlier.rowid < agents.rowid)
+);
+"#,
+    ),
 ];
 
 /// The group every agent starts in, and the one the UI keeps out of the way
@@ -828,6 +853,41 @@ mod tests {
         let pinned: i64 =
             conn.query_row("SELECT pinned FROM agents WHERE id='a'", [], |r| r.get(0)).unwrap();
         assert_eq!(pinned, 0, "an upgrade must not rearrange the rail");
+    }
+
+    #[test]
+    fn an_upgrade_arranges_the_rail_in_the_order_it_was_already_drawn() {
+        // The rail was ordered by who spoke last, and creation order underneath
+        // that. Backfilling anything else would rearrange a workspace the
+        // operator has been looking at for weeks, on launch, with no gesture.
+        let mut conn = memory();
+        let tx = conn.transaction().unwrap();
+        for (version, sql) in MIGRATIONS.iter().take_while(|(v, _)| *v < 20) {
+            tx.execute_batch(sql).unwrap();
+            tx.pragma_update(None, "user_version", *version).unwrap();
+        }
+        tx.commit().unwrap();
+
+        let row = "INSERT INTO agents (id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id)
+                   VALUES (?1,?1,'avocado','#000','m','','[]','active',1,?2,?2,?3)";
+        for (id, made) in [("late", 300), ("early", 100), ("middle", 200)] {
+            conn.execute(row, rusqlite::params![id, made, DEFAULT_GROUP_ID]).unwrap();
+        }
+
+        run(&mut conn).unwrap();
+
+        let arranged: Vec<(String, i64)> = conn
+            .prepare("SELECT id, rail_order FROM agents ORDER BY rail_order")
+            .unwrap()
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(
+            arranged,
+            vec![("early".into(), 0), ("middle".into(), 1), ("late".into(), 2)],
+            "an upgrade must draw the rail it drew before, and give every row its own place"
+        );
     }
 
     #[test]

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -164,6 +164,13 @@ impl Store {
     pub fn create_agent(&self, draft: &CleanDraft) -> Result<AgentCard, StoreError> {
         let conn = self.conn()?;
         let now = now_ms();
+        // The bottom of the rail. Read rather than defaulted: a new agent must
+        // not land in the middle of an arrangement the operator made, and a
+        // column default cannot know what the last row is.
+        let last: i32 =
+            conn.query_row("SELECT coalesce(max(rail_order), -1) FROM agents", [], |row| {
+                row.get(0)
+            })?;
         let card = AgentCard {
             id: AgentId::new(),
             group_id: draft.group_id.unwrap_or_else(default_group_id),
@@ -178,14 +185,15 @@ impl Store {
             sandbox_traffic_token: None,
             lifecycle: Lifecycle::Active,
             pinned: false,
+            rail_order: last.saturating_add(1),
             version: 1,
             created_at: now,
             updated_at: now,
         };
 
         conn.execute(
-            "INSERT INTO agents (id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)",
+            "INSERT INTO agents (id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id,rail_order)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13)",
             params![
                 card.id.to_string(),
                 card.name,
@@ -199,6 +207,7 @@ impl Store {
                 card.created_at,
                 card.updated_at,
                 card.group_id.to_string(),
+                card.rail_order,
             ],
         )
         .map_err(|e| classify(e, &card.name))?;
@@ -258,7 +267,7 @@ impl Store {
     pub fn get_agent(&self, id: AgentId) -> Result<Option<AgentCard>, StoreError> {
         let conn = self.conn()?;
         conn.query_row(
-            "SELECT id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id,sandbox_id,sandbox_envd_token,sandbox_traffic_token,pinned
+            "SELECT id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id,sandbox_id,sandbox_envd_token,sandbox_traffic_token,pinned,rail_order
                FROM agents WHERE id=?1",
             params![id.to_string()],
             row_to_card,
@@ -275,7 +284,7 @@ impl Store {
     pub fn list_agents(&self) -> Result<Vec<AgentCard>, StoreError> {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
-            "SELECT id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id,sandbox_id,sandbox_envd_token,sandbox_traffic_token,pinned
+            "SELECT id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id,sandbox_id,sandbox_envd_token,sandbox_traffic_token,pinned,rail_order
                FROM agents ORDER BY rowid",
         )?;
         let rows = stmt.query_map([], row_to_card)?;
@@ -300,6 +309,87 @@ impl Store {
         if changed == 0 {
             return Err(StoreError::AgentNotFound(id));
         }
+        self.get_agent(id)?.ok_or(StoreError::AgentNotFound(id))
+    }
+
+    /// Puts an agent where the operator dropped it.
+    ///
+    /// One call, because a drag is one gesture that can be both a reorder and a
+    /// move between groups, and doing it as two writes leaves a state where the
+    /// agent has arrived in the group but not in the place it was dropped.
+    ///
+    /// `before` is the row it lands in front of, and `None` means the end of
+    /// `group`. Naming the moved agent itself asks for nothing and does nothing.
+    /// Otherwise honoured only while that row is still live and still in `group`:
+    /// the operator dropped onto something they could see, and a row deleted in
+    /// the meantime must not cost them the half of the intent that still holds.
+    ///
+    /// Renumbers every live agent densely rather than finding a gap between two
+    /// neighbours. A workspace holds tens of agents, so the write is trivial,
+    /// and a scheme with gaps has a state where the gap is used up that this one
+    /// does not have. Not an edit: like `pinned`, this is where a row is drawn,
+    /// so the version does not move and no peer is told.
+    pub fn move_agent(
+        &self,
+        id: AgentId,
+        group: GroupId,
+        before: Option<AgentId>,
+    ) -> Result<AgentCard, StoreError> {
+        let mut conn = self.conn()?;
+        let tx = conn.transaction()?;
+        {
+            // The arrangement as it stands, which is what `before` refers to.
+            // Terminated agents are left out and left alone: they are not in the
+            // rail, so numbering them would spend positions on rows nobody can
+            // see and would move them under a later reader.
+            let mut stmt = tx.prepare(
+                "SELECT id, group_id FROM agents
+                  WHERE lifecycle <> 'terminated'
+                  ORDER BY rail_order, created_at, rowid",
+            )?;
+            let rows = stmt
+                .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+
+            let moving = id.to_string();
+            if !rows.iter().any(|(row_id, _)| *row_id == moving) {
+                return Err(StoreError::AgentNotFound(id));
+            }
+
+            let target = group.to_string();
+            // A row dropped on itself is not a move. Caught here as well as in
+            // the UI because the fallback for an anchor that is not in the group
+            // is the end of it, so letting this through would spend the
+            // operator's arrangement on a gesture that asked for nothing.
+            if before == Some(id) && rows.iter().any(|(r, g)| *r == moving && *g == target) {
+                return self.get_agent(id)?.ok_or(StoreError::AgentNotFound(id));
+            }
+            let mut order: Vec<(String, String)> =
+                rows.iter().filter(|(row_id, _)| *row_id != moving).cloned().collect();
+
+            let anchor = before.map(|b| b.to_string()).filter(|b| {
+                order.iter().any(|(row_id, row_group)| row_id == b && *row_group == target)
+            });
+
+            let at = match anchor {
+                Some(row) => order.iter().position(|(r, _)| *r == row).unwrap_or(order.len()),
+                // The end of the group rather than the end of the rail: this is
+                // one sequence over every group, and appending past the last
+                // group would put the agent below crews it is not in.
+                None => order
+                    .iter()
+                    .rposition(|(_, row_group)| *row_group == target)
+                    .map_or(order.len(), |last| last + 1),
+            };
+            order.insert(at, (moving.clone(), target.clone()));
+
+            let mut renumber = tx.prepare("UPDATE agents SET rail_order=?2 WHERE id=?1")?;
+            for (position, (row, _)) in order.iter().enumerate() {
+                renumber.execute(params![row, position as i32])?;
+            }
+            tx.execute("UPDATE agents SET group_id=?2 WHERE id=?1", params![moving, target])?;
+        }
+        tx.commit()?;
         self.get_agent(id)?.ok_or(StoreError::AgentNotFound(id))
     }
 
@@ -1603,6 +1693,7 @@ fn row_to_card(row: &Row<'_>) -> RowResult<AgentCard> {
             sandbox_envd_token: row.get(13)?,
             sandbox_traffic_token: row.get(14)?,
             pinned: row.get::<_, i64>(15)? != 0,
+            rail_order: row.get(16)?,
             version: row.get(8)?,
             created_at: row.get(9)?,
             updated_at: row.get(10)?,
@@ -2204,6 +2295,147 @@ mod tests {
         assert!(matches!(
             f.store.update_routine(made.id, "", "anything", Trigger::Once, 1),
             Err(StoreError::RoutineNotFound(_))
+        ));
+    }
+
+    /// The arrangement, read back the way the rail reads it.
+    fn arrangement(f: &Fixture) -> Vec<(String, i32)> {
+        let mut agents: Vec<_> = f
+            .store
+            .list_agents()
+            .unwrap()
+            .into_iter()
+            .filter(|a| a.lifecycle != Lifecycle::Terminated)
+            .map(|a| (a.name, a.rail_order, a.created_at))
+            .collect();
+        agents.sort_by_key(|(name, order, created)| (*order, *created, name.clone()));
+        agents.into_iter().map(|(name, order, _)| (name, order)).collect()
+    }
+
+    #[test]
+    fn agents_arrive_at_the_bottom_of_the_rail_in_the_order_they_were_made() {
+        // The rail used to float whoever spoke last, so where a new agent
+        // landed did not matter. It does now: an agent that arrived in the
+        // middle of an arrangement would look like the arrangement moved.
+        let f = fixture();
+        for name in ["First", "Second", "Third"] {
+            f.store.create_agent(&draft(name)).unwrap();
+        }
+        assert_eq!(
+            arrangement(&f),
+            vec![("First".to_string(), 0), ("Second".to_string(), 1), ("Third".to_string(), 2)]
+        );
+    }
+
+    #[test]
+    fn a_move_puts_a_row_in_front_of_the_one_it_was_dropped_on() {
+        let f = fixture();
+        let a = f.store.create_agent(&draft("First")).unwrap();
+        f.store.create_agent(&draft("Second")).unwrap();
+        let c = f.store.create_agent(&draft("Third")).unwrap();
+
+        let moved = f.store.move_agent(c.id, c.group_id, Some(a.id)).unwrap();
+        assert_eq!(
+            arrangement(&f).into_iter().map(|(name, _)| name).collect::<Vec<_>>(),
+            vec!["Third", "First", "Second"]
+        );
+
+        // Where a row is drawn, and nothing a peer reads. Same reasoning as a
+        // pin: bumping the version would tell every peer the card was rewritten.
+        assert_eq!(moved.version, c.version, "a move is not an edit");
+        assert_eq!(moved.updated_at, c.updated_at);
+        assert_eq!(moved.rail_order, 0);
+
+        // Densely renumbered, so the next drop has a whole position to land in
+        // rather than a gap that can run out.
+        assert_eq!(
+            arrangement(&f).into_iter().map(|(_, order)| order).collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+    }
+
+    #[test]
+    fn a_move_with_nothing_to_land_in_front_of_goes_to_the_end_of_that_group() {
+        // Not the end of the rail. One sequence covers every group, so
+        // appending past the last row would file the agent below crews it is
+        // not in and the rail would draw it under their heading.
+        let f = fixture();
+        let research = f.store.create_group(&group_named("Research")).unwrap();
+
+        let scout = f.store.create_agent(&draft("Scout")).unwrap();
+        let mut second = draft("Reader");
+        second.group_id = Some(research.id);
+        f.store.create_agent(&second).unwrap();
+        let cook = f.store.create_agent(&draft("Cook")).unwrap();
+
+        // Everyone in the default group, then Research, then Cook back in the
+        // default one: the arrangement interleaves groups until someone moves.
+        let moved = f.store.move_agent(cook.id, research.id, None).unwrap();
+        assert_eq!(moved.group_id, research.id, "one call moved it and placed it");
+        assert_eq!(
+            arrangement(&f).into_iter().map(|(name, _)| name).collect::<Vec<_>>(),
+            vec!["Scout", "Reader", "Cook"]
+        );
+
+        // And landing in front of a row in another group ignores the anchor
+        // rather than dragging the agent somewhere it was not dropped.
+        f.store.move_agent(cook.id, research.id, Some(scout.id)).unwrap();
+        assert_eq!(
+            f.store.get_agent(cook.id).unwrap().unwrap().group_id,
+            research.id,
+            "the group half of the intent still holds"
+        );
+        assert_eq!(
+            arrangement(&f).into_iter().map(|(name, _)| name).collect::<Vec<_>>(),
+            vec!["Scout", "Reader", "Cook"]
+        );
+    }
+
+    #[test]
+    fn a_row_dropped_on_itself_stays_where_it_is() {
+        // The fallback for an anchor that is not in the group is the end of it,
+        // so a null gesture that reached this far would move the row to the
+        // bottom of the rail: the one outcome the operator did not ask for.
+        let f = fixture();
+        f.store.create_agent(&draft("First")).unwrap();
+        let middle = f.store.create_agent(&draft("Middle")).unwrap();
+        f.store.create_agent(&draft("Last")).unwrap();
+
+        f.store.move_agent(middle.id, middle.group_id, Some(middle.id)).unwrap();
+        assert_eq!(
+            arrangement(&f).into_iter().map(|(name, _)| name).collect::<Vec<_>>(),
+            vec!["First", "Middle", "Last"]
+        );
+    }
+
+    #[test]
+    fn a_move_leaves_terminated_agents_out_of_the_numbering() {
+        // A terminated agent is not in the rail, so a position spent on it is a
+        // position the operator cannot drop into, and renumbering one would move
+        // a row in an old transcript's sidebar order for no reason.
+        let f = fixture();
+        let gone = f.store.create_agent(&draft("Gone")).unwrap();
+        let here = f.store.create_agent(&draft("Here")).unwrap();
+        f.store.set_lifecycle(gone.id, Lifecycle::Terminated).unwrap();
+
+        f.store.move_agent(here.id, here.group_id, None).unwrap();
+        assert_eq!(f.store.get_agent(here.id).unwrap().unwrap().rail_order, 0);
+        assert_eq!(
+            f.store.get_agent(gone.id).unwrap().unwrap().rail_order,
+            gone.rail_order,
+            "a terminated agent's place was not rewritten"
+        );
+    }
+
+    #[test]
+    fn moving_an_agent_that_is_not_there_is_an_error_rather_than_a_silent_renumber() {
+        let f = fixture();
+        let card = f.store.create_agent(&draft("Scout")).unwrap();
+        let group = card.group_id;
+        f.store.set_lifecycle(card.id, Lifecycle::Terminated).unwrap();
+        assert!(matches!(
+            f.store.move_agent(card.id, group, None),
+            Err(StoreError::AgentNotFound(_))
         ));
     }
 

--- a/src-tauri/src/domain/agent.rs
+++ b/src-tauri/src/domain/agent.rs
@@ -92,6 +92,14 @@ pub struct AgentCard {
     /// pinned agent is addressed, paid for and messaged exactly as before, so
     /// no peer is ever told about this.
     pub pinned: bool,
+    /// Where the operator put this row. Lower is higher up its section.
+    ///
+    /// The arrangement, not the drawn order: a working agent is lifted to the
+    /// top of its section by the rail itself and drops back here when it stops.
+    /// Where a row is drawn and nothing else, exactly like `pinned`, so it does
+    /// not bump the version and no peer is told. Ties are legal and are broken
+    /// by `created_at`, which is what an upgrade leaves behind.
+    pub rail_order: i32,
     /// Bumped on every update. A2A's Update phase exists so peers can detect
     /// that a card changed under them; the version is what makes that possible.
     pub version: u32,
@@ -405,6 +413,7 @@ mod tests {
             sandbox_traffic_token: None,
             lifecycle: Lifecycle::Active,
             pinned: false,
+            rail_order: 0,
             version: 1,
             created_at: 0,
             updated_at: 0,

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -3347,6 +3347,7 @@ mod tests {
             sandbox_traffic_token: None,
             lifecycle,
             pinned: false,
+            rail_order: 0,
             version: 1,
             created_at: 0,
             updated_at: 0,

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -564,6 +564,7 @@ mod tests {
             skills: vec!["delegation".into(), "scheduling".into()],
             lifecycle: Lifecycle::Active,
             pinned: false,
+            rail_order: 0,
             version: 1,
             created_at: 0,
             updated_at: 0,

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -14,6 +14,7 @@ import type { AgentCard, Routine, Settings } from "./lib/types";
 
 const listAgents = vi.fn<() => Promise<AgentCard[]>>(async () => []);
 const agentLastActive = vi.fn<() => Promise<Record<string, number>>>(async () => ({}));
+const agentActivity = vi.fn<() => Promise<Record<string, unknown>>>(async () => ({}));
 const agentRoutines = vi.fn<() => Promise<Routine[]>>(async () => []);
 const setAgentPinned = vi.fn<(id: string, pinned: boolean) => Promise<AgentCard>>();
 const duplicateAgent = vi.fn<(id: string) => Promise<AgentCard>>();
@@ -54,7 +55,7 @@ vi.mock("./lib/ipc", () => ({
         apiKeyHint: "",
       },
     ],
-    agentActivity: async () => ({}),
+    agentActivity: () => agentActivity(),
     usageSummary: async () => [],
     approvalStates: async () => ({}),
     agentLastActive: () => agentLastActive(),
@@ -79,9 +80,10 @@ vi.mock("./lib/ipc", () => ({
 const { default: App } = await import("./App");
 const { useStore } = await import("./lib/store");
 
-function agent(name: string): AgentCard {
+function agent(name: string, railOrder = 0): AgentCard {
   return {
     id: `id-${name}`,
+    railOrder,
     groupId: "00000000-0000-4000-8000-000000000001",
     sandboxId: null,
     name,
@@ -112,16 +114,24 @@ function railRow(name: string): HTMLElement {
   return row as HTMLElement;
 }
 
+/** Every row in the rail, top to bottom. */
+function railNames(): (string | null)[] {
+  const rail = screen.getByRole("navigation", { name: /agents/i });
+  return [...rail.querySelectorAll(".agent-row__name")].map((n) => n.textContent);
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   listAgents.mockResolvedValue([]);
   agentLastActive.mockResolvedValue({});
+  agentActivity.mockResolvedValue({});
   useStore.setState({
     agents: [],
     activity: {},
     lastActive: {},
     settings: null,
     selected: null,
+    railGroup: null,
     messages: {},
     streams: {},
     pulses: [],
@@ -154,17 +164,31 @@ describe("App", () => {
     await waitFor(() => expect(screen.getByRole("heading", { name: "Manager" })).toBeTruthy());
   });
 
-  it("puts the most recently active agent at the top of the rail", async () => {
-    listAgents.mockResolvedValue([agent("Manager"), agent("Chef"), agent("Host")]);
+  it("draws the rail in the order the operator arranged it", async () => {
+    // Having spoken recently is not a reason to move. The rail used to be
+    // ordered by nothing else, so a conversation rewrote the arrangement and
+    // the row you reached for was the row that had just left.
+    listAgents.mockResolvedValue([agent("Manager", 0), agent("Chef", 1), agent("Host", 2)]);
     agentLastActive.mockResolvedValue({ "id-Host": 900, "id-Chef": 500 });
     render(<App />);
 
     await waitFor(() => expect(screen.getByText("Manager")).toBeTruthy());
-    const rail = screen.getByRole("navigation", { name: /agents/i });
-    const names = [...rail.querySelectorAll(".agent-row__name")].map((n) => n.textContent);
-    // Host spoke last, then Chef. Manager has never spoken, so it keeps its
-    // creation position at the bottom.
-    expect(names).toEqual(["Host", "Chef", "Manager"]);
+    expect(railNames()).toEqual(["Manager", "Chef", "Host"]);
+  });
+
+  it("lifts whoever is working to the top, and gives the place back", async () => {
+    listAgents.mockResolvedValue([agent("Manager", 0), agent("Chef", 1), agent("Host", 2)]);
+    agentActivity.mockResolvedValue({ "id-Host": { state: "thinking" } });
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Manager")).toBeTruthy());
+    expect(railNames()).toEqual(["Host", "Manager", "Chef"]);
+
+    // The turn ends, and the row goes back where it was put.
+    useStore
+      .getState()
+      .applyEvent({ type: "activityChanged", agentId: "id-Host", activity: { state: "idle" } });
+    await waitFor(() => expect(railNames()).toEqual(["Manager", "Chef", "Host"]));
   });
 
   it("keeps deleted agents out of the rail", async () => {
@@ -201,20 +225,19 @@ describe("App", () => {
   });
 
   it("puts a pinned agent above the rest and leaves it there", async () => {
-    // The rail floats whoever just spoke to the top. A row pinned so it could
-    // be found in one glance must not join in.
+    // The rail lifts whoever is working to the top of its section. A row pinned
+    // so it could be found in one glance must not join in, wherever it sits in
+    // the arrangement.
     listAgents.mockResolvedValue([
-      agent("Manager"),
-      { ...agent("Chef"), pinned: true },
-      agent("Host"),
+      agent("Manager", 0),
+      { ...agent("Chef", 1), pinned: true },
+      agent("Host", 2),
     ]);
-    agentLastActive.mockResolvedValue({ "id-Host": 900, "id-Manager": 500 });
+    agentActivity.mockResolvedValue({ "id-Chef": { state: "thinking" } });
     render(<App />);
 
     await waitFor(() => expect(screen.getByText("Chef")).toBeTruthy());
-    const rail = screen.getByRole("navigation", { name: /agents/i });
-    const names = [...rail.querySelectorAll(".agent-row__name")].map((n) => n.textContent);
-    expect(names).toEqual(["Chef", "Host", "Manager"]);
+    expect(railNames()).toEqual(["Chef", "Manager", "Host"]);
     expect(screen.getByText("Pinned")).toBeTruthy();
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,9 @@ export default function App() {
   const refreshAgents = useStore((s) => s.refreshAgents);
   const select = useStore((s) => s.select);
   const loadChannel = useStore((s) => s.loadChannel);
+  const groups = useStore((s) => s.groups);
+  const nudgeAgent = useStore((s) => s.nudgeAgent);
+  const dropAgent = useStore((s) => s.dropAgent);
 
   const [editing, setEditing] = useState<AgentCard | "new" | null>(null);
   const [editingGroup, setEditingGroup] = useState<Group | "new" | null>(null);
@@ -236,9 +239,17 @@ export default function App() {
       {menu && (
         <AgentMenu
           target={menu}
+          groups={groups}
           onClose={() => setMenu(null)}
           onEditProfile={(agent) => setEditing(agent)}
           onTogglePin={(agent) => void onAgent(() => api.setAgentPinned(agent.id, !agent.pinned))}
+          // Both go through the store: it holds the roster and the activity the
+          // rail's order is computed from, so it is the only place that can say
+          // which row is above this one right now.
+          onNudge={(agent, delta) => void onAgent(() => nudgeAgent(agent.id, delta))}
+          onMoveToGroup={(agent, group) =>
+            void onAgent(() => dropAgent(agent.id, { kind: "group", id: group.id }))
+          }
           onTogglePause={(agent) =>
             void onAgent(() => api.setAgentPaused(agent.id, agent.lifecycle !== "paused"))
           }

--- a/src/components/ActivityFlow.test.tsx
+++ b/src/components/ActivityFlow.test.tsx
@@ -22,6 +22,7 @@ function card(id: string, name: string, color = "#c7d96b"): AgentCard {
     skills: [],
     lifecycle: "active",
     pinned: false,
+    railOrder: 0,
     version: 1,
     createdAt: 0,
     updatedAt: 0,

--- a/src/components/AgentMenu.test.tsx
+++ b/src/components/AgentMenu.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import type { AgentCard } from "../lib/types";
+import type { AgentCard, Group } from "../lib/types";
 import { AgentMenu } from "./AgentMenu";
 
 function card(over: Partial<AgentCard> = {}): AgentCard {
@@ -17,6 +17,7 @@ function card(over: Partial<AgentCard> = {}): AgentCard {
     skills: [],
     lifecycle: "active",
     pinned: false,
+    railOrder: 0,
     version: 1,
     createdAt: 0,
     updatedAt: 0,
@@ -24,7 +25,20 @@ function card(over: Partial<AgentCard> = {}): AgentCard {
   };
 }
 
-function open(agent: AgentCard, at = { x: 40, y: 40 }) {
+function group(id: string, name: string): Group {
+  return {
+    id,
+    name,
+    agentCount: 1,
+    createdAt: 0,
+    baseUrl: null,
+    defaultModel: null,
+    apiKeySet: false,
+    apiKeyHint: "",
+  };
+}
+
+function open(agent: AgentCard, at = { x: 40, y: 40 }, groups: Group[] = []) {
   const handlers = {
     onClose: vi.fn(),
     onEditProfile: vi.fn(),
@@ -32,15 +46,25 @@ function open(agent: AgentCard, at = { x: 40, y: 40 }) {
     onTogglePause: vi.fn(),
     onDuplicate: vi.fn(),
     onClearHistory: vi.fn(),
+    onNudge: vi.fn(),
+    onMoveToGroup: vi.fn(),
   };
-  render(<AgentMenu target={{ agent, ...at }} {...handlers} />);
+  render(<AgentMenu target={{ agent, ...at }} groups={groups} {...handlers} />);
   return handlers;
 }
 
 describe("AgentMenu", () => {
   it("offers everything you do to an agent, from either place it opens", () => {
     open(card());
-    for (const name of ["Pause", "Edit profile", "Pin to top", "Duplicate", "Clear history…"]) {
+    for (const name of [
+      "Pause",
+      "Edit profile",
+      "Pin to top",
+      "Move up",
+      "Move down",
+      "Duplicate",
+      "Clear history…",
+    ]) {
       expect(screen.getByRole("button", { name })).toBeTruthy();
     }
   });
@@ -63,6 +87,33 @@ describe("AgentMenu", () => {
     open(card({ pinned: true }));
     expect(screen.getByRole("button", { name: "Unpin" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Pin to top" })).toBeNull();
+  });
+
+  it("arranges the rail without a mouse", () => {
+    // A rail that can only be arranged by dragging cannot be arranged from a
+    // keyboard at all, and this menu is already where everything else lives.
+    const handlers = open(card());
+    fireEvent.click(screen.getByRole("button", { name: "Move up" }));
+    expect(handlers.onNudge).toHaveBeenCalledWith(expect.objectContaining({ id: "a1" }), -1);
+  });
+
+  it("offers the crews this agent is not in, and never the one it is", () => {
+    const handlers = open(card(), { x: 40, y: 40 }, [
+      group("g1", "everyone"),
+      group("g2", "research"),
+    ]);
+
+    expect(screen.queryByRole("button", { name: "Move to everyone" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Move to research" }));
+    expect(handlers.onMoveToGroup).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "a1" }),
+      expect.objectContaining({ id: "g2" }),
+    );
+  });
+
+  it("says nothing about groups while there is only one", () => {
+    open(card(), { x: 40, y: 40 }, [group("g1", "everyone")]);
+    expect(screen.queryByText(/^Move to /)).toBeNull();
   });
 
   it("closes as it acts, so the menu is never left over a stale row", () => {

--- a/src/components/AgentMenu.tsx
+++ b/src/components/AgentMenu.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
-import type { AgentCard } from "../lib/types";
+import type { AgentCard, Group } from "../lib/types";
 
 export interface MenuTarget {
   agent: AgentCard;
@@ -10,12 +10,17 @@ export interface MenuTarget {
 
 interface Props {
   target: MenuTarget;
+  /** Every group, so the ones this agent is not in can be offered. */
+  groups: Group[];
   onClose: () => void;
   onEditProfile: (agent: AgentCard) => void;
   onTogglePin: (agent: AgentCard) => void;
   onTogglePause: (agent: AgentCard) => void;
   onDuplicate: (agent: AgentCard) => void;
   onClearHistory: (agent: AgentCard) => void;
+  /** One row up or down: the drag, without a mouse. */
+  onNudge: (agent: AgentCard, delta: -1 | 1) => void;
+  onMoveToGroup: (agent: AgentCard, group: Group) => void;
 }
 
 /** Roughly what the menu measures. Only used to keep it inside the window. */
@@ -40,12 +45,15 @@ const MARGIN = 8;
  */
 export function AgentMenu({
   target,
+  groups,
   onClose,
   onEditProfile,
   onTogglePin,
   onTogglePause,
   onDuplicate,
   onClearHistory,
+  onNudge,
+  onMoveToGroup,
 }: Props) {
   const { agent } = target;
   const ref = useRef<HTMLDivElement>(null);
@@ -131,7 +139,18 @@ export function AgentMenu({
         {item(agent.lifecycle === "paused" ? "Resume" : "Pause", () => onTogglePause(agent))}
         {item("Edit profile", () => onEditProfile(agent))}
         {item(agent.pinned ? "Unpin" : "Pin to top", () => onTogglePin(agent))}
+        {/* The same two moves a drag makes, reachable without one. A rail that
+            can only be arranged by dragging cannot be arranged from a keyboard
+            at all, and this menu is already where everything else about an
+            agent lives. */}
+        {item("Move up", () => onNudge(agent, -1))}
+        {item("Move down", () => onNudge(agent, 1))}
         {item("Duplicate", () => onDuplicate(agent))}
+        {/* Absent while there is one group, for the same reason the strip in
+            the rail is: there is nowhere else to go. */}
+        {groups
+          .filter((group) => group.id !== agent.groupId)
+          .map((group) => item(`Move to ${group.name}`, () => onMoveToGroup(agent, group)))}
         <hr className="menu__rule" />
         {confirming ? (
           item("Delete this history", () => onClearHistory(agent), "danger")

--- a/src/components/ApprovalRequest.test.tsx
+++ b/src/components/ApprovalRequest.test.tsx
@@ -27,6 +27,7 @@ const MANAGER: AgentCard = {
   skills: [],
   lifecycle: "active",
   pinned: false,
+  railOrder: 0,
   version: 1,
   createdAt: 0,
   updatedAt: 0,

--- a/src/components/ChannelView.perf.test.tsx
+++ b/src/components/ChannelView.perf.test.tsx
@@ -58,6 +58,7 @@ function agent(id: string, name: string): AgentCard {
     skills: [],
     lifecycle: "active",
     pinned: false,
+    railOrder: 0,
     createdAt: 0,
     updatedAt: 0,
     sandboxId: null,

--- a/src/components/ChannelView.test.tsx
+++ b/src/components/ChannelView.test.tsx
@@ -48,6 +48,7 @@ function card(id: string, name: string): AgentCard {
     skills: [],
     lifecycle: "active",
     pinned: false,
+    railOrder: 0,
     version: 1,
     createdAt: 0,
     updatedAt: 0,

--- a/src/components/ComputerScreen.test.tsx
+++ b/src/components/ComputerScreen.test.tsx
@@ -29,6 +29,7 @@ function card(id: string, name: string): AgentCard {
     skills: [],
     lifecycle: "active",
     pinned: false,
+    railOrder: 0,
     version: 1,
     createdAt: 0,
     updatedAt: 0,

--- a/src/components/GroupOrb.tsx
+++ b/src/components/GroupOrb.tsx
@@ -1,0 +1,92 @@
+import { AgentAvatar } from "../avatars/AgentAvatar";
+import { liftOf } from "../lib/rail";
+import type { Activity, AgentCard, AgentId, Group } from "../lib/types";
+
+interface Props {
+  group: Group;
+  /** Live members, in the order the rail arranged them. */
+  members: AgentCard[];
+  activity: Record<AgentId, Activity>;
+  /** Whether the rail is currently looking inside this group. */
+  current: boolean;
+  /** Whether a dragged row would land here if it were dropped now. */
+  over: boolean;
+  onOpen: () => void;
+  onDragOver: () => void;
+  onDragOut: () => void;
+}
+
+/** How many faces fit in the circle before it starts counting instead. */
+const FACES = 4;
+
+/**
+ * A group, small enough to sit in a strip and be aimed at.
+ *
+ * Faces rather than a name, because a crew is recognised by who is in it long
+ * before its name is read, and four of these have to fit across a rail that is
+ * 15.5rem wide. The name is still there for anything that reads rather than
+ * looks: the label, the tooltip, and the heading you get after clicking.
+ *
+ * Two jobs in one control, which is why it is a circle and not a row in a menu.
+ * Clicking opens the group. Dropping an agent on it puts the agent in the group,
+ * so the shortest gesture for moving somebody between crews is the one that also
+ * says which crew, and it is on screen the whole time you are dragging.
+ */
+export function GroupOrb({
+  group,
+  members,
+  activity,
+  current,
+  over,
+  onOpen,
+  onDragOver,
+  onDragOut,
+}: Props) {
+  const faces = members.slice(0, FACES);
+  const rest = members.length - faces.length;
+
+  // The two states worth interrupting a glance for. Asking is louder because
+  // the agent is parked until the operator answers, and after focusing on one
+  // group the strip is the only place the other crews are still visible at all.
+  const asking = members.some((m) => activity[m.id]?.state === "awaitingApproval");
+  const working = members.some((m) => liftOf(activity[m.id]) > 0);
+
+  const state = asking ? "asking" : working ? "working" : undefined;
+  const busy = asking ? "someone needs you" : working ? "working" : null;
+
+  return (
+    <button
+      type="button"
+      className="orb"
+      aria-current={current}
+      aria-label={`${group.name}, ${members.length} ${members.length === 1 ? "agent" : "agents"}${
+        busy ? `, ${busy}` : ""
+      }`}
+      title={group.name}
+      data-state={state}
+      data-over={over ? "true" : undefined}
+      onClick={onOpen}
+      onPointerEnter={onDragOver}
+      onPointerLeave={onDragOut}
+    >
+      <span className="orb__ring">
+        <span className="orb__faces" data-count={faces.length}>
+          {faces.map((member) => (
+            <AgentAvatar
+              key={member.id}
+              avatar={member.avatar}
+              color={member.color}
+              size="xs"
+              seed={member.id}
+              lifecycle={member.lifecycle}
+              title={member.name}
+            />
+          ))}
+          {faces.length === 0 && <span className="orb__none">·</span>}
+        </span>
+        {rest > 0 && <span className="orb__more">+{rest}</span>}
+      </span>
+      <span className="orb__name">{group.name}</span>
+    </button>
+  );
+}

--- a/src/components/MessageItem.test.tsx
+++ b/src/components/MessageItem.test.tsx
@@ -26,6 +26,7 @@ function card(id: string, name: string): AgentCard {
     skills: [],
     lifecycle: "active",
     pinned: false,
+    railOrder: 0,
     version: 1,
     createdAt: 0,
     updatedAt: 0,

--- a/src/components/Search.test.tsx
+++ b/src/components/Search.test.tsx
@@ -45,6 +45,7 @@ function agent(name: string, extra: Partial<AgentCard> = {}): AgentCard {
     skills: [],
     lifecycle: "active",
     pinned: false,
+    railOrder: 0,
     version: 1,
     createdAt: 1,
     updatedAt: 1,

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -1,22 +1,30 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useStore } from "../lib/store";
-import type { Group } from "../lib/types";
+import type { Activity, AgentCard, Group } from "../lib/types";
 import { Sidebar } from "./Sidebar";
+
+const moveAgent =
+  vi.fn<(id: string, groupId: string, before: string | null) => Promise<AgentCard>>();
+const setAgentPinned = vi.fn<(id: string, pinned: boolean) => Promise<AgentCard>>();
 
 vi.mock("../lib/ipc", () => ({
   api: {
     listAgents: async () => [],
     listGroups: async () => [],
+    moveAgent: (id: string, groupId: string, before: string | null) =>
+      moveAgent(id, groupId, before),
+    setAgentPinned: (id: string, pinned: boolean) => setAgentPinned(id, pinned),
   },
 }));
 
 const MODEL = "anthropic/claude-opus-4-1-20250805";
+const DEFAULT_GROUP = "00000000-0000-4000-8000-000000000001";
 
-function group(name: string, defaultModel: string | null): Group {
+function group(name: string, defaultModel: string | null = null, id = DEFAULT_GROUP): Group {
   return {
-    id: "00000000-0000-4000-8000-000000000001",
+    id,
     name,
     agentCount: 0,
     createdAt: 0,
@@ -27,16 +35,40 @@ function group(name: string, defaultModel: string | null): Group {
   };
 }
 
-function draw(g: Group) {
+function agent(name: string, over: Partial<AgentCard> = {}): AgentCard {
+  return {
+    id: name,
+    groupId: DEFAULT_GROUP,
+    sandboxId: null,
+    name,
+    avatar: "avocado",
+    color: "#c7d96b",
+    model: "m",
+    systemPrompt: "",
+    skills: [],
+    lifecycle: "active",
+    pinned: false,
+    railOrder: 0,
+    version: 1,
+    createdAt: 0,
+    updatedAt: 0,
+    ...over,
+  };
+}
+
+function draw(groups: Group[], agents: AgentCard[] = [], activity: Record<string, Activity> = {}) {
   useStore.setState({
-    agents: [],
-    groups: [g],
-    activity: {},
+    agents,
+    groups,
+    activity,
     lastActive: {},
-    usage: { [g.id]: { prompt: 900_000, completion: 900_000, calls: 400, cost: 123.45 } },
+    usage: Object.fromEntries(
+      groups.map((g) => [g.id, { prompt: 900_000, completion: 900_000, calls: 400, cost: 123.45 }]),
+    ),
     pulse: {},
     pulses: [],
     selected: null,
+    railGroup: null,
   });
   return render(
     <Sidebar
@@ -51,18 +83,249 @@ function draw(g: Group) {
   );
 }
 
-describe("group header", () => {
-  beforeEach(() => {
-    useStore.setState({ groups: [], agents: [] });
-  });
+/** A row, by the name written in it. */
+function row(name: string): HTMLElement {
+  const found = screen
+    .getAllByRole("button")
+    .find((node) => node.className === "agent-row" && node.textContent?.startsWith(name));
+  if (!found) throw new Error(`no row for ${name}`);
+  return found;
+}
 
+/**
+ * One drag, from a row to whatever should catch it.
+ *
+ * Written out rather than wrapped in a helper that fires everything at once,
+ * because the press has to travel before it becomes a drag and that threshold is
+ * the thing keeping a row a button.
+ */
+async function dragTo(from: HTMLElement, onto: HTMLElement) {
+  fireEvent.pointerDown(from, { button: 0, clientX: 100, clientY: 200 });
+  fireEvent.pointerMove(window, { clientX: 100, clientY: 240 });
+  fireEvent.pointerEnter(onto, { clientX: 100, clientY: 260 });
+  fireEvent.pointerUp(window, { clientX: 100, clientY: 260 });
+  // The drop is a command and a re-read, so let both settle.
+  await vi.waitFor(() =>
+    expect(moveAgent.mock.calls.length + setAgentPinned.mock.calls.length).toBeGreaterThan(0),
+  );
+}
+
+beforeEach(() => {
+  moveAgent.mockReset();
+  moveAgent.mockResolvedValue(agent("Manager"));
+  setAgentPinned.mockReset();
+  setAgentPinned.mockResolvedValue(agent("Manager"));
+  useStore.setState({ groups: [], agents: [], railGroup: null });
+});
+
+describe("group header", () => {
   it("does not draw the pinned model in the rail at all", () => {
     // The rail is 15.5rem. A model id beside the name left one letter of
     // "everyone" and an ellipsis; on a line of its own it cost a whole row per
     // group to say something the gear already shows.
-    const { container } = draw(group("everyone", MODEL));
+    const { container } = draw([group("everyone", MODEL)]);
 
     expect(container.querySelector(".rail__group-head")?.textContent).toContain("everyone");
     expect(screen.queryByText(MODEL)).toBeNull();
+  });
+});
+
+describe("arranging the rail", () => {
+  it("drops a row in front of the one it stopped on coming up", async () => {
+    draw(
+      [group("everyone")],
+      [
+        agent("Manager", { railOrder: 0 }),
+        agent("Cook", { railOrder: 1 }),
+        agent("Scribe", { railOrder: 2 }),
+      ],
+    );
+
+    await dragTo(row("Scribe"), row("Manager"));
+
+    expect(moveAgent).toHaveBeenCalledWith("Scribe", DEFAULT_GROUP, "Manager");
+  });
+
+  it("drops a row after the one it passed going down", async () => {
+    draw(
+      [group("everyone")],
+      [
+        agent("Manager", { railOrder: 0 }),
+        agent("Cook", { railOrder: 1 }),
+        agent("Scribe", { railOrder: 2 }),
+      ],
+    );
+
+    await dragTo(row("Manager"), row("Cook"));
+
+    expect(moveAgent).toHaveBeenCalledWith("Manager", DEFAULT_GROUP, "Scribe");
+  });
+
+  it("marks the row a release would land in front of, and the row in hand", () => {
+    // The only two things on screen saying what the gesture will do. A drag
+    // that shows neither is a drag the operator has to guess the result of.
+    draw(
+      [group("everyone")],
+      [agent("Manager", { railOrder: 0 }), agent("Cook", { railOrder: 1 })],
+    );
+
+    fireEvent.pointerDown(row("Cook"), { button: 0, clientX: 100, clientY: 300 });
+    fireEvent.pointerMove(window, { clientX: 100, clientY: 250 });
+    fireEvent.pointerEnter(row("Manager"), { clientX: 100, clientY: 240 });
+
+    expect(row("Manager").dataset.over).toBe("true");
+    expect(row("Cook").dataset.held).toBe("true");
+    // Not on the row being carried, which is not somewhere it can land.
+    expect(row("Cook").dataset.over).toBeUndefined();
+  });
+
+  it("draws the arrangement while a drag is on, not whoever is mid-turn", async () => {
+    // Dragging is arranging, so it has to operate on the arrangement. A row
+    // dropped under a peer that is only near the top because it is working
+    // would land somewhere the operator never aimed at.
+    draw(
+      [group("everyone")],
+      [
+        agent("Manager", { railOrder: 0 }),
+        agent("Cook", { railOrder: 1 }),
+        agent("Scribe", { railOrder: 2 }),
+      ],
+      { Scribe: { state: "thinking" } },
+    );
+
+    const names = () =>
+      [...document.querySelectorAll(".agent-row__name")].map((n) => n.textContent);
+    expect(names()).toEqual(["Scribe", "Manager", "Cook"]);
+
+    fireEvent.pointerDown(row("Manager"), { button: 0, clientX: 100, clientY: 300 });
+    fireEvent.pointerMove(window, { clientX: 100, clientY: 250 });
+    expect(names()).toEqual(["Manager", "Cook", "Scribe"]);
+  });
+
+  it("leaves the rail alone when a press does not travel", () => {
+    // A row is a button first. Selecting an agent with a hand that is not
+    // perfectly still must not start rearranging anything.
+    draw([group("everyone")], [agent("Manager"), agent("Cook", { railOrder: 1 })]);
+
+    fireEvent.pointerDown(row("Manager"), { button: 0, clientX: 100, clientY: 200 });
+    fireEvent.pointerEnter(row("Cook"), { clientX: 100, clientY: 202 });
+    fireEvent.pointerUp(window, { clientX: 100, clientY: 202 });
+
+    expect(moveAgent).not.toHaveBeenCalled();
+  });
+
+  it("abandons a drag on escape without moving anything", () => {
+    draw([group("everyone")], [agent("Manager"), agent("Cook", { railOrder: 1 })]);
+
+    fireEvent.pointerDown(row("Manager"), { button: 0, clientX: 100, clientY: 200 });
+    fireEvent.pointerMove(window, { clientX: 100, clientY: 240 });
+    fireEvent.pointerEnter(row("Cook"), { clientX: 100, clientY: 260 });
+    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.pointerUp(window, { clientX: 100, clientY: 260 });
+
+    expect(moveAgent).not.toHaveBeenCalled();
+  });
+
+  it("pins a row dropped on the pinned section and moves it nowhere", async () => {
+    // The section spans groups, so there is no place in it to express. Pinning
+    // is the whole of what the gesture asked for.
+    draw(
+      [group("everyone")],
+      [agent("Manager", { railOrder: 0, pinned: true }), agent("Cook", { railOrder: 1 })],
+    );
+
+    const pinned = document.querySelector(".rail__group");
+    if (!pinned) throw new Error("the pinned section was not drawn");
+
+    fireEvent.pointerDown(row("Cook"), { button: 0, clientX: 100, clientY: 300 });
+    fireEvent.pointerMove(window, { clientX: 100, clientY: 250 });
+    fireEvent.pointerEnter(pinned, { clientX: 100, clientY: 210 });
+    fireEvent.pointerUp(window, { clientX: 100, clientY: 210 });
+
+    await vi.waitFor(() => expect(setAgentPinned).toHaveBeenCalledWith("Cook", true));
+    expect(moveAgent).not.toHaveBeenCalled();
+  });
+
+  it("unpins a row dragged out of the pins and into a crew", async () => {
+    draw(
+      [group("everyone")],
+      [
+        agent("Manager", { railOrder: 0, pinned: true }),
+        agent("Cook", { railOrder: 1 }),
+        agent("Scribe", { railOrder: 2 }),
+      ],
+    );
+
+    await dragTo(row("Manager"), row("Scribe"));
+
+    // In front of Scribe, not at the end: an agent arriving from another
+    // section has no place in this one to have travelled from, so there is no
+    // direction to read and it takes the place of what it was dropped on.
+    expect(setAgentPinned).toHaveBeenCalledWith("Manager", false);
+    expect(moveAgent).toHaveBeenCalledWith("Manager", DEFAULT_GROUP, "Scribe");
+  });
+});
+
+describe("groups as places", () => {
+  const RESEARCH = "00000000-0000-4000-8000-000000000002";
+
+  it("keeps the strip out of the way while there is one group", () => {
+    draw([group("everyone")], [agent("Manager")]);
+    expect(screen.queryByLabelText("Groups")).toBeNull();
+  });
+
+  it("draws one circle per group, and the faces in it", () => {
+    draw(
+      [group("everyone"), group("research", null, RESEARCH)],
+      [agent("Manager"), agent("Reader", { groupId: RESEARCH, railOrder: 1 })],
+    );
+
+    expect(screen.getByLabelText("Groups")).toBeTruthy();
+    expect(screen.getByLabelText("research, 1 agent")).toBeTruthy();
+    expect(screen.getByTitle("Reader")).toBeTruthy();
+  });
+
+  it("says on the circle when somebody inside it needs the operator", () => {
+    // After focusing on one group the strip is the only place the other crews
+    // are still visible, so it has to carry the one state that is waiting on a
+    // person.
+    draw(
+      [group("everyone"), group("research", null, RESEARCH)],
+      [agent("Manager"), agent("Reader", { groupId: RESEARCH, railOrder: 1 })],
+      { Reader: { state: "awaitingApproval" } },
+    );
+
+    expect(screen.getByLabelText("research, 1 agent, someone needs you")).toBeTruthy();
+  });
+
+  it("draws only that group after clicking into it, and everyone again after leaving", () => {
+    draw(
+      [group("everyone"), group("research", null, RESEARCH)],
+      [agent("Manager"), agent("Reader", { groupId: RESEARCH, railOrder: 1 })],
+    );
+
+    fireEvent.click(screen.getByLabelText("research, 1 agent"));
+    expect(screen.getByText("Reader")).toBeTruthy();
+    expect(screen.queryByText("Manager")).toBeNull();
+
+    fireEvent.click(screen.getByLabelText("All groups, 2 agents"));
+    expect(screen.getByText("Manager")).toBeTruthy();
+  });
+
+  it("moves an agent into the group whose circle it was dropped on", async () => {
+    draw(
+      [group("everyone"), group("research", null, RESEARCH)],
+      [agent("Manager"), agent("Reader", { groupId: RESEARCH, railOrder: 1 })],
+    );
+
+    fireEvent.pointerDown(row("Manager"), { button: 0, clientX: 100, clientY: 300 });
+    fireEvent.pointerMove(window, { clientX: 100, clientY: 250 });
+    fireEvent.pointerEnter(screen.getByLabelText("research, 1 agent"), {
+      clientX: 60,
+      clientY: 120,
+    });
+    fireEvent.pointerUp(window, { clientX: 60, clientY: 120 });
+
+    await vi.waitFor(() => expect(moveAgent).toHaveBeenCalledWith("Manager", RESEARCH, null));
   });
 });

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,10 +1,12 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { AgentAvatar, type Look } from "../avatars/AgentAvatar";
 import { FLIGHT_MS, roleOf, usePulseChoreography } from "../lib/choreography";
+import { type DropTarget, railOrder } from "../lib/rail";
 import { ACTIVITY_CHANNEL, useLiveAgents, useStore } from "../lib/store";
 import { relativeTime, useNow } from "../lib/time";
 import type { Activity, AgentCard, AgentId, Group } from "../lib/types";
+import { GroupOrb } from "./GroupOrb";
 import { TokenMeter } from "./TokenMeter";
 
 interface Props {
@@ -30,6 +32,24 @@ function prefersReducedMotion(): boolean {
  */
 const FIND_KEY = /mac/i.test(navigator.platform || navigator.userAgent) ? "⌘K" : "Ctrl K";
 
+/**
+ * How far the pointer travels before a press becomes a drag.
+ *
+ * A row is a button first. Anything smaller than this and selecting an agent
+ * with a hand that is not perfectly still starts rearranging the rail instead.
+ */
+const DRAG_SLOP = 5;
+
+/** How close to an edge of the list the pointer scrolls it, and by how much. */
+const EDGE = 36;
+const EDGE_STEP = 14;
+
+/** A row in flight, and what it is currently over. */
+interface Drag {
+  id: AgentId;
+  over: DropTarget | null;
+}
+
 export function Sidebar({
   onNewAgent,
   onEditAgent,
@@ -47,6 +67,9 @@ export function Sidebar({
   const select = useStore((s) => s.select);
   const pulses = useStore((s) => s.pulses);
   const dismissPulse = useStore((s) => s.dismissPulse);
+  const railGroup = useStore((s) => s.railGroup);
+  const focusGroup = useStore((s) => s.focusGroup);
+  const dropAgent = useStore((s) => s.dropAgent);
   const now = useNow();
 
   const listRef = useRef<HTMLDivElement>(null);
@@ -54,8 +77,35 @@ export function Sidebar({
   const [rowCenters, setRowCenters] = useState<Map<AgentId, number>>(new Map());
   const previousTops = useRef(new Map<AgentId, number>());
 
+  /** The press that has not yet travelled far enough to be a drag. */
+  const press = useRef<{ id: AgentId; x: number; y: number } | null>(null);
+  const [drag, setDrag] = useState<Drag | null>(null);
+  /**
+   * Where the pointer is, and the thing that follows it.
+   *
+   * A ref and a direct style write rather than state, because this changes on
+   * every pointer frame and every row in the rail has an animating character in
+   * it. Rendering the whole rail sixty times a second to move one box is the
+   * one thing that would make dragging feel worse than not being able to.
+   */
+  const point = useRef({ x: 0, y: 0 });
+  const heldRef = useRef<HTMLDivElement>(null);
+
   // Messages arrive in bursts; this spaces them out so each throw is watchable.
   const { staged, inFlight } = usePulseChoreography(pulses, dismissPulse);
+
+  const focused = groups.find((g) => g.id === railGroup) ?? null;
+
+  /**
+   * How every section of the rail is ordered right now.
+   *
+   * Frozen while something is being dragged, because dragging is arranging: a
+   * row dropped below a peer that is only near the top because it happens to be
+   * mid-turn would land somewhere the operator never aimed at, and the rail
+   * would look like it had ignored the gesture the moment that turn ended.
+   */
+  const shape = { activity, lastActive, frozen: drag !== null };
+  const dragging = drag?.id ?? null;
 
   // One layout pass does two jobs: slide rows that moved, and record where
   // every row ended up so the travelling message knows where to fly.
@@ -107,7 +157,111 @@ export function Sidebar({
     const observer = new ResizeObserver(measure);
     if (listRef.current) observer.observe(listRef.current);
     return () => observer.disconnect();
-  }, [agents]);
+    // Everything the drawn order is computed from. Activity and recency are in
+    // here because a row lifted for working moves without the roster changing,
+    // and a move nothing slid is a row that jumped.
+  }, [agents, activity, lastActive, dragging, railGroup]);
+
+  /** Moves the thing in hand to where the pointer is, without a render. */
+  const place = useCallback(() => {
+    const node = heldRef.current;
+    if (!node) return;
+    node.style.left = `${point.current.x}px`;
+    node.style.top = `${point.current.y}px`;
+  }, []);
+
+  // The first frame of a drag: the box has only just been put in the tree, so
+  // the handler that has been tracking the pointer had nothing to move.
+  useLayoutEffect(place, [place, drag?.id]);
+
+  /**
+   * The rest of a drag, once one has started.
+   *
+   * On the window rather than on the rows, because the pointer leaves the row it
+   * picked up almost immediately and a release outside the rail still has to end
+   * the drag. Pointer events rather than HTML5 drag and drop: `dragDropEnabled`
+   * is what lets a dropped document reach Rust without entering the renderer,
+   * and it is the same setting that stops `dragstart` firing inside the webview
+   * on some platforms. A rail that only rearranges on macOS is not a feature.
+   */
+  useEffect(() => {
+    const move = (event: PointerEvent) => {
+      const held = press.current;
+      if (held && !drag) {
+        if (Math.abs(event.clientX - held.x) + Math.abs(event.clientY - held.y) < DRAG_SLOP) return;
+        // Whatever the press began selecting is not what the operator meant.
+        window.getSelection()?.removeAllRanges();
+        // Released here, not on the way out: this handler runs again on the
+        // next movement with a closure that still thinks nothing is being
+        // dragged, and a press it could still see would start a second drag on
+        // top of this one and lose whatever the pointer had reached.
+        press.current = null;
+        point.current = { x: event.clientX, y: event.clientY };
+        setDrag({ id: held.id, over: null });
+        return;
+      }
+      if (!drag) return;
+
+      point.current = { x: event.clientX, y: event.clientY };
+      place();
+
+      // Reaching a row that is off the bottom of the rail has to be possible
+      // without letting go. Stepped per movement rather than on a timer: a
+      // pointer held still in the margin is a pointer that has arrived.
+      const list = listRef.current;
+      if (!list || list.scrollHeight <= list.clientHeight) return;
+      const box = list.getBoundingClientRect();
+      if (event.clientY < box.top + EDGE) list.scrollBy({ top: -EDGE_STEP });
+      else if (event.clientY > box.bottom - EDGE) list.scrollBy({ top: EDGE_STEP });
+    };
+
+    const release = () => {
+      const finished = drag;
+      press.current = null;
+      setDrag(null);
+      if (finished?.over) void dropAgent(finished.id, finished.over);
+    };
+
+    const cancel = () => {
+      press.current = null;
+      setDrag(null);
+    };
+
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") cancel();
+    };
+
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", release);
+    window.addEventListener("pointercancel", cancel);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", release);
+      window.removeEventListener("pointercancel", cancel);
+      window.removeEventListener("keydown", onKey);
+    };
+    // Rebound when the drag starts, ends, or reaches a different target: a
+    // handful of times per drag. The pointer's own position is deliberately not
+    // in here, or this would be four listeners torn down and replaced on every
+    // frame of every drag.
+  }, [drag, dropAgent, place]);
+
+  /** Marks what the pointer is over, while it is over it. */
+  const hover = useCallback((target: DropTarget | null) => {
+    setDrag((current) => {
+      if (!current) return current;
+      if (target === null) return { ...current, over: null };
+      return { ...current, over: target };
+    });
+  }, []);
+
+  /** Whether a drop target is the one currently under the pointer. */
+  const isOver = (target: DropTarget): boolean => {
+    const over = drag?.over;
+    if (!over || over.kind !== target.kind) return false;
+    return over.kind === "pinned" || ("id" in over && "id" in target && over.id === target.id);
+  };
 
   /** Which way an agent should turn to face a peer. */
   const facing = (self: AgentId, other: AgentId | undefined): Look => {
@@ -145,10 +299,11 @@ export function Sidebar({
     }
   };
 
-  /** One agent row. Shared by the flat and grouped layouts. */
+  /** One agent row. Shared by every section and both views. */
   const row = (agent: AgentCard) => {
     const role = roleOf(staged, agent.id);
     const label = meta(agent.id, activity[agent.id]);
+    const target: DropTarget = { kind: "row", id: agent.id };
 
     return (
       <button
@@ -161,6 +316,8 @@ export function Sidebar({
         className="agent-row"
         aria-current={selected === agent.id}
         data-lifecycle={agent.lifecycle}
+        data-held={dragging === agent.id ? "true" : undefined}
+        data-over={dragging && dragging !== agent.id && isOver(target) ? "true" : undefined}
         style={{ "--accent": agent.color } as React.CSSProperties}
         onClick={() => void select(agent.id)}
         onDoubleClick={() => onEditAgent(agent)}
@@ -168,6 +325,14 @@ export function Sidebar({
           event.preventDefault();
           onOpenMenu(agent, { x: event.clientX, y: event.clientY });
         }}
+        // The press is remembered and nothing else happens yet: a row is a
+        // button first, and it only becomes a handle once the pointer moves.
+        onPointerDown={(event) => {
+          if (event.button !== 0) return;
+          press.current = { id: agent.id, x: event.clientX, y: event.clientY };
+        }}
+        onPointerEnter={() => hover(target)}
+        onPointerLeave={() => hover(null)}
       >
         <AgentAvatar
           avatar={agent.avatar}
@@ -187,17 +352,39 @@ export function Sidebar({
     );
   };
 
+  /** The controls that belong to a group, wherever its name is drawn. */
+  const groupTail = (group: Group, count: number) => (
+    <span className="rail__group-tail">
+      <TokenMeter groupId={group.id} />
+      <span className="rail__group-count">{count}</span>
+      <button
+        type="button"
+        className="rail__gear"
+        onClick={() => onEditGroup(group)}
+        title={`${group.name} settings`}
+        aria-label={`${group.name} settings`}
+      >
+        ⚙
+      </button>
+    </span>
+  );
+
   // Pinned agents are lifted out of their group rather than drawn twice. Two
   // rows for one agent would be two nodes in `rowRefs`, and the wire would
   // have to pick one of them to throw a message at.
   //
-  // Ordered by when they were made, which is the one order that does not move.
-  // The rest of the rail floats whoever just spoke to the top, and a row
-  // pinned so it could be found in one glance must not do that.
-  const pinned = agents.filter((a) => a.pinned).sort((a, b) => a.createdAt - b.createdAt);
+  // Ordered by the arrangement, which is the one order that does not move on
+  // its own. The rest of a section lifts whoever is working to the top, and a
+  // row pinned so it could be found in one glance must not do that.
+  const pinned = railOrder(
+    agents.filter((a) => a.pinned),
+    shape,
+  );
+
+  const held = drag ? agents.find((a) => a.id === drag.id) : undefined;
 
   return (
-    <nav className="rail" aria-label="Agents">
+    <nav className="rail" aria-label="Agents" data-dragging={drag ? "true" : undefined}>
       <div className="rail__brand" data-tauri-drag-region>
         <span className="rail__wordmark">Guaca</span>
       </div>
@@ -225,6 +412,45 @@ export function Sidebar({
         activity
       </button>
 
+      {/* The crews, as things you can go inside and drop somebody into. Absent
+          while there is one group, which is the state most workspaces are in:
+          a strip offering a choice of one is a row of chrome that never changes
+          and a drop target that cannot move anybody anywhere. */}
+      {groups.length > 1 && (
+        <nav className="rail__strip" aria-label="Groups">
+          <button
+            type="button"
+            className="orb orb--all"
+            aria-current={focused === null}
+            aria-label={`All groups, ${agents.length} agents`}
+            onClick={() => focusGroup(null)}
+          >
+            <span className="orb__ring">
+              {/* The count, because the word is already under it and a circle
+                  that says "all" above a label that says "All" says one thing
+                  twice. A group's name can be anything, including "everyone",
+                  so this one must not be a name at all. */}
+              <span className="orb__all-count">{agents.length}</span>
+            </span>
+            <span className="orb__name">All</span>
+          </button>
+
+          {groups.map((group) => (
+            <GroupOrb
+              key={group.id}
+              group={group}
+              members={agents.filter((a) => a.groupId === group.id)}
+              activity={activity}
+              current={focused?.id === group.id}
+              over={isOver({ kind: "group", id: group.id })}
+              onOpen={() => focusGroup(focused?.id === group.id ? null : group.id)}
+              onDragOver={() => hover({ kind: "group", id: group.id })}
+              onDragOut={() => hover(null)}
+            />
+          ))}
+        </nav>
+      )}
+
       {/* The wire lives on this wrapper rather than on the scroll container, so
           it runs the full height of the rail down to the footer instead of
           stopping wherever the list happens to end. It is only drawn while a
@@ -251,55 +477,92 @@ export function Sidebar({
             );
           })}
 
-          {/* Whoever the operator wants to hand, above the groups and in the
-              same place every time. Unlike the rest of the rail this does not
-              reorder itself as agents talk: a row you pinned so you could find
-              it must be where you left it. */}
-          {pinned.length > 0 && (
-            <div className="rail__group">
-              <div className="rail__group-head">
-                <span className="rail__group-name">Pinned</span>
+          {focused ? (
+            // Inside one group. The heading carries the name and the controls
+            // that were squeezed onto a 0.6rem label in the overview, because
+            // here there is one group on screen and room to say so. The pins
+            // stay at the head of the list rather than in a section of their
+            // own: everybody drawn here is in this crew already, so a second
+            // heading over one or two rows would divide nothing.
+            <div
+              className="rail__group rail__group--open"
+              data-over={isOver({ kind: "group", id: focused.id }) ? "true" : undefined}
+              onPointerEnter={() => hover({ kind: "group", id: focused.id })}
+              onPointerLeave={() => hover(null)}
+            >
+              <div className="rail__open-head">
+                <span className="rail__open-name">{focused.name}</span>
+                {groupTail(focused, agents.filter((a) => a.groupId === focused.id).length)}
               </div>
-              {pinned.map(row)}
+              {railOrder(
+                agents.filter((a) => a.groupId === focused.id),
+                { ...shape, pinnedFirst: true },
+              ).map(row)}
+              {agents.every((a) => a.groupId !== focused.id) && (
+                <p className="rail__empty">
+                  Nobody is in here yet. Drag an agent onto this group, or make one.
+                </p>
+              )}
             </div>
-          )}
-
-          {/* Every group gets a header, including the only one, because the
-              gear on it is where that group's model and endpoint live. */}
-          {groups.map((group) => {
-            const members = agents.filter((a) => a.groupId === group.id);
-            // Drawn here minus whoever is pinned above, but counted in full: a
-            // pinned agent is still in this group, still costs it money and is
-            // still someone its peers can message.
-            const here = members.filter((a) => !a.pinned);
-            return (
-              <div key={group.id} className="rail__group">
-                <div className="rail__group-head">
-                  <span className="rail__group-name">{group.name}</span>
-                  <span className="rail__group-tail">
-                    <TokenMeter groupId={group.id} />
-                    <span className="rail__group-count">{members.length}</span>
-                    <button
-                      type="button"
-                      className="rail__gear"
-                      onClick={() => onEditGroup(group)}
-                      title={`${group.name} settings`}
-                      aria-label={`${group.name} settings`}
-                    >
-                      ⚙
-                    </button>
-                  </span>
+          ) : (
+            <>
+              {/* Whoever the operator wants to hand, above the groups and in
+                  the same place every time. */}
+              {pinned.length > 0 && (
+                <div
+                  className="rail__group"
+                  data-over={isOver({ kind: "pinned" }) ? "true" : undefined}
+                  onPointerEnter={() => hover({ kind: "pinned" })}
+                  onPointerLeave={() => hover(null)}
+                >
+                  <div className="rail__group-head">
+                    <span className="rail__group-name">Pinned</span>
+                  </div>
+                  {pinned.map(row)}
                 </div>
-                {here.map(row)}
-                {members.length === 0 && <p className="rail__empty">No agents in here.</p>}
-              </div>
-            );
-          })}
+              )}
 
-          {/* Anything whose group did not come back still gets drawn. The rail
-              hiding an agent is worse than the rail looking untidy, and an
-              empty group list used to hide every agent at once. */}
-          {agents.filter((a) => !a.pinned && !groups.some((g) => g.id === a.groupId)).map(row)}
+              {/* Every group gets a header, including the only one, because the
+                  gear on it is where that group's model and endpoint live. */}
+              {groups.map((group) => {
+                const members = agents.filter((a) => a.groupId === group.id);
+                // Drawn here minus whoever is pinned above, but counted in
+                // full: a pinned agent is still in this group, still costs it
+                // money and is still someone its peers can message.
+                const here = railOrder(
+                  members.filter((a) => !a.pinned),
+                  shape,
+                );
+                return (
+                  // The whole block catches a drop, not just the heading:
+                  // anywhere in a group that is not a row means the group and no
+                  // particular place in it, which is all an empty one can offer.
+                  <div
+                    key={group.id}
+                    className="rail__group"
+                    data-over={isOver({ kind: "group", id: group.id }) ? "true" : undefined}
+                    onPointerEnter={() => hover({ kind: "group", id: group.id })}
+                    onPointerLeave={() => hover(null)}
+                  >
+                    <div className="rail__group-head">
+                      <span className="rail__group-name">{group.name}</span>
+                      {groupTail(group, members.length)}
+                    </div>
+                    {here.map(row)}
+                    {members.length === 0 && <p className="rail__empty">No agents in here.</p>}
+                  </div>
+                );
+              })}
+
+              {/* Anything whose group did not come back still gets drawn. The
+                  rail hiding an agent is worse than the rail looking untidy,
+                  and an empty group list used to hide every agent at once. */}
+              {railOrder(
+                agents.filter((a) => !a.pinned && !groups.some((g) => g.id === a.groupId)),
+                shape,
+              ).map(row)}
+            </>
+          )}
 
           {agents.length === 0 && <p className="rail__empty">No agents yet.</p>}
         </div>
@@ -325,6 +588,22 @@ export function Sidebar({
           App settings
         </button>
       </div>
+
+      {/* What the hand is holding. Drawn at the pointer and outside the list so
+          nothing it passes over can clip it, and transparent to the pointer so
+          the row underneath is still the row being aimed at. */}
+      {drag && held && (
+        <div className="rail__held" aria-hidden="true" ref={heldRef}>
+          <AgentAvatar
+            avatar={held.avatar}
+            color={held.color}
+            size="sm"
+            seed={held.id}
+            lifecycle={held.lifecycle}
+          />
+          <span className="rail__held-name">{held.name}</span>
+        </div>
+      )}
     </nav>
   );
 }

--- a/src/components/SigninList.test.tsx
+++ b/src/components/SigninList.test.tsx
@@ -27,6 +27,7 @@ function card(over: Partial<AgentCard> = {}): AgentCard {
     skills: [],
     lifecycle: "active",
     pinned: false,
+    railOrder: 0,
     version: 1,
     createdAt: 0,
     updatedAt: 0,

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -126,6 +126,16 @@ export const api = {
   setAgentPinned: (id: AgentId, pinned: boolean) =>
     invoke<AgentCard>("set_agent_pinned", { id, pinned }),
 
+  /**
+   * Puts an agent where the operator dropped it: which group, and which place.
+   *
+   * One call because a drag is one gesture that can be both, and two would
+   * leave a state where the agent has joined the group but not landed in it.
+   * `before` is the row it goes in front of; `null` is the end of the group.
+   */
+  moveAgent: (id: AgentId, groupId: GroupId, before: AgentId | null) =>
+    invoke<AgentCard>("move_agent", { id, groupId, before }),
+
   agentActivity: () => invoke<Record<AgentId, Activity>>("agent_activity"),
 
   agentLastActive: () => invoke<Record<AgentId, number>>("agent_last_active"),

--- a/src/lib/rail.test.ts
+++ b/src/lib/rail.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+
+import { landsBefore, nudgeTarget, railOrder } from "./rail";
+import type { Activity, AgentCard, AgentId } from "./types";
+
+function agent(name: string, over: Partial<AgentCard> = {}): AgentCard {
+  return {
+    id: name,
+    groupId: "g1",
+    sandboxId: null,
+    name,
+    avatar: "avocado",
+    color: "#c7d96b",
+    model: "m",
+    systemPrompt: "",
+    skills: [],
+    lifecycle: "active",
+    pinned: false,
+    railOrder: 0,
+    version: 1,
+    createdAt: 0,
+    updatedAt: 0,
+    ...over,
+  };
+}
+
+/** Three agents in the order the operator arranged them. */
+function crew(): AgentCard[] {
+  return [
+    agent("Manager", { railOrder: 0 }),
+    agent("Cook", { railOrder: 1 }),
+    agent("Scribe", { railOrder: 2 }),
+  ];
+}
+
+function names(rows: AgentCard[]): string[] {
+  return rows.map((row) => row.name);
+}
+
+function drawn(
+  rows: AgentCard[],
+  activity: Record<AgentId, Activity> = {},
+  lastActive: Record<AgentId, number> = {},
+  options: { frozen?: boolean; pinnedFirst?: boolean } = {},
+): string[] {
+  return names(railOrder(rows, { activity, lastActive, ...options }));
+}
+
+describe("the arrangement", () => {
+  it("is what the rail draws when nothing is happening", () => {
+    // The old rail was ordered by who spoke last and by nothing else, so a
+    // conversation rewrote it and no arrangement could survive one.
+    expect(drawn(crew(), {}, { Scribe: 9_000, Cook: 5_000 })).toEqual([
+      "Manager",
+      "Cook",
+      "Scribe",
+    ]);
+  });
+
+  it("does not depend on the order it was handed", () => {
+    const shuffled = [...crew()].reverse();
+    expect(drawn(shuffled)).toEqual(["Manager", "Cook", "Scribe"]);
+  });
+
+  it("breaks a tie by the order the rows arrived in", () => {
+    // Every row is at 0 immediately after an upgrade, and a rail that reorders
+    // itself on launch is a rail that lost the arrangement it was preserving.
+    const tied = [agent("First"), agent("Second"), agent("Third")];
+    expect(drawn(tied)).toEqual(["First", "Second", "Third"]);
+  });
+});
+
+describe("what activity is lent", () => {
+  it("lifts a working row to the top of its section and gives the place back", () => {
+    const rows = crew();
+    const working: Record<AgentId, Activity> = { Scribe: { state: "thinking" } };
+    expect(drawn(rows, working)).toEqual(["Scribe", "Manager", "Cook"]);
+    // The same rail a moment later, with the turn finished.
+    expect(drawn(rows, {}, { Scribe: 9_000 })).toEqual(["Manager", "Cook", "Scribe"]);
+  });
+
+  it("puts the one asking for something above the ones working", () => {
+    const rows = crew();
+    const state: Record<AgentId, Activity> = {
+      Manager: { state: "thinking" },
+      Scribe: { state: "awaitingApproval" },
+      Cook: { state: "queued", depth: 2 },
+    };
+    expect(drawn(rows, state)).toEqual(["Scribe", "Manager", "Cook"]);
+  });
+
+  it("separates two working rows by who spoke last and nothing else", () => {
+    const rows = crew();
+    const state: Record<AgentId, Activity> = {
+      Manager: { state: "thinking" },
+      Scribe: { state: "thinking" },
+    };
+    expect(drawn(rows, state, { Manager: 1_000, Scribe: 9_000 })).toEqual([
+      "Scribe",
+      "Manager",
+      "Cook",
+    ]);
+  });
+
+  it("leaves a paused row where the operator put it", () => {
+    // Paused is not work in progress, it is a row that will not move until
+    // somebody moves it, so lifting it would hold the top indefinitely.
+    const rows = crew();
+    expect(drawn(rows, { Scribe: { state: "paused" } })).toEqual(["Manager", "Cook", "Scribe"]);
+  });
+
+  it("never lifts a pinned row, which is the whole of what a pin is for", () => {
+    const rows = [
+      agent("Manager", { railOrder: 0 }),
+      agent("Cook", { railOrder: 1, pinned: true }),
+      agent("Scribe", { railOrder: 2 }),
+    ];
+    expect(drawn(rows, { Cook: { state: "thinking" } })).toEqual(["Manager", "Cook", "Scribe"]);
+  });
+
+  it("lends nothing while a drag is in progress", () => {
+    // Dragging is arranging, so it has to operate on the arrangement: a row
+    // dropped under a peer that is only near the top because it is mid-turn
+    // would land somewhere nobody aimed at.
+    const rows = crew();
+    const working: Record<AgentId, Activity> = { Scribe: { state: "thinking" } };
+    expect(drawn(rows, working, {}, { frozen: true })).toEqual(["Manager", "Cook", "Scribe"]);
+  });
+
+  it("keeps the pins at the head of a section that is a whole group", () => {
+    const rows = [
+      agent("Manager", { railOrder: 0 }),
+      agent("Cook", { railOrder: 1 }),
+      agent("Scribe", { railOrder: 2, pinned: true }),
+    ];
+    expect(drawn(rows, { Cook: { state: "thinking" } }, {}, { pinnedFirst: true })).toEqual([
+      "Scribe",
+      "Cook",
+      "Manager",
+    ]);
+  });
+});
+
+describe("where a dropped row lands", () => {
+  it("goes after the row it passed on the way down", () => {
+    const rows = crew();
+    expect(landsBefore(rows, "Manager", "Cook")).toBe("Scribe");
+  });
+
+  it("is the end of the group when it passed the last row", () => {
+    const rows = crew();
+    expect(landsBefore(rows, "Manager", "Scribe")).toBeNull();
+  });
+
+  it("goes in front of the row it stopped on coming up", () => {
+    const rows = crew();
+    expect(landsBefore(rows, "Scribe", "Manager")).toBe("Manager");
+  });
+
+  it("goes in front of the target when it came from another group", () => {
+    // An agent arriving from elsewhere has no place in this section to have
+    // travelled from, so there is no direction to read.
+    const rows = crew();
+    expect(landsBefore(rows, "Outsider", "Cook")).toBe("Cook");
+  });
+
+  it("asks for nothing when a row is dropped on itself", () => {
+    // The runtime treats an anchor it cannot find as the end of the group, so a
+    // null gesture that reached it would move the row to the bottom.
+    const rows = crew();
+    expect(landsBefore(rows, "Cook", "Cook")).toBeUndefined();
+    expect(landsBefore(rows, "Cook", "Gone")).toBeUndefined();
+  });
+});
+
+describe("one row at a time", () => {
+  it("swaps with the row above or below", () => {
+    const rows = crew();
+    expect(nudgeTarget(rows, "Cook", -1)).toBe("Manager");
+    expect(nudgeTarget(rows, "Cook", 1)).toBeNull();
+    expect(nudgeTarget(rows, "Manager", 1)).toBe("Scribe");
+  });
+
+  it("says there is nowhere to go at either end", () => {
+    const rows = crew();
+    expect(nudgeTarget(rows, "Manager", -1)).toBeUndefined();
+    expect(nudgeTarget(rows, "Scribe", 1)).toBeUndefined();
+    expect(nudgeTarget(rows, "Nobody", -1)).toBeUndefined();
+  });
+});

--- a/src/lib/rail.ts
+++ b/src/lib/rail.ts
@@ -1,0 +1,158 @@
+/**
+ * What order the rail draws agents in.
+ *
+ * Two orders, not one. The arrangement is what the operator dragged into place
+ * and it is durable, held as `railOrder` on the card. Activity is a loan: an
+ * agent that is working is lifted to the top of its section for as long as it
+ * is working, and the place goes back the moment it stops.
+ *
+ * The rail used to have only the second half, ordered by who spoke last for as
+ * long as that stayed true, which meant the list you reached into was the list
+ * that had just moved and no arrangement could survive a conversation. Keeping
+ * both halves is what makes a drag worth doing: the shape you arranged is the
+ * shape the rail returns to.
+ */
+
+import type { Activity, AgentCard, AgentId, GroupId } from "./types";
+
+/**
+ * What a dragged row was let go over.
+ *
+ * Three targets rather than one, because the rail says three different things.
+ * A row is a place in an arrangement. A group is a crew, and dropping on one
+ * asks for membership without saying where. Pinned is neither: it is a flag on
+ * an agent, drawn as a section so it can be aimed at.
+ */
+export type DropTarget =
+  | { kind: "row"; id: AgentId }
+  | { kind: "group"; id: GroupId }
+  | { kind: "pinned" };
+
+/**
+ * How loudly a state asks for the top of its section.
+ *
+ * `awaitingApproval` outranks working because it is the one state the operator
+ * is the fix for: the agent is parked until they answer, and the request is in a
+ * channel they may not have open. Paused scores nothing on purpose. It is not
+ * work in progress, it is a row that will not move until someone moves it, and
+ * lifting it would hold a place at the top indefinitely.
+ */
+export function liftOf(activity: Activity | undefined): number {
+  switch (activity?.state) {
+    case "awaitingApproval":
+      return 3;
+    case "thinking":
+      return 2;
+    case "queued":
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+export interface RailOptions {
+  activity: Record<AgentId, Activity>;
+  /** Newest message per agent. Only ever separates two lifted rows. */
+  lastActive: Record<AgentId, number>;
+  /**
+   * Draw the arrangement itself, with nobody lifted.
+   *
+   * Used while a drag is in progress. Dragging is arranging, so it has to
+   * operate on the arrangement: dropping a row below a peer that is only there
+   * because it happens to be mid-turn would file it somewhere the operator did
+   * not aim at, and the rail would appear to have ignored the gesture the
+   * moment that turn ended.
+   */
+  frozen?: boolean;
+  /**
+   * Keep pinned members at the head of this section.
+   *
+   * For a section that is a whole group, which is what focusing on one draws. In
+   * the rail's overview the pinned rows are lifted out into their own section
+   * above the groups, so there is nothing to keep at the head of anything.
+   */
+  pinnedFirst?: boolean;
+}
+
+/** Which band of its section a row sits in. Lower is nearer the top. */
+function bandOf(agent: AgentCard, lift: number, pinnedFirst: boolean): number {
+  if (pinnedFirst && agent.pinned) return 0;
+  // A pinned row never floats, wherever it is drawn. It is where it is so it can
+  // be found in one glance, and a row that moves when the agent gets busy is the
+  // one thing a pin is for stopping.
+  if (lift > 0 && !agent.pinned) return 1;
+  return 2;
+}
+
+/**
+ * One section of the rail, in the order it is drawn.
+ *
+ * Self-sufficient about the arrangement: it sorts by `railOrder` rather than
+ * trusting the order it was handed, so a caller that filtered a roster cannot
+ * accidentally decide where rows go.
+ */
+export function railOrder(agents: AgentCard[], options: RailOptions): AgentCard[] {
+  const { activity, lastActive, frozen = false, pinnedFirst = false } = options;
+
+  return agents
+    .map((agent, index) => {
+      const lift = frozen ? 0 : liftOf(activity[agent.id]);
+      return { agent, index, lift, band: bandOf(agent, lift, pinnedFirst) };
+    })
+    .sort((a, b) => {
+      if (a.band !== b.band) return a.band - b.band;
+      // Recency separates two working rows and nothing else. Outside the lifted
+      // band it is exactly the ordering this replaced, and letting it through
+      // there would reorder a settled rail every time anybody spoke.
+      if (a.band === 1) {
+        if (a.lift !== b.lift) return b.lift - a.lift;
+        const spoke = (lastActive[b.agent.id] ?? 0) - (lastActive[a.agent.id] ?? 0);
+        if (spoke !== 0) return spoke;
+      }
+      return a.agent.railOrder - b.agent.railOrder || a.index - b.index;
+    })
+    .map((entry) => entry.agent);
+}
+
+/**
+ * Which row a dragged agent lands in front of, given the row it was dropped on.
+ * `null` is the end of the group.
+ *
+ * Read off two positions rather than measured against a pointer. A row's
+ * midpoint is geometry a test cannot see and a hand cannot aim at; the
+ * direction the row travelled says which side of the target it belongs on.
+ * Dragging down puts it after what it passed, dragging up puts it in front,
+ * which is what both look like while the drag is happening.
+ *
+ * `order` is the section as drawn, so an agent arriving from another group has
+ * no position in it and lands in front of the row it was dropped on.
+ */
+export function landsBefore(
+  order: AgentCard[],
+  dragged: AgentId,
+  onto: AgentId,
+): AgentId | null | undefined {
+  if (dragged === onto) return undefined;
+  const to = order.findIndex((a) => a.id === onto);
+  if (to < 0) return undefined;
+
+  const from = order.findIndex((a) => a.id === dragged);
+  if (from >= 0 && from < to) return order[to + 1]?.id ?? null;
+  return onto;
+}
+
+/**
+ * Where a row goes when the operator asks for it one place up or down, which is
+ * the same move without a mouse. `undefined` means there is nowhere to go.
+ */
+export function nudgeTarget(
+  order: AgentCard[],
+  id: AgentId,
+  delta: -1 | 1,
+): AgentId | null | undefined {
+  const at = order.findIndex((a) => a.id === id);
+  if (at < 0) return undefined;
+  const onto = order[at + delta];
+  if (!onto) return undefined;
+  return landsBefore(order, id, onto.id);
+}

--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -20,6 +20,7 @@ function agent(name: string, extra: Partial<AgentCard> = {}): AgentCard {
     skills: [],
     lifecycle: "active",
     pinned: false,
+    railOrder: 0,
     version: 1,
     createdAt: 1,
     updatedAt: 1,

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -11,7 +11,11 @@ vi.mock("./ipc", () => ({
     getSettings: vi.fn(async () => null),
     channelMessages: vi.fn(async () => [] as Envelope[]),
     activityFeed: vi.fn(async () => [] as Envelope[]),
+    conversationFlow: vi.fn(async () => [] as Envelope[]),
     usageSummary: vi.fn(async () => []),
+    listGroups: vi.fn(async () => []),
+    moveAgent: vi.fn(async () => null),
+    setAgentPinned: vi.fn(async () => null),
   },
   onRuntimeEvent: vi.fn(),
 }));
@@ -49,6 +53,7 @@ const AGENTS: AgentCard[] = [
     skills: [],
     lifecycle: "active",
     pinned: false,
+    railOrder: 0,
     version: 1,
     createdAt: 0,
     updatedAt: 0,
@@ -65,6 +70,7 @@ const AGENTS: AgentCard[] = [
     skills: [],
     lifecycle: "active",
     pinned: false,
+    railOrder: 0,
     version: 1,
     createdAt: 0,
     updatedAt: 0,
@@ -85,6 +91,7 @@ function reset(messages: Record<string, Envelope[] | undefined> = {}) {
     usage: {},
     pulse: {},
     banner: null,
+    railGroup: null,
   });
 }
 
@@ -333,6 +340,105 @@ describe("sidebar ordering", () => {
     apply({ type: "messageAppended", message: envelope({ id: "a", createdAt: 900 }) });
     apply({ type: "messageAppended", message: envelope({ id: "b", createdAt: 100 }) });
     expect(useStore.getState().lastActive.chef).toBe(900);
+  });
+});
+
+describe("the group the rail is inside", () => {
+  const RESEARCH = "00000000-0000-4000-8000-000000000002";
+
+  it("is left alone while the channel being opened is in it", async () => {
+    reset({ chef: [] });
+    useStore.getState().focusGroup(AGENTS[0]!.groupId);
+    await useStore.getState().select("manager");
+    expect(useStore.getState().railGroup).toBe(AGENTS[0]!.groupId);
+  });
+
+  it("is left alone by the activity feed, which belongs to no group", async () => {
+    reset({ chef: [] });
+    useStore.getState().focusGroup(AGENTS[0]!.groupId);
+    await useStore.getState().select(ACTIVITY_CHANNEL);
+    expect(useStore.getState().railGroup).toBe(AGENTS[0]!.groupId);
+  });
+
+  it("is let go when the channel being opened belongs to another crew", async () => {
+    // A search hit or a click on the flow board can land anywhere. A rail still
+    // showing one crew while the pane shows a member of another has the open
+    // channel nowhere on it.
+    reset({ chef: [] });
+    useStore.setState({
+      agents: [AGENTS[0]!, { ...AGENTS[1]!, groupId: RESEARCH }],
+    });
+    useStore.getState().focusGroup(RESEARCH);
+
+    await useStore.getState().select("manager");
+    expect(useStore.getState().railGroup).toBeNull();
+  });
+
+  it("is let go by a jump to a message in another crew's channel", async () => {
+    reset({ chef: [] });
+    useStore.setState({
+      agents: [AGENTS[0]!, { ...AGENTS[1]!, groupId: RESEARCH }],
+    });
+    useStore.getState().focusGroup(RESEARCH);
+
+    await useStore.getState().openMessage("manager", "m-old");
+    expect(useStore.getState().railGroup).toBeNull();
+  });
+});
+
+describe("one row at a time", () => {
+  it("moves a row up past the one above it", async () => {
+    reset();
+    useStore.setState({
+      agents: [
+        { ...AGENTS[0]!, railOrder: 0 },
+        { ...AGENTS[1]!, railOrder: 1 },
+      ],
+    });
+
+    await useStore.getState().nudgeAgent("chef", -1);
+
+    const { moveAgent } = (await import("./ipc")).api as unknown as {
+      moveAgent: ReturnType<typeof vi.fn>;
+    };
+    expect(moveAgent).toHaveBeenCalledWith("chef", AGENTS[0]!.groupId, "manager");
+  });
+
+  it("orders from the arrangement and not from whoever is mid-turn", async () => {
+    // The keyboard path has to agree with the drag: both edit the arrangement,
+    // so neither may be measured against a rail with somebody lifted on top.
+    reset();
+    useStore.setState({
+      agents: [
+        { ...AGENTS[0]!, railOrder: 0 },
+        { ...AGENTS[1]!, railOrder: 1 },
+      ],
+      activity: { chef: { state: "thinking" } },
+    });
+
+    await useStore.getState().nudgeAgent("chef", -1);
+
+    const { moveAgent } = (await import("./ipc")).api as unknown as {
+      moveAgent: ReturnType<typeof vi.fn>;
+    };
+    expect(moveAgent).toHaveBeenCalledWith("chef", AGENTS[0]!.groupId, "manager");
+  });
+
+  it("asks for nothing at the end of a section", async () => {
+    reset();
+    useStore.setState({
+      agents: [
+        { ...AGENTS[0]!, railOrder: 0 },
+        { ...AGENTS[1]!, railOrder: 1 },
+      ],
+    });
+
+    const { moveAgent } = (await import("./ipc")).api as unknown as {
+      moveAgent: ReturnType<typeof vi.fn>;
+    };
+    moveAgent.mockClear();
+    await useStore.getState().nudgeAgent("manager", -1);
+    expect(moveAgent).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -10,6 +10,7 @@ import { useCallback, useMemo } from "react";
 import { create } from "zustand";
 
 import { api } from "./ipc";
+import { type DropTarget, landsBefore, nudgeTarget, railOrder } from "./rail";
 import { keepThought } from "./reasoning";
 import type {
   Activity,
@@ -51,6 +52,15 @@ export interface Pulse {
 /** How long the group meters look back. */
 export const PULSE_WINDOW_MS = 90_000;
 
+/** Where a move leaves an agent. */
+export interface Placement {
+  groupId: GroupId;
+  /** The row it lands in front of. `null` is the end of the group. */
+  before: AgentId | null;
+  /** Absent leaves the section it is in alone. */
+  pinned?: boolean;
+}
+
 interface State {
   agents: AgentCard[];
   groups: Group[];
@@ -77,6 +87,16 @@ interface State {
   approvals: Record<ApprovalId, ApprovalState | undefined>;
 
   selected: ChannelKey | null;
+  /**
+   * The group the rail is looking inside, or `null` for all of them.
+   *
+   * Here rather than in the sidebar because opening a channel can invalidate
+   * it: an agent reached from search or from the flow board may live in another
+   * crew, and a rail that keeps showing the group you were in has the open
+   * channel nowhere on it. `select` is what knows a channel changed, so `select`
+   * is what lets the focus go.
+   */
+  railGroup: GroupId | null;
   messages: Record<ChannelKey, Envelope[] | undefined>;
   streams: Record<MessageId, StreamBuffer | undefined>;
   /**
@@ -108,6 +128,17 @@ interface State {
   refreshUsage: () => Promise<void>;
   refreshApprovals: () => Promise<void>;
   select: (key: ChannelKey) => Promise<void>;
+  /** Looks inside one group, or back out at all of them. */
+  focusGroup: (id: GroupId | null) => void;
+  /**
+   * Puts an agent somewhere: which group, in front of which row, and whether it
+   * is pinned. Absent `pinned` leaves the section it is in alone.
+   */
+  moveAgent: (id: AgentId, at: Placement) => Promise<void>;
+  /** One drop, resolved against the rules that drew the rail. */
+  dropAgent: (id: AgentId, target: DropTarget) => Promise<void>;
+  /** The same move one row at a time, for an operator who is not dragging. */
+  nudgeAgent: (id: AgentId, delta: -1 | 1) => Promise<void>;
   loadChannel: (key: ChannelKey, through?: MessageId) => Promise<void>;
   /** Opens a message's channel with the message itself in the window. */
   openMessage: (channel: AgentId, message: MessageId) => Promise<void>;
@@ -146,6 +177,20 @@ function insert(existing: Envelope[] | undefined, message: Envelope): Envelope[]
   return next;
 }
 
+/**
+ * Whether the rail can stay inside the group it is inside.
+ *
+ * It can, unless the channel being opened belongs to an agent in another one. A
+ * search hit or a click on the flow board can land anywhere, and a rail still
+ * showing one crew while the pane shows a member of another has the open channel
+ * nowhere on it. The activity feed belongs to no group and changes nothing.
+ */
+function keptFocus(state: State, key: ChannelKey): GroupId | null {
+  if (state.railGroup === null || key === ACTIVITY_CHANNEL) return state.railGroup;
+  const agent = state.agents.find((a) => a.id === key);
+  return agent && agent.groupId !== state.railGroup ? null : state.railGroup;
+}
+
 export const useStore = create<State>((set, get) => ({
   agents: [],
   groups: [],
@@ -156,6 +201,7 @@ export const useStore = create<State>((set, get) => ({
   pulse: {},
   approvals: {},
   selected: null,
+  railGroup: null,
   messages: {},
   streams: {},
   reasoning: {},
@@ -186,7 +232,13 @@ export const useStore = create<State>((set, get) => ({
     // Groups come back with the roster because an agent moving between them
     // changes both counts, and one refresh keeps the two consistent on screen.
     const [agents, groups] = await Promise.all([api.listAgents(), api.listGroups()]);
-    set({ agents, groups });
+    // A group the rail was looking inside can be deleted from the group editor,
+    // and a focus on one that is gone draws an empty rail with no way out of it.
+    set((state) => ({
+      agents,
+      groups,
+      railGroup: groups.some((g) => g.id === state.railGroup) ? state.railGroup : null,
+    }));
 
     // If the open channel was just deleted, fall back rather than showing a
     // dead pane.
@@ -202,8 +254,121 @@ export const useStore = create<State>((set, get) => ({
   },
 
   async select(key) {
-    set({ selected: key, focused: null });
+    set((state) => ({ selected: key, focused: null, railGroup: keptFocus(state, key) }));
     await get().loadChannel(key);
+  },
+
+  focusGroup(id) {
+    set({ railGroup: id });
+  },
+
+  /**
+   * The whole of a move, applied.
+   *
+   * Read back rather than patched locally. The runtime renumbers every live row
+   * to close the gap the agent left, so the one card that came back is not the
+   * change: guessing the rest here would leave the rail drawing an arrangement
+   * the database does not have until the next unrelated refresh.
+   *
+   * Pinning first, and only when it differs. It is a separate command because
+   * it is a separate fact, and doing it second would mean a refresh that draws
+   * the row in its new place and its old section.
+   */
+  async moveAgent(id, at) {
+    const current = get().agents.find((a) => a.id === id);
+    if (at.pinned !== undefined && current && current.pinned !== at.pinned) {
+      await api.setAgentPinned(id, at.pinned);
+    }
+    await api.moveAgent(id, at.groupId, at.before);
+    await get().refreshAgents();
+  },
+
+  /**
+   * One drop, resolved.
+   *
+   * Which section the target row belongs to is worked out here rather than
+   * handed in, because the same rules that drew the rail have to decide where
+   * the row lands and a component recomputing them would be a second place for
+   * them to drift.
+   *
+   * The pinned section is a flag and not a place. It spans groups, so a row
+   * dropped among pins keeps its own crew: the alternative is a gesture that
+   * says "keep this where I can see it" and quietly moves the agent to a
+   * different set of peers.
+   */
+  async dropAgent(id, target) {
+    const state = get();
+    const dragged = state.agents.find((a) => a.id === id);
+    if (!dragged) return;
+
+    if (target.kind === "pinned") {
+      if (dragged.pinned) return;
+      await api.setAgentPinned(id, true);
+      await get().refreshAgents();
+      return;
+    }
+
+    const live = state.agents.filter((a) => a.lifecycle !== "terminated");
+
+    if (target.kind === "group") {
+      await get().moveAgent(id, { groupId: target.id, before: null, pinned: false });
+      return;
+    }
+
+    const onto = live.find((a) => a.id === target.id);
+    if (!onto || onto.id === id) return;
+
+    // Dropped among the pins from another crew: pin it, and leave the crew and
+    // the place it already had. There is no position in that section to express,
+    // because the section is drawn from rows the arrangement holds apart.
+    if (onto.pinned && onto.groupId !== dragged.groupId) {
+      if (!dragged.pinned) {
+        await api.setAgentPinned(id, true);
+        await get().refreshAgents();
+      }
+      return;
+    }
+
+    const section = onto.pinned
+      ? live.filter((a) => a.pinned && a.groupId === onto.groupId)
+      : live.filter((a) => a.groupId === onto.groupId && !a.pinned);
+    const order = railOrder(section, {
+      activity: state.activity,
+      lastActive: state.lastActive,
+      frozen: true,
+    });
+    const before = landsBefore(order, id, onto.id);
+    if (before === undefined) return;
+    await get().moveAgent(id, { groupId: onto.groupId, before, pinned: onto.pinned });
+  },
+
+  /**
+   * One row up or down, for an operator who is not holding a mouse.
+   *
+   * Ordered from the same function that draws the rail, and frozen, so this
+   * moves the row within the arrangement rather than within whatever the
+   * arrangement currently looks like with somebody mid-turn on top of it.
+   */
+  async nudgeAgent(id, delta) {
+    const state = get();
+    const agent = state.agents.find((a) => a.id === id);
+    if (!agent) return;
+
+    const live = state.agents.filter((a) => a.lifecycle !== "terminated");
+    // A pinned row moves among the pinned rows: that section spans groups and is
+    // drawn above them, so its neighbours are the other pins and not the crew.
+    const section = agent.pinned
+      ? live.filter((a) => a.pinned)
+      : live.filter((a) => a.groupId === agent.groupId && !a.pinned);
+
+    const order = railOrder(section, {
+      activity: state.activity,
+      lastActive: state.lastActive,
+      frozen: true,
+    });
+    const before = nudgeTarget(order, id, delta);
+    if (before === undefined) return;
+    await get().moveAgent(id, { groupId: agent.groupId, before });
   },
 
   async loadChannel(key, through) {
@@ -224,7 +389,11 @@ export const useStore = create<State>((set, get) => ({
    * the operator sees where they are going rather than a pause.
    */
   async openMessage(channel, message) {
-    set({ selected: channel, focused: message });
+    set((state) => ({
+      selected: channel,
+      focused: message,
+      railGroup: keptFocus(state, channel),
+    }));
     await get().loadChannel(channel, message);
   },
 
@@ -462,11 +631,13 @@ export const useStore = create<State>((set, get) => ({
 }));
 
 /**
- * Agents shown in the rail, most recently active first.
+ * Every agent still in the workspace, in the order the operator arranged them.
  *
- * Agents that have never spoken keep their creation order at the bottom, so a
- * fresh workspace reads in the order you built it and a busy one floats whoever
- * just spoke to the top.
+ * The arrangement and not the drawn order: this is one flat list across every
+ * group, and where a row is lifted for working is a question about one section
+ * of the rail. `lib/rail.ts` answers that, and the sidebar asks it per section.
+ * A caller that just wants the roster, like the composer's mention list, gets
+ * the arrangement, which is the order the operator would look for a name in.
  *
  * Memoized, and that is load-bearing rather than an optimization. `filter`
  * allocates a new array on every render, so an unmemoized result is a fresh
@@ -476,15 +647,14 @@ export const useStore = create<State>((set, get) => ({
  */
 export function useLiveAgents(): AgentCard[] {
   const agents = useStore((s) => s.agents);
-  const lastActive = useStore((s) => s.lastActive);
 
   return useMemo(() => {
     return agents
       .filter((a) => a.lifecycle !== "terminated")
-      .map((agent, order) => ({ agent, order, at: lastActive[agent.id] ?? 0 }))
-      .sort((a, b) => b.at - a.at || a.order - b.order)
+      .map((agent, order) => ({ agent, order }))
+      .sort((a, b) => a.agent.railOrder - b.agent.railOrder || a.order - b.order)
       .map((entry) => entry.agent);
-  }, [agents, lastActive]);
+  }, [agents]);
 }
 
 /**

--- a/src/lib/transcript.test.ts
+++ b/src/lib/transcript.test.ts
@@ -16,6 +16,7 @@ function card(id: string, name: string): AgentCard {
     skills: [],
     lifecycle: "active",
     pinned: false,
+    railOrder: 0,
     version: 1,
     createdAt: 0,
     updatedAt: 0,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -237,6 +237,13 @@ export interface AgentCard {
   lifecycle: Lifecycle;
   /** Kept at the top of the rail. Where the row is drawn, and nothing else. */
   pinned: boolean;
+  /**
+   * Where the operator put this row. Lower is higher up its section.
+   *
+   * The arrangement, not the drawn order: a working agent is lifted to the top
+   * of its section and drops back here when it stops. See `lib/rail.ts`.
+   */
+  railOrder: number;
   version: number;
   createdAt: number;
   updatedAt: number;

--- a/src/styles.css
+++ b/src/styles.css
@@ -214,6 +214,14 @@ button {
   gap: 0.45rem;
   margin-left: auto;
   flex: none;
+  /* Sized here rather than inherited from the heading. The same tail hangs off
+     the 0.6rem label in the overview and off the group's own name once the rail
+     is inside it, and inheriting made the member count twice the size in one of
+     them. */
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.14em;
+  color: var(--rail-muted);
 }
 
 /* The group's pinned model is not drawn here at all. A model id is longer than
@@ -463,6 +471,286 @@ button {
    snapping them is disorienting, especially when several move at once. */
 .agent-row[data-sliding="true"] {
   transition: transform 500ms cubic-bezier(0.2, 0.85, 0.25, 1);
+}
+
+/* ==========================================================================
+   Arranging the rail
+
+   The rail is ordered by hand and lends the top of a section to whoever is
+   working. Dragging is how the arrangement is edited, so while a drag is on the
+   rail draws the arrangement itself and marks the one place a release would
+   land. See lib/rail.ts.
+   ========================================================================== */
+
+/* A rail being rearranged is not a rail being read. Selection is off for the
+   whole of it: the gesture starts on a row whose name is selectable text, and a
+   half-highlighted name left behind reads as something having gone wrong. */
+.rail[data-dragging="true"] {
+  user-select: none;
+  cursor: grabbing;
+}
+
+/* The row the hand is holding. Left in place rather than removed: a list that
+   closes up under the pointer moves every target while it is being aimed at. */
+.agent-row[data-held="true"] {
+  opacity: 0.3;
+}
+
+/* Where it would land. A line above the row rather than a filled block,
+   because a block says "into this" and the answer is "in front of this". */
+.agent-row[data-over="true"]::before {
+  content: "";
+  position: absolute;
+  left: 0.6rem;
+  right: 0.75rem;
+  top: -1px;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--flesh);
+  box-shadow: 0 0 6px color-mix(in oklab, var(--flesh) 55%, transparent);
+}
+
+/* A whole crew as the target, which is what dropping anywhere but on a row
+   means: this group, no particular place in it. */
+.rail__group[data-over="true"],
+.orb[data-over="true"] .orb__ring {
+  background: color-mix(in oklab, var(--flesh) 12%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--flesh) 45%, transparent);
+}
+
+/* What the hand is holding, at the pointer. Fixed to the window so nothing it
+   passes over can clip it, and transparent to the pointer so the row underneath
+   is still the row being aimed at. */
+.rail__held {
+  position: fixed;
+  z-index: 40;
+  /* Below and to the right of the pointer, not under it. Centred on the pointer
+     it covered the top edge of the row being aimed at, which is exactly where
+     the line saying "it lands here" is drawn. */
+  transform: translate(0.9rem, 0.35rem);
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.25rem 0.6rem 0.25rem 0.35rem;
+  border-radius: 0.5rem;
+  background: var(--rail-raised);
+  border: 1px solid var(--rail-edge);
+  box-shadow: 0 8px 20px rgb(0 0 0 / 35%);
+  opacity: 0.95;
+}
+
+.rail__held-name {
+  font-family: var(--font-display);
+  font-size: 0.82rem;
+  color: var(--rail-text);
+  white-space: nowrap;
+}
+
+/* ==========================================================================
+   Groups, as places
+
+   A crew is recognised by who is in it before its name is read, so a group is
+   drawn as a circle of its members' faces. Clicking one takes the rail inside
+   it; dropping an agent on one puts the agent in it. The strip is absent while
+   there is one group, because a choice of one is chrome.
+   ========================================================================== */
+
+.rail__strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.2rem;
+  padding: 0.5rem 0.6rem 0.35rem;
+  border-bottom: 1px solid var(--rail-edge);
+}
+
+.orb {
+  flex: none;
+  width: 3.4rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.25rem 0 0.3rem;
+  background: none;
+  border: 0;
+  color: inherit;
+  border-radius: 0.5rem;
+}
+
+.orb__ring {
+  position: relative;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--rail-raised);
+  box-shadow: inset 0 0 0 1px var(--rail-edge);
+  transition:
+    box-shadow 160ms ease,
+    background 160ms ease;
+}
+
+.orb:hover .orb__ring {
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--rail-text) 30%, transparent);
+}
+
+/* The group the rail is inside. The ring is the only permanent mark of it: the
+   heading below says which group by name, and two loud statements of one fact
+   is one too many. */
+.orb[aria-current="true"] .orb__ring {
+  box-shadow: inset 0 0 0 2px var(--flesh);
+}
+
+.orb[aria-current="true"] .orb__name {
+  color: var(--rail-text);
+}
+
+/* Faces, tiled. Four in a square rather than a row of overlaps: a 2.4rem
+   circle is 38px across, and three 1.35rem avatars in a row measure 51px even
+   leaning on each other, so a row either overflowed the ring or hid the faces
+   it was there to show. A square of four fits, and it is what a group of people
+   looks like everywhere else.
+
+   Sized here rather than through the avatar's own scale, because these have to
+   fit a circle rather than sit beside a name. The selector carries the extra
+   class deliberately: `.avatar--xs` is defined further down the file. */
+.orb__faces {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.05rem;
+  place-content: center;
+  width: 1.85rem;
+}
+
+.orb__faces > .avatar {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1;
+}
+
+.orb__faces[data-count="1"] {
+  grid-template-columns: 1fr;
+  width: 1.7rem;
+}
+
+.orb__faces[data-count="2"] {
+  width: 2.1rem;
+}
+
+/* Three in a square leaves the last one in a corner. Spanning both columns
+   centres it, so the shape reads as a group and not as a gap. */
+.orb__faces[data-count="3"] > .avatar:last-child {
+  grid-column: span 2;
+  justify-self: center;
+  width: 50%;
+}
+
+.orb__none {
+  font-family: var(--font-mono);
+  color: var(--rail-muted);
+}
+
+/* The members that did not fit. A number, because four faces at this size is
+   four smudges. */
+.orb__more {
+  position: absolute;
+  right: -0.1rem;
+  bottom: -0.1rem;
+  font-family: var(--font-mono);
+  font-size: 0.52rem;
+  line-height: 1;
+  padding: 0.12rem 0.2rem;
+  border-radius: 0.35rem;
+  background: var(--rail-ground);
+  box-shadow: inset 0 0 0 1px var(--rail-edge);
+  color: var(--rail-muted);
+}
+
+.orb__all-count {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--rail-muted);
+}
+
+.orb--all[aria-current="true"] .orb__all-count {
+  color: var(--rail-text);
+}
+
+.orb__name {
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--rail-muted);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Somebody in this crew is working. After focusing on one group the strip is
+   the only place the others are still visible, so it has to carry that. */
+.orb[data-state="working"] .orb__ring {
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--flesh) 60%, transparent);
+  animation: orb-breathe 2.6s ease-in-out infinite;
+}
+
+/* And louder for the one state the operator is the fix for. */
+.orb[data-state="asking"] .orb__ring::after {
+  content: "";
+  position: absolute;
+  top: -0.1rem;
+  right: -0.1rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--flesh);
+  box-shadow: 0 0 0 2px var(--rail-ground);
+}
+
+@keyframes orb-breathe {
+  50% {
+    box-shadow: inset 0 0 0 2px color-mix(in oklab, var(--flesh) 75%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .orb[data-state="working"] .orb__ring {
+    animation: none;
+  }
+}
+
+/* Inside one group. The name and its controls get a line of their own, because
+   here there is one group on screen and the 0.6rem label the overview uses was
+   sized to sit above a list of others. */
+.rail__open-head {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.7rem 0.6rem 0.45rem 1rem;
+}
+
+.rail__open-name {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--rail-text);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Its gear does not wait to be hovered. In the overview the heading is one of
+   several and the gear is noise; here it is the group's own controls. */
+.rail__group--open .rail__gear {
+  opacity: 1;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
The rail was ordered by who spoke last and by nothing else, so every reply rewrote it and no arrangement could survive a conversation; `railOrder` on the card is the arrangement now, and activity only lends a row the top of its section for as long as it is working.

Rows are dragged to reorder and dragged between groups, and because dragging is arranging, the rail draws the arrangement itself while a drag is on with nobody lifted. Groups became places you can be inside: a strip of circles tiled with their members' faces, which you click to take the rail into one crew and drop an agent onto to move it there, absent entirely while there is only one group. Pointer events rather than HTML5 drag and drop, because `dragDropEnabled` is what lets a dropped document reach Rust without entering the renderer and is the same setting that stops `dragstart` firing in the webview on some platforms; every move a drag makes is in the agent's menu too, so the rail is arrangeable without a mouse.

Migration 20 backfills `rail_order` in creation order so an upgrade draws the rail it drew before, and the reasoning is in `docs/WORKSPACE.md`.
