### PR TITLE
feat: a crew is hired from the cafeteria rather than typed out one by one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ table below says which one to open before changing something.
 src/                  React + TypeScript. A view over the runtime, nothing more.
   lib/transcript.ts   What a channel shows, and what it collapses. Read first.
   lib/search.ts       One ranking over hits from SQLite and from the store.
+  lib/cafeteria.ts    Preset agents, waiting to be hired. Content, not runtime.
   lib/ipc.ts          Every call into Rust.
   components/         One file per surface.
 src-tauri/src/
@@ -58,6 +59,7 @@ repo: the frontend renders state and forwards intent.
 | Schedules and triggers | `docs/ROUTINES.md` |
 | Sandboxes, the browser, sign-ins, credentials | `docs/MACHINES.md`, then *Connectors* in `docs/PROTOCOL.md` |
 | Channels, the rail, search: what the operator sees | `docs/WORKSPACE.md`, then `src/lib/transcript.ts` |
+| Preset agents, hiring a crew | *The cafeteria is a copy machine* in `docs/WORKSPACE.md`, then `src/lib/cafeteria.ts` |
 | A prompt, or anything that changes how much a crew talks | *Three test suites, asking different questions*, then run the live evals |
 
 Unqualified section names are headings in `docs/ARCHITECTURE.md`.

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -30,6 +30,45 @@ same wall, same bill, same peers. Two rows for one agent would be two nodes in
 the sidebar's `rowRefs`, and the wire would have to pick one to throw a message
 at.
 
+## The cafeteria is a copy machine, not a registry
+
+Sixteen agents written out once, well, so that a new workspace is a few clicks
+rather than an hour of typing. They are named after jobs rather than functions:
+"Chief of Staff" and "Paralegal", not "Manager" and "Reviewer". A role carries
+duties and refusals a function label does not, so the operator does not have to
+supply them in the prompt, which is the work this removes. Titles are capped at
+three words because peers resolve each other by whole name and the composer's
+`@` typeahead gives up after two spaces, so a longer title is an agent nobody
+can delegate to.
+
+A hire copies the preset's fields into an ordinary `AgentDraft` and forgets
+where they came from: there is no preset id on
+the card, nothing joins back to `lib/cafeteria.ts`, and an agent hired yesterday
+does not change when the catalog does. That is what stops a UI file from
+becoming a schema the database has to agree with, and it is the reason there is
+no "update from preset" anywhere.
+
+A preset's model is deliberately blank, which means inherit. Writing the app
+default in at hire time is the obvious thing and it is wrong: it pins every
+hired agent to the app model and silently ignores a group that chose its own
+endpoint, which is exactly what a group-level model exists to express.
+
+`hire_agents` takes the batch rather than the UI looping `create_agent`, for
+two reasons that both bite at four agents and up. Every create emits
+`AgentsChanged` and the rail answers each by re-reading the whole roster. And
+names are unique per group, so a batch has to be settled against the roster
+*and* against itself: two `Researcher`s picked in one go are both free until the
+first one is written. `domain::agent::hire_names` does that in the same place
+`copy_name` already lived, so the app has one rule for a name somebody else is
+holding instead of two that can disagree.
+
+The catalog is content with a test, `lib/cafeteria.test.ts`, holding it to the
+avatar and accent catalogs and to what `AgentDraft::validate` will accept. The
+rule that is not mechanically checkable is the one that matters most: every
+preset prompt states a stopping condition. A prompt without one makes a crew
+that talks to itself, no automated suite can see it, and the evals are what
+catch it. Run `./scripts/evals.sh` after touching a preset.
+
 ## A duplicate copies the card and nothing an agent went and did
 
 Look, model, skills and instructions; not the sandbox, the memory, the schedule,

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -237,6 +237,7 @@ pub fn run() {
             commands::update_agent,
             commands::delete_agent,
             commands::duplicate_agent,
+            commands::hire_agents,
             commands::set_agent_paused,
             commands::set_agent_pinned,
             commands::agent_activity,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::config::{self, AppConfig, RedactedConfig};
-use crate::domain::agent::{copy_name, AgentCard, AgentDraft, Lifecycle};
+use crate::domain::agent::{copy_name, hire_names, AgentCard, AgentDraft, Lifecycle};
 use crate::domain::approval::{Approval, ApprovalState, Decision, ProtectedAction};
 use crate::domain::attachment::Attachment;
 use crate::domain::connector::{Connector, ConnectorDraft};
@@ -460,6 +460,73 @@ pub fn duplicate_agent(state: State<'_, AppState>, id: AgentId) -> Reply<AgentCa
     state.runtime.start_agent(card.id);
     state.runtime.emit(UiEvent::AgentsChanged);
     Ok(card)
+}
+
+/// Hires a set of preconfigured agents into one group.
+///
+/// One command rather than one `create_agent` per agent, and the reason is not
+/// only round trips. Every create emits `AgentsChanged`, and the rail answers
+/// each one by re-reading the whole roster, so a crew of six hired one at a
+/// time redraws the sidebar six times while it is being filled in. Worse, a
+/// draft rejected halfway leaves the operator with three agents and an error
+/// about a fourth, and nothing that says which three.
+///
+/// So the batch is resolved and validated in full before anything is written:
+/// the group has to exist, every name is settled against the roster and against
+/// the rest of the batch by `hire_names`, and every draft has to pass
+/// `validate`. The rows then go in as one transaction, because a name taken by
+/// another window between the check and the write is a failure validation
+/// cannot see. A hire either happens or does not.
+///
+/// `group_id` is required and overrides whatever the drafts carry. The whole
+/// point of the cafeteria is that a crew lands somewhere the operator chose,
+/// and a batch that could scatter across groups is a batch that can arrive
+/// half outside the wall its agents were picked to sit behind.
+#[tauri::command]
+pub fn hire_agents(
+    state: State<'_, AppState>,
+    group_id: GroupId,
+    drafts: Vec<AgentDraft>,
+) -> Reply<Vec<AgentCard>> {
+    if drafts.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let store = state.runtime.store();
+    // Checked rather than left to the foreign key, which would surface as an
+    // opaque storage failure on a group the operator picked from a list. The
+    // realistic way to get here is a group deleted while the cafeteria was open.
+    if !store.list_groups()?.iter().any(|g| g.id == group_id) {
+        return Err(CommandError::new(
+            "notFound",
+            "that group no longer exists. Close the cafeteria and pick another one.",
+        ));
+    }
+
+    // Only the group being hired into, and only agents that still hold their
+    // name: a terminated agent frees it. Same rule `duplicate_agent` uses.
+    let taken: Vec<String> = store
+        .list_agents()?
+        .into_iter()
+        .filter(|c| c.group_id == group_id && c.lifecycle != Lifecycle::Terminated)
+        .map(|c| c.name)
+        .collect();
+
+    let wanted: Vec<String> = drafts.iter().map(|d| d.name.clone()).collect();
+    let clean = hire_names(&wanted, &taken)
+        .into_iter()
+        .zip(drafts)
+        .map(|(name, draft)| AgentDraft { group_id: Some(group_id), name, ..draft }.validate())
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let hired = store.create_agents(&clean)?;
+    // Actors start only once the rows are committed. Starting them inside the
+    // write would leave a live agent behind for a hire that rolled back.
+    for card in &hired {
+        state.runtime.start_agent(card.id);
+    }
+    state.runtime.emit(UiEvent::AgentsChanged);
+    Ok(hired)
 }
 
 #[tauri::command]

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -72,6 +72,56 @@ fn default_group_id() -> GroupId {
     migrations::DEFAULT_GROUP_ID.parse().expect("the pinned default group id is a valid uuid")
 }
 
+/// A fresh card from a validated draft. Everything an agent goes on to acquire
+/// (a machine, its tokens, a pin) starts empty: those are things it did, not
+/// things anybody wrote down.
+fn new_card(draft: &CleanDraft) -> AgentCard {
+    let now = now_ms();
+    AgentCard {
+        id: AgentId::new(),
+        group_id: draft.group_id.unwrap_or_else(default_group_id),
+        name: draft.name.clone(),
+        avatar: draft.avatar.clone(),
+        color: draft.color.clone(),
+        model: draft.model.clone(),
+        system_prompt: draft.system_prompt.clone(),
+        skills: draft.skills.clone(),
+        sandbox_id: None,
+        sandbox_envd_token: None,
+        sandbox_traffic_token: None,
+        lifecycle: Lifecycle::Active,
+        pinned: false,
+        version: 1,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+/// Takes a `&Connection` rather than a `&Store` so one insert serves both a
+/// single create and a batch inside a transaction; `Transaction` derefs here.
+fn insert_agent(conn: &rusqlite::Connection, card: &AgentCard) -> Result<(), StoreError> {
+    conn.execute(
+        "INSERT INTO agents (id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)",
+        params![
+            card.id.to_string(),
+            card.name,
+            card.avatar,
+            card.color,
+            card.model,
+            card.system_prompt,
+            serde_json::to_string(&card.skills).unwrap_or_else(|_| "[]".into()),
+            card.lifecycle.as_str(),
+            card.version,
+            card.created_at,
+            card.updated_at,
+            card.group_id.to_string(),
+        ],
+    )
+    .map_err(|e| classify(e, &card.name))?;
+    Ok(())
+}
+
 /// Maps SQLite's unique-constraint failure onto a domain error, so callers get
 /// "that name is taken" instead of a raw driver string.
 fn classify(err: rusqlite::Error, name: &str) -> StoreError {
@@ -163,47 +213,28 @@ impl Store {
 
     pub fn create_agent(&self, draft: &CleanDraft) -> Result<AgentCard, StoreError> {
         let conn = self.conn()?;
-        let now = now_ms();
-        let card = AgentCard {
-            id: AgentId::new(),
-            group_id: draft.group_id.unwrap_or_else(default_group_id),
-            name: draft.name.clone(),
-            avatar: draft.avatar.clone(),
-            color: draft.color.clone(),
-            model: draft.model.clone(),
-            system_prompt: draft.system_prompt.clone(),
-            skills: draft.skills.clone(),
-            sandbox_id: None,
-            sandbox_envd_token: None,
-            sandbox_traffic_token: None,
-            lifecycle: Lifecycle::Active,
-            pinned: false,
-            version: 1,
-            created_at: now,
-            updated_at: now,
-        };
-
-        conn.execute(
-            "INSERT INTO agents (id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)",
-            params![
-                card.id.to_string(),
-                card.name,
-                card.avatar,
-                card.color,
-                card.model,
-                card.system_prompt,
-                serde_json::to_string(&card.skills).unwrap_or_else(|_| "[]".into()),
-                card.lifecycle.as_str(),
-                card.version,
-                card.created_at,
-                card.updated_at,
-                card.group_id.to_string(),
-            ],
-        )
-        .map_err(|e| classify(e, &card.name))?;
-
+        let card = new_card(draft);
+        insert_agent(&conn, &card)?;
         Ok(card)
+    }
+
+    /// Creates a whole crew, or none of it.
+    ///
+    /// Written in one transaction because the alternative fails halfway. Names
+    /// are unique per group, and the realistic way a batch dies on its fourth
+    /// row is another window taking a name between the check and the write,
+    /// which no amount of validating up front prevents. Leaving three agents
+    /// behind and reporting an error about a fourth gives the operator a
+    /// workspace they did not ask for and no list of what landed.
+    pub fn create_agents(&self, drafts: &[CleanDraft]) -> Result<Vec<AgentCard>, StoreError> {
+        let mut conn = self.conn()?;
+        let tx = conn.transaction()?;
+        let cards: Vec<AgentCard> = drafts.iter().map(new_card).collect();
+        for card in &cards {
+            insert_agent(&tx, card)?;
+        }
+        tx.commit()?;
+        Ok(cards)
     }
 
     /// Applies an operator edit and bumps the card version.
@@ -2477,6 +2508,49 @@ mod tests {
             matches!(&err, StoreError::DuplicateName(name) if name == "manager"),
             "expected DuplicateName, got {err:?}"
         );
+    }
+
+    #[test]
+    fn a_crew_written_in_one_go_is_readable_as_a_crew() {
+        let f = fixture();
+        let crew = [draft("Manager"), draft("Researcher"), draft("Critic")];
+        let cards = f.store.create_agents(&crew).unwrap();
+
+        assert_eq!(cards.len(), 3);
+        let names: Vec<&str> = cards.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, ["Manager", "Researcher", "Critic"], "order is the order asked for");
+        assert_eq!(f.store.list_agents().unwrap().len(), 3);
+        // Every one is a real card, not a half-written row.
+        for card in &cards {
+            assert_eq!(f.store.get_agent(card.id).unwrap().as_ref(), Some(card));
+        }
+    }
+
+    #[test]
+    fn a_crew_that_cannot_be_written_in_full_is_not_written_at_all() {
+        // The realistic failure: a name taken between the check and the write.
+        // Three agents landing plus an error about a fourth is a workspace the
+        // operator did not ask for and no list of what arrived.
+        let f = fixture();
+        f.store.create_agent(&draft("Critic")).unwrap();
+
+        let crew = [draft("Manager"), draft("Researcher"), draft("critic")];
+        let err = f.store.create_agents(&crew).unwrap_err();
+        assert!(
+            matches!(&err, StoreError::DuplicateName(name) if name == "critic"),
+            "expected DuplicateName, got {err:?}"
+        );
+
+        let left: Vec<String> =
+            f.store.list_agents().unwrap().into_iter().map(|c| c.name).collect();
+        assert_eq!(left, ["Critic"], "the rolled-back hire left agents behind: {left:?}");
+    }
+
+    #[test]
+    fn hiring_nobody_writes_nothing_and_is_not_an_error() {
+        let f = fixture();
+        assert!(f.store.create_agents(&[]).unwrap().is_empty());
+        assert!(f.store.list_agents().unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/domain/agent.rs
+++ b/src-tauri/src/domain/agent.rs
@@ -297,6 +297,31 @@ pub fn copy_name(original: &str, taken: &[String]) -> String {
         .unwrap_or_else(|| truncate_name(&first))
 }
 
+/// Names for a set of agents hired in one go, given who already holds a name in
+/// the group they are joining.
+///
+/// Resolved in sequence rather than independently, and that is the whole point:
+/// two agents hired from the same preset, or two presets that happen to share a
+/// name, are both free against the roster as it stands and would both be told
+/// they can have it. The second write then fails a unique index on a button
+/// whose job is to succeed. Each name handed out joins the pool the next one is
+/// checked against.
+///
+/// A name nobody is using is returned untouched, so an ordinary hire produces
+/// the name on the card rather than a decorated one. Clashes fall through to
+/// [`copy_name`], because one naming rule the operator can predict beats two.
+pub fn hire_names(wanted: &[String], taken: &[String]) -> Vec<String> {
+    let mut pool = taken.to_vec();
+    let mut out = Vec::with_capacity(wanted.len());
+    for want in wanted {
+        let clash = pool.iter().any(|held| held.trim().eq_ignore_ascii_case(want.trim()));
+        let name = if clash { copy_name(want, &pool) } else { want.trim().to_string() };
+        pool.push(name.clone());
+        out.push(name);
+    }
+    out
+}
+
 /// Keeps a generated name inside the limit `validate` enforces, by characters
 /// rather than bytes: a crew of emoji-named agents is legal.
 fn truncate_name(name: &str) -> String {
@@ -465,6 +490,57 @@ mod tests {
         assert_eq!(copy.chars().count(), MAX_NAME_LEN);
         let draft = AgentDraft { name: copy, ..draft() };
         assert!(draft.validate().is_ok());
+    }
+
+    #[test]
+    fn a_hire_keeps_the_name_on_the_card_when_nobody_holds_it() {
+        let wanted = taken_names(&["Manager", "Researcher"]);
+        assert_eq!(hire_names(&wanted, &[]), wanted);
+    }
+
+    #[test]
+    fn hiring_the_same_preset_twice_in_one_go_does_not_ask_for_one_name_twice() {
+        // Both are free against the roster as it stands, so resolving them
+        // independently hands out "Researcher" twice and the second write dies
+        // on the unique index.
+        let wanted = taken_names(&["Researcher", "Researcher"]);
+        assert_eq!(hire_names(&wanted, &[]), taken_names(&["Researcher", "Researcher copy"]));
+    }
+
+    #[test]
+    fn a_hire_steps_around_whoever_is_already_in_the_group() {
+        assert_eq!(
+            hire_names(&taken_names(&["Manager"]), &taken_names(&["Manager"])),
+            taken_names(&["Manager copy"])
+        );
+        // Case is not a difference the database recognises, so it is not one
+        // here either.
+        assert_eq!(
+            hire_names(&taken_names(&["Manager"]), &taken_names(&["manager"])),
+            taken_names(&["Manager copy"])
+        );
+    }
+
+    #[test]
+    fn a_batch_of_hires_is_a_batch_of_legal_drafts() {
+        // The names this hands out go straight into `validate`, so anything it
+        // can produce has to survive it. A crew hired into a group that already
+        // holds every one of them is the case that decorates every name.
+        let roster = taken_names(&["Manager", "Researcher", "Critic"]);
+        let names = hire_names(&roster, &roster);
+        assert_eq!(names.len(), roster.len());
+        for name in &names {
+            let draft = AgentDraft { name: name.clone(), ..draft() };
+            assert!(draft.validate().is_ok(), "{name:?} is not a name an operator could save");
+        }
+        let unique: std::collections::HashSet<String> =
+            names.iter().map(|n| n.to_lowercase()).collect();
+        assert_eq!(unique.len(), names.len(), "two hires were given the same name: {names:?}");
+    }
+
+    #[test]
+    fn hiring_nobody_creates_nobody() {
+        assert!(hire_names(&[], &taken_names(&["Manager"])).is_empty());
     }
 
     fn taken_names(names: &[&str]) -> Vec<String> {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -140,8 +140,16 @@ describe("App", () => {
 
   it("offers a way in when there are no agents", async () => {
     render(<App />);
-    expect(await screen.findByRole("button", { name: /starter crew/i })).toBeTruthy();
+    expect(await screen.findByRole("button", { name: /open the cafeteria/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /create one agent/i })).toBeTruthy();
+  });
+
+  it("opens the cafeteria from the empty state", async () => {
+    // The one path a workspace with nothing in it is expected to take, so it
+    // has to reach somewhere that can actually fill it.
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: /open the cafeteria/i }));
+    expect(await screen.findByRole("dialog", { name: /cafeteria/i })).toBeTruthy();
   });
 
   it("lists agents and opens a channel", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { AgentAvatar } from "./avatars/AgentAvatar";
 import { AgentEditor } from "./components/AgentEditor";
 import { AgentMenu, type MenuTarget } from "./components/AgentMenu";
+import { Cafeteria } from "./components/Cafeteria";
 import { ChannelView } from "./components/ChannelView";
 import { GroupEditor } from "./components/GroupEditor";
 import { Inspector } from "./components/Inspector";
@@ -11,50 +12,7 @@ import { SettingsDialog } from "./components/SettingsDialog";
 import { Sidebar } from "./components/Sidebar";
 import { api, onRuntimeEvent } from "./lib/ipc";
 import { ACTIVITY_CHANNEL, useLiveAgents, useStore } from "./lib/store";
-import { type AgentCard, type AgentDraft, errorMessage, type Group } from "./lib/types";
-
-/**
- * A crew that demonstrates the point of the app on first run: one agent whose
- * job is to delegate, and three with distinct jobs for it to delegate to.
- */
-const STARTER_CREW: AgentDraft[] = [
-  {
-    name: "Manager",
-    avatar: "avocado",
-    color: "#c7d96b",
-    model: "",
-    skills: ["delegation", "planning"],
-    systemPrompt:
-      "You coordinate the other agents. Prefer delegating to doing the work yourself: find who is best suited with `directory`, then message them. Keep your replies to two sentences.",
-  },
-  {
-    name: "Researcher",
-    avatar: "owl",
-    color: "#6aa9d9",
-    model: "",
-    skills: ["research", "fact checking"],
-    systemPrompt:
-      "You gather and verify information. State what you are confident about and what you are not. Never invent a citation.",
-  },
-  {
-    name: "Critic",
-    avatar: "chilli",
-    color: "#e2674a",
-    model: "",
-    skills: ["review", "finding holes"],
-    systemPrompt:
-      "You find the weakest part of any plan or claim put to you, say what it is plainly, and suggest the smallest change that fixes it. Be direct, never rude.",
-  },
-  {
-    name: "Scribe",
-    avatar: "star",
-    color: "#9b8ad4",
-    model: "",
-    skills: ["summarising", "note taking"],
-    systemPrompt:
-      "You turn scattered discussion into short, ordered notes. Lead with the decision, then the reasoning. Never pad.",
-  },
-];
+import { type AgentCard, errorMessage, type Group } from "./lib/types";
 
 export default function App() {
   const agents = useLiveAgents();
@@ -74,7 +32,7 @@ export default function App() {
   const [showSettings, setShowSettings] = useState(false);
   const [searching, setSearching] = useState(false);
   const [ready, setReady] = useState(false);
-  const [seeding, setSeeding] = useState(false);
+  const [showCafeteria, setShowCafeteria] = useState(false);
 
   // Both modifiers, on every platform. The app is one window with one find
   // shortcut, and an operator who learned it on a laptop should not have to
@@ -124,23 +82,6 @@ export default function App() {
     };
   }, [applyEvent, bootstrap, setBanner]);
 
-  const addStarterCrew = async () => {
-    setSeeding(true);
-    try {
-      const model = settings?.defaultModel ?? "";
-      for (const draft of STARTER_CREW) {
-        await api.createAgent({ ...draft, model: draft.model || model });
-      }
-      await refreshAgents();
-      const created = useStore.getState().agents.find((a) => a.name === "Manager");
-      if (created) await select(created.id);
-    } catch (error) {
-      setBanner({ tone: "error", text: errorMessage(error) });
-    } finally {
-      setSeeding(false);
-    }
-  };
-
   /**
    * Runs something on one agent and re-reads the roster.
    *
@@ -168,6 +109,7 @@ export default function App() {
         onNewAgent={() => setEditing("new")}
         onEditAgent={(agent) => setEditing(agent)}
         onNewGroup={() => setEditingGroup("new")}
+        onOpenCafeteria={() => setShowCafeteria(true)}
         onEditGroup={(group) => setEditingGroup(group)}
         onOpenSettings={() => setShowSettings(true)}
         onOpenSearch={() => setSearching(true)}
@@ -205,16 +147,15 @@ export default function App() {
             <h2 className="empty__title">No agents yet</h2>
             <p className="empty__body">
               Agents are the people in this workspace. You talk to them, and they can talk to each
-              other. Start with a crew, or build one from scratch.
+              other. Hire a few who are already set up, or write one from scratch.
             </p>
             <div style={{ display: "flex", gap: "0.5rem", justifyContent: "center" }}>
               <button
                 type="button"
                 className="btn btn--primary"
-                disabled={seeding}
-                onClick={() => void addStarterCrew()}
+                onClick={() => setShowCafeteria(true)}
               >
-                {seeding ? "Adding…" : "Add a starter crew"}
+                Open the cafeteria
               </button>
               <button type="button" className="btn" onClick={() => setEditing("new")}>
                 Create one agent
@@ -273,6 +214,7 @@ export default function App() {
           onClose={() => setEditingGroup(null)}
         />
       )}
+      {showCafeteria && <Cafeteria onClose={() => setShowCafeteria(false)} />}
       {showSettings && <SettingsDialog onClose={() => setShowSettings(false)} />}
       {searching && (
         <Search
@@ -281,6 +223,7 @@ export default function App() {
           onEditGroup={(group) => setEditingGroup(group)}
           onNewAgent={() => setEditing("new")}
           onNewGroup={() => setEditingGroup("new")}
+          onOpenCafeteria={() => setShowCafeteria(true)}
           onOpenSettings={() => setShowSettings(true)}
         />
       )}

--- a/src/components/Cafeteria.test.tsx
+++ b/src/components/Cafeteria.test.tsx
@@ -1,0 +1,219 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentCard, AgentDraft, Group } from "../lib/types";
+
+/**
+ * The cafeteria, over a mocked store.
+ *
+ * The catalog has its own tests; what is worth checking here is the part that
+ * could send the runtime the wrong thing: which presets a click actually hires,
+ * which group they land in, and that a refused hire leaves the operator looking
+ * at their selection rather than at an empty workspace.
+ */
+
+const KITCHEN = "00000000-0000-4000-8000-000000000001";
+const GARDEN = "00000000-0000-4000-8000-000000000002";
+
+const hireAgents = vi.fn<(groupId: string, drafts: AgentDraft[]) => Promise<AgentCard[]>>(
+  async () => [],
+);
+
+vi.mock("../lib/ipc", () => ({
+  api: {
+    hireAgents: (groupId: string, drafts: AgentDraft[]) => hireAgents(groupId, drafts),
+    listAgents: async () => [],
+    listGroups: async () => [],
+    channelMessages: async () => [],
+    conversationFlow: async () => [],
+  },
+}));
+
+const { Cafeteria } = await import("./Cafeteria");
+const { useStore } = await import("../lib/store");
+const { HIREABLE, STARTER_CREW } = await import("../lib/cafeteria");
+
+function group(id: string, name: string): Group {
+  return {
+    id,
+    name,
+    baseUrl: null,
+    defaultModel: null,
+    apiKeySet: false,
+    apiKeyHint: "",
+    agentCount: 0,
+    createdAt: 1,
+  };
+}
+
+function agent(name: string, groupId = KITCHEN): AgentCard {
+  return {
+    id: `id-${name}`,
+    groupId,
+    sandboxId: null,
+    name,
+    avatar: "avocado",
+    color: "#c7d96b",
+    model: "",
+    systemPrompt: "",
+    skills: [],
+    lifecycle: "active",
+    pinned: false,
+    version: 1,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+const onClose = vi.fn();
+
+function open(groups: Group[] = [group(KITCHEN, "Kitchen")], agents: AgentCard[] = []) {
+  useStore.setState({ agents, groups, activity: {}, lastActive: {}, selected: null });
+  return render(<Cafeteria onClose={onClose} />);
+}
+
+/** The button that commits the hire, whatever it currently says. */
+function hireButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: /^(hire \d+ into|nobody picked|hiring)/i });
+}
+
+/** The tile for one preset, by the name written on it. */
+function tile(name: string): HTMLElement {
+  const heading = screen.getByText(name);
+  const button = heading.closest("button");
+  if (!button) throw new Error(`no hireable tile for ${name}`);
+  return button;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hireAgents.mockResolvedValue([]);
+});
+
+describe("picking", () => {
+  it("offers every preset in the catalog", () => {
+    open();
+    for (const preset of HIREABLE) {
+      expect(tile(preset.name), preset.id).toBeTruthy();
+    }
+  });
+
+  it("hires nobody until somebody is picked", () => {
+    open();
+    const button = screen.getByRole("button", { name: /nobody picked/i });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("toggles a tile on and back off", () => {
+    open();
+    const manager = tile("Chief of Staff");
+    expect(manager.getAttribute("aria-pressed")).toBe("false");
+
+    fireEvent.click(manager);
+    expect(manager.getAttribute("aria-pressed")).toBe("true");
+    expect(hireButton().disabled).toBe(false);
+
+    fireEvent.click(manager);
+    expect(manager.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("names the group on the button, so a hire says where it is going", () => {
+    open([group(KITCHEN, "Kitchen"), group(GARDEN, "Garden")]);
+    fireEvent.click(tile("Chief of Staff"));
+    expect(screen.getByRole("button", { name: /hire 1 into kitchen/i })).toBeTruthy();
+  });
+
+  it("sends only the presets that were picked", async () => {
+    open();
+    fireEvent.click(tile("Chief of Staff"));
+    fireEvent.click(tile("Market Researcher"));
+    fireEvent.click(screen.getByRole("button", { name: /hire 2 into kitchen/i }));
+
+    await waitFor(() => expect(hireAgents).toHaveBeenCalledTimes(1));
+    const [groupId, drafts] = hireAgents.mock.calls[0]!;
+    expect(groupId).toBe(KITCHEN);
+    expect(drafts.map((draft) => draft.name)).toEqual(["Chief of Staff", "Market Researcher"]);
+    // Blank means inherit. A pinned model here would override the group's own.
+    expect(drafts.every((draft) => draft.model === "")).toBe(true);
+  });
+
+  it("hires into the group the operator chose, not the first one", async () => {
+    open([group(KITCHEN, "Kitchen"), group(GARDEN, "Garden")]);
+    fireEvent.change(screen.getByLabelText(/hire into/i), { target: { value: GARDEN } });
+    fireEvent.click(tile("Chief of Staff"));
+    fireEvent.click(screen.getByRole("button", { name: /hire 1 into garden/i }));
+
+    await waitFor(() => expect(hireAgents).toHaveBeenCalledTimes(1));
+    expect(hireAgents.mock.calls[0]![0]).toBe(GARDEN);
+  });
+
+  it("does not ask which group when there is only one", () => {
+    open();
+    expect(screen.queryByLabelText(/hire into/i)).toBeNull();
+  });
+
+  it("clears a selection without hiring anything", () => {
+    open();
+    fireEvent.click(tile("Chief of Staff"));
+    fireEvent.click(screen.getByRole("button", { name: /^clear$/i }));
+    expect(tile("Chief of Staff").getAttribute("aria-pressed")).toBe("false");
+    expect(hireAgents).not.toHaveBeenCalled();
+  });
+});
+
+describe("the starter crew", () => {
+  it("picks a crew for an empty group", () => {
+    open();
+    fireEvent.click(screen.getByRole("button", { name: /starter crew/i }));
+    expect(
+      screen.getByRole("button", { name: new RegExp(`hire ${STARTER_CREW.length} into`, "i") }),
+    ).toBeTruthy();
+  });
+
+  it("is not offered to a group that already has agents in it", () => {
+    // A crew of four is a suggestion for an empty room. It says nothing to an
+    // operator who already built one.
+    open([group(KITCHEN, "Kitchen")], [agent("Chief of Staff")]);
+    expect(screen.queryByRole("button", { name: /starter crew/i })).toBeNull();
+  });
+});
+
+describe("who is already here", () => {
+  it("marks a preset whose name the group already holds", () => {
+    open([group(KITCHEN, "Kitchen")], [agent("Chief of Staff")]);
+    expect(tile("Chief of Staff").textContent).toContain("on staff");
+    expect(tile("Market Researcher").textContent).not.toContain("on staff");
+  });
+
+  it("marks nobody from another group", () => {
+    // Names are unique per group, not per workspace, so a Manager in the Garden
+    // is no reason to warn about hiring one into the Kitchen.
+    open([group(KITCHEN, "Kitchen"), group(GARDEN, "Garden")], [agent("Chief of Staff", GARDEN)]);
+    expect(tile("Chief of Staff").textContent).not.toContain("on staff");
+  });
+
+  it("still lets a second one be hired", async () => {
+    // Deliberate: two researchers is a thing operators want. The runtime is
+    // what settles the name.
+    open([group(KITCHEN, "Kitchen")], [agent("Chief of Staff")]);
+    fireEvent.click(tile("Chief of Staff"));
+    fireEvent.click(screen.getByRole("button", { name: /hire 1 into kitchen/i }));
+    await waitFor(() => expect(hireAgents).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe("when a hire is refused", () => {
+  it("says why and leaves the selection alone", async () => {
+    hireAgents.mockRejectedValue({ kind: "storage", message: "the database is locked" });
+    open();
+    fireEvent.click(tile("Chief of Staff"));
+    fireEvent.click(screen.getByRole("button", { name: /hire 1 into kitchen/i }));
+
+    await waitFor(() => expect(screen.getByText(/the database is locked/i)).toBeTruthy());
+    // Closing here would lose the picks and leave the operator guessing what
+    // landed and what did not.
+    expect(onClose).not.toHaveBeenCalled();
+    expect(tile("Chief of Staff").getAttribute("aria-pressed")).toBe("true");
+    expect(hireButton().disabled).toBe(false);
+  });
+});

--- a/src/components/Cafeteria.tsx
+++ b/src/components/Cafeteria.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { AgentAvatar } from "../avatars/AgentAvatar";
+import { HIREABLE, type Hireable, pick, STARTER_CREW, STATIONS, toDraft } from "../lib/cafeteria";
+import { api } from "../lib/ipc";
+import { useStore } from "../lib/store";
+import { errorMessage, type GroupId } from "../lib/types";
+
+interface Props {
+  onClose: () => void;
+}
+
+/**
+ * Agents that are already set up, and the group they get hired into.
+ *
+ * Browsing and picking, then one action, then back to the workspace. That shape
+ * is a dialog rather than a place, which is why this is not a channel: there is
+ * nothing here to come back to, no state worth addressing, and nothing that
+ * changes while you are not looking at it.
+ *
+ * Everything is a copy. A hired agent has no link back to the preset it came
+ * from, so editing it later is editing an ordinary agent and this file cannot
+ * become something the database has to agree with.
+ */
+export function Cafeteria({ onClose }: Props) {
+  const groups = useStore((s) => s.groups);
+  const agents = useStore((s) => s.agents);
+  const select = useStore((s) => s.select);
+  const refreshAgents = useStore((s) => s.refreshAgents);
+
+  const [picked, setPicked] = useState<Set<string>>(new Set());
+  const [groupId, setGroupId] = useState<GroupId | "">(() => groups[0]?.id ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    panelRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  // A group deleted in another window would leave the picker holding an id
+  // nothing matches, and the hire would be refused by a command the operator
+  // never saw make a choice.
+  useEffect(() => {
+    if (groups.length > 0 && !groups.some((group) => group.id === groupId)) {
+      setGroupId(groups[0]!.id);
+    }
+  }, [groups, groupId]);
+
+  const group = groups.find((entry) => entry.id === groupId);
+
+  /**
+   * Who is already in the group being hired into.
+   *
+   * Shown on the card rather than enforced, because hiring a second Researcher
+   * is a thing operators do on purpose. The runtime settles the name; this is
+   * only so nobody is surprised by what it settles on.
+   */
+  const employed = useMemo(() => {
+    const here = agents.filter((a) => a.groupId === groupId && a.lifecycle !== "terminated");
+    return new Set(here.map((a) => a.name.toLowerCase()));
+  }, [agents, groupId]);
+
+  const toggle = (id: string) =>
+    setPicked((current) => {
+      const next = new Set(current);
+      if (!next.delete(id)) next.add(id);
+      return next;
+    });
+
+  const hire = async () => {
+    if (!group || picked.size === 0) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const hired = await api.hireAgents(group.id, pick(picked).map(toDraft));
+      await refreshAgents();
+      // Opening the first hire is what makes the button feel like it did
+      // something: the rail is ordered by who spoke last, and nobody hired has
+      // spoken, so a new crew lands at the bottom of a busy workspace.
+      if (hired[0]) await select(hired[0].id);
+      onClose();
+    } catch (caught) {
+      setError(errorMessage(caught));
+      setBusy(false);
+    }
+  };
+
+  const card = (preset: Hireable) => {
+    const chosen = picked.has(preset.id);
+    const already = employed.has(preset.name.toLowerCase());
+    return (
+      <button
+        key={preset.id}
+        type="button"
+        className="hire"
+        aria-pressed={chosen}
+        style={{ "--accent": preset.color } as React.CSSProperties}
+        onClick={() => toggle(preset.id)}
+      >
+        <span className="hire__face">
+          <AgentAvatar avatar={preset.avatar} color={preset.color} size="md" seed={preset.id} />
+        </span>
+        <span className="hire__body">
+          <span className="hire__name">
+            {preset.name}
+            {already && (
+              <span
+                className="hire__already"
+                title={`${group?.name ?? "This group"} already has one`}
+              >
+                on staff
+              </span>
+            )}
+          </span>
+          <span className="hire__tagline">{preset.tagline}</span>
+          <span className="hire__skills">
+            {preset.skills.map((skill) => (
+              <span key={skill} className="hire__skill">
+                {skill}
+              </span>
+            ))}
+          </span>
+        </span>
+      </button>
+    );
+  };
+
+  return (
+    <div className="scrim">
+      <button type="button" className="scrim__close" aria-label="Close dialog" onClick={onClose} />
+      <div
+        className="dialog dialog--cafeteria"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Cafeteria"
+        tabIndex={-1}
+        ref={panelRef}
+      >
+        <div className="cafeteria__head">
+          <div>
+            <h2 className="dialog__title">Cafeteria</h2>
+            <p className="dialog__lede" style={{ margin: 0 }}>
+              Agents that are already set up. Hire as many as you like: each one arrives as an
+              ordinary agent you can rename, rewrite or delete.
+            </p>
+          </div>
+
+          {/* Only asked once there is a choice to make. With one group the
+              boundary has not been drawn yet, and the button below names the
+              destination in every case anyway. */}
+          {groups.length > 1 && (
+            <label className="field" style={{ margin: 0, minWidth: "11rem" }}>
+              <span className="field__label">Hire into</span>
+              <select
+                className="input input--mono"
+                value={groupId}
+                onChange={(event) => setGroupId(event.target.value)}
+              >
+                {groups.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+        </div>
+
+        <div className="cafeteria__stations">
+          {STATIONS.map((station) => (
+            <section key={station} className="cafeteria__station">
+              <h3 className="cafeteria__station-name">{station}</h3>
+              <div className="cafeteria__grid">
+                {HIREABLE.filter((preset) => preset.station === station).map(card)}
+              </div>
+            </section>
+          ))}
+        </div>
+
+        {error && (
+          <div className="banner banner--error" style={{ margin: "0 1.35rem" }}>
+            <span>{error}</span>
+          </div>
+        )}
+
+        <div className="cafeteria__foot">
+          {/* Only offered to a group with nobody in it. A crew of four is a
+              suggestion for an empty room, and says nothing useful to an
+              operator who already has thirty agents. */}
+          {employed.size === 0 && (
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={() => setPicked(new Set(STARTER_CREW))}
+            >
+              Pick a starter crew
+            </button>
+          )}
+          <button
+            type="button"
+            className="btn btn--ghost"
+            disabled={picked.size === 0}
+            onClick={() => setPicked(new Set())}
+          >
+            Clear
+          </button>
+
+          <span className="cafeteria__spacer" />
+
+          <button type="button" className="btn" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn btn--primary"
+            disabled={busy || picked.size === 0 || !group}
+            onClick={() => void hire()}
+          >
+            {busy
+              ? "Hiring…"
+              : picked.size === 0
+                ? "Nobody picked"
+                : `Hire ${picked.size} into ${group?.name ?? "…"}`}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Search.test.tsx
+++ b/src/components/Search.test.tsx
@@ -58,6 +58,7 @@ const handlers = {
   onEditGroup: vi.fn(),
   onNewAgent: vi.fn(),
   onNewGroup: vi.fn(),
+  onOpenCafeteria: vi.fn(),
   onOpenSettings: vi.fn(),
 };
 

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -21,6 +21,7 @@ interface Props {
   onEditGroup: (group: Group) => void;
   onNewAgent: () => void;
   onNewGroup: () => void;
+  onOpenCafeteria: () => void;
   onOpenSettings: () => void;
 }
 
@@ -52,6 +53,7 @@ export function Search({
   onEditGroup,
   onNewAgent,
   onNewGroup,
+  onOpenCafeteria,
   onOpenSettings,
 }: Props) {
   const agents = useStore((s) => s.agents);
@@ -134,6 +136,9 @@ export function Search({
         case "newGroup":
           onNewGroup();
           break;
+        case "openCafeteria":
+          onOpenCafeteria();
+          break;
       }
       onClose();
     },
@@ -145,6 +150,7 @@ export function Search({
       onEditGroup,
       onNewAgent,
       onNewGroup,
+      onOpenCafeteria,
       onOpenSettings,
       openMessage,
       select,

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -44,6 +44,7 @@ function draw(g: Group) {
       onEditAgent={vi.fn()}
       onNewGroup={vi.fn()}
       onEditGroup={vi.fn()}
+      onOpenCafeteria={vi.fn()}
       onOpenSettings={vi.fn()}
       onOpenSearch={vi.fn()}
       onOpenMenu={vi.fn()}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ interface Props {
   onEditAgent: (agent: AgentCard) => void;
   onNewGroup: () => void;
   onEditGroup: (group: Group) => void;
+  onOpenCafeteria: () => void;
   onOpenSettings: () => void;
   onOpenSearch: () => void;
   /** Where the operator right-clicked, and on whom. */
@@ -35,6 +36,7 @@ export function Sidebar({
   onEditAgent,
   onNewGroup,
   onEditGroup,
+  onOpenCafeteria,
   onOpenSettings,
   onOpenSearch,
   onOpenMenu,
@@ -306,6 +308,14 @@ export function Sidebar({
       </div>
 
       <div className="rail__foot">
+        {/* Above "New agent" because it is the faster of the two ways to add
+            somebody, and the one an operator reaches for more than once. */}
+        <button type="button" className="btn btn--rail" onClick={onOpenCafeteria}>
+          <span aria-hidden="true" className="rail__hash">
+            ☰
+          </span>
+          Cafeteria
+        </button>
         <button type="button" className="btn btn--rail" onClick={onNewAgent}>
           <span aria-hidden="true" className="rail__hash">
             +

--- a/src/lib/cafeteria.test.ts
+++ b/src/lib/cafeteria.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import { ACCENTS, CHARACTERS, lookupCharacter } from "../avatars/catalog";
+import { HIREABLE, pick, STARTER_CREW, STATIONS, toDraft } from "./cafeteria";
+import { matchMentions, mentionAt } from "./mentions";
+
+/**
+ * The cafeteria is data, so this is where its rules live.
+ *
+ * Nothing here needs a running app: a preset that names a character nobody
+ * draws, or a colour the editor cannot show, is wrong the moment it is written
+ * and should fail the build rather than a first run.
+ */
+
+const MAX_NAME_LEN = 48; // domain::agent::MAX_NAME_LEN
+
+describe("the cafeteria catalog", () => {
+  it("has presets to hire", () => {
+    // Without this the rest of the file passes vacuously on an empty array.
+    expect(HIREABLE.length).toBeGreaterThan(5);
+  });
+
+  it("gives every preset an id nothing else uses", () => {
+    // Selection is keyed by id. Two presets sharing one means picking either
+    // hires both, which reads as the app inventing an agent.
+    const ids = HIREABLE.map((preset) => preset.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("gives every preset a name nothing else in the catalog uses", () => {
+    // Names are unique per group in the database. Two presets sharing one is
+    // legal, and it is also a batch that quietly hires "Editor copy" for a
+    // preset the operator picked by its own name.
+    const names = HIREABLE.map((preset) => preset.name.toLowerCase());
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("draws every preset with a character the catalog actually has", () => {
+    // `lookupCharacter` never fails: an unknown key falls back to a hash of
+    // itself, so a typo here is a face nobody chose rather than a blank one,
+    // and it would go unnoticed forever. The whole promise of the cafeteria is
+    // that the look was chosen.
+    const drawn = new Set(CHARACTERS.map((character) => character.key));
+    const strays = HIREABLE.filter((preset) => !drawn.has(preset.avatar));
+    expect(strays.map((preset) => `${preset.id}: ${preset.avatar}`)).toEqual([]);
+  });
+
+  it("colours every preset with an accent the editor offers", () => {
+    // So that opening a hired agent shows its swatch already selected, rather
+    // than a colour the operator cannot get back if they click away.
+    const offered = new Set(ACCENTS.map((accent) => accent.value));
+    const strays = HIREABLE.filter((preset) => !offered.has(preset.color));
+    expect(strays.map((preset) => `${preset.id}: ${preset.color}`)).toEqual([]);
+  });
+
+  it("gives each station a distinct silhouette", () => {
+    // Two agents side by side at one counter have to be tellable apart at the
+    // 22px the rail draws them at, and colour is not what does that.
+    for (const station of STATIONS) {
+      const here = HIREABLE.filter((preset) => preset.station === station);
+      const faces = here.map((preset) => lookupCharacter(preset.avatar).key);
+      expect(new Set(faces).size, `${station} draws two agents the same way`).toBe(here.length);
+    }
+  });
+
+  it("puts every preset at a station that is drawn", () => {
+    const strays = HIREABLE.filter((preset) => !STATIONS.includes(preset.station));
+    expect(
+      strays.map((preset) => preset.id),
+      "would not appear anywhere",
+    ).toEqual([]);
+  });
+
+  it("leaves no station empty", () => {
+    const empty = STATIONS.filter((station) => !HIREABLE.some((p) => p.station === station));
+    expect(empty, "a heading with nothing under it").toEqual([]);
+  });
+
+  it("writes every preset so the runtime would accept it", () => {
+    // The same rules `AgentDraft::validate` enforces on the Rust side. A preset
+    // that fails them is a card that cannot be hired, and the operator finds
+    // out by clicking the button.
+    for (const preset of HIREABLE) {
+      expect(preset.name.trim(), preset.id).not.toBe("");
+      expect([...preset.name].length, `${preset.id} name is too long`).toBeLessThanOrEqual(
+        MAX_NAME_LEN,
+      );
+      expect(preset.color, `${preset.id} colour`).toMatch(/^#[0-9a-f]{6}$/);
+      expect(preset.avatar.trim(), preset.id).not.toBe("");
+    }
+  });
+
+  it("tells peers what every preset is for", () => {
+    // Skills are what another agent reads when it decides who to ask, so a
+    // preset without them is one the crew cannot route work to.
+    for (const preset of HIREABLE) {
+      expect(preset.skills.length, `${preset.id} has no skills`).toBeGreaterThan(0);
+      expect(
+        preset.skills.every((skill) => skill.trim().length > 0),
+        preset.id,
+      ).toBe(true);
+      expect(preset.tagline.trim(), `${preset.id} has nothing to read`).not.toBe("");
+    }
+  });
+
+  it("gives every preset a title a peer can actually address", () => {
+    // Peers resolve each other by whole name, and the composer's `@` typeahead
+    // gives up after two spaces. A four-word job title is an agent nobody can
+    // mention and nobody can delegate to, which is most of the point of it.
+    for (const preset of HIREABLE) {
+      const spaces = preset.name.split(" ").length - 1;
+      expect(spaces, `${preset.id} has too many words to mention`).toBeLessThanOrEqual(2);
+
+      // The real path, not a reimplementation of the rule: type the whole name
+      // after an `@` and check the menu still offers it.
+      const typed = `@${preset.name}`;
+      const query = mentionAt(typed, typed.length);
+      expect(query, `@${preset.name} does not read as a mention`).not.toBeNull();
+      expect(matchMentions([preset.name], query!.term)).toEqual([preset.name]);
+    }
+  });
+
+  it("names presets after jobs rather than after functions", () => {
+    // A guard on the thing that makes this catalog worth having. Bare function
+    // labels carry no duties and no refusals, so the operator ends up writing
+    // the role into the prompt anyway.
+    const generic = ["manager", "editor", "reviewer", "writer", "analyst", "assistant"];
+    const bare = HIREABLE.filter((preset) => generic.includes(preset.name.toLowerCase()));
+    expect(
+      bare.map((preset) => preset.name),
+      "too generic to be a job title",
+    ).toEqual([]);
+  });
+
+  it("keeps every prompt short enough that somebody read it", () => {
+    // Not a rule about models, a rule about maintenance. A preset prompt long
+    // enough to hide a stopping rule inside is one nobody will check again,
+    // and a prompt with no stopping rule is the defect the evals exist to
+    // catch. Kept where a reviewer can hold the whole thing in their head.
+    for (const preset of HIREABLE) {
+      expect(preset.systemPrompt.trim(), preset.id).not.toBe("");
+      expect(preset.systemPrompt.length, `${preset.id} prompt is too long to review`).toBeLessThan(
+        500,
+      );
+    }
+  });
+});
+
+describe("hiring", () => {
+  it("hands the runtime a draft that inherits its model", () => {
+    const draft = toDraft(HIREABLE[0]!);
+    // Blank means inherit. A preset that pinned a model would override a group
+    // that deliberately chose its own endpoint and model.
+    expect(draft.model).toBe("");
+    expect(draft.name).toBe(HIREABLE[0]!.name);
+    expect(draft.systemPrompt).toBe(HIREABLE[0]!.systemPrompt);
+    expect(draft.skills).toEqual(HIREABLE[0]!.skills);
+  });
+
+  it("sends no group on the draft, because the command carries it", () => {
+    // `hire_agents` takes one group and overrides whatever the drafts hold, so
+    // a group here would be a value that silently does nothing.
+    expect(toDraft(HIREABLE[0]!).groupId).toBeUndefined();
+  });
+
+  it("picks presets in catalog order, whatever order they were selected in", () => {
+    const ids = [HIREABLE[3]!.id, HIREABLE[0]!.id];
+    expect(pick(ids).map((preset) => preset.id)).toEqual([HIREABLE[0]!.id, HIREABLE[3]!.id]);
+  });
+
+  it("drops an id nothing matches rather than inventing an agent", () => {
+    expect(pick(["nobody-by-that-name"])).toEqual([]);
+  });
+
+  it("names a starter crew that is actually in the catalog", () => {
+    // This is what an empty workspace hires on the first click. An id that
+    // stopped matching would make that button hire fewer agents than it says,
+    // or none.
+    expect(pick(STARTER_CREW)).toHaveLength(STARTER_CREW.length);
+  });
+
+  it("starts a crew with somebody to delegate and somebody to delegate to", () => {
+    const crew = pick(STARTER_CREW);
+    expect(crew.length).toBeGreaterThan(1);
+    expect(crew.some((preset) => preset.skills.includes("delegation"))).toBe(true);
+  });
+});

--- a/src/lib/cafeteria.ts
+++ b/src/lib/cafeteria.ts
@@ -1,0 +1,293 @@
+/**
+ * The cafeteria: agents that are already set up, waiting to be hired.
+ *
+ * Every field an operator would otherwise fill in by hand is written down here
+ * once, well. The point is not that these are agents nobody could have written;
+ * it is that writing sixteen of them is an hour of work standing between a new
+ * operator and a crew, and that hour buys nothing that a good default does not.
+ *
+ * **They are jobs, not functions.** "Chief of Staff" and "Paralegal", not
+ * "Manager" and "Reviewer". A person staffing a workspace is thinking about a
+ * role they would hire, and a role carries its own duties, its own judgement
+ * and its own refusals: a paralegal declines to give a legal opinion, an
+ * account manager does not promise a discount. A generic function label carries
+ * none of that, and the operator has to supply all of it in the prompt, which
+ * is the work this file exists to remove.
+ *
+ * A hire is a copy. Nothing here is referenced afterwards: an agent hired from
+ * the cafeteria is an ordinary agent with an ordinary card, editable, deletable
+ * and indistinguishable from one typed out by hand. There is no upgrade path
+ * from a preset to an agent because there is no link to upgrade along, which is
+ * what stops this file from becoming a schema the database has to agree with.
+ *
+ * **House style for a prompt.** What the agent does, how it decides, and one
+ * hard limit. The limit is the part that matters and the part that is easiest
+ * to leave out: the cascade evals exist because a prompt with no stopping rule
+ * makes a crew that talks to itself, and nothing in CI can see that. A preset
+ * added without one is a regression that passes every automated suite. See
+ * *Three test suites, asking different questions* in `docs/ARCHITECTURE.md`,
+ * and run `./scripts/evals.sh` after touching anything below.
+ */
+
+import type { AgentDraft } from "./types";
+
+/** Which counter of the cafeteria an agent stands at. */
+export type Station =
+  | "Front office"
+  | "Revenue"
+  | "Finance and legal"
+  | "Product and engineering"
+  | "Customers and research";
+
+/** Drawn in this order: whoever the operator deals with first, first. */
+export const STATIONS: Station[] = [
+  "Front office",
+  "Revenue",
+  "Finance and legal",
+  "Product and engineering",
+  "Customers and research",
+];
+
+export interface Hireable {
+  /**
+   * Stable across renames. Selection, the starter crew and the tests all
+   * address a preset by this, so changing a `name` never silently changes
+   * which agent a button hires.
+   */
+  id: string;
+  /**
+   * The job title the agent is hired under, and how peers address it.
+   *
+   * At most three words. Peers resolve each other by whole name and the
+   * composer's `@` typeahead gives up after two spaces, so a four-word title is
+   * an agent nobody can mention.
+   */
+  name: string;
+  station: Station;
+  /** The one line the operator reads while browsing. Not sent to any model. */
+  tagline: string;
+  /** Key into the character catalog. */
+  avatar: string;
+  /** One of the accents in that same catalog. */
+  color: string;
+  skills: string[];
+  systemPrompt: string;
+}
+
+export const HIREABLE: Hireable[] = [
+  {
+    id: "chief-of-staff",
+    name: "Chief of Staff",
+    station: "Front office",
+    tagline: "Runs the crew. Decides who does what, and chases it.",
+    avatar: "avocado",
+    color: "#c7d96b",
+    skills: ["delegation", "planning", "following up"],
+    systemPrompt:
+      "You run the crew on the operator's behalf. Prefer delegating to doing the work yourself: find who is suited with `directory`, message them, then follow up on what you asked for. Give one person one job at a time. Keep your own replies to two sentences.",
+  },
+  {
+    id: "executive-assistant",
+    name: "Executive Assistant",
+    station: "Front office",
+    tagline: "Guards the calendar and the inbox. Says what actually needs you.",
+    avatar: "corn",
+    color: "#e8b84b",
+    skills: ["scheduling", "correspondence", "triage"],
+    systemPrompt:
+      "You handle scheduling, correspondence and follow-ups. Sort what arrives into what needs the operator, what needs another agent, and what needs nobody, and say where you sent each. Never accept, decline or commit to anything in the operator's name unless you were told you could.",
+  },
+  {
+    id: "recruiter",
+    name: "Recruiter",
+    station: "Front office",
+    tagline: "Sources candidates, screens them, hands you a shortlist.",
+    avatar: "cilantro",
+    color: "#6faa5c",
+    skills: ["sourcing", "screening", "interview scheduling"],
+    systemPrompt:
+      "You source and screen candidates against a role. Give a shortlist with one line of evidence for each person and one reason to doubt them, and say where you found them. Never rank on anything the brief did not ask for, and never infer a protected characteristic.",
+  },
+  {
+    id: "sdr",
+    name: "Sales Development Rep",
+    station: "Revenue",
+    tagline: "Finds prospects and writes the first message to them.",
+    avatar: "chilli",
+    color: "#e2674a",
+    skills: ["prospecting", "outreach", "qualifying"],
+    systemPrompt:
+      "You research prospects and draft outreach. One specific, verifiable reason you are contacting this person, in their language, under a hundred words. Never send anything yourself, and never state a fact about a company you did not read somewhere you can cite.",
+  },
+  {
+    id: "account-manager",
+    name: "Account Manager",
+    station: "Revenue",
+    tagline: "Keeps the customers you have, and flags the ones going quiet.",
+    avatar: "tomato",
+    color: "#d9534f",
+    skills: ["renewals", "account health", "escalation"],
+    systemPrompt:
+      "You look after accounts that already exist: renewals, check-ins, and problems before they turn into churn. Lead with the account's status and what you want done about it. Never promise a discount, a date or a feature.",
+  },
+  {
+    id: "content-marketer",
+    name: "Content Marketer",
+    station: "Revenue",
+    tagline: "Turns a rough idea into a post that sounds like you.",
+    avatar: "radish",
+    color: "#d97ea8",
+    skills: ["copywriting", "editing", "writing to a voice"],
+    systemPrompt:
+      "You write posts, emails and landing copy in the voice you are asked for. If the voice was not given, ask once, then commit to it. Hand back the draft alone: no preamble, no summary of it, no offer to revise.",
+  },
+  {
+    id: "bookkeeper",
+    name: "Bookkeeper",
+    station: "Finance and legal",
+    tagline: "Categorises what moved and chases what is missing.",
+    avatar: "mill",
+    color: "#8aa0a6",
+    skills: ["reconciliation", "categorisation", "expenses"],
+    systemPrompt:
+      "You keep the books: categorise transactions, reconcile accounts, and chase missing receipts. Give a figure with the period it covers. Never guess a category or invent a counterparty. List what you could not place and stop.",
+  },
+  {
+    id: "financial-analyst",
+    name: "Financial Analyst",
+    station: "Finance and legal",
+    tagline: "Builds the model and says what it actually shows.",
+    avatar: "pit",
+    color: "#9b8ad4",
+    skills: ["forecasting", "variance analysis", "modelling"],
+    systemPrompt:
+      "You work with figures. Give the number, then what it means, then what would change it. Say when a period is too short or a sample too small to carry the conclusion being asked of it. Never round away a difference that matters.",
+  },
+  {
+    id: "paralegal",
+    name: "Paralegal",
+    station: "Finance and legal",
+    tagline: "Reads the contract and marks what you should not sign.",
+    avatar: "garlic",
+    color: "#b0784a",
+    skills: ["contract review", "filings", "redlining"],
+    systemPrompt:
+      "You review contracts and filings. Quote the clause, say what it does in plain words, and say whether it is normal. Flag anything auto-renewing, uncapped or one-sided. You are not a lawyer: never give a legal opinion, say what needs one.",
+  },
+  {
+    id: "product-manager",
+    name: "Product Manager",
+    station: "Product and engineering",
+    tagline: "Turns complaints into something somebody can actually build.",
+    avatar: "pepper",
+    color: "#6aa9d9",
+    skills: ["specification", "prioritisation", "user research"],
+    systemPrompt:
+      "You turn problems into work that can be built. State the user, the problem, and how you will know it is fixed, in that order. Cut anything that is a solution looking for a problem. Never write a requirement you cannot test.",
+  },
+  {
+    id: "software-engineer",
+    name: "Software Engineer",
+    station: "Product and engineering",
+    tagline: "Writes the code on its own machine, and runs it before it reports.",
+    avatar: "salt",
+    color: "#7fd1a3",
+    skills: ["programming", "automation", "debugging"],
+    systemPrompt:
+      "You solve problems with code on your own computer. Run what you write before reporting that it works, and include the output that proves it. When something fails, say what failed and what you already tried.",
+  },
+  {
+    id: "code-reviewer",
+    name: "Code Reviewer",
+    station: "Product and engineering",
+    tagline: "Reads the change and says whether it is safe to ship.",
+    avatar: "onion",
+    color: "#c2926b",
+    skills: ["code review", "risk", "correctness"],
+    systemPrompt:
+      "You review changes. Lead with the verdict: ship, or do not ship and why. Raise correctness before style, and raise nothing you would not block on. If the change is fine, say so in one line and stop.",
+  },
+  {
+    id: "qa-tester",
+    name: "QA Tester",
+    station: "Product and engineering",
+    tagline: "Tries to break it, and writes down exactly how it broke.",
+    avatar: "chip",
+    color: "#c7d96b",
+    skills: ["testing", "reproducing bugs", "edge cases"],
+    systemPrompt:
+      "You try to break things and report how. Give the steps, the expected result, and what happened instead, in that order. One defect per report. Never report a defect you have not reproduced yourself.",
+  },
+  {
+    id: "support-specialist",
+    name: "Support Specialist",
+    station: "Customers and research",
+    tagline: "Answers the customer, and escalates what it cannot answer.",
+    avatar: "lime",
+    color: "#e8b84b",
+    skills: ["customer support", "troubleshooting", "escalation"],
+    systemPrompt:
+      "You answer customer questions. Lead with the answer, then the steps. When you do not know or cannot act, say so and name who can, rather than guessing. Never tell a customer something is fixed unless you watched it get fixed.",
+  },
+  {
+    id: "market-researcher",
+    name: "Market Researcher",
+    station: "Customers and research",
+    tagline: "Goes and reads the sources, then says how sure it is.",
+    avatar: "mushroom",
+    color: "#6faa5c",
+    skills: ["research", "competitor analysis", "fact checking"],
+    systemPrompt:
+      "You research markets, competitors and claims using your computer's browser. Report what the page said and the URL you read it on, and separate what you are confident about from what you are not. Never invent a citation or describe a page you did not open.",
+  },
+  {
+    id: "data-analyst",
+    name: "Data Analyst",
+    station: "Customers and research",
+    tagline: "Pulls the data and answers the question that was asked.",
+    avatar: "carrot",
+    color: "#9b8ad4",
+    skills: ["analysis", "reporting", "working with figures"],
+    systemPrompt:
+      "You answer questions with data. State the answer, the size of the set behind it, and the period it covers. Say when the data cannot answer the question rather than answering a nearby one. Never present a correlation as a cause.",
+  },
+];
+
+/**
+ * The four an empty workspace starts with: somebody whose job is to delegate,
+ * and three with distinct jobs to delegate to. Between them they can take
+ * "look into X and draft something about it" end to end, which is the shortest
+ * demonstration of what the app is for.
+ *
+ * By id rather than by copy, so the crew a first run gets and the cards the
+ * cafeteria draws cannot drift apart. This was a second literal in `App.tsx`
+ * and had already drifted: it named characters from a retired set, which the
+ * avatar aliases resolved to something nobody had chosen.
+ */
+export const STARTER_CREW = [
+  "chief-of-staff",
+  "market-researcher",
+  "content-marketer",
+  "executive-assistant",
+];
+
+/** What a hire sends across IPC. */
+export function toDraft(preset: Hireable): AgentDraft {
+  return {
+    name: preset.name,
+    avatar: preset.avatar,
+    color: preset.color,
+    // Blank means inherit, so a hire picks up the group's model if it pins one
+    // and the app default otherwise. Writing the app default in here instead
+    // would pin every hire to it and quietly ignore a group that chose its own.
+    model: "",
+    systemPrompt: preset.systemPrompt,
+    skills: preset.skills,
+  };
+}
+
+/** Presets by id, in catalog order. Unknown ids are dropped rather than faked. */
+export function pick(ids: Iterable<string>): Hireable[] {
+  const wanted = new Set(ids);
+  return HIREABLE.filter((preset) => wanted.has(preset.id));
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -119,6 +119,18 @@ export const api = {
    */
   duplicateAgent: (id: AgentId) => invoke<AgentCard>("duplicate_agent", { id }),
 
+  /**
+   * Hires a set of preconfigured agents into one group, in one call.
+   *
+   * Batched rather than looped for two reasons. Every create announces itself
+   * and the rail re-reads the whole roster, so six hires done one at a time
+   * redraw the sidebar six times. And a name already taken in the group is
+   * settled on the Rust side against the roster *and* the rest of the batch,
+   * which is the one place that rule can live without being written twice.
+   */
+  hireAgents: (groupId: GroupId, drafts: AgentDraft[]) =>
+    invoke<AgentCard[]>("hire_agents", { groupId, drafts }),
+
   setAgentPaused: (id: AgentId, paused: boolean) =>
     invoke<AgentCard>("set_agent_paused", { id, paused }),
 

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -48,7 +48,8 @@ export type SearchAction =
   | { do: "editGroup"; groupId: GroupId }
   | { do: "openSettings" }
   | { do: "newAgent" }
-  | { do: "newGroup" };
+  | { do: "newGroup" }
+  | { do: "openCafeteria" };
 
 export interface SearchResult {
   /** Unique within a result set: the React key, and what selection tracks. */
@@ -362,6 +363,14 @@ function actionsFor(agents: AgentCard[], groups: Group[]): Omit<SearchResult, "s
       detail: "A crew that cannot see the others",
       meta: "Action",
       action: { do: "newGroup" },
+    },
+    {
+      key: "action:cafeteria",
+      kind: "actions",
+      title: "Cafeteria",
+      detail: "Hire agents that are already set up",
+      meta: "Action",
+      action: { do: "openCafeteria" },
     },
   );
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -3397,3 +3397,168 @@ button {
     background: color-mix(in oklab, var(--flesh) 14%, transparent);
   }
 }
+
+/* ==========================================================================
+   Cafeteria
+
+   A wider dialog than the rest, because this one is browsed rather than filled
+   in: the operator is comparing fourteen agents, and a column that shows three
+   at a time turns a glance into a scroll. The head and the foot are pinned so
+   the group being hired into and the count are readable from anywhere in the
+   list; only the stations move.
+   ========================================================================== */
+
+/* Focus lands here on open so the dialog owns the keyboard, but this is a
+   landing spot rather than a control: the ring belongs on the tiles and the
+   buttons inside, not around the whole panel. */
+.dialog--cafeteria:focus,
+.dialog--cafeteria:focus-visible {
+  outline: none;
+}
+
+.dialog--cafeteria {
+  width: min(58rem, 100%);
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 3rem);
+  padding: 0;
+}
+
+.cafeteria__head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.2rem;
+  padding: 1.35rem 1.35rem 1rem;
+  border-bottom: 1px solid var(--edge);
+  flex: none;
+}
+
+.cafeteria__stations {
+  overflow-y: auto;
+  padding: 0.35rem 1.35rem 1rem;
+  flex: 1;
+}
+
+.cafeteria__station {
+  margin-top: 1.1rem;
+}
+
+.cafeteria__station-name {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin: 0 0 0.55rem;
+}
+
+.cafeteria__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(15.5rem, 1fr));
+  gap: 0.5rem;
+}
+
+/* One hireable agent. A button rather than a card with a checkbox in it: the
+   whole tile is the target, and `aria-pressed` is what says it is a toggle
+   instead of something that opens. */
+.hire {
+  display: grid;
+  grid-template-columns: 2.6rem 1fr;
+  align-items: start;
+  gap: 0.65rem;
+  text-align: left;
+  padding: 0.7rem 0.75rem;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  background: var(--raised);
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.hire:hover {
+  border-color: color-mix(in oklab, var(--accent) 45%, var(--edge));
+  background: var(--ground);
+}
+
+/* Selection is carried by the agent's own accent, so a picked crew reads as
+   the colours that will be in the rail a moment later. */
+.hire[aria-pressed="true"] {
+  border-color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 9%, var(--raised));
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.hire__face {
+  display: grid;
+  place-items: center;
+  padding-top: 0.1rem;
+}
+
+.hire__body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.hire__name {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-display);
+  font-size: 0.92rem;
+  font-weight: 600;
+  letter-spacing: -0.004em;
+  color: var(--text);
+}
+
+/* Said quietly and on purpose. Hiring a second Researcher is a thing operators
+   do deliberately, so this reports what is already there rather than warning
+   about it. */
+.hire__already {
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--faint);
+  border: 1px solid var(--edge);
+  border-radius: 99px;
+  padding: 0.05rem 0.35rem;
+}
+
+.hire__tagline {
+  font-size: 0.79rem;
+  line-height: 1.35;
+  color: var(--muted);
+}
+
+.hire__skills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-top: 0.15rem;
+}
+
+.hire__skill {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  color: var(--muted);
+  background: var(--sunken);
+  border-radius: 99px;
+  padding: 0.1rem 0.4rem;
+}
+
+.cafeteria__foot {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.9rem 1.35rem;
+  border-top: 1px solid var(--edge);
+  flex: none;
+}
+
+.cafeteria__spacer {
+  margin-left: auto;
+}


### PR DESCRIPTION
Adds a cafeteria: sixteen preconfigured agents named after jobs rather than functions (Chief of Staff, Paralegal, not Manager, Reviewer), each with a chosen character, skills and a prompt that states a stopping rule, hireable as a batch into a group the operator picks. A hire is a copy with no link back to the preset, and a preset's model is blank so a hire cannot override a group that pinned its own endpoint. `hire_agents` replaces a loop over `create_agent`: every create otherwise makes the rail re-read the whole roster, and names are unique per group, so the batch is settled against the roster *and* against itself by `hire_names` and the rows go in as one transaction. It is reachable from the rail, the empty state and ⌘K, and it replaces the hardcoded starter crew in `App.tsx`, which had already drifted onto characters from a retired avatar set. Titles are capped at three words because peers resolve each other by whole name and the composer's mention typeahead gives up after two spaces, so a longer title is an agent nobody can delegate to.

Verified with `./scripts/ci.sh`: 446 frontend tests, 558 Rust. `./scripts/evals.sh` has **not** been run, and it is the suite that would catch a preset prompt with no stopping rule.