### PR TITLE
feat: a routine says which day it keeps, and a firing is one line

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ repo: the frontend renders state and forwards intent.
 | What an agent may do with a page it has just read | *A page that was read this turn cannot quietly press a button* |
 | Attachments, previews, drops | *Files are references, and what a model gets depends on what they are* |
 | SQLite, the pool, migrations | *Storage*, and the two comments in `Store::open` |
-| Schedules and triggers | `docs/ROUTINES.md` |
+| Schedules, triggers, what a firing looks like | `docs/ROUTINES.md` |
 | Sandboxes, the browser, sign-ins, credentials | `docs/MACHINES.md`, then *Connectors* in `docs/PROTOCOL.md` |
 | Channels, the rail, search: what the operator sees | `docs/WORKSPACE.md`, then `src/lib/transcript.ts` |
 | The rail's order, dragging a row, groups as places you go inside | *The rail is arranged by hand*, *A drop is one call* and *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/rail.ts` |
@@ -73,7 +73,10 @@ lands on one side fails the build rather than at runtime.
 
 **Migrations are forward-only and numbered.** One has already run against a real
 database by the time you think of an improvement, and editing it leaves that
-database at the same `user_version` with a different schema. Add another.
+database at the same `user_version` with a different schema. Add another. They
+run with foreign key enforcement off, which is what SQLite's own table-rebuild
+procedure wants and what a migration cannot arrange for itself: the pragma is a
+no-op inside a transaction. See `migrations::run`.
 
 **A secret never reaches a model.** A credential's value and a cookie's value do
 not enter a prompt, a transcript, an event or the webview, and there is no field
@@ -97,6 +100,13 @@ on the types that cross those boundaries for one to arrive in. Keep it that way:
 - **An envelope booked against a run is released by whatever consumes it.** A
   path that takes one without turning it into a turn leaves the run outstanding
   for the life of the process.
+- **A fired routine carries `Part::Routine`, not text.** The instruction reaches
+  the model either way, because `as_plain_text` returns it. The part is what
+  keeps the transcript from drawing a schedule firing as Guaca talking to the
+  operator: `docs/ROUTINES.md`.
+- **`Routine::next_run_at` is an `Option` because some triggers have no next
+  run.** A sentinel date would be shown to the operator, and it is one bad
+  comparison away from firing something that was waiting on a connector.
 
 ## Conventions
 

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -2,26 +2,84 @@
 
 A routine is an instruction an agent gives itself when a trigger comes due.
 `domain/routine.rs` holds the shape, the scheduler is in `runtime/mod.rs`, and
-`RoutineList` and `RoutineDetail` draw them.
+`RoutineList` and `RoutineDetail` draw them. `lib/routine.ts` is the webview's
+half: the only file on that side that reads a trigger's stored text.
+
+## A trigger is one string, in both places it lives, and two kinds of thing
+
+The column is text and so is the wire form, which is why `Trigger` has a
+hand-written `Serialize`: a derived one would hand the webview a tagged object
+and SQLite `weekdays` for the same fact, and only one of the two would be read
+by the frontend.
+
+Underneath that one string are two families. A `Cadence` is a moment or a repeat
+of them, and the scheduler owns it. An `EventTrigger` is something happening in
+a service the group is connected to, written `event:stripe/invoice.payment_failed`,
+and it owns nothing: it has no next moment, and no clock will ever produce one.
+Splitting them in the type is what keeps `next_after`, `first_run` and `accepts`
+off a value that has no answer for any of them.
+
+**Nothing delivers an event yet.** What exists is every layer under it: the
+value parses and round-trips, the row stores, the scheduler leaves it alone, the
+panel and the list draw it, `Test run` fires it, and the history records it. What
+is missing is the one part that cannot be written without a service to receive
+from, a webhook or a poll that turns an arriving event into
+`Runtime::send_from_routine`. It is deliberately not in the trigger picker
+either: a routine an operator can set and then watch never fire is worse than
+one they cannot set yet.
+
+## A routine with no next firing has no next firing
+
+`next_run_at` is `Option<i64>`, and NULL in SQLite since migration 21. The
+alternative was a sentinel date, which is a date the operator eventually gets
+shown, and one bad comparison away from firing something that was meant to wait
+for Stripe. NULL also tells the scheduler for free: SQL compares NULL to
+nothing, so `next_run_at <= now` skips these without `due_routines` knowing what
+kinds of trigger exist.
+
+Everything reading that column has to answer for the empty case rather than
+invent a moment. `NextSlot` is the shape of that: `Due`, `Waiting` and `Done`
+are three answers, not two, because "nothing on the clock" and "finished" mean
+opposite things to the row and reading them off the same `None` deleted every
+event routine the first time it fired. `ORDER BY next_run_at` needs the same
+care: NULL sorts first in SQLite, so a routine waiting on an event drew above
+one firing in ten minutes.
+
+Migration 21 rebuilds the table, which is the only way SQLite will drop NOT
+NULL. `migrations::run` turns foreign key enforcement off around the whole
+sequence for it: with enforcement on, `DROP TABLE routines` performs an implicit
+delete first and fires `routine_runs`' `ON DELETE CASCADE`, taking every
+recorded firing with it.
 
 ## A repeat is a shape, not a number of seconds
 
 `every weekday` and `every month` cannot be gaps, and `every day` should not be
 one: a day is 23 or 25 hours twice a year, so a daily nine o'clock routine
-stored as 86400 seconds drifts to eight and stays there. `domain/routine.rs`
-holds the shape and `next_run_at` holds the hour, and the next slot is computed
-in local time from the slot it was due at rather than from the moment it ran, so
-a machine asleep through three of them fires once on waking instead of three
+stored as 86400 seconds drifts to eight and stays there. `Cadence` holds the
+shape and `next_run_at` holds the hour, and the next slot is computed in local
+time from the slot it was due at rather than from the moment it ran, so a
+machine asleep through three of them fires once on waking instead of three
 times. A gap still exists, because an agent scheduling itself works in seconds
 and nothing shorter than a day has an hour to keep.
 
-## A trigger is one string in both places it lives
+## The moment is the only record of which day a repeat keeps
 
-The column is text and so is the wire form, which is why `Trigger` has a
-hand-written `Serialize`: a derived one would hand the webview a tagged object
-and SQLite `weekdays` for the same fact, and only one of the two would be read
-by the frontend. Text also means the trigger after these, a connector event, is
-a new value rather than a new column.
+A weekly routine keeps the weekday of its first firing and a monthly one keeps
+the day of the month. Neither is stored anywhere else, and for a while neither
+was askable: the panel offered a time of day, so "every week at nine" landed on
+whichever day the operator happened to be at the keyboard, and nothing on screen
+said so. `anchorFor` in `lib/routine.ts` says which part of a moment each trigger
+actually keeps, and `firstRunDelay` turns what the operator picked into the one
+number the backend takes.
+
+Two rules in there are not obvious. A monthly 31st goes to the next month that
+*has* a 31st rather than clamping to the end of a short one, because clamping
+would anchor the routine on the 28th and every firing after it would inherit
+that day: the walk backwards down the calendar `months_after` is careful to
+avoid. And a moment already gone is refused rather than sent, because a negative
+delay reaches the scheduler as a routine overdue and fires on the next tick,
+which is not what picking a date means. A one-off takes a date for the same
+reason: a time on its own can only ever mean the next 24 hours.
 
 ## Switching a routine off and editing one are different actions
 
@@ -40,6 +98,19 @@ edited one answers a different question and reads as the edit having done
 nothing. Both kinds are recorded in `routine_runs` and the test is marked,
 because in the transcript the two are identical.
 
+## A firing that spent nothing is a routine that did not run
+
+`routine_runs` records that a firing happened. What the operator actually wants
+to know is whether it worked, and a delivery to an agent that never took a turn
+is indistinguishable, row for row, from one that did the job. So the history
+joins `usage` by `run_id` and every firing carries what it bought: `calls: 0` is
+the one worth seeing.
+
+Joined at read time rather than stored on the row, because a firing's cost is
+not known when it is recorded and keeps moving until the run settles. A column
+would be a snapshot of a number that was still changing, and the model calls are
+already filed under the run id.
+
 ## A routine's row is one line and its instruction is not in it
 
 The instruction is written to be acted on with no other context, which is
@@ -48,6 +119,33 @@ The row is a name and a cadence; opening it gives the panel over to that
 routine. An agent naming its own routine is optional, so `routineTitle` cuts the
 instruction down when nobody named it, on a word boundary and after the first
 sentence.
+
+The end of that second line is where the row is honest about what it is looking
+at. A switched-off routine must not claim a next firing, and one waiting on an
+event has no next firing to claim, so both say when they last ran instead: on a
+routine that is not about to do anything, that is the only news left.
+
+## A firing is a line in the transcript, not a message
+
+The instruction has to reach the model, and it does: the envelope carries
+`Part::Routine`, `as_plain_text` returns the instruction, and prompt assembly,
+dedup and the emptiness check are all unchanged. What the part buys is the
+drawing. A firing used to arrive as a chat bubble from "Guaca" carrying all
+several sentences of it, in the middle of the operator's own conversation with
+their agent: the system prompting the agent, in the shape of somebody talking to
+the reader. The reflex is to read it as addressed to you, and it never is.
+
+So it is one chip naming the routine, and the click opens that routine in the
+panel beside the transcript, where the instruction is the thing you came to
+read. The part carries the routine's id and its name *at the time it fired*, so
+a routine since renamed does not rewrite what the transcript said it was. The
+two ends are in different columns of the window, so the click goes through
+`openingRoutine` in the store rather than a prop threaded through every message,
+which is the same arrangement `focused` already uses for search hits.
+
+Old transcripts still hold text parts and still draw as bubbles. Migrations are
+forward-only and a message is a record of what happened; rewriting one to change
+how it looks is not worth being able to say the record was edited.
 
 ## What a routine delivers is work, and the runtime is what sent it
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -725,9 +725,32 @@ impl RoutineDraft {
         let trigger = Trigger::parse(&self.trigger).ok_or_else(|| {
             CommandError::new("validation", format!("no trigger called {:?}", self.trigger))
         })?;
-        routine::validate(&self.name, &self.what, trigger, self.in_secs)
+        routine::validate(&self.name, &self.what, &trigger, self.in_secs)
             .map_err(|e| CommandError::new("validation", e.to_string()))?;
         Ok(trigger)
+    }
+}
+
+/// Where an edited routine's next firing lands.
+///
+/// Three cases, and the difference between them is what the operator did. A
+/// stated time is honoured. An untouched time keeps the slot it was holding,
+/// because correcting a typo must not push the schedule to tomorrow. And a
+/// trigger swapped for one that would never fire at that moment has to move:
+/// "every hour" turned into "every weekday" keeps its hour but cannot keep its
+/// Saturday, or the label and the firing disagree from the moment it is saved.
+///
+/// A trigger that is not a clock lands nowhere at all, whatever was asked for.
+fn next_slot_for(trigger: &Trigger, existing: &Routine, in_secs: Option<u32>) -> Option<i64> {
+    let cadence = trigger.cadence()?;
+    let now = now_ms();
+    match (in_secs, existing.next_run_at) {
+        (Some(_), _) => Some(cadence.first_run(now, in_secs)),
+        // Coming back to the clock from a trigger that held no slot: there is
+        // nothing to keep, so it starts one interval out like a new routine.
+        (None, None) => Some(cadence.first_run(now, None)),
+        (None, Some(slot)) if cadence.accepts(slot) => Some(slot),
+        (None, Some(slot)) => Some(cadence.next_after(slot, now).unwrap_or(slot)),
     }
 }
 
@@ -758,14 +781,7 @@ pub fn update_routine(
         .store()
         .get_routine(id)?
         .ok_or_else(|| CommandError::new("notFound", format!("no routine with id {id}")))?;
-    let next = match draft.in_secs {
-        Some(_) => trigger.first_run(now_ms(), draft.in_secs),
-        // The slot only stays put while the trigger does. "Every hour" turned
-        // into "every weekday" keeps its hour but has to move off a Saturday,
-        // or the label and the firing disagree from the moment it is saved.
-        None if trigger.accepts(existing.next_run_at) => existing.next_run_at,
-        None => trigger.next_after(existing.next_run_at, now_ms()).unwrap_or(existing.next_run_at),
-    };
+    let next = next_slot_for(&trigger, &existing, draft.in_secs);
 
     let routine =
         state.runtime.store().update_routine(id, &draft.name, &draft.what, trigger, next)?;

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -105,9 +105,9 @@ VALUES ('00000000-0000-4000-8000-000000000001', 'Everyone', 0);
 -- Rebuilt rather than ALTERed. SQLite refuses to ADD COLUMN when the column
 -- carries both a REFERENCES clause and a non-NULL default, so the alternative
 -- was to drop the foreign key and hope nothing ever writes a dangling group.
--- The rebuild is the documented way to add a constraint and behaves the same
--- whichever way `foreign_keys` happens to be set; migrations run on the
--- bootstrap connection, where it is off, which is what that procedure wants.
+-- The rebuild is the documented way to add a constraint, and `run` turns
+-- foreign key enforcement off around the whole migration sequence, which is
+-- what that procedure wants and what a migration cannot arrange for itself.
 CREATE TABLE agents_new (
     id            TEXT    PRIMARY KEY,
     name          TEXT    NOT NULL,
@@ -517,6 +517,55 @@ UPDATE agents SET rail_order = (
 );
 "#,
     ),
+    (
+        21,
+        r#"
+-- A routine that is not waiting on a clock.
+--
+-- `fires` was made text so the trigger after the calendar ones would be a new
+-- value rather than a new column, and that half held. This is the other half:
+-- a trigger that is not a clock has no next firing at all, and `next_run_at`
+-- was NOT NULL, so the only ways to store one were a sentinel date or a second
+-- column. A sentinel is a date the operator eventually gets shown, and it is
+-- one bad comparison away from firing something meant to wait for Stripe.
+--
+-- NULL says it plainly, and it says it to the scheduler for free: SQL compares
+-- NULL to nothing, so `next_run_at <= now` skips these without the sweep
+-- knowing what kinds of trigger exist.
+--
+-- SQLite cannot drop NOT NULL in place, so the table is rebuilt. Every routine
+-- that exists today waits on a clock and carries its slot over unchanged.
+--
+-- The history survives the rebuild because migrations run on the bootstrap
+-- connection, where `foreign_keys` is off. With it on, `DROP TABLE routines`
+-- performs an implicit DELETE first and fires `routine_runs`' ON DELETE
+-- CASCADE, taking every recorded firing with it. That is the same reason the
+-- agents rebuild in migration 1 is written this way.
+CREATE TABLE routines_new (
+    id          TEXT    PRIMARY KEY,
+    agent_id    TEXT    NOT NULL REFERENCES agents(id),
+    name        TEXT    NOT NULL DEFAULT '',
+    what        TEXT    NOT NULL,
+    fires       TEXT    NOT NULL DEFAULT 'once',
+    active      INTEGER NOT NULL DEFAULT 1,
+    next_run_at INTEGER,
+    last_run_at INTEGER,
+    created_at  INTEGER NOT NULL
+);
+
+INSERT INTO routines_new (id,agent_id,name,what,fires,active,next_run_at,last_run_at,created_at)
+SELECT id,agent_id,name,what,fires,active,next_run_at,last_run_at,created_at FROM routines;
+
+DROP TABLE routines;
+ALTER TABLE routines_new RENAME TO routines;
+
+-- Both indexes go with the old table and are rebuilt. The due index is partial
+-- now: a routine with no slot is never an answer to "what is due", so it has no
+-- business in the index the scheduler reads on every tick.
+CREATE INDEX routines_due ON routines (next_run_at) WHERE next_run_at IS NOT NULL;
+CREATE INDEX routines_agent ON routines (agent_id);
+"#,
+    ),
 ];
 
 /// The group every agent starts in, and the one the UI keeps out of the way
@@ -550,8 +599,31 @@ pub fn latest_version() -> i32 {
 /// opening a transaction would let two racing callers both see version 0 and
 /// both try to create the tables.
 pub fn run(conn: &mut Connection) -> Result<i32, MigrationError> {
-    let target = latest_version();
+    // Foreign keys off for the duration, which is what SQLite's own procedure
+    // for rebuilding a table asks for and what a migration cannot do for
+    // itself: the pragma is a no-op inside a transaction, and every migration
+    // runs in one. With enforcement on, the `DROP TABLE` in a rebuild performs
+    // an implicit DELETE first and fires the ON DELETE CASCADE of everything
+    // pointing at that table, so migration 21 took every routine's recorded
+    // firings with it.
+    //
+    // Nothing is lost by it here. Migrations are DDL written in this file, not
+    // input, and the connection this runs on exists only to run them: the pool
+    // the app actually works through turns enforcement on for every connection
+    // in `Store::open`. Restored anyway, because tests call this directly.
+    let enforced: bool = conn.query_row("PRAGMA foreign_keys", [], |row| row.get(0))?;
+    if enforced {
+        conn.pragma_update(None, "foreign_keys", false)?;
+    }
+    let applied = apply(conn, latest_version());
+    if enforced {
+        // Best effort: whatever the migrations said is the answer worth having.
+        let _ = conn.pragma_update(None, "foreign_keys", true);
+    }
+    applied
+}
 
+fn apply(conn: &mut Connection, target: i32) -> Result<i32, MigrationError> {
     loop {
         // `Immediate` takes the write lock at BEGIN rather than at first write,
         // so the loser waits here instead of failing partway through a batch.
@@ -838,6 +910,86 @@ mod tests {
         let name: String =
             conn.query_row("SELECT name FROM routines WHERE id='r1'", [], |r| r.get(0)).unwrap();
         assert_eq!(name, "", "nothing invents a name for a routine an agent set");
+    }
+
+    #[test]
+    fn rebuilding_the_routines_table_keeps_every_schedule_and_its_history() {
+        // The one migration that drops a table other rows point at. With
+        // foreign keys on, DROP TABLE fires `routine_runs`' ON DELETE CASCADE
+        // and takes every recorded firing with it, so this checks the history
+        // is still there and the slots came over unchanged.
+        let mut conn = memory();
+        let tx = conn.transaction().unwrap();
+        for (version, sql) in MIGRATIONS.iter().take(20) {
+            tx.execute_batch(sql).unwrap();
+            tx.pragma_update(None, "user_version", *version).unwrap();
+        }
+        tx.commit().unwrap();
+
+        conn.execute(
+            "INSERT INTO agents (id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id)
+             VALUES ('a','Manager','avocado','#000','m','','[]','active',1,0,0,?1)",
+            [DEFAULT_GROUP_ID],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO routines (id,agent_id,name,what,fires,active,next_run_at,last_run_at,created_at)
+             VALUES ('r1','a','Sweep','check','weekdays',0,1750000000000,1740000000000,5)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO routine_runs (routine_id,run_id,kind,at) VALUES ('r1','run-1','test',7)",
+            [],
+        )
+        .unwrap();
+
+        run(&mut conn).unwrap();
+
+        let (name, fires, active, next, last, created): (String, String, i64, i64, i64, i64) = conn
+            .query_row(
+                "SELECT name,fires,active,next_run_at,last_run_at,created_at FROM routines
+                  WHERE id='r1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?, r.get(5)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            (name.as_str(), fires.as_str(), active, next, last, created),
+            ("Sweep", "weekdays", 0, 1750000000000, 1740000000000, 5),
+            "every column came over as it was, including being switched off"
+        );
+
+        let runs: i64 =
+            conn.query_row("SELECT count(*) FROM routine_runs", [], |r| r.get(0)).unwrap();
+        assert_eq!(runs, 1, "the history must not be cascaded away by the rebuild");
+
+        // And the point of the rebuild: a routine with no slot is now storable.
+        conn.execute(
+            "INSERT INTO routines (id,agent_id,name,what,fires,active,next_run_at,created_at)
+             VALUES ('r2','a','Dunning','chase','event:stripe/invoice.payment_failed',1,NULL,0)",
+            [],
+        )
+        .unwrap();
+        let due: i64 = conn
+            .query_row("SELECT count(*) FROM routines WHERE next_run_at <= ?1", [i64::MAX], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(due, 1, "and it is not due, however far ahead you look");
+    }
+
+    #[test]
+    fn foreign_key_enforcement_is_off_only_while_migrations_run() {
+        // A rebuild needs it off; everything after this must not inherit that.
+        // The pool sets it per connection, but `run` is handed a connection
+        // somebody else keeps, and leaving it off there disables every cascade
+        // in the app.
+        let mut conn = memory();
+        conn.pragma_update(None, "foreign_keys", true).unwrap();
+        run(&mut conn).unwrap();
+        let on: bool = conn.query_row("PRAGMA foreign_keys", [], |r| r.get(0)).unwrap();
+        assert!(on, "enforcement has to come back on");
     }
 
     #[test]

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -19,7 +19,7 @@ use crate::domain::envelope::{Envelope, Intent, Part, Participant, Trust};
 use crate::domain::group::{CleanGroup, Group, GroupInference};
 use crate::domain::ids::{AgentId, ApprovalId, ConnectorId, GroupId, MessageId, RoutineId, RunId};
 use crate::domain::now_ms;
-use crate::domain::routine::{Routine, RoutineRun, RunKind, Trigger};
+use crate::domain::routine::{NextSlot, Routine, RoutineRun, RunKind, Trigger};
 use crate::domain::search::{
     contains_fold, excerpt, like_pattern, links_in, FileHit, LinkHit, MessageHit, SearchHits,
 };
@@ -438,13 +438,18 @@ impl Store {
 
     // ---- routines --------------------------------------------------------
 
+    /// Files a new routine.
+    ///
+    /// `first_run_at` is `None` for a trigger that does not wait on the clock:
+    /// an event routine holds no slot, and the column is NULL rather than a
+    /// date far enough away to look like never.
     pub fn create_routine(
         &self,
         agent: AgentId,
         name: &str,
         what: &str,
         trigger: Trigger,
-        first_run_at: i64,
+        first_run_at: Option<i64>,
     ) -> Result<Routine, StoreError> {
         let conn = self.conn()?;
         let routine = Routine {
@@ -498,7 +503,7 @@ impl Store {
         name: &str,
         what: &str,
         trigger: Trigger,
-        next_run_at: i64,
+        next_run_at: Option<i64>,
     ) -> Result<Routine, StoreError> {
         let conn = self.conn()?;
         let changed = conn.execute(
@@ -519,8 +524,12 @@ impl Store {
     pub fn agent_routines(&self, agent: AgentId) -> Result<Vec<Routine>, StoreError> {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
+            // Soonest first, then whatever holds no slot. NULL sorts before
+            // everything in SQLite, which would put a routine waiting on an
+            // event above one firing in ten minutes.
             "SELECT id,agent_id,name,what,fires,active,next_run_at,last_run_at,created_at
-               FROM routines WHERE agent_id=?1 ORDER BY next_run_at",
+               FROM routines WHERE agent_id=?1
+              ORDER BY next_run_at IS NULL, next_run_at, created_at",
         )?;
         let rows = stmt.query_map(params![agent.to_string()], row_to_routine)?;
         let mut out = Vec::new();
@@ -534,6 +543,11 @@ impl Store {
     ///
     /// Only for agents that can still act: a routine belonging to a deleted or
     /// paused agent would otherwise fire into nothing, repeatedly.
+    ///
+    /// A routine with no slot is not due and never will be, which is the whole
+    /// mechanism keeping a trigger that is not a clock out of this sweep: SQL
+    /// compares NULL to nothing, so `next_run_at <= now` excludes it without
+    /// this query needing to know what kinds of trigger exist.
     pub fn due_routines(&self, now: i64) -> Result<Vec<Routine>, StoreError> {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
@@ -551,20 +565,29 @@ impl Store {
         Ok(out)
     }
 
-    /// Records that a routine ran, and when it is next due.
+    /// Records that a routine ran, and what became of its slot.
     ///
     /// A one-shot is removed rather than left with a time in the past, so the
     /// scheduler never has to reason about whether something already happened.
+    /// A routine that holds no slot keeps its row: reading "nothing on the
+    /// clock" and "finished" off the same answer would delete an event routine
+    /// the first time it fired.
     pub fn routine_ran(&self, routine: &Routine, now: i64) -> Result<(), StoreError> {
         let conn = self.conn()?;
         match routine.after_running(now) {
-            Some(next) => {
+            NextSlot::Due(next) => {
                 conn.execute(
                     "UPDATE routines SET next_run_at=?2, last_run_at=?3 WHERE id=?1",
                     params![routine.id.to_string(), next, now],
                 )?;
             }
-            None => {
+            NextSlot::Waiting => {
+                conn.execute(
+                    "UPDATE routines SET next_run_at=NULL, last_run_at=?2 WHERE id=?1",
+                    params![routine.id.to_string(), now],
+                )?;
+            }
+            NextSlot::Done => {
                 conn.execute("DELETE FROM routines WHERE id=?1", params![routine.id.to_string()])?;
             }
         }
@@ -611,12 +634,26 @@ impl Store {
         Ok(())
     }
 
-    /// What a routine has done lately, newest first.
+    /// What a routine has done lately, newest first, and what each firing spent.
+    ///
+    /// The spend is joined rather than stored on the row. A firing's cost is
+    /// not known when it is recorded and keeps moving until the run settles, so
+    /// a column would be a snapshot of a number that was still changing; the
+    /// model calls are already filed under the run id. Read at the moment the
+    /// operator looks, it also answers the question the history is actually for:
+    /// a firing that bought no model call is a routine that did not run, and
+    /// nothing else in the row tells the two apart.
     pub fn routine_runs(&self, id: RoutineId, limit: usize) -> Result<Vec<RoutineRun>, StoreError> {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
-            "SELECT run_id,kind,at FROM routine_runs
-              WHERE routine_id=?1 ORDER BY at DESC LIMIT ?2",
+            "SELECT r.run_id, r.kind, r.at,
+                    COALESCE(SUM(u.prompt),0), COALESCE(SUM(u.completion),0),
+                    SUM(u.cost), COUNT(u.id)
+               FROM routine_runs r
+               LEFT JOIN usage u ON u.run_id = r.run_id
+              WHERE r.routine_id=?1
+              GROUP BY r.id
+              ORDER BY r.at DESC LIMIT ?2",
         )?;
         let rows = stmt.query_map(params![id.to_string(), limit as i64], row_to_routine_run)?;
         let mut out = Vec::new();
@@ -1428,7 +1465,7 @@ impl Store {
             r"SELECT id,agent_id,name,what,fires,active,next_run_at,last_run_at,created_at
                 FROM routines
                WHERE what LIKE ?1 ESCAPE '\' OR name LIKE ?1 ESCAPE '\'
-               ORDER BY next_run_at ASC LIMIT ?2",
+               ORDER BY next_run_at IS NULL, next_run_at ASC LIMIT ?2",
         )?;
         let rows = stmt.query_map(params![pattern, limit], row_to_routine)?;
         let mut out = Vec::new();
@@ -1774,6 +1811,14 @@ fn row_to_routine_run(row: &Row<'_>) -> RowResult<RoutineRun> {
             kind: RunKind::parse(&kind_raw)
                 .ok_or_else(|| StoreError::Corrupt(format!("unknown run kind {kind_raw:?}")))?,
             at: row.get(2)?,
+            spent: Tokens {
+                prompt: row.get::<_, i64>(3)? as u64,
+                completion: row.get::<_, i64>(4)? as u64,
+                // NULL where nothing was priced, which is not the same as free
+                // and must not be summed as zero.
+                cost: row.get::<_, Option<f64>>(5)?,
+                calls: row.get::<_, i64>(6)? as u64,
+            },
         })
     })())
 }
@@ -1952,6 +1997,12 @@ mod tests {
     use crate::domain::attachment::Attachment;
     use crate::domain::envelope::channel_for;
     use crate::domain::ids::RunId;
+    use crate::domain::routine::{Cadence, EventTrigger};
+
+    /// A trigger on the clock, which is what most of these are about.
+    fn clock(cadence: Cadence) -> Trigger {
+        Trigger::Clock(cadence)
+    }
 
     struct Fixture {
         store: Store,
@@ -2269,8 +2320,8 @@ mod tests {
                 card.id,
                 "Listings sweep",
                 "check the listings",
-                Trigger::Every(3600),
-                1_000_000,
+                clock(Cadence::Every(3600)),
+                Some(1_000_000),
             )
             .unwrap();
 
@@ -2280,20 +2331,20 @@ mod tests {
                 made.id,
                 "Listings sweep",
                 "check the listings and say what is new",
-                Trigger::Every(3600),
+                clock(Cadence::Every(3600)),
                 made.next_run_at,
             )
             .unwrap();
         assert_eq!(fixed.what, "check the listings and say what is new");
         assert_eq!(fixed.next_run_at, made.next_run_at, "the schedule did not move");
-        assert_eq!(fixed.trigger, Trigger::Every(3600));
+        assert_eq!(fixed.trigger, clock(Cadence::Every(3600)));
         assert_eq!(fixed.name, "Listings sweep");
 
         // And a routine that is gone is a clear error rather than a silent
         // success, so an operator editing a stale screen is told.
         f.store.delete_routine(made.id).unwrap();
         assert!(matches!(
-            f.store.update_routine(made.id, "", "anything", Trigger::Once, 1),
+            f.store.update_routine(made.id, "", "anything", clock(Cadence::Once), Some(1)),
             Err(StoreError::RoutineNotFound(_))
         ));
     }
@@ -2463,12 +2514,15 @@ mod tests {
         // parse would be a schedule that silently never fires again.
         let f = fixture();
         let card = f.store.create_agent(&draft("Scout")).unwrap();
-        for trigger in
-            [Trigger::Once, Trigger::Weekdays, Trigger::Weekly, Trigger::Monthly, Trigger::Daily]
+        for cadence in
+            [Cadence::Once, Cadence::Weekdays, Cadence::Weekly, Cadence::Monthly, Cadence::Daily]
         {
-            let made = f.store.create_routine(card.id, "", "check", trigger, 1_000_000).unwrap();
+            let made = f
+                .store
+                .create_routine(card.id, "", "check", clock(cadence), Some(1_000_000))
+                .unwrap();
             let read = f.store.get_routine(made.id).unwrap().unwrap();
-            assert_eq!(read.trigger, trigger);
+            assert_eq!(read.trigger, clock(cadence));
             assert_eq!(read.name, "", "a routine an agent set has no name to invent");
         }
     }
@@ -2480,14 +2534,18 @@ mod tests {
         let f = fixture();
         let card = f.store.create_agent(&draft("Scout")).unwrap();
         let friday = friday_at_nine();
-        let made = f.store.create_routine(card.id, "", "check", Trigger::Weekdays, friday).unwrap();
+        let made = f
+            .store
+            .create_routine(card.id, "", "check", clock(Cadence::Weekdays), Some(friday))
+            .unwrap();
 
         f.store.routine_ran(&made, friday + 1000).unwrap();
 
         let moved = f.store.get_routine(made.id).unwrap().unwrap();
-        assert_eq!(moved.next_run_at, Trigger::Weekdays.next_after(friday, friday + 1000).unwrap());
+        let expected = Cadence::Weekdays.next_after(friday, friday + 1000).unwrap();
+        assert_eq!(moved.next_run_at, Some(expected));
         assert_eq!(moved.last_run_at, Some(friday + 1000));
-        assert!(moved.next_run_at - friday > 2 * 86_400_000, "it skipped the weekend");
+        assert!(expected - friday > 2 * 86_400_000, "it skipped the weekend");
     }
 
     #[test]
@@ -2498,7 +2556,13 @@ mod tests {
         let card = f.store.create_agent(&draft("Scout")).unwrap();
         let made = f
             .store
-            .create_routine(card.id, "Sweep", "check the listings", Trigger::Daily, 1_000)
+            .create_routine(
+                card.id,
+                "Sweep",
+                "check the listings",
+                clock(Cadence::Daily),
+                Some(1_000),
+            )
             .unwrap();
         assert!(made.active, "a routine arrives running");
         assert_eq!(f.store.due_routines(2_000).unwrap().len(), 1);
@@ -2522,7 +2586,10 @@ mod tests {
         // firing look the same in the list.
         let f = fixture();
         let card = f.store.create_agent(&draft("Scout")).unwrap();
-        let made = f.store.create_routine(card.id, "", "check", Trigger::Daily, 1_000).unwrap();
+        let made = f
+            .store
+            .create_routine(card.id, "", "check", clock(Cadence::Daily), Some(1_000))
+            .unwrap();
 
         let scheduled = RunId::new();
         let tested = RunId::new();
@@ -2542,7 +2609,10 @@ mod tests {
         // ever draw, and the id is free to be reused.
         let f = fixture();
         let card = f.store.create_agent(&draft("Scout")).unwrap();
-        let made = f.store.create_routine(card.id, "", "check", Trigger::Daily, 1_000).unwrap();
+        let made = f
+            .store
+            .create_routine(card.id, "", "check", clock(Cadence::Daily), Some(1_000))
+            .unwrap();
         f.store.record_routine_run(made.id, RunId::new(), RunKind::Scheduled, 1_000).unwrap();
 
         f.store.delete_routine(made.id).unwrap();
@@ -2550,10 +2620,105 @@ mod tests {
     }
 
     #[test]
+    fn a_routine_waiting_on_an_event_is_never_due_and_survives_firing() {
+        // The scheduler asks one question: what is due. A trigger that is not a
+        // clock has to answer "not me" without the query knowing it exists, and
+        // it must not be deleted like a one-shot when it does fire: it fires
+        // every time its event happens.
+        let f = fixture();
+        let card = f.store.create_agent(&draft("Scout")).unwrap();
+        let trigger = Trigger::Event(EventTrigger {
+            service: "stripe".into(),
+            topic: "invoice.payment_failed".into(),
+        });
+        let made =
+            f.store.create_routine(card.id, "Dunning", "chase it", trigger.clone(), None).unwrap();
+
+        assert_eq!(made.next_run_at, None, "it holds no slot");
+        assert!(
+            f.store.due_routines(i64::MAX).unwrap().is_empty(),
+            "and no moment, however far ahead, makes it due"
+        );
+
+        // Fired anyway, which today is the operator pressing Test run.
+        f.store.routine_ran(&made, 5_000).unwrap();
+        let after = f.store.get_routine(made.id).unwrap().unwrap();
+        assert_eq!(after.trigger, trigger, "the trigger survives the round trip");
+        assert_eq!(after.next_run_at, None, "still holding no slot");
+        assert_eq!(after.last_run_at, Some(5_000), "and it recorded having run");
+    }
+
+    #[test]
+    fn a_schedule_lists_what_is_due_soonest_and_what_is_waiting_last() {
+        // NULL sorts first in SQLite, so the panel drew a routine waiting on an
+        // event above one firing in ten minutes.
+        let f = fixture();
+        let card = f.store.create_agent(&draft("Scout")).unwrap();
+        f.store
+            .create_routine(
+                card.id,
+                "Waiting",
+                "chase it",
+                Trigger::Event(EventTrigger { service: "stripe".into(), topic: "x.y".into() }),
+                None,
+            )
+            .unwrap();
+        f.store.create_routine(card.id, "Later", "b", clock(Cadence::Daily), Some(9_000)).unwrap();
+        f.store.create_routine(card.id, "Sooner", "a", clock(Cadence::Daily), Some(1_000)).unwrap();
+
+        let names: Vec<String> =
+            f.store.agent_routines(card.id).unwrap().into_iter().map(|r| r.name).collect();
+        assert_eq!(names, ["Sooner", "Later", "Waiting"]);
+    }
+
+    #[test]
+    fn a_firing_reports_what_it_spent_and_a_firing_that_did_nothing_says_so() {
+        // The history's job is "has this been working". A delivery that bought
+        // no model call is a routine that did not run, and the row is otherwise
+        // identical to one that did.
+        let f = fixture();
+        let card = f.store.create_agent(&draft("Scout")).unwrap();
+        let made = f
+            .store
+            .create_routine(card.id, "", "check", clock(Cadence::Daily), Some(1_000))
+            .unwrap();
+
+        let worked = RunId::new();
+        let silent = RunId::new();
+        f.store.record_routine_run(made.id, worked, RunKind::Scheduled, 1_000).unwrap();
+        f.store.record_routine_run(made.id, silent, RunKind::Scheduled, 2_000).unwrap();
+        for (prompt, completion, cost) in [(900u32, 100u32, Some(0.002)), (400, 50, Some(0.001))] {
+            f.store
+                .record_usage(&UsageEntry {
+                    agent_id: card.id,
+                    group_id: card.group_id,
+                    run_id: worked,
+                    model: "test/model".into(),
+                    prompt,
+                    completion,
+                    cost,
+                })
+                .unwrap();
+        }
+
+        let history = f.store.routine_runs(made.id, 20).unwrap();
+        assert_eq!(history.len(), 2, "one row per firing, whatever it spent");
+        assert_eq!(history[0].run_id, silent, "newest first");
+        assert_eq!(history[0].spent.calls, 0, "nothing was spent, so nothing ran");
+        assert_eq!(history[0].spent.cost, None, "and unpriced is not free");
+        assert_eq!(history[1].spent.calls, 2, "model calls, not turns");
+        assert_eq!(history[1].spent.total(), 1450);
+        assert_eq!(history[1].spent.cost, Some(0.003));
+    }
+
+    #[test]
     fn a_one_shot_that_fires_leaves_no_row_behind() {
         let f = fixture();
         let card = f.store.create_agent(&draft("Scout")).unwrap();
-        let made = f.store.create_routine(card.id, "", "wake me", Trigger::Once, 1_000).unwrap();
+        let made = f
+            .store
+            .create_routine(card.id, "", "wake me", clock(Cadence::Once), Some(1_000))
+            .unwrap();
         f.store.routine_ran(&made, 2_000).unwrap();
         assert!(f.store.get_routine(made.id).unwrap().is_none());
     }
@@ -2598,7 +2763,13 @@ mod tests {
         f.store.set_lifecycle(scholar.id, Lifecycle::Terminated).unwrap();
 
         f.store
-            .create_routine(scholar.id, "", "check the listings", Trigger::Every(3600), 1)
+            .create_routine(
+                scholar.id,
+                "",
+                "check the listings",
+                clock(Cadence::Every(3600)),
+                Some(1),
+            )
             .unwrap();
         f.store
             .record_usage(&UsageEntry {
@@ -2951,9 +3122,17 @@ mod tests {
             }),
         ]);
         f.store
-            .create_routine(writer.id, "", "post the budget summary", Trigger::Every(3600), 5_000)
+            .create_routine(
+                writer.id,
+                "",
+                "post the budget summary",
+                clock(Cadence::Every(3600)),
+                Some(5_000),
+            )
             .unwrap();
-        f.store.create_routine(writer.id, "Watering", "the plants", Trigger::Daily, 4_000).unwrap();
+        f.store
+            .create_routine(writer.id, "Watering", "the plants", clock(Cadence::Daily), Some(4_000))
+            .unwrap();
 
         Searchable { f, writer: writer.id }
     }

--- a/src-tauri/src/domain/envelope.rs
+++ b/src-tauri/src/domain/envelope.rs
@@ -12,7 +12,7 @@ use sha2::{Digest, Sha256};
 
 use super::approval::{DetailField, ProtectedAction};
 use super::attachment::Attachment;
-use super::ids::{AgentId, ApprovalId, MessageId, RunId};
+use super::ids::{AgentId, ApprovalId, MessageId, RoutineId, RunId};
 
 /// Who is at one end of an envelope.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -169,6 +169,23 @@ pub enum Part {
     /// for it, is the runtime's decision and depends on what kind of file it
     /// is.
     File(Attachment),
+    /// A routine coming due, rendered as one line the operator can open.
+    ///
+    /// The instruction is in `what` and reaches the model exactly as a text
+    /// part would: `as_plain_text` returns it, so prompt assembly, dedup and
+    /// emptiness checks are unchanged. What changes is the transcript, where a
+    /// schedule firing used to arrive as a full chat bubble from Guaca several
+    /// sentences long. An operator reading a conversation with their agent was
+    /// shown the system prompting it, in the shape of someone talking to them.
+    ///
+    /// `name` is carried so the chip can be titled by the same rule the routine
+    /// list uses, and both are the wording at the moment it fired: a routine
+    /// since renamed does not rewrite what the transcript said it was.
+    Routine {
+        routine_id: RoutineId,
+        name: String,
+        what: String,
+    },
     /// An agent asking the operator for permission, rendered as buttons.
     ///
     /// The request travels in the transcript rather than in a dialog, because
@@ -221,9 +238,14 @@ impl Part {
     }
 
     /// The plain-text projection, used for prompts, dedup hashing, and search.
+    ///
+    /// A routine's instruction is here rather than only in the part, because
+    /// what a fired routine says to the model must not depend on how the
+    /// transcript chose to draw it. The part exists to change the drawing.
     pub fn as_plain_text(&self) -> Option<&str> {
         match self {
             Part::Text { text } => Some(text),
+            Part::Routine { what, .. } => Some(what),
             _ => None,
         }
     }

--- a/src-tauri/src/domain/routine.rs
+++ b/src-tauri/src/domain/routine.rs
@@ -1,12 +1,20 @@
-//! Routines: an agent's own schedule.
+//! Routines: an agent's own schedule, and whatever else sets one off.
 //!
 //! An agent sets these for itself. "Check the listings every five hours" and
 //! "wake me in an hour" are the same thing with and without a repeat, so both
-//! are one row: what to do, and when it is next due.
+//! are one row: what to do, and what makes it happen.
 //!
 //! What is stored is the next due time rather than a running timer, so a
 //! schedule survives a restart. Nothing has to be held in memory for a routine
 //! to fire tomorrow.
+//!
+//! Not every routine waits on a clock. A [`Trigger`] is either a [`Cadence`],
+//! which owns a moment and is what the scheduler sweeps for, or an
+//! [`EventTrigger`], which owns nothing and waits to be told. The second kind
+//! has no next moment, which is why the moment is an `Option` here and nullable
+//! in SQLite: a routine waiting on Stripe with a slot in it would either fire
+//! on the clock or need a sentinel, and a sentinel is a date the operator would
+//! eventually be shown.
 
 use chrono::{
     DateTime, Datelike, Duration, Local, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Weekday,
@@ -17,21 +25,32 @@ use super::ids::{AgentId, RoutineId, RunId};
 
 /// What makes a routine fire.
 ///
-/// Today every one of these is a clock, which is why the wire form is a string
-/// and not a number: the trigger an operator will eventually want is "when a
-/// Linear issue is assigned to me", and that has to be a new value in this
-/// column rather than a new column.
+/// One string, on the wire and in the database both, which is why this has a
+/// hand-written `Serialize`. A derived one would give the webview a tagged
+/// object and SQLite a string for the same fact, and the two would drift the
+/// first time either gained a variant.
+///
+/// The string is also what makes a new kind of trigger a new value rather than
+/// a new column: `every:3600` and `event:stripe/invoice.payment_failed` are
+/// both one `fires` column and one `trigger` field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Trigger {
+    /// A moment, or a repeat of them. The scheduler owns these.
+    Clock(Cadence),
+    /// Something happening in a service the group is connected to. No moment:
+    /// it waits.
+    Event(EventTrigger),
+}
+
+/// A repeat on the clock.
 ///
 /// `Daily`, `Weekly` and `Monthly` are deliberately not gaps in seconds even
 /// though two of them nearly are. A day is 23 or 25 hours twice a year, and a
 /// month is four different lengths, so a routine stored as a gap wanders off
-/// the hour it was set for. What is stored is the shape of the repeat; the
-/// hour it happens at comes from `next_run_at`.
-/// One string, on the wire and in the database both. A derived form would give
-/// the webview a tagged object and SQLite a string for the same fact, and the
-/// two would drift the first time either gained a variant.
+/// the hour it was set for. What is stored is the shape of the repeat; the hour
+/// it happens at comes from the slot it is holding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Trigger {
+pub enum Cadence {
     /// Fires once and is done.
     Once,
     /// A fixed gap, in seconds. What the agent's own `schedule` tool sets, and
@@ -47,54 +66,121 @@ pub enum Trigger {
     Monthly,
 }
 
-impl Trigger {
-    /// The stored form. Parsed back by [`Trigger::parse`].
+/// Something happening somewhere else.
+///
+/// `service` names a connector the group holds and `topic` is that service's
+/// own word for what happened, verbatim: `stripe` and
+/// `invoice.payment_failed`. Both are identifiers rather than prose, which is
+/// what [`EventTrigger::parse`] enforces, and the service is lowered so the
+/// stored form is canonical: one routine per event, not one per spelling.
+///
+/// **Nothing delivers one of these yet.** There is no event source, so a
+/// routine triggered this way fires only when the operator presses Test run.
+/// What exists is the shape: it stores, it reads back, it is described, it
+/// keeps a history, and the scheduler leaves it alone. What is missing is the
+/// half that cannot be written without a service to receive from: a webhook or
+/// a poll that turns an arriving event into `Runtime::send_from_routine`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventTrigger {
+    pub service: String,
+    pub topic: String,
+}
+
+/// A service name longer than this is prose. Matches `connector::MAX_SERVICE_LEN`,
+/// because this names one of those.
+pub const MAX_EVENT_SERVICE_LEN: usize = 48;
+/// Vendors' event names are long: `customer.subscription.pending_update_expired`.
+pub const MAX_EVENT_TOPIC_LEN: usize = 120;
+
+impl EventTrigger {
+    /// What marks an event out from a cadence in the stored form.
+    pub const PREFIX: &'static str = "event:";
+
+    /// Reads `stripe/invoice.payment_failed`, the part after the prefix.
+    ///
+    /// Split at the first slash only: a service's own topic names can contain
+    /// more of them, and the service is the half this has to be sure of.
+    pub fn parse(rest: &str) -> Option<Self> {
+        let (service, topic) = rest.trim().split_once('/')?;
+        let service = service.trim().to_lowercase();
+        let topic = topic.trim().to_string();
+        let sound = |part: &str, max: usize| {
+            !part.is_empty() && part.chars().count() <= max && !part.contains(char::is_whitespace)
+        };
+        if !sound(&service, MAX_EVENT_SERVICE_LEN) || !sound(&topic, MAX_EVENT_TOPIC_LEN) {
+            return None;
+        }
+        Some(EventTrigger { service, topic })
+    }
+
+    pub fn as_str(&self) -> String {
+        format!("{}{}/{}", Self::PREFIX, self.service, self.topic)
+    }
+
+    /// How it reads to whoever set it: `when Stripe reports invoice.paid`.
+    pub fn describe(&self) -> String {
+        format!("when {} reports {}", titled(&self.service), self.topic)
+    }
+}
+
+/// `stripe` as `Stripe`. The service is stored lowered so it can be matched;
+/// it is shown the way the operator wrote it down.
+fn titled(service: &str) -> String {
+    let mut chars = service.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+impl Cadence {
+    /// The stored form. Parsed back by [`Cadence::parse`].
     pub fn as_str(&self) -> String {
         match self {
-            Trigger::Once => "once".to_string(),
-            Trigger::Every(secs) => format!("every:{secs}"),
-            Trigger::Daily => "daily".to_string(),
-            Trigger::Weekdays => "weekdays".to_string(),
-            Trigger::Weekly => "weekly".to_string(),
-            Trigger::Monthly => "monthly".to_string(),
+            Cadence::Once => "once".to_string(),
+            Cadence::Every(secs) => format!("every:{secs}"),
+            Cadence::Daily => "daily".to_string(),
+            Cadence::Weekdays => "weekdays".to_string(),
+            Cadence::Weekly => "weekly".to_string(),
+            Cadence::Monthly => "monthly".to_string(),
         }
     }
 
     pub fn parse(value: &str) -> Option<Self> {
         match value.trim() {
-            "once" => Some(Trigger::Once),
-            "daily" => Some(Trigger::Daily),
-            "weekdays" => Some(Trigger::Weekdays),
-            "weekly" => Some(Trigger::Weekly),
-            "monthly" => Some(Trigger::Monthly),
-            other => other.strip_prefix("every:")?.parse().ok().map(Trigger::Every),
+            "once" => Some(Cadence::Once),
+            "daily" => Some(Cadence::Daily),
+            "weekdays" => Some(Cadence::Weekdays),
+            "weekly" => Some(Cadence::Weekly),
+            "monthly" => Some(Cadence::Monthly),
+            other => other.strip_prefix("every:")?.parse().ok().map(Cadence::Every),
         }
     }
 
     pub fn repeats(&self) -> bool {
-        !matches!(self, Trigger::Once)
+        !matches!(self, Cadence::Once)
     }
 
     /// How it reads to whoever set it.
     pub fn describe(&self) -> String {
         match self {
-            Trigger::Once => "once".to_string(),
-            Trigger::Every(secs) => format!("every {}", human_gap(*secs)),
-            Trigger::Daily => "every day".to_string(),
-            Trigger::Weekdays => "every weekday".to_string(),
-            Trigger::Weekly => "every week".to_string(),
-            Trigger::Monthly => "every month".to_string(),
+            Cadence::Once => "once".to_string(),
+            Cadence::Every(secs) => format!("every {}", human_gap(*secs)),
+            Cadence::Daily => "every day".to_string(),
+            Cadence::Weekdays => "every weekday".to_string(),
+            Cadence::Weekly => "every week".to_string(),
+            Cadence::Monthly => "every month".to_string(),
         }
     }
 
-    /// Whether a moment is one this trigger would ever fire on.
+    /// Whether a moment is one this cadence would ever fire on.
     ///
     /// Only weekdays can say no. It exists so a first run the operator asked
     /// for on a Saturday moves to Monday instead of firing on a day the
     /// routine says it never runs.
     pub fn accepts(&self, at: i64) -> bool {
         match self {
-            Trigger::Weekdays => match local(at) {
+            Cadence::Weekdays => match local(at) {
                 Some(when) => !is_weekend(when.date_naive()),
                 None => false,
             },
@@ -110,11 +196,11 @@ impl Trigger {
     /// up. `None` means it is finished and the row goes.
     pub fn next_after(&self, slot: i64, now: i64) -> Option<i64> {
         match self {
-            Trigger::Once => None,
+            Cadence::Once => None,
             // A gap is counted from when it ran rather than from when it was
             // due, for the same no-catch-up reason. There is no hour to hold
             // on to here, so there is nothing to anchor to.
-            Trigger::Every(secs) => Some(now + i64::from(*secs) * 1000),
+            Cadence::Every(secs) => Some(now + i64::from(*secs) * 1000),
             _ => self.next_calendar_slot(slot, now),
         }
     }
@@ -123,16 +209,16 @@ impl Trigger {
     ///
     /// A repeat with no stated start waits one whole interval, which is what
     /// "every weekday" means to the person who said it: not now and then every
-    /// weekday. A stated start is honoured, except on a day this trigger never
+    /// weekday. A stated start is honoured, except on a day this cadence never
     /// fires on.
     pub fn first_run(&self, now: i64, in_secs: Option<u32>) -> i64 {
         let asked = in_secs.map(|delay| now + i64::from(delay) * 1000);
         match (self, asked) {
-            (Trigger::Once, _) => asked.unwrap_or(now),
+            (Cadence::Once, _) => asked.unwrap_or(now),
             (_, Some(at)) if self.accepts(at) => at,
-            (Trigger::Every(secs), None) => now + i64::from(*secs) * 1000,
+            (Cadence::Every(secs), None) => now + i64::from(*secs) * 1000,
             // A start on a day this never fires on, or none at all: the anchor
-            // keeps the hour and the trigger picks the day.
+            // keeps the hour and the cadence picks the day.
             (_, asked) => {
                 let anchor = asked.unwrap_or(now);
                 self.next_after(anchor, now).unwrap_or(anchor)
@@ -158,19 +244,72 @@ impl Trigger {
         None
     }
 
-    /// The `n`th date this trigger fires on after `anchor`.
+    /// The `n`th date this cadence fires on after `anchor`.
     ///
     /// Counted from the anchor every time rather than from the previous answer,
     /// so a monthly routine set on the 31st is the 28th in February and the
     /// 31st again in March instead of walking backwards down the calendar.
     fn nth_date(&self, anchor: NaiveDate, n: i64) -> Option<NaiveDate> {
         match self {
-            Trigger::Daily => anchor.checked_add_signed(Duration::days(n)),
-            Trigger::Weekly => anchor.checked_add_signed(Duration::days(n * 7)),
-            Trigger::Weekdays => nth_weekday_after(anchor, n),
-            Trigger::Monthly => months_after(anchor, n),
-            Trigger::Once | Trigger::Every(_) => None,
+            Cadence::Daily => anchor.checked_add_signed(Duration::days(n)),
+            Cadence::Weekly => anchor.checked_add_signed(Duration::days(n * 7)),
+            Cadence::Weekdays => nth_weekday_after(anchor, n),
+            Cadence::Monthly => months_after(anchor, n),
+            Cadence::Once | Cadence::Every(_) => None,
         }
+    }
+}
+
+impl Trigger {
+    /// The stored form. Parsed back by [`Trigger::parse`].
+    pub fn as_str(&self) -> String {
+        match self {
+            Trigger::Clock(cadence) => cadence.as_str(),
+            Trigger::Event(event) => event.as_str(),
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        let value = value.trim();
+        match value.strip_prefix(EventTrigger::PREFIX) {
+            Some(rest) => EventTrigger::parse(rest).map(Trigger::Event),
+            None => Cadence::parse(value).map(Trigger::Clock),
+        }
+    }
+
+    /// The cadence, when this is one. `None` is a trigger the scheduler has no
+    /// business looking at.
+    pub fn cadence(&self) -> Option<Cadence> {
+        match self {
+            Trigger::Clock(cadence) => Some(*cadence),
+            Trigger::Event(_) => None,
+        }
+    }
+
+    /// Whether this fires more than once.
+    ///
+    /// An event trigger does: it fires every time the thing it names happens,
+    /// which is exactly why it must not be deleted after one firing the way a
+    /// one-shot is.
+    pub fn repeats(&self) -> bool {
+        match self {
+            Trigger::Clock(cadence) => cadence.repeats(),
+            Trigger::Event(_) => true,
+        }
+    }
+
+    /// How it reads to whoever set it.
+    pub fn describe(&self) -> String {
+        match self {
+            Trigger::Clock(cadence) => cadence.describe(),
+            Trigger::Event(event) => event.describe(),
+        }
+    }
+
+    /// When a routine just set should first fire, or `None` when it does not
+    /// wait on the clock at all.
+    pub fn first_run(&self, now: i64, in_secs: Option<u32>) -> Option<i64> {
+        self.cadence().map(|cadence| cadence.first_run(now, in_secs))
     }
 }
 
@@ -264,9 +403,31 @@ pub struct Routine {
     /// survive being switched off, which is what makes it different from
     /// deleting the thing.
     pub active: bool,
-    pub next_run_at: i64,
+    /// The moment it is next due, for a routine that waits on the clock.
+    ///
+    /// `None` is a routine that does not: an event trigger fires when its event
+    /// arrives and holds no slot in the meantime. The scheduler asks for slots
+    /// at or before now, so an empty one is never due, and that is the whole
+    /// mechanism keeping event triggers out of the sweep.
+    pub next_run_at: Option<i64>,
     pub last_run_at: Option<i64>,
     pub created_at: i64,
+}
+
+/// What becomes of a routine's slot once it has fired.
+///
+/// Three answers rather than an `Option<i64>`, because "nothing on the clock"
+/// and "finished" mean opposite things to the row: one keeps it and one deletes
+/// it, and reading them off the same `None` deleted every event routine the
+/// first time it fired.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NextSlot {
+    /// Due again at this moment.
+    Due(i64),
+    /// Holding no slot, and still standing.
+    Waiting,
+    /// Done. The row goes.
+    Done,
 }
 
 /// Why a routine ran.
@@ -305,12 +466,16 @@ impl Serialize for RunKind {
 ///
 /// `run_id` is the thread back to everything else the firing produced: the
 /// messages in the channel and the model calls on the bill are filed under it.
+/// `spent` is the second of those, read back at the same time, because "did
+/// Tuesday's sweep actually do anything" is answered by whether the firing
+/// bought any model calls and not by the fact that it was delivered.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RoutineRun {
     pub run_id: RunId,
     pub kind: RunKind,
     pub at: i64,
+    pub spent: super::usage::Tokens,
 }
 
 impl Routine {
@@ -327,14 +492,27 @@ impl Routine {
         }
     }
 
-    /// When this should next fire, given that it just ran at `now`.
-    pub fn after_running(&self, now: i64) -> Option<i64> {
-        self.trigger.next_after(self.next_run_at, now)
+    /// What happens to its slot, given that it just ran at `now`.
+    pub fn after_running(&self, now: i64) -> NextSlot {
+        match self.trigger.cadence() {
+            // A clock routine always holds a slot. An empty one would be a row
+            // written by something that did not know that, and `now` is the
+            // reading that keeps the cadence's own hour closest to true.
+            Some(cadence) => match cadence.next_after(self.next_run_at.unwrap_or(now), now) {
+                Some(next) => NextSlot::Due(next),
+                None => NextSlot::Done,
+            },
+            None => NextSlot::Waiting,
+        }
     }
 
     /// How it reads back to the agent that set it.
     pub fn describe(&self) -> String {
-        format!("{}, next {}", self.trigger.describe(), when(self.next_run_at))
+        match self.next_run_at {
+            Some(at) => format!("{}, next {}", self.trigger.describe(), when(at)),
+            // Nothing to promise: it happens when the event does.
+            None => self.trigger.describe(),
+        }
     }
 }
 
@@ -392,13 +570,15 @@ pub enum RoutineError {
     TooOften { got: u32 },
     #[error("that is further ahead than this can schedule")]
     TooFar,
+    #[error("an event trigger has no start time: it fires when {service} reports {topic}")]
+    EventHasNoStart { service: String, topic: String },
 }
 
 /// Checks what was asked for before it becomes a row.
 pub fn validate(
     name: &str,
     what: &str,
-    trigger: Trigger,
+    trigger: &Trigger,
     in_secs: Option<u32>,
 ) -> Result<(), RoutineError> {
     if what.trim().is_empty() {
@@ -407,13 +587,25 @@ pub fn validate(
     if name.trim().chars().count() > MAX_NAME_LEN {
         return Err(RoutineError::NameTooLong);
     }
-    if let Trigger::Every(every) = trigger {
-        if every < MIN_EVERY_SECS {
-            return Err(RoutineError::TooOften { got: every });
+    match trigger {
+        Trigger::Clock(Cadence::Every(every)) => {
+            if *every < MIN_EVERY_SECS {
+                return Err(RoutineError::TooOften { got: *every });
+            }
+            if *every > MAX_DELAY_SECS {
+                return Err(RoutineError::TooFar);
+            }
         }
-        if every > MAX_DELAY_SECS {
-            return Err(RoutineError::TooFar);
+        // A delay is a statement about a clock, so asking for one here is a
+        // misunderstanding worth naming rather than a field to drop silently:
+        // whoever sent it thinks they have scheduled something.
+        Trigger::Event(event) if in_secs.is_some() => {
+            return Err(RoutineError::EventHasNoStart {
+                service: titled(&event.service),
+                topic: event.topic.clone(),
+            })
         }
+        _ => {}
     }
     if in_secs.is_some_and(|delay| delay > MAX_DELAY_SECS) {
         return Err(RoutineError::TooFar);
@@ -424,6 +616,7 @@ pub fn validate(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::usage::Tokens;
     use chrono::NaiveTime;
 
     /// A local wall-clock moment, as a timestamp. Every calendar assertion in
@@ -435,7 +628,15 @@ mod tests {
         instant(date.and_time(time)).unwrap()
     }
 
-    fn routine(trigger: Trigger, next_run_at: i64) -> Routine {
+    fn clock(cadence: Cadence) -> Trigger {
+        Trigger::Clock(cadence)
+    }
+
+    fn event(service: &str, topic: &str) -> Trigger {
+        Trigger::Event(EventTrigger { service: service.into(), topic: topic.into() })
+    }
+
+    fn routine(trigger: Trigger, next_run_at: Option<i64>) -> Routine {
         Routine {
             id: RoutineId::new(),
             agent_id: AgentId::new(),
@@ -462,15 +663,17 @@ mod tests {
     #[test]
     fn a_trigger_survives_the_round_trip_through_its_stored_form() {
         for trigger in [
-            Trigger::Once,
-            Trigger::Every(3600),
-            Trigger::Every(18_000),
-            Trigger::Daily,
-            Trigger::Weekdays,
-            Trigger::Weekly,
-            Trigger::Monthly,
+            clock(Cadence::Once),
+            clock(Cadence::Every(3600)),
+            clock(Cadence::Every(18_000)),
+            clock(Cadence::Daily),
+            clock(Cadence::Weekdays),
+            clock(Cadence::Weekly),
+            clock(Cadence::Monthly),
+            event("stripe", "invoice.payment_failed"),
+            event("linear", "issue.assigned"),
         ] {
-            assert_eq!(Trigger::parse(&trigger.as_str()), Some(trigger), "{trigger:?}");
+            assert_eq!(Trigger::parse(&trigger.as_str()), Some(trigger.clone()), "{trigger:?}");
         }
         assert_eq!(Trigger::parse("nonsense"), None);
         assert_eq!(Trigger::parse("every:"), None);
@@ -478,37 +681,93 @@ mod tests {
     }
 
     #[test]
+    fn an_event_is_two_identifiers_and_is_refused_when_it_is_not() {
+        // The stored form is a key: a future event source will look a routine
+        // up by it. Prose in either half is a routine nothing will ever match.
+        assert_eq!(
+            Trigger::parse("event:Stripe/invoice.paid"),
+            Some(event("stripe", "invoice.paid")),
+            "the service is lowered, so one event is not two routines"
+        );
+        // The topic is the vendor's identifier and is kept exactly.
+        assert_eq!(
+            Trigger::parse("event:github/Issues.Opened"),
+            Some(event("github", "Issues.Opened"))
+        );
+        // A topic of its own may carry slashes; the service may not.
+        assert_eq!(
+            Trigger::parse("event:hubspot/deal/stage.changed"),
+            Some(event("hubspot", "deal/stage.changed"))
+        );
+
+        assert_eq!(Trigger::parse("event:stripe"), None, "an event needs a topic");
+        assert_eq!(Trigger::parse("event:/invoice.paid"), None, "and a service");
+        assert_eq!(Trigger::parse("event:stripe/"), None);
+        assert_eq!(Trigger::parse("event:stripe/an invoice failed"), None, "not a sentence");
+        assert_eq!(Trigger::parse(&format!("event:{}/x", "s".repeat(49))), None, "not a paragraph");
+    }
+
+    #[test]
     fn a_trigger_crosses_the_ipc_boundary_as_the_string_it_is_stored_as() {
         // The webview and SQLite have to be reading the same thing. A derived
         // enum would hand the webview `{"kind":"every","secs":3600}` and the
         // database `every:3600`, and the frontend parses neither by accident.
-        let routine = routine(Trigger::Every(3600), 0);
-        let json = serde_json::to_value(&routine).unwrap();
+        let hourly = routine(clock(Cadence::Every(3600)), Some(0));
+        let json = serde_json::to_value(&hourly).unwrap();
         assert_eq!(json["trigger"], serde_json::json!("every:3600"));
 
-        let weekdays = serde_json::to_value(Trigger::Weekdays).unwrap();
+        let weekdays = serde_json::to_value(clock(Cadence::Weekdays)).unwrap();
         assert_eq!(weekdays, serde_json::json!("weekdays"));
         assert_eq!(
             serde_json::from_value::<Trigger>(serde_json::json!("monthly")).unwrap(),
-            Trigger::Monthly
+            clock(Cadence::Monthly)
         );
+
+        // An event trigger is one string too, and the routine holding one says
+        // plainly that it has no next firing rather than inventing a date.
+        let waiting = routine(event("stripe", "invoice.payment_failed"), None);
+        let json = serde_json::to_value(&waiting).unwrap();
+        assert_eq!(json["trigger"], serde_json::json!("event:stripe/invoice.payment_failed"));
+        assert_eq!(json["nextRunAt"], serde_json::Value::Null);
+
         // And a value this build does not know is refused rather than guessed.
         assert!(serde_json::from_value::<Trigger>(serde_json::json!("fortnightly")).is_err());
+        assert!(serde_json::from_value::<Trigger>(serde_json::json!("event:stripe")).is_err());
+    }
+
+    #[test]
+    fn an_event_routine_holds_no_slot_and_is_not_finished_by_firing() {
+        // Both halves matter. Nothing on the clock keeps it out of the
+        // scheduler's sweep; not being finished keeps it from being deleted
+        // like a one-shot the first time it fires.
+        let trigger = event("stripe", "invoice.payment_failed");
+        assert_eq!(trigger.cadence(), None);
+        assert_eq!(trigger.first_run(1_000, None), None);
+        assert_eq!(trigger.first_run(1_000, Some(60)), None, "a delay does not give it a slot");
+        assert!(trigger.repeats(), "it fires every time the event happens");
+
+        let waiting = routine(trigger, None);
+        assert_eq!(waiting.after_running(5_000), NextSlot::Waiting);
+        assert_eq!(
+            waiting.describe(),
+            "when Stripe reports invoice.payment_failed",
+            "and it promises no next firing, because it does not have one"
+        );
     }
 
     #[test]
     fn a_repeat_is_counted_from_when_it_ran_not_from_when_it_was_due() {
         // A machine asleep through three slots must not wake and fire three
         // times to catch up.
-        let routine = routine(Trigger::Every(3600), 1_000);
-        assert_eq!(routine.after_running(10_000_000), Some(10_000_000 + 3_600_000));
+        let routine = routine(clock(Cadence::Every(3600)), Some(1_000));
+        assert_eq!(routine.after_running(10_000_000), NextSlot::Due(10_000_000 + 3_600_000));
     }
 
     #[test]
     fn a_one_shot_has_no_next_time() {
-        let routine = routine(Trigger::Once, 1_000);
+        let routine = routine(clock(Cadence::Once), Some(1_000));
         assert!(!routine.repeats());
-        assert_eq!(routine.after_running(5_000), None);
+        assert_eq!(routine.after_running(5_000), NextSlot::Done);
     }
 
     #[test]
@@ -516,9 +775,9 @@ mod tests {
         // 2025-03-09 is when the US springs forward. A day counted in seconds
         // would move a 9am routine to 10am and leave it there.
         let slot = at(2025, 3, 8, 9, 0);
-        let next = Trigger::Daily.next_after(slot, slot + 1000).unwrap();
+        let next = Cadence::Daily.next_after(slot, slot + 1000).unwrap();
         assert_eq!(next, at(2025, 3, 9, 9, 0));
-        let after = Trigger::Daily.next_after(next, next + 1000).unwrap();
+        let after = Cadence::Daily.next_after(next, next + 1000).unwrap();
         assert_eq!(after, at(2025, 3, 10, 9, 0));
     }
 
@@ -526,12 +785,12 @@ mod tests {
     fn weekdays_skip_the_weekend_and_land_on_monday() {
         // 2025-01-03 is a Friday.
         let friday = at(2025, 1, 3, 9, 0);
-        let next = Trigger::Weekdays.next_after(friday, friday + 1000).unwrap();
+        let next = Cadence::Weekdays.next_after(friday, friday + 1000).unwrap();
         assert_eq!(next, at(2025, 1, 6, 9, 0), "Friday's next weekday is Monday");
 
         let monday = at(2025, 1, 6, 9, 0);
         assert_eq!(
-            Trigger::Weekdays.next_after(monday, monday + 1000).unwrap(),
+            Cadence::Weekdays.next_after(monday, monday + 1000).unwrap(),
             at(2025, 1, 7, 9, 0)
         );
     }
@@ -543,7 +802,7 @@ mod tests {
         let friday = at(2025, 1, 3, 9, 0);
         let monday_afternoon = at(2025, 1, 6, 15, 0);
         assert_eq!(
-            Trigger::Weekdays.next_after(friday, monday_afternoon).unwrap(),
+            Cadence::Weekdays.next_after(friday, monday_afternoon).unwrap(),
             at(2025, 1, 7, 9, 0)
         );
     }
@@ -551,7 +810,7 @@ mod tests {
     #[test]
     fn a_weekly_routine_stays_on_its_weekday() {
         let thursday = at(2025, 1, 2, 14, 30);
-        let next = Trigger::Weekly.next_after(thursday, thursday + 1000).unwrap();
+        let next = Cadence::Weekly.next_after(thursday, thursday + 1000).unwrap();
         assert_eq!(next, at(2025, 1, 9, 14, 30));
     }
 
@@ -560,16 +819,16 @@ mod tests {
         // Clamping without re-anchoring turns the 31st into the 28th and then
         // keeps it there for the rest of the year.
         let jan = at(2025, 1, 31, 8, 0);
-        let feb = Trigger::Monthly.next_after(jan, jan + 1000).unwrap();
+        let feb = Cadence::Monthly.next_after(jan, jan + 1000).unwrap();
         assert_eq!(feb, at(2025, 2, 28, 8, 0), "February has no 31st");
-        let mar = Trigger::Monthly.next_after(jan, feb + 1000).unwrap();
+        let mar = Cadence::Monthly.next_after(jan, feb + 1000).unwrap();
         assert_eq!(mar, at(2025, 3, 31, 8, 0), "March does, so it is the 31st again");
     }
 
     #[test]
     fn a_monthly_routine_crosses_the_year() {
         let dec = at(2025, 12, 15, 10, 0);
-        assert_eq!(Trigger::Monthly.next_after(dec, dec + 1000).unwrap(), at(2026, 1, 15, 10, 0));
+        assert_eq!(Cadence::Monthly.next_after(dec, dec + 1000).unwrap(), at(2026, 1, 15, 10, 0));
     }
 
     #[test]
@@ -578,16 +837,16 @@ mod tests {
         // machine left switched off can produce.
         let long_ago = at(2015, 1, 5, 9, 0);
         let now = at(2025, 6, 10, 12, 0);
-        let next = Trigger::Daily.next_after(long_ago, now).unwrap();
+        let next = Cadence::Daily.next_after(long_ago, now).unwrap();
         assert_eq!(next, at(2025, 6, 11, 9, 0));
     }
 
     #[test]
     fn a_repeat_with_no_stated_start_waits_a_whole_interval() {
         let now = at(2025, 1, 2, 9, 0);
-        assert_eq!(Trigger::Every(3600).first_run(now, None), now + 3_600_000);
-        assert_eq!(Trigger::Daily.first_run(now, None), at(2025, 1, 3, 9, 0));
-        assert_eq!(Trigger::Once.first_run(now, None), now, "a one-shot with no delay is now");
+        assert_eq!(Cadence::Every(3600).first_run(now, None), now + 3_600_000);
+        assert_eq!(Cadence::Daily.first_run(now, None), at(2025, 1, 3, 9, 0));
+        assert_eq!(Cadence::Once.first_run(now, None), now, "a one-shot with no delay is now");
     }
 
     #[test]
@@ -598,17 +857,33 @@ mod tests {
         let friday = at(2025, 1, 3, 12, 0);
         let saturday = at(2025, 1, 4, 9, 0);
         let delay = ((saturday - friday) / 1000) as u32;
-        assert_eq!(Trigger::Weekdays.first_run(friday, Some(delay)), at(2025, 1, 6, 9, 0));
+        assert_eq!(Cadence::Weekdays.first_run(friday, Some(delay)), at(2025, 1, 6, 9, 0));
 
         // A weekday start is left exactly where it was asked for.
         let monday = at(2025, 1, 6, 9, 0);
         let to_monday = ((monday - friday) / 1000) as u32;
-        assert_eq!(Trigger::Weekdays.first_run(friday, Some(to_monday)), monday);
+        assert_eq!(Cadence::Weekdays.first_run(friday, Some(to_monday)), monday);
+    }
+
+    #[test]
+    fn a_stated_start_picks_the_weekday_a_weekly_routine_keeps() {
+        // The operator says "every week, Thursday at 9" by asking for the first
+        // firing on a Thursday at 9. Nothing else in the row records the day,
+        // so a start that was quietly moved would change the cadence itself.
+        let monday = at(2025, 6, 9, 12, 0);
+        let thursday = at(2025, 6, 12, 9, 0);
+        let delay = ((thursday - monday) / 1000) as u32;
+        assert_eq!(Cadence::Weekly.first_run(monday, Some(delay)), thursday);
+        assert_eq!(
+            Cadence::Weekly.next_after(thursday, thursday + 1000).unwrap(),
+            at(2025, 6, 19, 9, 0),
+            "and it stays on that Thursday"
+        );
     }
 
     #[test]
     fn a_routine_without_a_name_is_titled_by_what_it_does() {
-        let mut r = routine(Trigger::Daily, 0);
+        let mut r = routine(clock(Cadence::Daily), Some(0));
         r.what = "check the listings".into();
         assert_eq!(r.title(), "check the listings");
         r.name = "  ".into();
@@ -619,19 +894,51 @@ mod tests {
 
     #[test]
     fn a_routine_that_does_nothing_or_runs_constantly_is_refused() {
-        assert_eq!(validate("", "  ", Trigger::Daily, None), Err(RoutineError::Empty));
+        assert_eq!(validate("", "  ", &clock(Cadence::Daily), None), Err(RoutineError::Empty));
         assert_eq!(
-            validate("", "x", Trigger::Every(5), None),
+            validate("", "x", &clock(Cadence::Every(5)), None),
             Err(RoutineError::TooOften { got: 5 })
         );
         assert_eq!(
-            validate("", "x", Trigger::Once, Some(MAX_DELAY_SECS + 1)),
+            validate("", "x", &clock(Cadence::Once), Some(MAX_DELAY_SECS + 1)),
             Err(RoutineError::TooFar)
         );
         assert_eq!(
-            validate(&"n".repeat(MAX_NAME_LEN + 1), "x", Trigger::Daily, None),
+            validate(&"n".repeat(MAX_NAME_LEN + 1), "x", &clock(Cadence::Daily), None),
             Err(RoutineError::NameTooLong)
         );
-        assert_eq!(validate("Sweep", "x", Trigger::Every(3600), Some(60)), Ok(()));
+        assert_eq!(validate("Sweep", "x", &clock(Cadence::Every(3600)), Some(60)), Ok(()));
+    }
+
+    #[test]
+    fn a_start_time_on_an_event_trigger_is_refused_rather_than_dropped() {
+        // Silently ignoring it would leave whoever sent it believing they had
+        // scheduled something, and the refusal has to say what will happen
+        // instead: an error an agent reads mid-turn needs a way forward.
+        let trigger = event("stripe", "invoice.payment_failed");
+        let refused = validate("Dunning", "chase it", &trigger, Some(3600)).unwrap_err();
+        assert_eq!(
+            refused.to_string(),
+            "an event trigger has no start time: it fires when Stripe reports \
+             invoice.payment_failed"
+        );
+        assert_eq!(validate("Dunning", "chase it", &trigger, None), Ok(()));
+    }
+
+    #[test]
+    fn a_firing_carries_what_it_spent() {
+        // The history exists to answer "has this been working", and a delivery
+        // that bought no model call is a routine that did not run. Nothing else
+        // in the row distinguishes the two.
+        let run = RoutineRun {
+            run_id: RunId::new(),
+            kind: RunKind::Scheduled,
+            at: 1_000,
+            spent: Tokens { prompt: 900, completion: 100, cost: Some(0.002), calls: 2 },
+        };
+        let json = serde_json::to_value(&run).unwrap();
+        assert_eq!(json["kind"], serde_json::json!("scheduled"));
+        assert_eq!(json["spent"]["calls"], serde_json::json!(2));
+        assert_eq!(json["spent"]["cost"], serde_json::json!(0.002));
     }
 }

--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -14,7 +14,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::domain::envelope::Intent;
-use crate::domain::routine::Trigger;
+use crate::domain::routine::{Cadence, Trigger};
 use crate::llm::openrouter::{ToolCall, ToolSpec};
 
 pub const DIRECTORY: &str = "directory";
@@ -726,15 +726,19 @@ pub fn parse(call: &ToolCall) -> Result<ToolInvocation, ToolParseError> {
                     // A named repeat beats a gap in seconds when both arrive:
                     // it is the more specific of the two, and a model that
                     // sends "weekdays" alongside 86400 means the weekdays.
+                    //
+                    // Read as a cadence rather than as any trigger: this tool
+                    // sets a clock, and a model that improvised `event:...`
+                    // here would be handed a routine nothing can fire.
                     let trigger = match (repeat, every, delay) {
-                        (Some(named), _, _) => Trigger::parse(named).ok_or_else(|| {
-                            ToolParseError::IncompleteSchedule {
+                        (Some(named), _, _) => Cadence::parse(named)
+                            .map(Trigger::Clock)
+                            .ok_or_else(|| ToolParseError::IncompleteSchedule {
                                 needs: "`repeat` to be one of daily, weekdays, weekly or monthly"
                                     .to_string(),
-                            }
-                        })?,
-                        (None, Some(gap), _) => Trigger::Every(gap),
-                        (None, None, Some(_)) => Trigger::Once,
+                            })?,
+                        (None, Some(gap), _) => Trigger::Clock(Cadence::Every(gap)),
+                        (None, None, Some(_)) => Trigger::Clock(Cadence::Once),
                         (None, None, None) => {
                             return Err(ToolParseError::IncompleteSchedule {
                                 needs: "`repeat` or `every_secs` to keep doing it, or `in_secs` \
@@ -1144,7 +1148,7 @@ mod tests {
                 action: ScheduleAction::Add {
                     name: String::new(),
                     what: "check".into(),
-                    trigger: Trigger::Every(18000),
+                    trigger: Trigger::Clock(Cadence::Every(18000)),
                     in_secs: None
                 }
             })
@@ -1166,7 +1170,7 @@ mod tests {
                 action: ScheduleAction::Add {
                     name: "Standup".into(),
                     what: "check".into(),
-                    trigger: Trigger::Weekdays,
+                    trigger: Trigger::Clock(Cadence::Weekdays),
                     in_secs: None
                 }
             })
@@ -1194,7 +1198,7 @@ mod tests {
                 action: ScheduleAction::Add {
                     name: String::new(),
                     what: "wake me".into(),
-                    trigger: Trigger::Once,
+                    trigger: Trigger::Clock(Cadence::Once),
                     in_secs: Some(3600)
                 }
             })

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -900,7 +900,14 @@ impl Runtime {
     /// shows plainly that a schedule fired and nobody typed anything, while
     /// still carrying operator authority: the agent set this for itself, or was
     /// told to.
-    pub fn send_from_routine(&self, to: AgentId, text: &str) -> Result<RunId, RuntimeError> {
+    ///
+    /// Carried as [`Part::Routine`] rather than as text. The model reads the
+    /// same instruction either way; what the part buys is a transcript that
+    /// says a routine fired in one line the operator can open, instead of
+    /// several sentences of system prompting drawn as though somebody had
+    /// typed them into the conversation.
+    pub fn send_from_routine(&self, routine: &Routine) -> Result<RunId, RuntimeError> {
+        let to = routine.agent_id;
         let card = self.inner.store.get_agent(to)?.ok_or(RuntimeError::UnknownAgent(to))?;
         if card.lifecycle != Lifecycle::Active {
             return Err(RuntimeError::AgentTerminated(card.name));
@@ -913,7 +920,11 @@ impl Runtime {
             channel_id: to,
             from: Participant::System,
             to: Participant::Agent { id: to },
-            parts: vec![Part::text(text.trim())],
+            parts: vec![Part::Routine {
+                routine_id: routine.id,
+                name: routine.name.clone(),
+                what: routine.what.trim().to_string(),
+            }],
             trust: Trust::Operator,
             hop: 0,
             expects_reply: true,
@@ -934,7 +945,7 @@ impl Runtime {
     /// not move `next_run_at` or delete a one-shot: testing a routine must not
     /// be a way to spend the only firing it had.
     pub fn test_routine(&self, routine: &Routine) -> Result<RunId, RuntimeError> {
-        let run = self.send_from_routine(routine.agent_id, &routine.what)?;
+        let run = self.send_from_routine(routine)?;
         self.log_routine_run(routine, run, RunKind::Test, now_ms());
         Ok(run)
     }
@@ -980,10 +991,11 @@ impl Runtime {
 
                     tracing::info!(
                         agent = %routine.agent_id.short(),
+                        trigger = %routine.trigger.as_str(),
                         repeats = routine.repeats(),
                         "a routine came due"
                     );
-                    match runtime.send_from_routine(routine.agent_id, &routine.what) {
+                    match runtime.send_from_routine(&routine) {
                         Ok(run) => runtime.log_routine_run(&routine, run, RunKind::Scheduled, now),
                         Err(err) => tracing::warn!(%err, "a routine could not be delivered"),
                     }
@@ -2932,7 +2944,7 @@ impl Runtime {
             }
 
             tools::ScheduleAction::Add { name, what, trigger, in_secs } => {
-                if let Err(err) = validate(name, what, *trigger, *in_secs) {
+                if let Err(err) = validate(name, what, trigger, *in_secs) {
                     return Ok(format!(
                         "Refused: {err}. The shortest repeat is {}.",
                         human_gap(MIN_EVERY_SECS)
@@ -2941,7 +2953,7 @@ impl Runtime {
 
                 let first = trigger.first_run(now_ms(), *in_secs);
                 let routine =
-                    self.inner.store.create_routine(card.id, name, what, *trigger, first)?;
+                    self.inner.store.create_routine(card.id, name, what, trigger.clone(), first)?;
 
                 Ok(format!(
                     "Scheduled: {} ({}). Its id is {}.",

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -24,7 +24,7 @@ use guac_lib::domain::connector::CleanConnector;
 use guac_lib::domain::envelope::{Part, Participant};
 use guac_lib::domain::group::CleanGroup;
 use guac_lib::domain::now_ms;
-use guac_lib::domain::routine::{RunKind, Trigger};
+use guac_lib::domain::routine::{Cadence, RunKind, Trigger};
 use guac_lib::domain::signin::Signin;
 use guac_lib::llm::openrouter::LlmClient;
 use guac_lib::runtime::events::{Activity, RecordingSink, UiEvent};
@@ -1332,8 +1332,8 @@ async fn a_routine_that_is_due_wakes_its_agent() {
             h.id("Watcher"),
             "Listings sweep",
             "check the listings",
-            Trigger::Every(3600),
-            now_ms() - 1000,
+            Trigger::Clock(Cadence::Every(3600)),
+            Some(now_ms() - 1000),
         )
         .unwrap();
 
@@ -1347,7 +1347,7 @@ async fn a_routine_that_is_due_wakes_its_agent() {
     let routines = h.runtime.store().agent_routines(h.id("Watcher")).unwrap();
     assert_eq!(routines.len(), 1, "a repeat must survive its own run");
     assert!(
-        routines[0].next_run_at > now_ms(),
+        routines[0].next_run_at.expect("a clock routine holds a slot") > now_ms(),
         "and must not still be due, or it fires again on the next tick"
     );
     assert!(routines[0].last_run_at.is_some(), "it should record having run");
@@ -1360,7 +1360,13 @@ async fn a_one_off_routine_does_not_come_due_twice() {
 
     h.runtime
         .store()
-        .create_routine(h.id("Sleeper"), "", "wake up", Trigger::Once, now_ms() - 1000)
+        .create_routine(
+            h.id("Sleeper"),
+            "",
+            "wake up",
+            Trigger::Clock(Cadence::Once),
+            Some(now_ms() - 1000),
+        )
         .unwrap();
 
     h.runtime.start_scheduler();
@@ -1372,6 +1378,63 @@ async fn a_one_off_routine_does_not_come_due_twice() {
     assert!(
         h.runtime.store().agent_routines(h.id("Sleeper")).unwrap().is_empty(),
         "a one-off must be gone once it has run, not left with a time in the past"
+    );
+}
+
+#[tokio::test]
+async fn a_fired_routine_reaches_the_model_as_its_instruction_and_the_operator_as_one_line() {
+    // Both halves of the same delivery. The model has to be told exactly what
+    // the routine says, or a schedule does nothing. The operator was being
+    // shown the same several sentences as a chat bubble from Guaca, in the
+    // middle of their own conversation with the agent: the system prompting
+    // their agent, drawn as though somebody had typed it to them.
+    let stub = serve(|_| Script::Say("checked".into())).await;
+    let h = harness(&stub, &["Watcher"], GuardLimits::default());
+
+    let routine = h
+        .runtime
+        .store()
+        .create_routine(
+            h.id("Watcher"),
+            "Listings sweep",
+            "Check the listings and say what is new.",
+            Trigger::Clock(Cadence::Daily),
+            Some(now_ms() + 60_000),
+        )
+        .unwrap();
+
+    let run = h.runtime.test_routine(&routine).unwrap();
+    h.settle(run).await;
+
+    // What the model was sent: the instruction, unchanged.
+    let sent = h.runtime.store().channel_messages(h.id("Watcher"), 20).unwrap();
+    let fired = sent
+        .iter()
+        .find(|m| m.from == Participant::System)
+        .expect("the routine was delivered from the system");
+    assert_eq!(
+        fired.plain_text(),
+        "Check the listings and say what is new.",
+        "the prompt reads a routine's instruction the same way it reads any text"
+    );
+
+    // What the transcript holds: one part naming the routine, and no loose
+    // text for a bubble to draw.
+    match fired.parts.as_slice() {
+        [Part::Routine { routine_id, name, what }] => {
+            assert_eq!(*routine_id, routine.id, "so the operator can open the routine it names");
+            assert_eq!(name, "Listings sweep");
+            assert_eq!(what, "Check the listings and say what is new.");
+        }
+        other => panic!("a fired routine is one routine part, got {other:?}"),
+    }
+
+    // And the agent still did the work, which is the whole point of the change
+    // being only about how it is drawn.
+    assert!(
+        h.channel_texts("Watcher").iter().any(|t| t.contains("checked")),
+        "the routine fired and the agent said nothing:\n{}",
+        h.transcript()
     );
 }
 
@@ -1391,8 +1454,8 @@ async fn testing_a_routine_delivers_it_without_spending_the_schedule() {
             h.id("Watcher"),
             "Sweep",
             "check the listings",
-            Trigger::Once,
-            due_next_week,
+            Trigger::Clock(Cadence::Once),
+            Some(due_next_week),
         )
         .unwrap();
 
@@ -1404,7 +1467,7 @@ async fn testing_a_routine_delivers_it_without_spending_the_schedule() {
 
     let after = h.runtime.store().agent_routines(h.id("Watcher")).unwrap();
     assert_eq!(after.len(), 1, "a one-shot must survive being tested");
-    assert_eq!(after[0].next_run_at, due_next_week, "and must still be due when it was");
+    assert_eq!(after[0].next_run_at, Some(due_next_week), "and must still be due when it was");
     assert!(after[0].last_run_at.is_none(), "a test is not the routine having run");
 
     // It is in the history, marked as the test it was.
@@ -1440,8 +1503,8 @@ async fn a_routine_that_fires_is_work_to_do_rather_than_something_to_note() {
             h.id("Watcher"),
             "Listings sweep",
             "Check the listings and say what is new.",
-            Trigger::Daily,
-            now_ms() - 1000,
+            Trigger::Clock(Cadence::Daily),
+            Some(now_ms() - 1000),
         )
         .unwrap();
 
@@ -1502,8 +1565,8 @@ async fn a_routine_can_hand_its_work_to_the_specialist_it_belongs_to() {
             h.id("Manager"),
             "Weekly filings",
             "Have the filings checked and report what is new.",
-            Trigger::Weekly,
-            now_ms() - 1000,
+            Trigger::Clock(Cadence::Weekly),
+            Some(now_ms() - 1000),
         )
         .unwrap();
 
@@ -1565,7 +1628,7 @@ async fn a_standing_request_becomes_one_routine_that_does_the_job_when_it_fires(
     assert_eq!(booked.len(), 1, "one standing job is one routine, got {booked:?}");
     assert_eq!(
         booked[0].trigger,
-        Trigger::Weekdays,
+        Trigger::Clock(Cadence::Weekdays),
         "a weekday repeat is a shape on the calendar, not a gap in seconds"
     );
     assert_eq!(
@@ -1602,7 +1665,13 @@ async fn a_routine_that_is_switched_off_stays_quiet_and_starts_again_when_asked(
     let routine = h
         .runtime
         .store()
-        .create_routine(h.id("Watcher"), "Sweep", "check", Trigger::Daily, now_ms() - 1000)
+        .create_routine(
+            h.id("Watcher"),
+            "Sweep",
+            "check",
+            Trigger::Clock(Cadence::Daily),
+            Some(now_ms() - 1000),
+        )
         .unwrap();
     h.runtime.store().set_routine_active(routine.id, false).unwrap();
 

--- a/src-tauri/tests/evals.rs
+++ b/src-tauri/tests/evals.rs
@@ -1702,7 +1702,7 @@ mod live {
         );
         assert_eq!(
             booked[0].trigger,
-            guac_lib::domain::routine::Trigger::Weekdays,
+            guac_lib::domain::routine::Trigger::Clock(guac_lib::domain::routine::Cadence::Weekdays),
             "a weekday job is a shape on the calendar. Stored as a gap it fires on Saturday, and \
              stored as a day in seconds it loses an hour twice a year"
         );

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -473,6 +473,7 @@ fn parts_of(envelope: &Envelope) -> String {
             Part::ToolCall { name, outcome, .. } => format!("[{name} -> {outcome:?}]"),
             Part::File(file) => format!("[file {}]", file.name),
             Part::Approval { summary, .. } => format!("[asks: {summary}]"),
+            Part::Routine { name, what, .. } => format!("[routine {name:?}] {what}"),
             Part::Json { name, .. } => format!("[{name}]"),
         })
         .collect::<Vec<_>>()

--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import { useStore } from "../lib/store";
 import type { AgentCard, RoutineId } from "../lib/types";
 import { ComputerScreen } from "./ComputerScreen";
 import { RoutineDetail } from "./RoutineDetail";
@@ -67,6 +68,20 @@ export function Inspector({ agent, onEditProfile }: Props) {
   useEffect(() => {
     setRoutine(null);
   }, [agentId]);
+
+  // A fired routine in the transcript, clicked. The panel is opened along with
+  // it: the request came from a row the operator could see, so answering it by
+  // changing something behind a closed panel would read as the click doing
+  // nothing. Cleared as it is taken, so the same chip can be clicked again
+  // after navigating away.
+  const asked = useStore((state) => state.openingRoutine);
+  const taken = useStore((state) => state.routineOpened);
+  useEffect(() => {
+    if (asked === null) return;
+    setRoutine(asked);
+    setOpen(true);
+    taken();
+  }, [asked, taken]);
 
   // Nothing to inspect on the activity board, which is about the whole crew.
   if (!agent) return null;

--- a/src/components/MessageItem.test.tsx
+++ b/src/components/MessageItem.test.tsx
@@ -13,6 +13,11 @@ vi.mock("../lib/ipc", () => ({
   api: { retryTurn: (agentId: string, messageId: string) => retryTurn(agentId, messageId) },
 }));
 
+const openRoutine = vi.fn<(id: string) => void>();
+vi.mock("../lib/store", () => ({
+  useStore: { getState: () => ({ openRoutine, setBanner: vi.fn() }) },
+}));
+
 function card(id: string, name: string): AgentCard {
   return {
     id,
@@ -339,5 +344,51 @@ describe("redrawing a transcript", () => {
 
     expect(screen.getByText("second")).toBeTruthy();
     expect(screen.queryByText("first")).toBeNull();
+  });
+});
+
+describe("a routine coming due", () => {
+  const fired = (parts?: Part[]) =>
+    envelope({
+      from: { kind: "system" },
+      to: { kind: "agent", id: "manager" },
+      intent: "work",
+      parts: parts ?? [
+        {
+          type: "routine",
+          routineId: "rt1",
+          name: "Listings sweep",
+          what: "Check the listings. America/New_York. Post one copy and say what changed.",
+        },
+      ],
+    });
+
+  it("is one line naming the routine, not the instruction as dialogue", () => {
+    // What this replaces: a chat bubble from "Guaca" carrying several
+    // sentences of instruction, in the middle of the operator's own
+    // conversation with the agent.
+    show(fired());
+
+    expect(screen.getByText("Listings sweep")).toBeTruthy();
+    expect(screen.getByText("routine ran")).toBeTruthy();
+    expect(screen.queryByText(/America\/New_York/)).toBeNull();
+    expect(screen.queryByText("Guaca")).toBeNull();
+  });
+
+  it("titles an unnamed routine by what it says, like the schedule panel does", () => {
+    show(
+      fired([
+        { type: "routine", routineId: "rt1", name: "", what: "Check the listings. Then post." },
+      ]),
+    );
+    expect(screen.getByText("Check the listings")).toBeTruthy();
+  });
+
+  it("opens the routine it names", () => {
+    // The panel that draws a routine is the transcript's sibling, so the click
+    // asks for it through the store rather than through a prop on every row.
+    show(fired());
+    fireEvent.click(screen.getByRole("button"));
+    expect(openRoutine).toHaveBeenCalledWith("rt1");
   });
 });

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 
 import { AgentAvatar } from "../avatars/AgentAvatar";
 import { api } from "../lib/ipc";
+import { routineTitle } from "../lib/routine";
 import { useStore } from "../lib/store";
 import { whenLabel } from "../lib/time";
 import { type Lookups, toPeer } from "../lib/transcript";
@@ -13,11 +14,12 @@ import {
   type MessageId,
   type Part,
   type Participant,
+  type RoutineId,
 } from "../lib/types";
 import { ApprovalRequest } from "./ApprovalRequest";
 import { FileCard } from "./FileCard";
 import { Markdown } from "./Markdown";
-import { NoticeRow } from "./WireRow";
+import { NoticeRow, RoutineRow } from "./WireRow";
 
 interface Props {
   message: Envelope;
@@ -75,6 +77,16 @@ function keyed(message: Envelope) {
 }
 
 /**
+ * Opens the routine a fired-routine chip stands for.
+ *
+ * Imperative for the same reason as {@link onRetry}: the panel that draws a
+ * routine is a sibling of the transcript, and the store is where the two meet.
+ */
+function onOpenRoutine(routineId: RoutineId) {
+  useStore.getState().openRoutine(routineId);
+}
+
+/**
  * Sends a failed turn's message again.
  *
  * Imperative rather than a prop threaded through every message: this is one
@@ -120,6 +132,21 @@ export const MessageItem = memo(function MessageItem({
   if (asking) {
     const askerId = to.kind === "agent" ? to.id : message.channelId;
     return <ApprovalRequest part={asking} agent={lookups.byId(askerId)} />;
+  }
+
+  // A schedule firing. Drawn as one line rather than as the several sentences
+  // it carries: the instruction is written for the agent to act on with no
+  // other context, and as a bubble it read as Guaca talking to the operator.
+  const fired = message.parts.find((part) => part.type === "routine");
+  if (fired) {
+    return (
+      <RoutineRow
+        title={routineTitle({ name: fired.name, what: fired.what })}
+        what={fired.what}
+        at={message.createdAt}
+        onOpen={() => onOpenRoutine(fired.routineId)}
+      />
+    );
   }
 
   if (from.kind === "agent" && to.kind === "system") {

--- a/src/components/RoutineDetail.test.tsx
+++ b/src/components/RoutineDetail.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Routine, RoutineDraft, RoutineRun } from "../lib/types";
 import { RoutineDetail } from "./RoutineDetail";
@@ -24,8 +24,22 @@ vi.mock("../lib/ipc", () => ({
   },
 }));
 
-/** 2025-06-10 at 09:28 local. */
+/** 2025-06-10 at 09:28 local, a Tuesday. The slot every routine here holds. */
 const MORNING = new Date(2025, 5, 10, 9, 28, 0, 0).getTime();
+
+/**
+ * An hour before that slot, and where the clock is pinned.
+ *
+ * Every delay this panel sends is counted from now, so the assertions about
+ * what reaches the backend are only readable against a fixed now. Only `Date`
+ * is faked: `waitFor` and the panel's own clock need real timers.
+ */
+const NOW = MORNING - 3600_000;
+
+/** A firing's spend. Zero calls is the case the history exists to show. */
+function spent(over: Partial<RoutineRun["spent"]> = {}): RoutineRun["spent"] {
+  return { prompt: 0, completion: 0, cost: null, calls: 1, ...over };
+}
 
 function routine(over: Partial<Routine> = {}): Routine {
   return {
@@ -51,6 +65,8 @@ function open(over: Partial<Routine> = {}) {
 
 describe("RoutineDetail", () => {
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(NOW);
     vi.clearAllMocks();
     agentRoutines.mockResolvedValue([routine()]);
     routineRuns.mockResolvedValue([]);
@@ -59,6 +75,10 @@ describe("RoutineDetail", () => {
     setRoutineActive.mockImplementation(async (_id, active) => routine({ active }));
     testRoutine.mockResolvedValue("run-1");
     deleteRoutine.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("shows the whole instruction, which the list deliberately does not", async () => {
@@ -105,13 +125,104 @@ describe("RoutineDetail", () => {
     await screen.findByLabelText("Instruction");
     expect(screen.getByText("No runs yet.")).toBeTruthy();
 
-    routineRuns.mockResolvedValue([{ runId: "run-1", kind: "test", at: MORNING }]);
+    routineRuns.mockResolvedValue([
+      { runId: "run-1", kind: "test", at: MORNING, spent: spent({ calls: 2 }) },
+    ]);
     fireEvent.click(screen.getByRole("button", { name: "Test run" }));
 
     await waitFor(() => expect(testRoutine).toHaveBeenCalledWith("r1"));
     // Marked as a test: a button press and a real firing look identical in the
     // transcript, so "did it run on Tuesday" has to be answered here.
     expect(await screen.findByText("test run")).toBeTruthy();
+  });
+
+  it("says which firings did nothing, and what the others cost", async () => {
+    // A delivered routine whose agent never ran looks exactly like one that
+    // worked, and the operator's next move is not the same.
+    routineRuns.mockResolvedValue([
+      { runId: "run-2", kind: "scheduled", at: MORNING, spent: spent({ calls: 0 }) },
+      {
+        runId: "run-1",
+        kind: "scheduled",
+        at: MORNING - 86_400_000,
+        spent: { prompt: 1200, completion: 300, cost: 0.004, calls: 3 },
+      },
+    ]);
+    open();
+
+    expect(await screen.findByText("nothing ran")).toBeTruthy();
+    expect(screen.getByText("1.5k")).toBeTruthy();
+    // Four places, because a firing costs fractions of a cent and $0.00 reads
+    // as free.
+    expect(screen.getByText("$0.0040")).toBeTruthy();
+  });
+
+  it("asks which weekday a weekly routine keeps", async () => {
+    // The weekday is not stored anywhere but the first firing, so a picker
+    // that cannot say it means "every week" lands on whichever day the
+    // operator happened to be at the keyboard.
+    open({ trigger: "weekly" });
+    const day = (await screen.findByLabelText("Day of the week")) as HTMLSelectElement;
+    // 2025-06-10 is a Tuesday, and that is the day this routine is holding.
+    expect(day.value).toBe("2");
+
+    fireEvent.change(day, { target: { value: "4" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(updateRoutine).toHaveBeenCalledTimes(1));
+    // Thursday is two days after Tuesday, and the hour it kept is unchanged.
+    expect(updateRoutine.mock.calls[0]![1].inSecs).toBe(2 * 86_400 + 3600);
+  });
+
+  it("asks which day of the month a monthly routine keeps", async () => {
+    open({ trigger: "monthly" });
+    const day = (await screen.findByLabelText("Day of the month")) as HTMLSelectElement;
+    expect(day.value).toBe("10");
+    expect(screen.queryByLabelText("Day of the week")).toBeNull();
+  });
+
+  it("takes a date for a one-off rather than only a time of day", async () => {
+    // A time alone could only mean the next 24 hours: "remind me on the 3rd"
+    // had no way to be said at all.
+    open({ trigger: "once" });
+    const date = (await screen.findByLabelText("Date")) as HTMLInputElement;
+    expect(date.value).toBe("2025-06-10");
+
+    fireEvent.change(date, { target: { value: "2025-06-13" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(updateRoutine).toHaveBeenCalledTimes(1));
+    expect(updateRoutine.mock.calls[0]![1].inSecs).toBe(3 * 86_400 + 3600);
+  });
+
+  it("refuses to save a one-off whose moment has gone", async () => {
+    // A delay in the past reaches the scheduler as overdue and fires at once,
+    // which is not what picking a date means.
+    open({ trigger: "once" });
+    fireEvent.change(await screen.findByLabelText("Date"), { target: { value: "2020-01-01" } });
+
+    expect(
+      (screen.getByRole("button", { name: "Save changes" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(screen.getByText(/already passed/)).toBeTruthy();
+  });
+
+  it("draws a routine waiting on an event without inventing a next firing", async () => {
+    // Nothing delivers an event yet, so this is a row a future build writes and
+    // this one has to read. It must not claim a moment it does not hold.
+    open({ trigger: "event:stripe/invoice.payment_failed", nextRunAt: null });
+
+    await waitFor(() =>
+      expect((screen.getByLabelText("Trigger") as HTMLSelectElement).value).toBe(
+        "event:stripe/invoice.payment_failed",
+      ),
+    );
+    expect(screen.getByText(/keeps no place in the clock/)).toBeTruthy();
+    // No moment to state, so nothing offers to state one.
+    expect(screen.queryByLabelText("Time of day")).toBeNull();
+    expect(screen.queryByLabelText("Date")).toBeNull();
+    // And Test run is still there: it is the only way to fire one today.
+    expect(screen.getByRole("button", { name: "Test run" })).toBeTruthy();
   });
 
   it("does not move the schedule when only the wording changed", async () => {
@@ -126,7 +237,7 @@ describe("RoutineDetail", () => {
     expect(updateRoutine.mock.calls[0]![1].inSecs).toBeNull();
   });
 
-  it("moves the schedule when the time was the thing that changed", async () => {
+  it("moves the schedule when the moment was the thing that changed", async () => {
     open();
     await screen.findByLabelText("Time of day");
     fireEvent.change(screen.getByLabelText("Time of day"), { target: { value: "17:00" } });

--- a/src/components/RoutineDetail.tsx
+++ b/src/components/RoutineDetail.tsx
@@ -2,12 +2,18 @@ import { useCallback, useEffect, useState } from "react";
 
 import { api } from "../lib/ipc";
 import {
+  anchorFor,
   clockTime,
-  isTimed,
+  firstRunDelay,
+  type Moment,
+  momentOf,
+  nextRoundMoment,
+  ordinal,
+  parseTrigger,
+  repeatLabel,
   routineTitle,
-  secondsUntil,
   TRIGGER_CHOICES,
-  toTimeField,
+  WEEKDAYS,
 } from "../lib/routine";
 import { relativeTime, useNow } from "../lib/time";
 import {
@@ -18,6 +24,7 @@ import {
   type RoutineId,
   type RoutineRun,
 } from "../lib/types";
+import { compact, money } from "./TokenMeter";
 
 interface Props {
   agentId: AgentId;
@@ -31,8 +38,8 @@ interface Editing {
   name: string;
   what: string;
   trigger: string;
-  /** Local `HH:MM`. Ignored by triggers with no time of day. */
-  time: string;
+  /** When it should fire. Only the parts the trigger asks for are read. */
+  moment: Moment;
 }
 
 const DEFAULT_TRIGGER = "daily";
@@ -42,33 +49,41 @@ function editingFor(routine: Routine): Editing {
     name: routine.name,
     what: routine.what,
     trigger: routine.trigger,
-    time: toTimeField(routine.nextRunAt),
+    // A routine holding no moment still needs something in the fields, in case
+    // the operator switches it to a trigger that has one.
+    moment: routine.nextRunAt === null ? nextRoundMoment() : momentOf(routine.nextRunAt),
   };
 }
 
 function blank(): Editing {
-  // Now, rounded up to the next five minutes. A routine set at 9:28 first
-  // firing at 9:28 tomorrow is what the operator meant, and a round number is
-  // easier to recognise in the list afterwards.
-  const now = new Date();
-  now.setMinutes(Math.ceil(now.getMinutes() / 5) * 5, 0, 0);
-  return { name: "", what: "", trigger: DEFAULT_TRIGGER, time: toTimeField(now.getTime()) };
+  return { name: "", what: "", trigger: DEFAULT_TRIGGER, moment: nextRoundMoment() };
 }
 
 /**
  * What to send.
  *
- * `inSecs` is how a time of day reaches the backend: it anchors the first
- * firing, and every repeat after that keeps the hour. Null on an edit leaves
- * the schedule exactly where it was, which is what fixing a typo should do.
+ * `inSecs` is how a moment reaches the backend: it anchors the first firing,
+ * and every repeat after that inherits the hour, and for a weekly or monthly
+ * repeat the day as well. Null on an edit leaves the schedule exactly where it
+ * was, which is what fixing a typo should do.
  */
 function draftOf(editing: Editing, moved: boolean): RoutineDraft {
   return {
     name: editing.name.trim(),
     what: editing.what.trim(),
     trigger: editing.trigger,
-    inSecs: moved && isTimed(editing.trigger) ? secondsUntil(editing.time) : null,
+    inSecs: moved ? firstRunDelay(editing.trigger, editing.moment) : null,
   };
+}
+
+/** Why the moment on screen is not one, or null when it is. */
+function momentProblem(editing: Editing): string | null {
+  const anchor = anchorFor(editing.trigger);
+  if (anchor === "none") return null;
+  if (firstRunDelay(editing.trigger, editing.moment) !== null) return null;
+  return anchor === "date"
+    ? "That date and time have already passed. Pick one still ahead."
+    : "That is not a time of day.";
 }
 
 /**
@@ -89,7 +104,7 @@ export function RoutineDetail({ agentId, routineId, onBack }: Props) {
   const [routine, setRoutine] = useState<Routine | null>(null);
   const [draft, setDraft] = useState<Editing>(() => blank());
   const [runs, setRuns] = useState<RoutineRun[] | null>(null);
-  // Whether the time was touched. An untouched time on an edit has to leave
+  // Whether the moment was touched. An untouched one on an edit has to leave
   // the next firing where it is: rewording an instruction should not silently
   // push the schedule to tomorrow.
   const [moved, setMoved] = useState(false);
@@ -143,6 +158,11 @@ export function RoutineDetail({ agentId, routineId, onBack }: Props) {
   };
 
   const patch = (fields: Partial<Editing>) => setDraft((current) => ({ ...current, ...fields }));
+  /** Any change to when it fires is a change to the moment it is anchored on. */
+  const patchMoment = (fields: Partial<Moment>) => {
+    setDraft((current) => ({ ...current, moment: { ...current.moment, ...fields } }));
+    setMoved(true);
+  };
 
   const dirty =
     routine === null ||
@@ -150,6 +170,8 @@ export function RoutineDetail({ agentId, routineId, onBack }: Props) {
     draft.name.trim() !== routine.name ||
     draft.what.trim() !== routine.what ||
     draft.trigger !== routine.trigger;
+
+  const problem = momentProblem(draft);
 
   const save = () =>
     void run(async () => {
@@ -167,7 +189,8 @@ export function RoutineDetail({ agentId, routineId, onBack }: Props) {
 
   if (loading) return <p className="routines__note">Loading…</p>;
 
-  const timed = isTimed(draft.trigger);
+  const anchor = anchorFor(draft.trigger);
+  const waiting = parseTrigger(draft.trigger).kind === "event";
 
   return (
     <div className="detail">
@@ -291,16 +314,17 @@ export function RoutineDetail({ agentId, routineId, onBack }: Props) {
       <div className="field">
         <span className="field__label">When to run</span>
         <div className="when">
-          <span aria-hidden="true" className="routine__mark" />
+          <span aria-hidden="true" className="routine__mark" data-waiting={waiting || undefined} />
           <select
             className="input input--slim"
             aria-label="Trigger"
             value={draft.trigger}
             onChange={(event) => {
               patch({ trigger: event.target.value });
-              // Choosing a timed repeat is a decision about when, so the time
-              // goes with it rather than staying where the old row was.
-              if (isTimed(event.target.value)) setMoved(true);
+              // Choosing a trigger with a moment is a decision about when, so
+              // the moment goes with it rather than staying where the old row
+              // was. A trigger with none leaves the schedule alone.
+              if (anchorFor(event.target.value) !== "none") setMoved(true);
             }}
           >
             {TRIGGER_CHOICES.map((choice) => (
@@ -308,30 +332,82 @@ export function RoutineDetail({ agentId, routineId, onBack }: Props) {
                 {choice.label}
               </option>
             ))}
-            {/* A gap an agent chose for itself is not in the list, and dropping
-                it from the picker would silently rewrite the agent's schedule
-                the first time an operator saved an unrelated edit. */}
+            {/* A trigger this picker does not offer: a gap an agent chose for
+                itself, or an event. Dropping it would silently rewrite the
+                agent's schedule the first time an operator saved an unrelated
+                edit. */}
             {!TRIGGER_CHOICES.some((choice) => choice.spec === draft.trigger) && (
-              <option value={draft.trigger}>{draft.trigger}</option>
+              <option value={draft.trigger}>{repeatLabel(draft.trigger)}</option>
             )}
           </select>
-          {timed && (
+
+          {anchor === "weekday" && (
+            <select
+              className="input input--slim"
+              aria-label="Day of the week"
+              value={draft.moment.weekday}
+              onChange={(event) => patchMoment({ weekday: Number(event.target.value) })}
+            >
+              {WEEKDAYS.map((day) => (
+                <option key={day.day} value={day.day}>
+                  {day.label}
+                </option>
+              ))}
+            </select>
+          )}
+
+          {anchor === "monthday" && (
+            <select
+              className="input input--slim"
+              aria-label="Day of the month"
+              value={draft.moment.monthday}
+              onChange={(event) => patchMoment({ monthday: Number(event.target.value) })}
+            >
+              {Array.from({ length: 31 }, (_, index) => index + 1).map((day) => (
+                <option key={day} value={day}>
+                  {ordinal(day)}
+                </option>
+              ))}
+            </select>
+          )}
+
+          {anchor === "date" && (
+            <input
+              className="input input--slim"
+              type="date"
+              aria-label="Date"
+              value={draft.moment.date}
+              onChange={(event) => patchMoment({ date: event.target.value })}
+            />
+          )}
+
+          {anchor !== "none" && (
             <>
               <span className="hint">at</span>
               <input
                 className="input input--slim"
                 type="time"
                 aria-label="Time of day"
-                value={draft.time}
-                onChange={(event) => {
-                  patch({ time: event.target.value });
-                  setMoved(true);
-                }}
+                value={draft.moment.time}
+                onChange={(event) => patchMoment({ time: event.target.value })}
               />
             </>
           )}
         </div>
-        {routine?.active && !dirty && (
+
+        {anchor === "monthday" && draft.moment.monthday > 28 && (
+          <span className="field__hint">
+            Months without a {ordinal(draft.moment.monthday)} are skipped rather than moved, so it
+            stays on the {ordinal(draft.moment.monthday)} of the months that have one.
+          </span>
+        )}
+        {waiting && (
+          <span className="field__hint">
+            This one keeps no place in the clock: nothing fires until that happens. Test run
+            delivers it now.
+          </span>
+        )}
+        {routine?.active && !dirty && routine.nextRunAt !== null && (
           <span className="field__hint">
             Next in {relativeTime(now, routine.nextRunAt)}, on{" "}
             {new Date(routine.nextRunAt).toLocaleDateString(undefined, {
@@ -356,7 +432,7 @@ export function RoutineDetail({ agentId, routineId, onBack }: Props) {
           <button
             type="button"
             className="btn btn--small btn--primary"
-            disabled={busy || !draft.what.trim()}
+            disabled={busy || !draft.what.trim() || problem !== null}
             onClick={save}
           >
             {routine ? "Save changes" : "Create routine"}
@@ -373,34 +449,65 @@ export function RoutineDetail({ agentId, routineId, onBack }: Props) {
               Discard
             </button>
           )}
+          {problem && <span className="field__hint">{problem}</span>}
         </div>
       )}
 
-      {routine && (
-        <div className="field">
-          <span className="field__label">Run history</span>
-          {runs === null || runs.length === 0 ? (
-            <p className="routines__note">No runs yet.</p>
-          ) : (
-            <ul className="history">
-              {runs.map((entry) => (
-                <li key={entry.runId} className="history__row">
-                  <span className="history__when">
-                    {new Date(entry.at).toLocaleDateString(undefined, {
-                      month: "short",
-                      day: "numeric",
-                    })}{" "}
-                    at {clockTime(entry.at)}
-                  </span>
-                  {/* A button press and a real firing look the same in the
-                      transcript, so which one this was is said here. */}
-                  {entry.kind === "test" && <span className="history__kind">test run</span>}
-                  <span className="history__ago">{relativeTime(entry.at, now)}</span>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
+      {routine && <History runs={runs} now={now} />}
+    </div>
+  );
+}
+
+/**
+ * What a routine has actually done.
+ *
+ * Every firing carries what it spent, because that is the difference between a
+ * routine that is working and one that is being delivered to an agent which
+ * never runs: the two rows are otherwise identical, and the operator's next
+ * move is not the same.
+ */
+function History({ runs, now }: { runs: RoutineRun[] | null; now: number }) {
+  return (
+    <div className="field">
+      <span className="field__label">Run history</span>
+      {runs === null || runs.length === 0 ? (
+        <p className="routines__note">No runs yet.</p>
+      ) : (
+        <ul className="history">
+          {runs.map((entry) => (
+            <li key={entry.runId} className="history__row">
+              <span className="history__when">
+                {new Date(entry.at).toLocaleDateString(undefined, {
+                  month: "short",
+                  day: "numeric",
+                })}{" "}
+                at {clockTime(entry.at)}
+              </span>
+              {/* A button press and a real firing look the same in the
+                  transcript, so which one this was is said here. */}
+              {entry.kind === "test" && <span className="history__kind">test run</span>}
+              {entry.spent.calls === 0 ? (
+                <span
+                  className="history__quiet"
+                  title="Delivered, but no model call was made under it"
+                >
+                  nothing ran
+                </span>
+              ) : (
+                <span
+                  className="history__spend"
+                  title={`${entry.spent.prompt.toLocaleString()} in, ${entry.spent.completion.toLocaleString()} out, over ${entry.spent.calls} model call(s)`}
+                >
+                  {compact(entry.spent.prompt + entry.spent.completion)}
+                  {entry.spent.cost !== null && (
+                    <span className="history__cost">{money(entry.spent.cost)}</span>
+                  )}
+                </span>
+              )}
+              <span className="history__ago">{relativeTime(entry.at, now)}</span>
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/src/components/RoutineList.test.tsx
+++ b/src/components/RoutineList.test.tsx
@@ -60,13 +60,38 @@ describe("RoutineList", () => {
     expect(screen.queryByText(/America\/New_York/)).toBeNull();
   });
 
-  it("says which routines are switched off", async () => {
+  it("says which routines are switched off, and when they last ran", async () => {
     // Off is not deleted. It still has to be findable, and it must not claim a
-    // next firing it is never going to make.
-    agentRoutines.mockResolvedValue([routine({ active: false })]);
+    // next firing it is never going to make. When it last ran is the only news
+    // left about it, and the answer to "was this ever working".
+    agentRoutines.mockResolvedValue([
+      routine({ active: false, lastRunAt: MORNING - 2 * 86_400_000 }),
+    ]);
     render(<RoutineList agentId="a1" onOpen={vi.fn()} />);
 
-    expect(await screen.findByText(/· off/)).toBeTruthy();
+    expect(await screen.findByText(/· off, last ran/)).toBeTruthy();
+    expect(screen.queryByText(/next in/)).toBeNull();
+  });
+
+  it("says the day a weekly routine keeps, not just the hour", async () => {
+    // Nothing else on screen records which day it is: the row said "Every week
+    // at 9:28 AM" whichever day that was.
+    agentRoutines.mockResolvedValue([routine({ trigger: "weekly" })]);
+    render(<RoutineList agentId="a1" onOpen={vi.fn()} />);
+    expect(await screen.findByText(/Every Tuesday at 9:28/)).toBeTruthy();
+  });
+
+  it("draws a routine waiting on an event without counting down to anything", async () => {
+    // Nothing delivers an event yet, so this is a row a future build writes and
+    // this one has to read. A countdown here would be to a moment nothing is
+    // holding.
+    agentRoutines.mockResolvedValue([
+      routine({ trigger: "event:stripe/invoice.payment_failed", nextRunAt: null }),
+    ]);
+    render(<RoutineList agentId="a1" onOpen={vi.fn()} />);
+
+    expect(await screen.findByText(/When Stripe reports invoice.payment_failed/)).toBeTruthy();
+    expect(screen.getByText(/· waiting/)).toBeTruthy();
     expect(screen.queryByText(/next in/)).toBeNull();
   });
 

--- a/src/components/RoutineList.tsx
+++ b/src/components/RoutineList.tsx
@@ -1,9 +1,33 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { api } from "../lib/ipc";
-import { describeTrigger, routineTitle } from "../lib/routine";
+import { describeTrigger, parseTrigger, routineTitle } from "../lib/routine";
 import { relativeTime, useNow } from "../lib/time";
 import { type AgentId, errorMessage, type Routine, type RoutineId } from "../lib/types";
+
+/**
+ * The end of the second line: where this routine stands, right now.
+ *
+ * Three states, and the row has to be honest about all of them. A switched-off
+ * routine must not claim a next firing, and one waiting on an event has no
+ * next firing to claim: a countdown drawn there would be to a moment nothing
+ * is holding. When it last ran carries the weight instead, because on a
+ * routine that is not about to do anything that is the only news left.
+ */
+function standing(routine: Routine, now: number): string {
+  if (!routine.active) {
+    return routine.lastRunAt === null
+      ? " · off"
+      : ` · off, last ran ${relativeTime(routine.lastRunAt, now)}`;
+  }
+  if (routine.nextRunAt !== null) {
+    // Arguments swapped on purpose: this one is ahead of now.
+    return ` · next in ${relativeTime(now, routine.nextRunAt)}`;
+  }
+  return routine.lastRunAt === null
+    ? " · waiting"
+    : ` · waiting, last ran ${relativeTime(routine.lastRunAt, now)}`;
+}
 
 interface Props {
   agentId: AgentId;
@@ -74,20 +98,17 @@ export function RoutineList({ agentId, onOpen }: Props) {
             onClick={() => onOpen(routine.id)}
             title={routine.what}
           >
-            <span aria-hidden="true" className="routine__mark" />
+            <span
+              aria-hidden="true"
+              className="routine__mark"
+              // A clock face is a lie on something that does not wait on one.
+              data-waiting={parseTrigger(routine.trigger).kind === "event" || undefined}
+            />
             <span className="routine__body">
               <span className="routine__name">{routineTitle(routine)}</span>
               <span className="routine__when">
                 {describeTrigger(routine.trigger, routine.nextRunAt)}
-                {routine.active ? (
-                  // Arguments swapped on purpose: this one is ahead of now.
-                  <span className="routine__next">
-                    {" "}
-                    · next in {relativeTime(now, routine.nextRunAt)}
-                  </span>
-                ) : (
-                  <span className="routine__next"> · off</span>
-                )}
+                <span className="routine__next">{standing(routine, now)}</span>
               </span>
             </span>
           </button>

--- a/src/components/WireRow.tsx
+++ b/src/components/WireRow.tsx
@@ -282,6 +282,47 @@ export function WritingRow({ peer }: { peer: WirePeer }) {
 }
 
 /**
+ * A routine coming due, as one line.
+ *
+ * This used to be a chat bubble from "Guaca" carrying the whole instruction,
+ * which is several sentences by design: a routine is written to be acted on
+ * with no other context. An operator reading their own conversation with an
+ * agent was shown the system prompting it, in the shape of somebody talking to
+ * them, and the reflex is to read it as a message meant for you.
+ *
+ * So it is a chip. What it delivered is not lost: the click opens the routine
+ * in the panel, where the instruction is the thing you came to read, and the
+ * agent's answer is the next bubble either way.
+ */
+export function RoutineRow({
+  title,
+  what,
+  at,
+  onOpen,
+}: {
+  title: string;
+  what: string;
+  at: number;
+  onOpen: () => void;
+}) {
+  return (
+    <div className="wire wire--routine">
+      <button
+        type="button"
+        className="wire__chip wire__chip--open"
+        title={`Open this routine. It asked: ${what}`}
+        onClick={onOpen}
+      >
+        <span className="routine__mark" aria-hidden="true" />
+        <span className="wire__label">{title}</span>
+        <span className="wire__why">routine ran</span>
+        <span className="wire__meta">{clockTime(at)}</span>
+      </button>
+    </div>
+  );
+}
+
+/**
  * A centred system line: guard stops, upstream failures, lifecycle notes.
  *
  * `onRetry` is offered only where trying again could plausibly work. The

--- a/src/lib/routine.test.ts
+++ b/src/lib/routine.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  anchorFor,
   describeTrigger,
-  gapSeconds,
+  firstRunDelay,
   humanGap,
-  isTimed,
+  type Moment,
+  momentOf,
+  parseTrigger,
   repeatLabel,
   routineTitle,
   secondsUntil,
   TRIGGER_CHOICES,
+  toDateField,
   toTimeField,
 } from "./routine";
 
@@ -17,8 +21,13 @@ function at(y: number, m: number, d: number, hour: number, minute = 0): number {
   return new Date(y, m - 1, d, hour, minute, 0, 0).getTime();
 }
 
+/** A moment with everything filled in; each test overrides what it is about. */
+function moment(over: Partial<Moment> = {}): Moment {
+  return { time: "09:00", weekday: 1, monthday: 1, date: "2025-06-10", ...over };
+}
+
 describe("trigger vocabulary", () => {
-  it("offers a choice for every shape the backend can store", () => {
+  it("offers a choice for every shape the backend can store on a clock", () => {
     // The picker is the only place these are written down on this side. A
     // choice whose spec the Rust parser refuses is a routine that saves and
     // then never fires.
@@ -30,45 +39,89 @@ describe("trigger vocabulary", () => {
       "monthly",
       "once",
     ]);
+    // And no event trigger, because nothing delivers an event yet: offering one
+    // would be a routine the operator can set and watch never fire.
+    expect(TRIGGER_CHOICES.some((c) => c.spec.startsWith("event:"))).toBe(false);
   });
 
-  it("reads back a gap no choice offers", () => {
+  it("reads every stored form, including the ones no choice offers", () => {
+    expect(parseTrigger("weekdays")).toEqual({ kind: "calendar", repeat: "weekdays" });
+    expect(parseTrigger("once")).toEqual({ kind: "once" });
     // An agent setting its own schedule works in seconds and picks whatever it
     // likes. The row still has to be legible in the operator's list.
+    expect(parseTrigger("every:18000")).toEqual({ kind: "gap", secs: 18_000 });
     expect(repeatLabel("every:18000")).toBe("Every 5 hours");
-    expect(repeatLabel("every:3600")).toBe("Every hour");
     expect(repeatLabel("every:90")).toBe("Every 90 seconds");
-    expect(gapSeconds("every:18000")).toBe(18_000);
-    expect(gapSeconds("weekdays")).toBeNull();
+  });
+
+  it("reads a connector event as the two identifiers it is", () => {
+    expect(parseTrigger("event:stripe/invoice.payment_failed")).toEqual({
+      kind: "event",
+      service: "stripe",
+      topic: "invoice.payment_failed",
+    });
+    expect(repeatLabel("event:stripe/invoice.payment_failed")).toBe(
+      "When Stripe reports invoice.payment_failed",
+    );
+    // Half of one is not one. The Rust parser refuses these, so drawing them
+    // as though they worked would promise a routine that cannot exist.
+    expect(parseTrigger("event:stripe").kind).toBe("unknown");
+    expect(parseTrigger("event:/invoice.paid").kind).toBe("unknown");
   });
 
   it("draws a trigger from a build that knows more than this one", () => {
     // Forward-only migrations mean a newer build can write a value this one
     // has never heard of. Saying it is better than an empty row.
-    expect(repeatLabel("event:linear.assigned")).toBe("event:linear.assigned");
-    expect(gapSeconds("every:nonsense")).toBeNull();
-    expect(gapSeconds("every:-1")).toBeNull();
+    expect(repeatLabel("fortnightly")).toBe("fortnightly");
+    expect(parseTrigger("every:nonsense").kind).toBe("unknown");
+    expect(parseTrigger("every:-1").kind).toBe("unknown");
   });
 
-  it("says the time of day only for the triggers that have one", () => {
-    // An hourly routine has no hour to name, and claiming one would be a lie
-    // that changes every time it runs.
-    expect(isTimed("every:3600")).toBe(false);
-    expect(isTimed("weekdays")).toBe(true);
+  it("asks for the part of the moment each trigger actually keeps", () => {
+    // The complaint this answers: "every week at 09:00" landed on whichever day
+    // the operator happened to be setting it up on, and nothing said so.
+    expect(anchorFor("weekly")).toBe("weekday");
+    expect(anchorFor("monthly")).toBe("monthday");
+    expect(anchorFor("daily")).toBe("time");
+    expect(anchorFor("weekdays")).toBe("time");
+    // A one-off needs a date: a time alone can only mean the next 24 hours.
+    expect(anchorFor("once")).toBe("date");
+    // An hourly routine has no hour to name, and an event happens when it does.
+    expect(anchorFor("every:3600")).toBe("none");
+    expect(anchorFor("event:stripe/invoice.paid")).toBe("none");
+  });
 
-    const morning = at(2025, 6, 10, 9, 28);
-    expect(describeTrigger("weekdays", morning)).toBe("Weekdays at 9:28 AM");
-    expect(describeTrigger("every:3600", morning)).toBe("Every hour");
+  it("says the day a repeat keeps, not just the hour", () => {
+    const tuesday = at(2025, 6, 10, 9, 28);
+    expect(describeTrigger("weekdays", tuesday)).toBe("Weekdays at 9:28 AM");
+    expect(describeTrigger("weekly", tuesday)).toBe("Every Tuesday at 9:28 AM");
+    expect(describeTrigger("monthly", tuesday)).toBe("Monthly on the 10th at 9:28 AM");
+    expect(describeTrigger("every:3600", tuesday)).toBe("Every hour");
   });
 
   it("gives a one-off its date, because a time alone does not say when", () => {
     expect(describeTrigger("once", at(2025, 9, 25, 9, 0))).toBe("Once, on Sep 25 at 9:00 AM");
   });
 
-  it("round-trips a time of day through the field the operator edits", () => {
+  it("promises no moment for a trigger that holds none", () => {
+    // The countdown has nothing to count to, and a date drawn there would be
+    // one this side invented.
+    expect(describeTrigger("event:stripe/invoice.payment_failed", null)).toBe(
+      "When Stripe reports invoice.payment_failed",
+    );
+  });
+
+  it("round-trips the fields the operator edits", () => {
     expect(toTimeField(at(2025, 6, 10, 9, 5))).toBe("09:05");
     expect(toTimeField(at(2025, 6, 10, 17, 30))).toBe("17:30");
-    expect(toTimeField(at(2025, 6, 10, 0, 0))).toBe("00:00");
+    expect(toDateField(at(2025, 6, 10, 0, 0))).toBe("2025-06-10");
+    expect(momentOf(at(2025, 6, 10, 14, 15))).toEqual({
+      time: "14:15",
+      // 2025-06-10 is a Tuesday, which is 2 the way `Date.getDay` counts.
+      weekday: 2,
+      monthday: 10,
+      date: "2025-06-10",
+    });
   });
 
   it("counts to the next occurrence of a time, not to one already gone", () => {
@@ -95,6 +148,70 @@ describe("trigger vocabulary", () => {
     expect(humanGap(3600)).toBe("hour");
     expect(humanGap(86_400)).toBe("day");
     expect(humanGap(90)).toBe("90 seconds");
+  });
+});
+
+describe("firstRunDelay", () => {
+  /** Tuesday 2025-06-10, midday. */
+  const tuesday = at(2025, 6, 10, 12, 0);
+
+  const landsOn = (delay: number | null) => new Date(tuesday + (delay ?? 0) * 1000);
+
+  it("anchors a weekly repeat on the weekday that was picked", () => {
+    // The weekday is not stored anywhere else: the first firing is the only
+    // record of which day a weekly routine keeps.
+    const thursday = firstRunDelay("weekly", moment({ weekday: 4, time: "09:00" }), tuesday);
+    expect(landsOn(thursday)).toEqual(new Date(at(2025, 6, 12, 9, 0)));
+
+    // Today still counts while its time is ahead, and is next week once it is
+    // not: the same rule a time of day already follows.
+    expect(
+      landsOn(firstRunDelay("weekly", moment({ weekday: 2, time: "17:00" }), tuesday)),
+    ).toEqual(new Date(at(2025, 6, 10, 17, 0)));
+    expect(
+      landsOn(firstRunDelay("weekly", moment({ weekday: 2, time: "09:00" }), tuesday)),
+    ).toEqual(new Date(at(2025, 6, 17, 9, 0)));
+  });
+
+  it("anchors a monthly repeat on the day of the month that was picked", () => {
+    expect(
+      landsOn(firstRunDelay("monthly", moment({ monthday: 15, time: "08:00" }), tuesday)),
+    ).toEqual(new Date(at(2025, 6, 15, 8, 0)));
+    // A day already gone this month is next month's.
+    expect(
+      landsOn(firstRunDelay("monthly", moment({ monthday: 3, time: "08:00" }), tuesday)),
+    ).toEqual(new Date(at(2025, 7, 3, 8, 0)));
+  });
+
+  it("takes a monthly 31st to a month that has one rather than clamping", () => {
+    // Clamping to the end of a short month would anchor the routine on the
+    // 30th, and every firing after it would keep that day: the walk backwards
+    // down the calendar the backend is careful to avoid.
+    const june = at(2025, 6, 10, 12, 0);
+    const landed = new Date(
+      june + firstRunDelay("monthly", moment({ monthday: 31 }), june)! * 1000,
+    );
+    expect(landed).toEqual(new Date(at(2025, 7, 31, 9, 0)));
+  });
+
+  it("takes a one-off to the date it was given, not to the next 24 hours", () => {
+    const delay = firstRunDelay("once", moment({ date: "2025-09-25", time: "07:30" }), tuesday);
+    expect(landsOn(delay)).toEqual(new Date(at(2025, 9, 25, 7, 30)));
+  });
+
+  it("refuses a moment that has already passed rather than firing at once", () => {
+    // A negative delay reaches the backend as a routine due in the past, which
+    // the scheduler fires on its next tick. Saying no is the honest answer.
+    expect(
+      firstRunDelay("once", moment({ date: "2020-01-01", time: "09:00" }), tuesday),
+    ).toBeNull();
+    expect(firstRunDelay("once", moment({ date: "nonsense" }), tuesday)).toBeNull();
+    expect(firstRunDelay("weekly", moment({ time: "" }), tuesday)).toBeNull();
+  });
+
+  it("has nothing to state for a trigger with no moment", () => {
+    expect(firstRunDelay("every:3600", moment(), tuesday)).toBeNull();
+    expect(firstRunDelay("event:stripe/invoice.paid", moment(), tuesday)).toBeNull();
   });
 });
 

--- a/src/lib/routine.ts
+++ b/src/lib/routine.ts
@@ -1,26 +1,101 @@
 /**
- * How a routine reads to the operator: what to call it, and when it fires.
+ * How a routine reads to the operator, and what they have to be able to say.
  *
  * A trigger's stored form is one string, mirrored from
  * `domain::routine::Trigger` in Rust: `once`, `daily`, `weekdays`, `weekly`,
- * `monthly`, or `every:<seconds>`. Nothing outside this file reads that text.
+ * `monthly`, `every:<seconds>`, or `event:<service>/<topic>`. {@link
+ * parseTrigger} is the only thing that reads that text; everything else in the
+ * app branches on what it returns.
  *
- * A trigger says the shape of the repeat and not the hour it happens at. The
- * hour lives in `nextRunAt`, which is what lets one weekday routine be nine in
- * the morning and another be five in the afternoon without either of them
- * being a different kind of thing.
+ * A trigger says the shape of the repeat and not the moment it happens at. The
+ * moment lives in `nextRunAt`, which is what lets one weekday routine be nine
+ * in the morning and another be five in the afternoon without either of them
+ * being a different kind of thing. It also means the moment is the only record
+ * of which weekday a weekly routine keeps, or which day of the month a monthly
+ * one does: {@link firstRunDelay} is how the operator states it, and every
+ * repeat after the first inherits it.
  */
 
 import type { Routine, TriggerSpec } from "./types";
 
-/** The gaps a person picks by name. Anything else arrives as `every:N`. */
 const HOUR_SECS = 3600;
+const GAP_PREFIX = "every:";
+const EVENT_PREFIX = "event:";
+
+/** The calendar repeats, which are the ones that keep a time of day. */
+export type CalendarRepeat = "daily" | "weekdays" | "weekly" | "monthly";
+
+/**
+ * A trigger, read.
+ *
+ * `unknown` is a forward-only migration arriving: a newer build can write a
+ * value this one has never heard of, and drawing the raw text beats drawing
+ * nothing and beats guessing.
+ */
+export type Trigger =
+  | { kind: "gap"; secs: number }
+  | { kind: "calendar"; repeat: CalendarRepeat }
+  | { kind: "once" }
+  | { kind: "event"; service: string; topic: string }
+  | { kind: "unknown"; spec: string };
+
+/** Reads the stored form. Mirrors `Trigger::parse` in Rust. */
+export function parseTrigger(spec: TriggerSpec): Trigger {
+  const raw = spec.trim();
+  if (raw === "once") return { kind: "once" };
+  if (raw === "daily" || raw === "weekdays" || raw === "weekly" || raw === "monthly") {
+    return { kind: "calendar", repeat: raw };
+  }
+  if (raw.startsWith(GAP_PREFIX)) {
+    const secs = Number(raw.slice(GAP_PREFIX.length));
+    return Number.isFinite(secs) && secs > 0
+      ? { kind: "gap", secs }
+      : { kind: "unknown", spec: raw };
+  }
+  if (raw.startsWith(EVENT_PREFIX)) {
+    const rest = raw.slice(EVENT_PREFIX.length);
+    const cut = rest.indexOf("/");
+    const service = cut > 0 ? rest.slice(0, cut) : "";
+    const topic = cut > 0 ? rest.slice(cut + 1) : "";
+    // Both halves or neither: a service with no topic names nothing, and the
+    // Rust parser refuses it, so this must not draw it as though it worked.
+    return service && topic ? { kind: "event", service, topic } : { kind: "unknown", spec: raw };
+  }
+  return { kind: "unknown", spec: raw };
+}
+
+/**
+ * What the operator has to state for a trigger to mean what they meant.
+ *
+ * `weekday` and `monthday` are the reason this exists. A weekly routine keeps
+ * the weekday of its first firing and a monthly one keeps the day of the
+ * month, and neither was askable: "every week at 09:00" landed on whichever
+ * day the operator happened to be setting it up on, and there was nothing on
+ * screen that said so.
+ */
+export type Anchor = "none" | "time" | "weekday" | "monthday" | "date";
+
+/** Which of those a trigger needs. */
+export function anchorFor(spec: TriggerSpec): Anchor {
+  const trigger = parseTrigger(spec);
+  switch (trigger.kind) {
+    case "once":
+      // A time alone can only mean the next 24 hours, which is not what a
+      // one-off is for: "remind me on the 3rd" had no way to be said.
+      return "date";
+    case "calendar":
+      if (trigger.repeat === "weekly") return "weekday";
+      if (trigger.repeat === "monthly") return "monthday";
+      return "time";
+    // A gap has no hour to hold on to, and an event happens when it happens.
+    default:
+      return "none";
+  }
+}
 
 export interface TriggerChoice {
   spec: TriggerSpec;
   label: string;
-  /** Whether this one happens at a particular time of day. */
-  timed: boolean;
 }
 
 /**
@@ -29,43 +104,46 @@ export interface TriggerChoice {
  * "Every hour" is a gap because an hourly job has no hour to hold on to; the
  * rest are calendar repeats, which keep their time of day across a clock
  * change and, for weekdays, genuinely skip the weekend.
+ *
+ * No event trigger is offered. The storage, the scheduler, the panel and this
+ * file all handle one, but nothing delivers an event yet, so offering it would
+ * be a routine the operator could set and watch never fire.
  */
 export const TRIGGER_CHOICES: TriggerChoice[] = [
-  { spec: `every:${HOUR_SECS}`, label: "Every hour", timed: false },
-  { spec: "daily", label: "Every day", timed: true },
-  { spec: "weekdays", label: "Weekdays", timed: true },
-  { spec: "weekly", label: "Every week", timed: true },
-  { spec: "monthly", label: "Every month", timed: true },
-  { spec: "once", label: "Once", timed: true },
+  { spec: `every:${HOUR_SECS}`, label: "Every hour" },
+  { spec: "daily", label: "Every day" },
+  { spec: "weekdays", label: "Weekdays" },
+  { spec: "weekly", label: "Every week" },
+  { spec: "monthly", label: "Every month" },
+  { spec: "once", label: "Once" },
 ];
 
-/** Whether a trigger fires at a time of day worth showing and setting. */
-export function isTimed(spec: TriggerSpec): boolean {
-  return !spec.startsWith("every:");
-}
-
-/** The seconds in `every:N`, or null for anything else. */
-export function gapSeconds(spec: TriggerSpec): number | null {
-  if (!spec.startsWith("every:")) return null;
-  const secs = Number(spec.slice("every:".length));
-  return Number.isFinite(secs) && secs > 0 ? secs : null;
+/** `stripe` as `Stripe`. Mirrors `titled` in Rust. */
+function titled(word: string): string {
+  return word ? word[0]!.toUpperCase() + word.slice(1) : word;
 }
 
 /**
  * The repeat, in words.
  *
- * Handles gaps no choice offers, because an agent setting its own schedule
+ * Handles shapes no choice offers, because an agent setting its own schedule
  * works in seconds and picks whatever it likes: `every:18000` has to read as
  * "Every 5 hours" rather than as the raw row.
  */
 export function repeatLabel(spec: TriggerSpec): string {
-  const known = TRIGGER_CHOICES.find((choice) => choice.spec === spec);
-  if (known) return known.label;
-
-  const gap = gapSeconds(spec);
-  if (gap !== null) return `Every ${humanGap(gap)}`;
-  // A trigger written by a newer build. Saying so beats drawing nothing.
-  return spec;
+  const trigger = parseTrigger(spec);
+  switch (trigger.kind) {
+    case "event":
+      return `When ${titled(trigger.service)} reports ${trigger.topic}`;
+    case "gap":
+      return `Every ${humanGap(trigger.secs)}`;
+    case "unknown":
+      // A trigger from a build that knows more than this one. Saying it beats
+      // drawing nothing.
+      return trigger.spec;
+    default:
+      return TRIGGER_CHOICES.find((choice) => choice.spec === spec)?.label ?? spec;
+  }
 }
 
 /** Whole units where they divide evenly. Mirrors `human_gap` in Rust. */
@@ -121,18 +199,45 @@ export function clockTime(at: number): string {
  * The whole line under a routine's name: `Weekdays at 9:28 AM`.
  *
  * A one-off carries its date as well, because "Once at 9:00 AM" is not an
- * answer to when.
+ * answer to when. A weekly or monthly one carries the day it keeps, for the
+ * same reason: "Every week at 9:00 AM" leaves out the only part of the answer
+ * the operator cannot work out for themselves.
+ *
+ * `nextRunAt` is null for a trigger that holds no moment, and then there is
+ * nothing to add: what it says is already the whole of when.
  */
-export function describeTrigger(spec: TriggerSpec, nextRunAt: number): string {
-  if (spec === "once") {
-    const when = new Date(nextRunAt).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-    });
-    return `Once, on ${when} at ${clockTime(nextRunAt)}`;
+export function describeTrigger(spec: TriggerSpec, nextRunAt: number | null): string {
+  const trigger = parseTrigger(spec);
+  if (nextRunAt === null) return repeatLabel(spec);
+
+  switch (trigger.kind) {
+    case "once":
+      return `Once, on ${dayLabel(nextRunAt)} at ${clockTime(nextRunAt)}`;
+    case "calendar": {
+      if (trigger.repeat === "weekly") {
+        const weekday = new Date(nextRunAt).toLocaleDateString(undefined, { weekday: "long" });
+        return `Every ${weekday} at ${clockTime(nextRunAt)}`;
+      }
+      if (trigger.repeat === "monthly") {
+        return `Monthly on the ${ordinal(new Date(nextRunAt).getDate())} at ${clockTime(nextRunAt)}`;
+      }
+      return `${repeatLabel(spec)} at ${clockTime(nextRunAt)}`;
+    }
+    default:
+      return repeatLabel(spec);
   }
-  if (!isTimed(spec)) return repeatLabel(spec);
-  return `${repeatLabel(spec)} at ${clockTime(nextRunAt)}`;
+}
+
+/** `Sep 25`. */
+function dayLabel(at: number): string {
+  return new Date(at).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+/** `1st`, `2nd`, `23rd`. */
+export function ordinal(day: number): string {
+  const teen = day % 100 >= 11 && day % 100 <= 13;
+  const suffix = teen ? "th" : (["th", "st", "nd", "rd"][day % 10] ?? "th");
+  return `${day}${suffix}`;
 }
 
 /** `09:28`, the form an `<input type="time">` reads and writes. */
@@ -141,29 +246,153 @@ export function toTimeField(at: number): string {
   return `${String(when.getHours()).padStart(2, "0")}:${String(when.getMinutes()).padStart(2, "0")}`;
 }
 
-/**
- * How long until the next local `HH:MM`, in seconds.
- *
- * The one number the backend needs: it anchors the first firing, and every
- * repeat after it keeps that time of day. Today's slot is used while it is
- * still ahead, tomorrow's once it has gone by, and the day the trigger
- * actually accepts is the backend's decision rather than this one's: only it
- * knows that a routine set on a Friday evening for the weekday morning means
- * Monday.
- */
-export function secondsUntil(time: string, from: number = Date.now()): number | null {
+/** `2025-06-10`, the form an `<input type="date">` reads and writes. */
+export function toDateField(at: number): string {
+  const when = new Date(at);
+  const month = String(when.getMonth() + 1).padStart(2, "0");
+  return `${when.getFullYear()}-${month}-${String(when.getDate()).padStart(2, "0")}`;
+}
+
+/** Monday first, because a week of work starts there. `0` is Sunday in JS. */
+export const WEEKDAYS = [
+  { day: 1, label: "Monday" },
+  { day: 2, label: "Tuesday" },
+  { day: 3, label: "Wednesday" },
+  { day: 4, label: "Thursday" },
+  { day: 5, label: "Friday" },
+  { day: 6, label: "Saturday" },
+  { day: 0, label: "Sunday" },
+];
+
+/** What the operator picked, as far as the trigger needs it. */
+export interface Moment {
+  /** Local `HH:MM`. */
+  time: string;
+  /** `0`–`6`, Sunday first, as `Date.getDay` counts. For a weekly repeat. */
+  weekday: number;
+  /** `1`–`31`. For a monthly repeat. */
+  monthday: number;
+  /** Local `YYYY-MM-DD`. For a one-off. */
+  date: string;
+}
+
+/** Reads `HH:MM`, or null if it is not one. */
+function readTime(time: string): { hours: number; minutes: number } | null {
   const match = /^(\d{1,2}):(\d{2})$/.exec(time.trim());
   if (!match) return null;
   const hours = Number(match[1]);
   const minutes = Number(match[2]);
   if (hours > 23 || minutes > 59) return null;
+  return { hours, minutes };
+}
+
+/**
+ * How long until the next local `HH:MM`, in seconds.
+ *
+ * Today's slot is used while it is still ahead, tomorrow's once it has gone by,
+ * and the day the trigger actually accepts is the backend's decision rather
+ * than this one's: only it knows that a routine set on a Friday evening for the
+ * weekday morning means Monday.
+ */
+export function secondsUntil(time: string, from: number = Date.now()): number | null {
+  const clock = readTime(time);
+  if (!clock) return null;
 
   const target = new Date(from);
-  target.setHours(hours, minutes, 0, 0);
+  target.setHours(clock.hours, clock.minutes, 0, 0);
   // Built by mutating a local date rather than by arithmetic on milliseconds,
   // so the day a clock change shortens or lengthens still lands on the hour
   // that was asked for.
   if (target.getTime() <= from) target.setDate(target.getDate() + 1);
 
   return Math.round((target.getTime() - from) / 1000);
+}
+
+/** How many days a local month has. */
+function daysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+/**
+ * How long until the first firing the operator asked for, in seconds.
+ *
+ * The one number the backend needs. It anchors the first firing and every
+ * repeat after it inherits everything the moment carried: the hour, and for a
+ * weekly or monthly repeat the day as well.
+ *
+ * Null means "nothing to state", for a trigger with no moment, or "that is not
+ * a moment", for a field the operator has not finished filling in or a date
+ * that has already gone. The two are told apart by {@link anchorFor}, and the
+ * caller has to: null reaches the backend as "no delay", which is a deliberate
+ * and quite different instruction.
+ */
+export function firstRunDelay(
+  spec: TriggerSpec,
+  moment: Moment,
+  from: number = Date.now(),
+): number | null {
+  const anchor = anchorFor(spec);
+  if (anchor === "none") return null;
+
+  const clock = readTime(moment.time);
+  if (!clock) return null;
+  const { hours, minutes } = clock;
+
+  const seconds = (target: Date) => {
+    const ahead = Math.round((target.getTime() - from) / 1000);
+    return ahead > 0 ? ahead : null;
+  };
+
+  if (anchor === "time") return secondsUntil(moment.time, from);
+
+  if (anchor === "weekday") {
+    const target = new Date(from);
+    target.setHours(hours, minutes, 0, 0);
+    // Days rather than milliseconds, so a week containing a clock change is
+    // still seven days and still lands on the hour that was asked for.
+    const shift = (moment.weekday - target.getDay() + 7) % 7;
+    target.setDate(target.getDate() + shift);
+    if (target.getTime() <= from) target.setDate(target.getDate() + 7);
+    return seconds(target);
+  }
+
+  if (anchor === "monthday") {
+    // The next month that actually has that day, rather than the last day of
+    // this one. Clamping here would anchor a routine set for the 31st on the
+    // 28th of February and keep it there for the rest of the year, which is
+    // the walk backwards down the calendar the Rust side is careful to avoid.
+    const start = new Date(from);
+    for (let step = 0; step <= 14; step += 1) {
+      const month = new Date(start.getFullYear(), start.getMonth() + step, 1);
+      if (moment.monthday > daysInMonth(month.getFullYear(), month.getMonth())) continue;
+      const target = new Date(month.getFullYear(), month.getMonth(), moment.monthday);
+      target.setHours(hours, minutes, 0, 0);
+      if (target.getTime() > from) return seconds(target);
+    }
+    return null;
+  }
+
+  const parts = /^(\d{4})-(\d{2})-(\d{2})$/.exec(moment.date.trim());
+  if (!parts) return null;
+  const target = new Date(Number(parts[1]), Number(parts[2]) - 1, Number(parts[3]));
+  target.setHours(hours, minutes, 0, 0);
+  return seconds(target);
+}
+
+/** The moment a routine is currently set for, as the fields that state it. */
+export function momentOf(at: number): Moment {
+  const when = new Date(at);
+  return {
+    time: toTimeField(at),
+    weekday: when.getDay(),
+    monthday: when.getDate(),
+    date: toDateField(at),
+  };
+}
+
+/** Now, rounded up to the next five minutes: an easier row to recognise later. */
+export function nextRoundMoment(from: number = Date.now()): Moment {
+  const when = new Date(from);
+  when.setMinutes(Math.ceil(when.getMinutes() / 5) * 5, 0, 0);
+  return momentOf(when.getTime());
 }

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -275,7 +275,9 @@ export function searchResults(input: SearchInput): SearchResult[] {
       meta: describeTrigger(routine.trigger, routine.nextRunAt),
       // Either column is what somebody would type, and the store matches both.
       score: Math.max(score(routine.name, query), score(routine.what, query)),
-      at: routine.nextRunAt,
+      // When it fires next, for the recency tiebreak. A routine waiting on an
+      // event has no such moment, and when it was set up is the honest stand-in.
+      at: routine.nextRunAt ?? routine.createdAt,
       // The channel, not the profile: a schedule sits in the panel beside the
       // conversation, and the profile dialog no longer has it.
       action: { do: "openChannel", agentId: routine.agentId },

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -24,6 +24,7 @@ import type {
   GroupUsage,
   MessageId,
   Participant,
+  RoutineId,
   Settings,
   Tokens,
   UiEvent,
@@ -120,6 +121,17 @@ interface State {
    */
   focused: MessageId | null;
 
+  /**
+   * The routine a transcript row asked the panel to open, until it has.
+   *
+   * Held here for the same reason as `focused`: the two ends are in different
+   * columns of the window. A fired routine is drawn in the channel and read in
+   * the panel beside it, and threading a callback from the app root through
+   * every message to get there would put a prop on every row for the sake of
+   * one kind of chip.
+   */
+  openingRoutine: RoutineId | null;
+
   /** Non-blocking surface for the last thing that went wrong. */
   banner: { tone: "error" | "info" | "ok"; text: string } | null;
 
@@ -143,6 +155,9 @@ interface State {
   /** Opens a message's channel with the message itself in the window. */
   openMessage: (channel: AgentId, message: MessageId) => Promise<void>;
   clearFocus: () => void;
+  /** Asks the panel beside the transcript to open one routine. */
+  openRoutine: (id: RoutineId) => void;
+  routineOpened: () => void;
   applyEvent: (event: UiEvent) => void;
   dismissPulse: (id: number) => void;
   setBanner: (banner: State["banner"]) => void;
@@ -207,6 +222,7 @@ export const useStore = create<State>((set, get) => ({
   reasoning: {},
   pulses: [],
   focused: null,
+  openingRoutine: null,
   banner: null,
 
   async bootstrap() {
@@ -254,7 +270,16 @@ export const useStore = create<State>((set, get) => ({
   },
 
   async select(key) {
-    set((state) => ({ selected: key, focused: null, railGroup: keptFocus(state, key) }));
+    // A pending routine request goes with the channel it was asked from, for
+    // the same reason `focused` does: it is about a row on the screen the
+    // operator is leaving, and honouring it later would open something they
+    // asked for somewhere else.
+    set((state) => ({
+      selected: key,
+      focused: null,
+      openingRoutine: null,
+      railGroup: keptFocus(state, key),
+    }));
     await get().loadChannel(key);
   },
 
@@ -399,6 +424,14 @@ export const useStore = create<State>((set, get) => ({
 
   clearFocus() {
     set({ focused: null });
+  },
+
+  openRoutine(id) {
+    set({ openingRoutine: id });
+  },
+
+  routineOpened() {
+    set({ openingRoutine: null });
   },
 
   async refreshUsage() {

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -42,6 +42,17 @@ describe("plainText", () => {
     const message = envelope({ parts: [{ type: "notice", kind: "lifecycle", text: "x" }] });
     expect(plainText(message)).toBe("");
   });
+
+  it("counts a fired routine's instruction, which is what the model was sent", () => {
+    // The transcript draws a firing as one line instead of a bubble, and does
+    // it by choosing a row for the part. If that were done by hiding the words
+    // here, the activity board could not say what opened the run.
+    const message = envelope({
+      from: { kind: "system" },
+      parts: [{ type: "routine", routineId: "rt1", name: "Sweep", what: "check the listings" }],
+    });
+    expect(plainText(message)).toBe("check the listings");
+  });
 });
 
 describe("isInterAgent", () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -59,6 +59,13 @@ export type Part =
   | { type: "toolCall"; name: string; arguments: unknown; outcome: ToolOutcome }
   | ({ type: "file" } & Attachment)
   /**
+   * A routine coming due, drawn as one line the operator can open rather than
+   * as dialogue. The instruction is in `what` and is what the model was sent;
+   * `name` is the routine's name at the moment it fired, so a routine since
+   * renamed does not rewrite what the transcript said it was.
+   */
+  | { type: "routine"; routineId: RoutineId; name: string; what: string }
+  /**
    * An agent asking the operator for permission. Carries its own wording, so an
    * old channel still says what was asked; what came of it is read from
    * {@link Approval} state by `id`.
@@ -372,11 +379,13 @@ export type RoutineId = string;
 /**
  * What makes a routine fire.
  *
- * `once`, `daily`, `weekdays`, `weekly`, `monthly`, or `every:<seconds>` for a
- * fixed gap. A string rather than a union of literals because `every:N` is
- * open-ended and because the trigger after these is a connector event, which
- * has to be a new value here rather than a new field. Read it with
- * `parseTrigger` in `lib/trigger.ts`; nothing branches on the raw text.
+ * `once`, `daily`, `weekdays`, `weekly`, `monthly`, `every:<seconds>` for a
+ * fixed gap, or `event:<service>/<topic>` for something happening in a
+ * connected service. A string rather than a union of literals because both
+ * `every:N` and `event:x/y` are open-ended, and because the next kind of
+ * trigger should be a new value here rather than a new field. Read it with
+ * `parseTrigger` in `lib/routine.ts`; nothing outside that file branches on
+ * the raw text.
  */
 export type TriggerSpec = string;
 
@@ -391,7 +400,14 @@ export interface Routine {
   trigger: TriggerSpec;
   /** Set up but not running. Everything else about it survives being off. */
   active: boolean;
-  nextRunAt: number;
+  /**
+   * When it next fires, for a routine that waits on the clock.
+   *
+   * Null for one that does not: an event trigger fires when its event arrives
+   * and holds no slot in the meantime. Anything drawing a countdown has to
+   * answer for this case rather than render a date it invented.
+   */
+  nextRunAt: number | null;
   lastRunAt: number | null;
   createdAt: number;
 }
@@ -407,6 +423,14 @@ export interface RoutineRun {
   runId: RunId;
   kind: RunKind;
   at: number;
+  /**
+   * What the firing bought, summed over its model calls.
+   *
+   * `calls: 0` is the one an operator needs: the routine was delivered and
+   * nothing ran. Nothing else about the row tells that apart from a firing
+   * that worked.
+   */
+  spent: Tokens;
 }
 
 /** Absent `inSecs` on an edit leaves the next firing where it was. */
@@ -490,11 +514,18 @@ export function errorMessage(value: unknown): string {
   return "Something went wrong.";
 }
 
-/** Concatenated text of an envelope, matching the Rust `plain_text`. */
+/**
+ * Concatenated text of an envelope, matching the Rust `plain_text`.
+ *
+ * A fired routine's instruction counts, exactly as it does there: it is what
+ * the model was sent, so the activity board naming what opened a run has to be
+ * able to say it. Drawing a firing as a bubble is prevented by the transcript
+ * choosing a row for the part, not by this hiding the words.
+ */
 export function plainText(envelope: Envelope): string {
   return envelope.parts
-    .filter((p): p is Extract<Part, { type: "text" }> => p.type === "text")
-    .map((p) => p.text)
+    .map((part) => (part.type === "text" ? part.text : part.type === "routine" ? part.what : null))
+    .filter((text): text is string => text !== null)
     .join("\n")
     .trim();
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1685,6 +1685,20 @@ button {
   color: var(--pit);
 }
 
+/* A routine coming due.
+   Alone on its row, so it is not held to the 45% two chips have to share: the
+   name of a routine is up to forty-four characters and there is nothing beside
+   it to crowd. Accented in mint to match the clock face it carries, which is
+   the same glyph the schedule panel draws. */
+.wire--routine .wire__chip {
+  max-width: 100%;
+  --accent: var(--mint);
+}
+
+.wire--routine .routine__mark {
+  margin-top: 0;
+}
+
 /* Quieter still: bookkeeping the operator rarely needs, like a directory
    lookup. No rules either side, no click target. */
 .wire--quiet::before,
@@ -3257,6 +3271,27 @@ button {
   background: var(--faint);
 }
 
+/* A trigger that is not a clock: it waits to be told. The hands come off and
+   the ring goes dashed, because a clock face drawn on something that keeps no
+   place in the clock is the wrong thing to say at a glance, and the row beside
+   it has no countdown to back the glyph up. */
+.routine__mark[data-waiting] {
+  border-color: var(--flesh);
+  border-style: dashed;
+}
+
+.routine__mark[data-waiting]::after {
+  display: none;
+}
+
+.routine__mark[data-waiting]::before {
+  width: 0.22rem;
+  height: 0.22rem;
+  border-radius: 50%;
+  background: var(--flesh);
+  transform: translate(-50%, 50%);
+}
+
 /* The countdown is true but restless, and it is not what the row is about. */
 .routine__next {
   opacity: 0.75;
@@ -3373,6 +3408,34 @@ button {
   background: var(--pit-soft);
   border-radius: 999px;
   padding: 0.05rem 0.4rem;
+}
+
+/* What a firing bought. On the row rather than behind a click, because it is
+   the difference between a routine that is working and one whose instruction is
+   being delivered to an agent that never runs, and the two rows are otherwise
+   identical. */
+.history__spend {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  color: var(--faint);
+}
+
+.history__cost {
+  color: color-mix(in oklab, var(--mint) 70%, var(--faint));
+}
+
+/* Delivered, and nothing ran. Drawn as a state rather than as "0 tokens": a
+   zero in a column of numbers reads as a cheap run, not as a firing that never
+   reached a model. */
+.history__quiet {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--pit);
 }
 
 .history__ago {


### PR DESCRIPTION
The routine panel now asks for the part of the moment each trigger actually keeps (a weekday for a weekly repeat, a day of the month for a monthly one, a date for a one-off) rather than only a time of day, which left "every week at nine" on whichever day the operator happened to be at the keyboard, and a moment already gone is refused instead of reaching the scheduler as a delay it reads as overdue.

A firing now arrives in the transcript as `Part::Routine`: the model still reads the same instruction, but the operator gets one line naming the routine and opening it in the panel, in place of several sentences of system prompting drawn as though Guaca had typed them into the conversation.

Every firing in the run history carries what it spent, joined from the model calls filed under its run, because a firing that bought no call is a routine that did not run and nothing else in the row told the two apart.

Underneath, a trigger is a `Cadence` or an `EventTrigger` and `next_run_at` is nullable, so a trigger that is not a clock holds no slot and never comes due; nothing delivers a connector event yet and the picker does not offer one, but every layer beneath it stores, reads, draws and is tested, and migration 21 rebuilds `routines` for it with foreign key enforcement off for the sequence, since with it on the rebuild's `DROP TABLE` fires `routine_runs`' cascade and deletes every recorded firing.