### PR TITLE
feat: a turn's tool calls fold into chips, and a file says what it is

### DIFF
--- a/.claude/skills/run-guaca/SKILL.md
+++ b/.claude/skills/run-guaca/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: run-guaca
+description: Launch Guaca locally and get a change on screen, including the scratch-workspace path that needs no API key and costs nothing. Use when asked to run, start, launch or screenshot the app, to check a change in the real app rather than in tests, or when the app will not start.
+---
+
+# Running Guaca
+
+Two ways in. Pick by what you are actually trying to see.
+
+| You want to see | Use |
+|---|---|
+| A transcript row, a card, a dialog, anything the webview draws | **The harness.** Seconds, no Rust build, no key, no spend. |
+| IPC, the runtime, migrations, the file store, a real agent turn | **The app.** |
+
+Reach for the app when the harness cannot answer the question. Most chat work
+is the harness.
+
+## The harness
+
+`src/preview.tsx` is not committed. Write one, point Vite at it, screenshot it
+headless, then delete it. Nothing about it is precious.
+
+```sh
+cat > preview.html <<'EOF'
+<!doctype html>
+<html lang="en"><head><meta charset="UTF-8" /></head>
+<body><div id="root"></div><script type="module" src="/src/preview.tsx"></script></body></html>
+EOF
+npx vite --port 5199 --strictPort &
+```
+
+Two things the harness needs, and both bite silently:
+
+- **`convertFileSrc` reads the Tauri bridge off `window`.** Anything drawing a
+  file throws `Cannot read properties of undefined` without a stub. Set
+  `globalThis.__TAURI_INTERNALS__ = { convertFileSrc: (p, s) => `${s}://localhost/${p}` }`
+  before the first import that reaches `lib/files.ts`.
+- **`lib/ipc.ts` reaches for Tauri too.** Render leaf components rather than
+  `App`, or stub `api`.
+
+Screenshot it, and then **look at the image**. A render that throws still
+produces a PNG.
+
+```sh
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --headless --disable-gpu --hide-scrollbars --user-data-dir=/tmp/shot \
+  --window-size=900,700 --screenshot=/tmp/out.png --virtual-time-budget=5000 \
+  http://localhost:5199/preview.html
+```
+
+Use a fresh `--user-data-dir` per shot; a reused one hangs on the second run.
+Chrome takes tens of seconds to exit, so run it in the background and wait on
+the file rather than on the process.
+
+## The app
+
+```sh
+pnpm app                      # tauri dev
+GUAC_LOG=guac=debug pnpm app  # what you almost always want
+```
+
+The default filter is `guac=info,warn`, which hides `served a file`, the proxy,
+and every other line you would launch the app to read.
+
+Wait for the readiness line, not for the process: the binary exists long before
+the window does.
+
+```sh
+(GUAC_LOG=guac=debug pnpm app > /tmp/guac/app.log 2>&1 &)
+until grep -q "guac ready" /tmp/guac/app.log; do sleep 2; done
+```
+
+Write the log somewhere you own. A stale `/tmp/*.log` from another account
+fails the redirect with `permission denied` and the launch never happens, while
+the old file sits there looking like output.
+
+First build is ~440 crates. After that a relaunch is seconds.
+
+## It will not start
+
+**`database is at version N, newer than this build supports (M)`** is the
+common one, and it is the migration guard working. Your branch is behind a
+branch that added a migration, and the app refuses a schema it does not know
+rather than writing to it.
+
+```sh
+git fetch origin && git rebase origin/main
+```
+
+Do not delete the database and do not lower `user_version`. Either one throws
+away a real workspace to avoid a rebase.
+
+## The operator's data
+
+macOS: `~/Library/Application Support/com.madebywelch.guac/`
+
+`guac.db`, `config.json` (**holds the API key in plaintext — never print this
+file, and never print a field of it without redacting nested objects**), and
+`files/` addressed by digest.
+
+There is one profile per bundle identifier, so every workspace on this machine
+shares it. Treat it as production:
+
+- Back it up before writing to it, and put it back afterwards.
+- For anything experimental, rename it aside and let the app make a fresh one.
+  A running app follows its open file descriptors, so you can rename the
+  scratch profile out and the real one back in without stopping it.
+- Never seed test rows into a database the operator is using.
+
+## A workspace to test against
+
+`seed.py` fills a scratch profile with a crew and a transcript covering every
+row a channel can draw: bubbles, a peer burst, a folded tool trail with a
+failure and a credential spend, a routine firing, and files. No key, no
+network, no spend.
+
+```sh
+python3 .claude/skills/run-guaca/seed.py --help
+```
+
+## What you cannot do from here
+
+`screencapture` needs Screen Recording permission and `osascript` needs
+Accessibility, and neither is granted to the terminal. There is no way to
+screenshot or drive the real window from a shell. Use the harness for anything
+visual, and ask the operator to look when only the real app will do.
+
+## Before you say it works
+
+```sh
+./scripts/ci.sh
+```

--- a/.claude/skills/run-guaca/seed.py
+++ b/.claude/skills/run-guaca/seed.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Fill a Guaca workspace with a transcript that draws every row a channel has.
+
+Written for looking at the UI, so it costs nothing and needs no key: the rows
+go straight into SQLite in the shape the runtime writes them, and the app draws
+them through the real read path when it opens.
+
+It refuses to write to a database that already holds messages. There is one
+profile per bundle identifier and every workspace on the machine shares it, so
+the failure mode this is guarding against is seeding test rows into the
+operator's own workspace. Rename that profile aside first and let the app make
+a fresh one; `--force` is there for when you have done exactly that and want it
+anyway.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import time
+import uuid
+
+PROFILE = "~/Library/Application Support/com.madebywelch.guac"
+GROUP = "00000000-0000-4000-8000-000000000001"
+
+CREW = [
+    ("Manager", "avocado", "#4e6b16", ["Plans work", "Delegates by fit"]),
+    ("Researcher", "lime", "#1c7a51", ["Finds sources", "Checks claims"]),
+    ("Critic", "pit", "#8a5a2f", ["Reviews drafts", "Finds holes"]),
+    ("Scribe", "leaf", "#5b665e", ["Writes things up"]),
+]
+
+
+def ok(summary: str) -> dict:
+    return {"status": "ok", "summary": summary}
+
+
+def tool(name: str, arguments: dict, outcome: dict) -> dict:
+    return {"type": "toolCall", "name": name, "arguments": arguments, "outcome": outcome}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--db", default=os.path.join(os.path.expanduser(PROFILE), "guac.db"))
+    ap.add_argument("--force", action="store_true", help="write even if the database already holds messages")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.db):
+        print(f"no database at {args.db}\nstart the app once to create the schema, then run this", file=sys.stderr)
+        return 1
+
+    conn = sqlite3.connect(args.db)
+    held = conn.execute("SELECT count(*) FROM messages").fetchone()[0]
+    if held and not args.force:
+        print(
+            f"{args.db} already holds {held} messages.\n"
+            "This looks like a workspace somebody is using. Rename the profile aside and let the\n"
+            "app make a fresh one, or pass --force if you are certain.",
+            file=sys.stderr,
+        )
+        return 1
+
+    now = int(time.time() * 1000)
+    ids: dict[str, str] = {}
+    for order, (name, avatar, color, skills) in enumerate(CREW):
+        agent_id = str(uuid.uuid4())
+        ids[name] = agent_id
+        conn.execute(
+            "INSERT INTO agents (id,name,avatar,color,model,system_prompt,skills,lifecycle,version,"
+            "created_at,updated_at,group_id,pinned,rail_order) VALUES (?,?,?,?,'',?,?,'active',1,?,?,?,0,?)",
+            (agent_id, name, avatar, color, f"You are {name}.", json.dumps(skills), now, now, GROUP, order),
+        )
+
+    manager, researcher = ids["Manager"], ids["Researcher"]
+    run = str(uuid.uuid4())
+    clock = now - 95 * 60 * 1000
+    rows: list[tuple] = []
+
+    def add(frm, frm_id, to, to_id, parts, trust, intent="work", gap=4000):
+        nonlocal clock
+        clock += gap
+        rows.append((str(uuid.uuid4()), run, manager, frm, frm_id, to, to_id,
+                     json.dumps(parts), trust, 0, 0, None, clock, intent))
+
+    add("human", None, "agent", manager,
+        [{"type": "text", "text": "Check the top three stories on cnn, then summarise them."}], "operator")
+
+    # One turn writes one envelope, however many tools it reached for. This is
+    # what the trail row folds.
+    add("agent", manager, "system", None, [
+        tool("directory", {}, ok("3 agent(s): Researcher, Critic, Scribe")),
+        tool("browse", {"action": "open", "url": "https://www.cnn.com"}, ok("open in the browser")),
+        tool("browse", {"action": "read"}, ok("read in the browser")),
+        tool("browse", {"action": "click", "id": 14}, ok("click in the browser")),
+        tool("browse", {"action": "read"}, ok("read in the browser")),
+        tool("run_command", {"command": "python3 -c 'import sys; print(len(sys.stdin.read()))'"},
+             ok("exit 0, 4 bytes out")),
+        # Never folds: the operator's audit trail for their own tokens.
+        tool("run_command", {"command": 'curl -s -H "Authorization: Bearer $STRIPE_KEY" https://api.stripe.com/v1/charges'},
+             ok("used Stripe ($STRIPE_KEY) · exit 0, 812 bytes out")),
+        # Never folds either.
+        tool("run_command", {"command": "cat /tmp/headlines.json"},
+             {"status": "failed", "error": "your computer is not available (sandbox timed out)"}),
+        tool("use_screen", {"action": "look"}, ok("looked at the screen (1280x800)")),
+        tool("update_notes", {"content": "# Manager\n\n- Reads CNN first thing.\n- Three bullets, no preamble."},
+             ok("Memory saved (62 characters).")),
+    ], "system", intent="courtesy")
+
+    # Peer traffic, which the channel collapses into a burst.
+    add("agent", researcher, "agent", manager,
+        [{"type": "text", "text": "The market number matches Reuters."}], "peer")
+    add("agent", researcher, "agent", manager,
+        [{"type": "text", "text": "Nothing new on the storm since the 14:00 bulletin."}], "peer", gap=900)
+
+    add("agent", manager, "human", None, [{"type": "text", "text": (
+        "Three stories, top of the hour:\n\n"
+        "1. **Markets** — the index closed down 1.2%.\n"
+        "2. **Weather** — a storm makes landfall overnight.\n"
+        "3. **Politics** — the vote moved to Thursday.\n\n"
+        "Want me to keep watching any of these?")}], "peer")
+
+    # A guard stop, and a send that named nobody: neither folds.
+    add("agent", manager, "system", None, [
+        tool("send_message", {"text": "keeping an eye on this"},
+             {"status": "refused", "reason": "Refused: name a recipient. Put one or more agent names in `to`."}),
+        {"type": "notice", "kind": "guardStop", "text": "hop limit (8) reached"},
+    ], "system", intent="courtesy")
+
+    conn.executemany(
+        "INSERT INTO messages (id,run_id,channel_id,from_kind,from_agent,to_kind,to_agent,parts,trust,hop,"
+        "expects_reply,cause,created_at,intent) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)", rows)
+    conn.commit()
+    print(f"seeded {len(CREW)} agents and {len(rows)} messages into {args.db}")
+    print("open Manager's channel: bubbles, a peer burst, a folded trail, a failure, a credential and a guard stop")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ src/                  React + TypeScript. A view over the runtime, nothing more.
   lib/transcript.ts   What a channel shows, and what it collapses. Read first.
   lib/rail.ts         What order the rail draws agents in, and where a drop lands.
   lib/search.ts       One ranking over hits from SQLite and from the store.
+  lib/trail.ts        A turn's own tool calls: what folds into one chip.
   lib/cafeteria.ts    Preset agents, waiting to be hired. Content, not runtime.
   lib/ipc.ts          Every call into Rust.
   components/         One file per surface.
@@ -60,6 +61,8 @@ repo: the frontend renders state and forwards intent.
 | Schedules, triggers, what a firing looks like | `docs/ROUTINES.md` |
 | Sandboxes, the browser, sign-ins, credentials | `docs/MACHINES.md`, then *Connectors* in `docs/PROTOCOL.md` |
 | Channels, the rail, search: what the operator sees | `docs/WORKSPACE.md`, then `src/lib/transcript.ts` |
+| A turn's tool calls in a channel: what folds, what a chip says, what opens | *A turn's own work is chips* in `docs/WORKSPACE.md`, then `src/lib/trail.ts` |
+| Anything announced to a screen reader, or a live region | *A transcript is a log, and says one thing out loud* in `docs/WORKSPACE.md` |
 | The rail's order, dragging a row, groups as places you go inside | *The rail is arranged by hand*, *A drop is one call* and *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/rail.ts` |
 | Preset agents, hiring a crew | *The cafeteria is a copy machine* in `docs/WORKSPACE.md`, then `src/lib/cafeteria.ts` |
 | A prompt, or anything that changes how much a crew talks | *Three test suites, asking different questions*, then run the live evals |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,11 @@ the source rather than at the end.
 GUAC_LOG=guac=debug pnpm app
 ```
 
+Getting a change on screen has its own file: `.claude/skills/run-guaca`. It
+holds the harness that draws a component in seconds without a Rust build, a key
+or any spend; what to do when the app refuses to start; and the rule about the
+operator's own workspace, which every workspace on the machine shares.
+
 Three suites ask three different questions, and a change can pass one while
 failing the next. *Three test suites, asking different questions* in
 `docs/ARCHITECTURE.md` is the long version.

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -21,6 +21,89 @@ open, because two exchanges three hours apart are two things that happened.
 What a channel folds and what it must never fold is in *A channel says an
 exchange happened; the pair's thread is what it said*, in `ARCHITECTURE.md`.
 
+## A turn's own work is chips, not a line per call
+
+The third thing in a channel, after the operator's conversation and the peer
+traffic. It had the least design and by volume it was the most of it: a turn may
+make two dozen tool calls, because the round limit is twenty-four and a browsing
+turn legitimately spends most of it, and every one of those was a line reading
+`Chef used browse`. That is the same burial peer traffic was collapsed to fix,
+arriving from the other direction, and it sat between the operator's question
+and the answer to it.
+
+So a run of calls is one row of chips, one per kind of work, and the calls
+themselves open underneath it. `lib/trail.ts` holds the rules as pure functions
+over a list, the way `lib/rail.ts` does for the rail, so what folds can be read
+and tested without a DOM.
+
+Grouped by tool across the run rather than only where calls are adjacent. The
+order a model happens to interleave `browse` and `run_command` in is not
+something anybody asked about; "4 steps on cnn.com, ran 2 commands" is.
+
+**Two things never fold, and they are the two the row exists to be right
+about.** A call the runtime refused or that failed keeps its own chip with its
+reason on it, for the reason a refused send never joins a burst: it is the
+runtime stopping something rather than something happening. And a command that
+spent one of the operator's credentials keeps its own chip with the credential
+named on it, because that is their audit trail for their own tokens and it is
+not a thing to put behind a click. The value is not there and there is no field
+it could arrive in; the name and the variable are, which is what tells two
+tokens apart. `readSpent` mirrors `credentials_named_in` in `runtime/mod.rs` and
+the two have to agree: `lib/trail.test.ts` holds this side to that wording, so
+a change there is noticed here rather than quietly costing the operator the
+trail.
+
+**One call still says exactly what it was.** `Opened cnn.com` and `Ran a
+command` are what the operator wanted to know; `used browse` is the name of a
+function in a file they do not have. A count only replaces that where there are
+several of a kind, and it names what it can even then: a browsing turn that
+stayed on one site says which site, for the reason a burst draws one chip per
+peer rather than "5 messages with 2 agents".
+
+**What came back is on the chip in two cases and no others.** Most of these
+summaries are the line above read back in the runtime's words: `browse` answers
+`read in the browser`, `update_notes` answers with a character count printed
+directly over the characters. Nine of those turned a row into a paragraph of
+grey monospace. So the summary earns its place when the call went wrong, or when
+the call has nothing else to show and the summary is the whole of what came
+back: `2 agents: Chef, Scribe` is the answer to a directory lookup, not a
+restatement of it. Everything else is one click away, where an exit code is
+worth reading and a byte count can be ignored in peace.
+
+**A chip that opens nothing is not a button.** A directory lookup is one call
+whose whole content is the sentence already on it. A control that does nothing
+is one the operator stops trusting the rest of.
+
+Nobody is named on any of it. There is exactly one agent whose own work this can
+be, its portrait and name are at the top of the pane, and the rows this replaced
+put that name in front of every line. Same argument as *A channel names nobody*
+above, applied to the last place it had not reached.
+
+## A transcript is a log, and says one thing out loud
+
+Waiting for a reply is the shape of using this app, and a reader who cannot see
+the column arrive has no way of knowing one did. So `.pane__scroll` is
+`role="log"` and a message addressed to the operator is announced once, when it
+settles.
+
+The announcing is a region of its own rather than the log's own politeness, and
+each half of that is deliberate. A live transcript would read three hundred rows
+aloud when a channel is opened, which is the whole history recited for the crime
+of clicking a name. And it would read a bubble being typed a dozen times before
+it was finished, so the streams are `aria-live="off"` and `WorkingNote` already
+says the turn is alive.
+
+What is announced is exactly what is drawn as a full bubble, and that symmetry
+is the rule. Peer traffic and tool trails are collapsed on screen precisely
+because reading them line by line buries the conversation; read aloud they would
+bury it more thoroughly, because there is no glancing past a sentence being
+spoken. A permission request goes ahead of the text, as it does everywhere else:
+it is the one thing in a transcript the operator is expected to act on.
+
+The region sits outside the log. Inside it, the sentence is a second copy of the
+newest message for anybody reading the transcript itself, which is the cost of
+announcing it to everybody else.
+
 ## The rail is arranged by hand, and lends the top of a section out
 
 Two orders, not one. `railOrder` on the card is the arrangement: the operator

--- a/src/components/ChannelView.test.tsx
+++ b/src/components/ChannelView.test.tsx
@@ -252,13 +252,17 @@ describe("while an agent is working", () => {
     expect(screen.queryByText("Manager is working")).toBeNull();
     // And it stops being a live region while it holds a line that is replaced
     // several times a second, or a screen reader reads out every half sentence
-    // of it over whatever else it was saying.
-    expect(screen.queryByRole("status")).toBeNull();
+    // of it over whatever else it was saying. Asked of this line rather than of
+    // the pane: an arriving message is announced by a region of its own, which
+    // is the one thing here that is meant to be heard.
+    expect(document.querySelector(".working")?.getAttribute("role")).toBeNull();
 
     // The runtime clears it when the stream ends, and the line goes back to
     // saying only that the turn is still going.
     act(() => useStore.setState({ reasoning: {} }));
-    expect(screen.getByRole("status").textContent).toContain("Manager is working");
+    const note = document.querySelector(".working");
+    expect(note?.getAttribute("role")).toBe("status");
+    expect(note?.textContent).toContain("Manager is working");
   });
 
   it("draws another agent's thinking in that agent's channel and not this one", () => {

--- a/src/components/ChannelView.tsx
+++ b/src/components/ChannelView.tsx
@@ -4,7 +4,14 @@ import { api } from "../lib/ipc";
 import { thoughtLine } from "../lib/reasoning";
 import { ACTIVITY_CHANNEL, type ChannelKey, useAgentLookup, useStore } from "../lib/store";
 import { rowStandsFor, toPeer, transcriptRows } from "../lib/transcript";
-import { type Activity, type AgentCard, type AgentId, errorMessage } from "../lib/types";
+import {
+  type Activity,
+  type AgentCard,
+  type AgentId,
+  type Envelope,
+  errorMessage,
+  plainText,
+} from "../lib/types";
 import { ActivityFlow } from "./ActivityFlow";
 import { Composer } from "./Composer";
 import { MessageItem, StreamingMessage, WhenRow } from "./MessageItem";
@@ -183,7 +190,19 @@ export function ChannelView({ channel, onOpenMenu }: Props) {
         // board rather than a transcript.
         <ActivityFlow messages={messages ?? []} byId={lookups.byId} />
       ) : (
-        <div className="pane__scroll" ref={scrollRef}>
+        // A log rather than a plain box, so a screen reader offers it as the
+        // transcript it is. `aria-live` is off deliberately: the role would
+        // otherwise announce politely, and opening a channel replaces three
+        // hundred rows at once, which is the whole history read aloud for the
+        // crime of clicking a name. What is worth hearing is announced by
+        // `Arrivals` below, one message at a time, as it lands.
+        <div
+          className="pane__scroll"
+          ref={scrollRef}
+          role="log"
+          aria-live="off"
+          aria-label={`Conversation with ${agent?.name ?? "this agent"}`}
+        >
           {messages === undefined ? (
             <p className="hint" style={{ padding: "1rem 1.15rem" }}>
               Loading…
@@ -232,6 +251,10 @@ export function ChannelView({ channel, onOpenMenu }: Props) {
 
       {isActivity ? null : (
         <>
+          {/* Outside the log on purpose. Inside it the sentence is a second
+              copy of the newest message for anybody reading the transcript
+              itself, which is the cost of announcing it to everybody else. */}
+          <Arrivals channel={channel} messages={messages} lookups={lookups} />
           {agent && <WorkingNote agent={agent} state={activity[agent.id]} />}
           <Composer
             placeholder={`Message ${agent?.name ?? "agent"}`}
@@ -337,7 +360,10 @@ function LiveStreams({
   useLayoutEffect(follow);
 
   return (
-    <>
+    // Never announced. A live region reading a bubble as it is typed says the
+    // same sentence a dozen times before it is finished; the finished message
+    // is announced once, by `Arrivals`, and "is working" by `WorkingNote`.
+    <div aria-live="off">
       {live.map(([id, buffer]) => {
         if (!buffer) return null;
 
@@ -354,6 +380,87 @@ function LiveStreams({
           <StreamingMessage key={id} agent={lookups.byId(buffer.agentId)} text={buffer.text} />
         ) : null;
       })}
-    </>
+    </div>
   );
+}
+
+/**
+ * The one thing a transcript says out loud.
+ *
+ * Waiting for a reply is the whole shape of using this app, and a reader who
+ * cannot see the column arrive has no way of knowing one did. So a message
+ * addressed to the operator is announced once, when it settles, and nothing
+ * else is: what is announced is exactly what is drawn as a full bubble.
+ *
+ * That symmetry is the rule, and it is the same one the channel is arranged by.
+ * Peer traffic and tool trails are collapsed on screen precisely because
+ * reading them line by line buries the conversation; read aloud they would bury
+ * it far more thoroughly, since there is no glancing past a sentence being
+ * spoken.
+ *
+ * Its own component so a message landing in another agent's channel costs this
+ * one nothing, and so the sentence is built where it is announced rather than
+ * threaded down from the pane.
+ */
+function Arrivals({
+  channel,
+  messages,
+  lookups,
+}: {
+  channel: ChannelKey;
+  messages: Envelope[] | undefined;
+  lookups: ReturnType<typeof useAgentLookup>;
+}) {
+  const [said, setSaid] = useState("");
+  /** The newest message already accounted for. Null until the channel is read. */
+  const seen = useRef<string | null>(null);
+
+  // Declared before the one below so it runs first on the render that changes
+  // both: a channel switch has to forget what it had seen before that render
+  // decides whether the newest message is news.
+  useEffect(() => {
+    seen.current = null;
+    setSaid("");
+  }, [channel]);
+
+  useEffect(() => {
+    const newest = messages?.[messages.length - 1];
+    if (!newest) return;
+    // Opening a channel is not an arrival. Everything in it was already there.
+    if (seen.current === null || seen.current === newest.id) {
+      seen.current = newest.id;
+      return;
+    }
+    seen.current = newest.id;
+    setSaid(announcement(newest, lookups.byId));
+  }, [messages, lookups]);
+
+  return (
+    // Explicit rather than left to the role: the transcript above declares
+    // `aria-live="off"`, live-region settings are inherited, and an implicit
+    // value from `role="status"` is a weaker claim than a stated one.
+    <p className="offscreen" role="status" aria-live="polite" aria-atomic="true">
+      {said}
+    </p>
+  );
+}
+
+/** What an arriving message is worth saying, or nothing. */
+function announcement(message: Envelope, byId: ReturnType<typeof useAgentLookup>["byId"]): string {
+  if (message.from.kind !== "agent") return "";
+  const who = byId(message.from.id)?.name ?? "An agent";
+
+  // Ahead of the text, as everywhere else: this is the one thing in a
+  // transcript the operator is expected to act on rather than read.
+  const asking = message.parts.find((part) => part.type === "approval");
+  if (asking) return `${who} is asking you: ${asking.summary}`;
+
+  // Addressed to a peer, so it is a collapsed row here rather than a bubble.
+  if (message.to.kind !== "human") return "";
+
+  const body = plainText(message);
+  if (!body) return "";
+  // Long enough to be the message, short enough that a reader can interrupt it
+  // and go and read the column instead.
+  return body.length > 300 ? `${who}: ${body.slice(0, 300)}…` : `${who}: ${body}`;
 }

--- a/src/components/FileCard.test.tsx
+++ b/src/components/FileCard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Attachment } from "../lib/types";
@@ -65,9 +65,12 @@ describe("FileCard", () => {
   });
 
   it("gives a document its first page, in a frame that does not take the click", async () => {
-    const { unmount } = render(<FileCard file={file("brief.pdf", "application/pdf")} />);
+    const { unmount, container } = render(<FileCard file={file("brief.pdf", "application/pdf")} />);
 
-    const page = (await screen.findByTitle("brief.pdf")) as HTMLIFrameElement;
+    // By tag rather than by title: the name button carries the whole file name
+    // as a tooltip now, because it truncates.
+    await waitFor(() => expect(container.querySelector("iframe")).toBeTruthy());
+    const page = container.querySelector("iframe") as HTMLIFrameElement;
     // A copy of the document, not its address: WebKit refuses a custom scheme
     // as a frame source whatever the CSP says, and a document's own viewer only
     // runs in a frame. The bytes still arrive over the scheme.
@@ -87,7 +90,13 @@ describe("FileCard", () => {
     fetched.mockResolvedValue({ ok: false, status: 404, blob: async () => new Blob([]) });
     render(<FileCard file={file("missing.pdf", "application/pdf")} />);
 
-    await waitFor(() => expect(screen.getByText(/could not be read/)).toBeTruthy());
+    // The reason, not just the fact: a preview that fails while the store is
+    // still opening wants trying again, and one whose bytes are missing does
+    // not, and "could not be read" said neither.
+    await waitFor(() =>
+      expect(screen.getByText(/not in this workspace's file store/)).toBeTruthy(),
+    );
+    expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
   });
 
   it("reads the first lines of a text file into the transcript", async () => {
@@ -104,6 +113,10 @@ describe("FileCard", () => {
 
     expect(screen.getByText("archive.zip")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Open archive.zip" })).toBeNull();
+    // The one row with no preview to speak for it, so it says what it is. A
+    // name and a size and no other fact is what leaves an operator wondering
+    // what the app thinks it is holding.
+    expect(screen.getByText(/ZIP archive/)).toBeTruthy();
   });
 
   it("opens the full view on the name, whatever the file is", async () => {
@@ -113,8 +126,10 @@ describe("FileCard", () => {
     const dialog = screen.getByRole("dialog");
     expect(dialog.getAttribute("aria-label")).toBe("archive.zip");
     // Clicking a file that cannot be shown has to leave the operator somewhere
-    // better than where they were.
-    expect(screen.getByText(/Save a copy/)).toBeTruthy();
+    // better than where they were: what it is, and the one thing that always
+    // works on a file this app cannot open.
+    expect(within(dialog).getByText(/ZIP archive/)).toBeTruthy();
+    expect(within(dialog).getByRole("button", { name: "Save a copy" })).toBeTruthy();
   });
 
   it("closes the full view on Escape", () => {
@@ -130,7 +145,7 @@ describe("FileCard", () => {
     saveFile.mockResolvedValue("/Users/robert/Downloads/brief.pdf");
     render(<FileCard file={file("brief.pdf", "application/pdf")} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save a copy" }));
 
     await waitFor(() =>
       expect(saveFile).toHaveBeenCalledWith(
@@ -150,7 +165,7 @@ describe("FileCard", () => {
     saveFile.mockRejectedValue({ kind: "file", message: "no file here with that content" });
     render(<FileCard file={file("brief.pdf", "application/pdf")} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save a copy" }));
 
     await waitFor(() =>
       expect(setBanner).toHaveBeenCalledWith({
@@ -161,9 +176,32 @@ describe("FileCard", () => {
   });
 
   it("says a text file could not be read rather than showing an empty box", async () => {
-    fetched.mockRejectedValue(new Error("gone"));
+    fetched.mockRejectedValue(new Error("the file store was still opening"));
     render(<FileCard file={file("unreadable.md", "text/markdown")} />);
 
-    await waitFor(() => expect(screen.getByText(/could not be read/)).toBeTruthy());
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Could not read this file: the file store was still opening/),
+      ).toBeTruthy(),
+    );
+  });
+
+  it("offers another go at a read that failed, and takes it", async () => {
+    // The commonest failure here is one that has already stopped being true by
+    // the time it is on screen: the store answers 503 while it is opening, and
+    // a preview that mounted in that window used to stay broken for the life of
+    // the channel.
+    // Its own name, so its own digest: the read cache is keyed by content and
+    // outlives a test, which is the whole point of it everywhere else.
+    fetched.mockRejectedValueOnce(new Error("the file store was still opening"));
+    const { container } = render(<FileCard file={file("retry.md", "text/markdown")} />);
+
+    const retry = await screen.findByRole("button", { name: "Try again" });
+    fireEvent.click(retry);
+
+    await waitFor(() =>
+      expect(container.querySelector(".file__text")?.textContent).toContain("first line"),
+    );
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
   });
 });

--- a/src/components/FileCard.tsx
+++ b/src/components/FileCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 
 import {
   fileUrl,
+  kindLabel,
   localCopy,
   PREVIEW_BYTES,
   previewKind,
@@ -42,10 +43,22 @@ export function FileCard({ file }: { file: Attachment }) {
           </button>
         )}
         <div className="file__foot">
-          <button type="button" className="file__name" onClick={() => setOpen(true)}>
+          <button
+            type="button"
+            className="file__name"
+            title={file.name}
+            onClick={() => setOpen(true)}
+          >
             {file.name}
           </button>
-          <span className="file__size">{readableSize(file.bytes)}</span>
+          {/* The type only where nothing else says it. A picture, a page and a
+              log announce themselves; a zip is a name and a size and no other
+              fact, which is the row that leaves an operator wondering what the
+              app thinks it is holding. */}
+          <span className="file__meta">
+            {kind === "none" && `${kindLabel(file.mime)} · `}
+            {readableSize(file.bytes)}
+          </span>
           <SaveButton file={file} />
         </div>
       </div>
@@ -94,7 +107,7 @@ function Page({ file }: { file: Attachment }) {
       {copy.url && (
         <iframe className="file__frame" src={copy.url} title={file.name} tabIndex={-1} />
       )}
-      {copy.failed && <p className="hint">This document could not be read.</p>}
+      {copy.failed && <Unreadable file={file} why={copy.failed} onRetry={copy.again} />}
     </div>
   );
 }
@@ -108,12 +121,14 @@ function Page({ file }: { file: Attachment }) {
  */
 function useLocalCopy(file: Attachment, when: boolean) {
   const [url, setUrl] = useState<string | null>(null);
-  const [failed, setFailed] = useState(false);
+  const [failed, setFailed] = useState<string | null>(null);
+  const [attempt, again] = useAttempt();
 
   useEffect(() => {
     if (!when) return;
     let live = true;
     let made: string | null = null;
+    setFailed(null);
     localCopy(file)
       .then((copy) => {
         // A copy nobody is waiting for any more is revoked here rather than in
@@ -122,15 +137,61 @@ function useLocalCopy(file: Attachment, when: boolean) {
         made = copy;
         setUrl(copy);
       })
-      .catch(() => live && setFailed(true));
+      .catch((error) => live && setFailed(errorMessage(error)));
     return () => {
       live = false;
       if (made) URL.revokeObjectURL(made);
       setUrl(null);
     };
-  }, [file, when]);
+  }, [file, when, attempt]);
 
-  return { url, failed };
+  return { url, failed, again };
+}
+
+/**
+ * A counter that makes an effect run again.
+ *
+ * Reading a file is the one thing in a transcript that can fail for a reason
+ * that has since stopped being true: the store answers 503 while it is opening,
+ * and a preview that mounted in that window stays broken for the life of the
+ * channel with no way back other than closing it. So every failure offers
+ * another go.
+ */
+function useAttempt() {
+  const [attempt, setAttempt] = useState(0);
+  return [attempt, () => setAttempt((made) => made + 1)] as const;
+}
+
+/**
+ * A file the app has, and could not read.
+ *
+ * Says which of the reasons it was and offers the two ways forward, because
+ * every error the operator can hit in this app says what happened and what to
+ * do about it, and this one used to say neither. "This file could not be read"
+ * is the same sentence whether the store was still opening, the bytes are
+ * missing, or something else entirely went wrong, and those want different
+ * things done about them.
+ */
+function Unreadable({
+  file,
+  why,
+  onRetry,
+}: {
+  file: Attachment;
+  why: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="file__failed">
+      <p className="hint">Could not read this file: {why}.</p>
+      <div className="file__failed-actions">
+        <button type="button" className="btn btn--ghost btn--small" onClick={onRetry}>
+          Try again
+        </button>
+        <SaveButton file={file} />
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -150,19 +211,21 @@ function Snippet({
   sayTrimmed?: boolean;
 }) {
   const [read, setRead] = useState<{ text: string; trimmed: boolean } | null>(null);
-  const [failed, setFailed] = useState(false);
+  const [failed, setFailed] = useState<string | null>(null);
+  const [attempt, again] = useAttempt();
 
   useEffect(() => {
     let live = true;
+    setFailed(null);
     readFileText(file, limit)
       .then((got) => live && setRead(got))
-      .catch(() => live && setFailed(true));
+      .catch((error) => live && setFailed(errorMessage(error)));
     return () => {
       live = false;
     };
-  }, [file, limit]);
+  }, [file, limit, attempt]);
 
-  if (failed) return <p className="hint">This file could not be read.</p>;
+  if (failed) return <Unreadable file={file} why={failed} onRetry={again} />;
   return (
     <>
       <pre className="file__text">{read?.text ?? ""}</pre>
@@ -196,14 +259,29 @@ export function FilePreview({ file, onClose }: { file: Attachment; onClose: () =
       <button type="button" className="scrim__close" aria-label="Close dialog" onClick={onClose} />
       <div className="dialog dialog--file" role="dialog" aria-modal="true" aria-label={file.name}>
         <div className="file-view__head">
-          <h2 className="dialog__title" style={{ margin: 0 }}>
+          {/* The name truncates and the whole of it is a hover away. What must
+              never fold is the line under it: `48 KB` broken across two lines
+              is the dialog telling the operator its own layout gave up. */}
+          <h2 className="dialog__title" title={file.name}>
             {file.name}
           </h2>
-          <span className="hint">{readableSize(file.bytes)}</span>
+          <p className="file-view__what">
+            {kindLabel(file.mime)} · {readableSize(file.bytes)}
+          </p>
           <div className="file-view__actions">
             <SaveButton file={file} />
-            <button type="button" className="btn btn--ghost" onClick={onClose}>
-              Close
+            {/* Its own corner rather than a second button beside Save. Side by
+                side they read as a pair of answers to a question nobody asked,
+                which is how "Save" came to look like it might change the file
+                rather than copy it out. */}
+            <button
+              type="button"
+              className="file-view__close"
+              aria-label="Close"
+              title="Close"
+              onClick={onClose}
+            >
+              ×
             </button>
           </div>
         </div>
@@ -217,8 +295,8 @@ export function FilePreview({ file, onClose }: { file: Attachment; onClose: () =
             <Snippet file={file} limit={PREVIEW_BYTES} sayTrimmed />
           ) : (
             <p className="hint">
-              Nothing here can show this kind of file. Save a copy and open it with something that
-              can.
+              Guaca cannot show a {kindLabel(file.mime).toLowerCase()}. Save a copy and open it with
+              something that can.
             </p>
           )}
         </div>
@@ -231,7 +309,7 @@ export function FilePreview({ file, onClose }: { file: Attachment; onClose: () =
 function Document({ file }: { file: Attachment }) {
   const copy = useLocalCopy(file, true);
 
-  if (copy.failed) return <p className="hint">This document could not be read.</p>;
+  if (copy.failed) return <Unreadable file={file} why={copy.failed} onRetry={copy.again} />;
   return copy.url ? (
     <iframe className="file-view__frame" src={copy.url} title={file.name} />
   ) : (
@@ -246,6 +324,12 @@ function Document({ file }: { file: Attachment }) {
  * has to go looking for has not really been saved. Imperative on the store, as
  * the retry button is, because this is one button on a component that is
  * rendered once per file in a transcript and holds no other state.
+ *
+ * It says what it does. "Save" beside a document is the word every editor uses
+ * for writing changes back, so on a file the operator did not write and cannot
+ * edit it reads as a button whose effect is anybody's guess. This one copies
+ * the file out to the downloads folder and never touches the original, and
+ * three words are cheaper than the guess.
  */
 function SaveButton({ file }: { file: Attachment }) {
   const [saving, setSaving] = useState(false);
@@ -254,6 +338,7 @@ function SaveButton({ file }: { file: Attachment }) {
     <button
       type="button"
       className="btn btn--ghost btn--small"
+      title={`Copy ${file.name} to your downloads folder`}
       disabled={saving}
       onClick={() => {
         setSaving(true);
@@ -266,7 +351,7 @@ function SaveButton({ file }: { file: Attachment }) {
           .finally(() => setSaving(false));
       }}
     >
-      {saving ? "Saving…" : "Save"}
+      {saving ? "Saving…" : "Save a copy"}
     </button>
   );
 }

--- a/src/components/MessageItem.test.tsx
+++ b/src/components/MessageItem.test.tsx
@@ -174,7 +174,12 @@ describe("an agent's own record of what it did", () => {
         outcome: { status: "ok", summary: "2 agent(s): Chef, Scribe" },
       }),
     );
-    expect(screen.getByText(/checked who is available/)).toBeTruthy();
+    // Sentence-cased and unnamed: there is exactly one agent whose own work
+    // this can be, and its name is at the top of the pane. The row this
+    // replaced put that name in front of every line of it.
+    expect(screen.getByText("Checked who is available")).toBeTruthy();
+    // Nothing behind it, so nothing to press. A control that opens nothing is
+    // one the operator stops trusting the rest of.
     expect(screen.queryByRole("button")).toBeNull();
   });
 
@@ -190,7 +195,12 @@ describe("an agent's own record of what it did", () => {
       }),
     );
     expect(screen.queryByText(/no one/)).toBeNull();
-    expect(screen.getByText(/updated its memory/)).toBeTruthy();
+    expect(screen.getByText("Updated its memory")).toBeTruthy();
+
+    // And what it wrote is one click away, which is the whole of what an
+    // operator wants from this row and the one thing it never showed.
+    fireEvent.click(screen.getByRole("button", { name: /Updated its memory/ }));
+    expect(screen.getByText("Smith handles verification.")).toBeTruthy();
   });
 
   it("names an unrecognised tool rather than guessing it was a send", () => {
@@ -203,7 +213,7 @@ describe("an agent's own record of what it did", () => {
       }),
     );
     expect(screen.queryByText(/no one/)).toBeNull();
-    expect(screen.getByText(/used run_code/)).toBeTruthy();
+    expect(screen.getByText("Used run_code")).toBeTruthy();
   });
 
   it("says why a tool call failed, not just that it happened", () => {
@@ -303,8 +313,74 @@ describe("a command that used a credential", () => {
       <MessageItem message={used} lookups={lookups} continued={false} />,
     );
 
-    expect(container.textContent).toContain("used Mistral ($MISTRAL_API_KEY)");
-    expect(container.textContent).toContain("Manager used run_command");
+    // On the row itself, never behind a click and never folded into a count:
+    // this is the operator's audit trail for their own tokens.
+    expect(screen.getByText("Mistral ($MISTRAL_API_KEY)")).toBeTruthy();
+    // The exit code and the command are behind the click, which is where an
+    // exit code is worth reading. The credential is not, which is the whole
+    // point of it.
+    expect(container.textContent).not.toContain("exit 0, 812 bytes out");
+    expect(container.textContent).not.toContain("curl -H");
+
+    fireEvent.click(screen.getByRole("button", { name: /Ran a command/ }));
+    expect(container.textContent).toContain("exit 0, 812 bytes out");
+    expect(screen.getByText(/Authorization: Bearer \$MISTRAL_API_KEY/)).toBeTruthy();
+  });
+});
+
+describe("a turn that used its computer two dozen times", () => {
+  /** What the runtime writes for one turn: every call in one envelope. */
+  function browsing(): Envelope {
+    return envelope({
+      from: { kind: "agent", id: "manager" },
+      to: { kind: "system" },
+      trust: "system",
+      parts: [
+        {
+          type: "toolCall",
+          name: "browse",
+          arguments: { action: "open", url: "https://cnn.com" },
+          outcome: { status: "ok", summary: "open in the browser" },
+        },
+        {
+          type: "toolCall",
+          name: "browse",
+          arguments: { action: "read" },
+          outcome: { status: "ok", summary: "read in the browser" },
+        },
+        {
+          type: "toolCall",
+          name: "browse",
+          arguments: { action: "click", id: 12 },
+          outcome: { status: "ok", summary: "click in the browser" },
+        },
+      ],
+    });
+  }
+
+  it("draws one line for the run of them, naming where it went", () => {
+    // Twenty-four rounds is the limit and a browsing turn spends most of it.
+    // A line apiece is the same burial peer traffic was collapsed to fix.
+    const { container } = render(
+      <MessageItem message={browsing()} lookups={lookups} continued={false} />,
+    );
+    expect(screen.getByRole("button", { name: /3 steps on cnn.com/ })).toBeTruthy();
+    expect(container.querySelectorAll(".trail__chip")).toHaveLength(1);
+  });
+
+  it("opens the calls behind it, in order, and closes again", () => {
+    render(<MessageItem message={browsing()} lookups={lookups} continued={false} />);
+    const chip = screen.getByRole("button", { name: /3 steps on cnn.com/ });
+    expect(chip.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(chip);
+    expect(chip.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("Opened cnn.com")).toBeTruthy();
+    expect(screen.getByText("Read the page")).toBeTruthy();
+    expect(screen.getByText("Clicked on the page")).toBeTruthy();
+
+    fireEvent.click(chip);
+    expect(screen.queryByText("Read the page")).toBeNull();
   });
 });
 

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -5,7 +5,8 @@ import { api } from "../lib/ipc";
 import { routineTitle } from "../lib/routine";
 import { useStore } from "../lib/store";
 import { whenLabel } from "../lib/time";
-import { type Lookups, toPeer } from "../lib/transcript";
+import { type Step, trailStep } from "../lib/trail";
+import type { Lookups } from "../lib/transcript";
 import {
   type AgentCard,
   type AgentId,
@@ -19,6 +20,7 @@ import {
 import { ApprovalRequest } from "./ApprovalRequest";
 import { FileCard } from "./FileCard";
 import { Markdown } from "./Markdown";
+import { TrailRow } from "./Trail";
 import { NoticeRow, RoutineRow } from "./WireRow";
 
 interface Props {
@@ -150,7 +152,7 @@ export const MessageItem = memo(function MessageItem({
   }
 
   if (from.kind === "agent" && to.kind === "system") {
-    return <ActivityRecord message={message} lookups={lookups} />;
+    return <ActivityRecord message={message} />;
   }
 
   return <ChatBubble message={message} byId={lookups.byId} continued={continued} named={named} />;
@@ -164,49 +166,44 @@ export const MessageItem = memo(function MessageItem({
  * row, leaving this the trail around them. A send that named nobody does stay,
  * because there is no peer to file it under and the reason it went nowhere is
  * the whole of what there is to see.
+ *
+ * Tool calls are drawn as one row per run of them rather than one row each: a
+ * turn can make two dozen, and a line apiece buried the operator's own
+ * conversation exactly as peer traffic did before it was collapsed. A notice
+ * ends the run it interrupts, for the reason a tool trail ends a burst in
+ * `transcriptRows`: the notice is usually about the calls either side of it,
+ * and folding across it would put the explanation somewhere other than the
+ * thing it explains.
+ *
+ * A `json` part is the one kind that reaches here and draws nothing. Nothing in
+ * the runtime emits one yet; it is the seam a model-authored artifact would
+ * arrive through, and a renderer for it before there is a producer is surface
+ * with no caller.
  */
-function ActivityRecord({ message, lookups }: { message: Envelope; lookups: Lookups }) {
-  const actorId = message.from.kind === "agent" ? message.from.id : "";
-  const actor = toPeer(lookups.byId(actorId), actorId);
+function ActivityRecord({ message }: { message: Envelope }) {
+  const rows: React.ReactNode[] = [];
+  let run: { steps: Step[]; key: string } | null = null;
 
-  return (
-    <>
-      {keyed(message).map(({ part, key }) => {
-        if (part.type === "notice") {
-          return <NoticeRow key={key} kind={part.kind} text={part.text} />;
-        }
-        if (part.type !== "toolCall") return null;
+  const close = () => {
+    if (run) rows.push(<TrailRow key={run.key} steps={run.steps} />);
+    run = null;
+  };
 
-        // Naming the tools rather than describing whatever came back: a tool
-        // this does not know about should read as a tool nobody has explained
-        // yet, not as a send. `update_notes`, which has no recipients, was once
-        // drawn as "Sent to no one" with the memory body as the message.
-        const outcome = part.outcome;
-        const said =
-          outcome.status === "ok" || outcome.status === "partial"
-            ? outcome.summary
-            : outcome.status === "refused"
-              ? outcome.reason
-              : outcome.error;
-        const what =
-          part.name === "directory"
-            ? "checked who is available"
-            : part.name === "update_notes"
-              ? "updated its memory"
-              : part.name === "create_agent"
-                ? "asked to add an agent"
-                : `used ${part.name}`;
-        return (
-          <div className="wire wire--quiet" key={key}>
-            <span className="wire__quiet-text">
-              {actor.name} {what}
-              {said ? ` — ${said}` : ""}
-            </span>
-          </div>
-        );
-      })}
-    </>
-  );
+  for (const { part, key } of keyed(message)) {
+    if (part.type === "toolCall") {
+      const step = trailStep(part, key);
+      if (run) run.steps.push(step);
+      else run = { steps: [step], key };
+      continue;
+    }
+    close();
+    if (part.type === "notice") {
+      rows.push(<NoticeRow key={key} kind={part.kind} text={part.text} />);
+    }
+  }
+  close();
+
+  return <>{rows}</>;
 }
 
 function ChatBubble({

--- a/src/components/Trail.tsx
+++ b/src/components/Trail.tsx
@@ -1,0 +1,159 @@
+import { useId, useState } from "react";
+
+import {
+  foldTrail,
+  hasDetail,
+  type Step,
+  saysMore,
+  type TrailGroup,
+  tellsMore,
+} from "../lib/trail";
+
+/**
+ * What an agent did on its own turn, collapsed.
+ *
+ * The quietest row a channel draws, and the one that used to be the loudest by
+ * volume: a browsing turn spends most of its twenty-four rounds in the browser,
+ * and every one of those was a line of its own reading `Chef used browse`. Now
+ * a turn is chips, one per kind of work, and the calls behind a chip open in
+ * place.
+ *
+ * Nobody is named. There is exactly one agent whose own work this can be, its
+ * portrait and name are at the top of the pane, and the row this replaced put
+ * that name in front of every line.
+ *
+ * `lib/trail.ts` decides what folds and what a chip says. This decides only how
+ * it is drawn and what a click opens, so the rules can be read and tested
+ * without a DOM.
+ */
+export function TrailRow({ steps }: { steps: Step[] }) {
+  const groups = foldTrail(steps);
+  const [open, setOpen] = useState<ReadonlySet<string>>(() => new Set());
+  const region = useId();
+
+  if (groups.length === 0) return null;
+
+  const toggle = (key: string) =>
+    setOpen((held) => {
+      const next = new Set(held);
+      if (!next.delete(key)) next.add(key);
+      return next;
+    });
+
+  return (
+    <div className="trail">
+      <div className="trail__chips">
+        {groups.map((group) => (
+          <TrailChip
+            key={group.key}
+            group={group}
+            id={`${region}-${group.key}`}
+            open={open.has(group.key)}
+            onToggle={() => toggle(group.key)}
+          />
+        ))}
+      </div>
+
+      {groups
+        .filter((group) => open.has(group.key))
+        .map((group) => (
+          <ul className="trail__steps" id={`${region}-${group.key}`} key={group.key}>
+            {group.steps.map((step) => (
+              <StepRow key={step.key} step={step} />
+            ))}
+          </ul>
+        ))}
+    </div>
+  );
+}
+
+/**
+ * One kind of work, and whether there is more of it to read.
+ *
+ * A chip is only a button where something opens: a directory lookup is one call
+ * whose whole content is the sentence already on the chip, and a control that
+ * does nothing is one the operator stops trusting the rest of.
+ */
+function TrailChip({
+  group,
+  id,
+  open,
+  onToggle,
+}: {
+  group: TrailGroup;
+  id: string;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const only = group.steps.length === 1 ? group.steps[0]! : null;
+  const face = (
+    <>
+      <span className="trail__label">{group.label}</span>
+      {/* Only where it belongs to one call and adds something the label has
+          not already said. Several calls have several answers, and a chip
+          quoting whichever happened to be first is a chip that is wrong about
+          the rest. */}
+      {only && saysMore(only) && <span className="trail__said">{only.said}</span>}
+      {group.spent.map((credential) => (
+        <span className="trail__spent" key={credential}>
+          {credential}
+        </span>
+      ))}
+    </>
+  );
+
+  if (!hasDetail(group)) {
+    return (
+      <span className="trail__chip" data-failed={group.failed || undefined}>
+        {face}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className="trail__chip trail__chip--open"
+      data-failed={group.failed || undefined}
+      aria-expanded={open}
+      aria-controls={open ? id : undefined}
+      onClick={onToggle}
+    >
+      <span className="trail__caret" aria-hidden="true">
+        {open ? "▾" : "▸"}
+      </span>
+      {face}
+    </button>
+  );
+}
+
+/**
+ * One call, opened.
+ *
+ * The command, the URL or the memory that was written, as machine text and
+ * exactly as it was: this is a record of what happened, so it is never markdown
+ * and never anything a model could format its way out of. Long ones scroll
+ * rather than push the transcript sideways.
+ */
+function StepRow({ step }: { step: Step }) {
+  // A url, a pair of coordinates or an element number is a few characters, and
+  // a few characters in a block of their own is a grey rectangle drawn around
+  // nothing. A command and a rewritten memory are the reason the block exists.
+  const inline = step.target !== null && step.target.length <= 48 && !step.target.includes("\n");
+
+  return (
+    <li className="trail__step" data-failed={step.failed || undefined}>
+      <div className="trail__step-head">
+        <span className="trail__step-title">{step.title}</span>
+        {inline && <span className="trail__inline">{step.target}</span>}
+        {step.said && tellsMore(step) && <span className="trail__said">{step.said}</span>}
+        {step.spent.map((credential) => (
+          <span className="trail__spent" key={credential}>
+            {credential}
+          </span>
+        ))}
+      </div>
+      {step.target && !inline && <pre className="trail__target">{step.target}</pre>}
+    </li>
+  );
+}

--- a/src/lib/files.test.ts
+++ b/src/lib/files.test.ts
@@ -98,9 +98,19 @@ describe("readFileText", () => {
     expect(read.trimmed).toBe(false);
   });
 
-  it("fails by name when the file cannot be read", async () => {
+  it("fails with the reason, because the name is already on the row", async () => {
+    // The three answers the file store gives mean different things to the
+    // person reading, and one sentence covering all of them is the reason the
+    // only failure anybody has hit was also the one nobody could diagnose.
     fetched.mockResolvedValue({ ok: false, status: 404, text: async () => "" });
-    await expect(readFileText(file("gone.txt", "text/plain"), 2048)).rejects.toThrow("gone.txt");
+    await expect(readFileText(file("gone.txt", "text/plain"), 2048)).rejects.toThrow(
+      "not in this workspace's file store",
+    );
+
+    fetched.mockResolvedValue({ ok: false, status: 503, text: async () => "" });
+    await expect(readFileText(file("early.txt", "text/plain"), 2048)).rejects.toThrow(
+      "still opening",
+    );
   });
 
   it("reads one file once, however many times the transcript redraws it", async () => {

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -46,6 +46,32 @@ export function previewKind(mime: string): PreviewKind {
 }
 
 /**
+ * What kind of file this is, in the words a person would use.
+ *
+ * Only ever drawn where nothing else says it: a picture, a page of a document
+ * and the first lines of a log all announce themselves, and a label under one
+ * of those is a caption on a photograph of a cat saying "cat". A zip and a
+ * spreadsheet announce nothing at all, and a row carrying a name and a size and
+ * no other fact is the row that makes an operator ask what the app even thinks
+ * it is holding.
+ *
+ * From the type rather than the extension, because the type is what every
+ * other decision about this file was made from and a label that disagreed with
+ * the preview would be worse than no label.
+ */
+export function kindLabel(mime: string): string {
+  if (mime === "application/pdf") return "PDF";
+  if (mime === "application/zip") return "ZIP archive";
+  if (mime.startsWith("image/")) return `${mime.slice("image/".length).toUpperCase()} image`;
+  if (mime.startsWith("text/")) return mime.slice("text/".length).toUpperCase();
+  if (mime === "application/json") return "JSON";
+  if (mime.includes("wordprocessingml") || mime === "application/msword") return "Word document";
+  if (mime.includes("spreadsheetml") || mime === "application/vnd.ms-excel") return "Spreadsheet";
+  if (mime === "application/octet-stream") return "File";
+  return mime;
+}
+
+/**
  * Where the bytes of a stored file are, as a URL.
  *
  * The name travels with the digest because the type is worked out from it on
@@ -79,8 +105,23 @@ export function readableSize(bytes: number): string {
  */
 export async function localCopy(file: Attachment): Promise<string> {
   const response = await fetch(fileUrl(file));
-  if (!response.ok) throw new Error(`could not read ${file.name}`);
+  if (!response.ok) throw new Error(whyNot(response.status));
   return URL.createObjectURL(await response.blob());
+}
+
+/**
+ * Why the file store turned a preview down, in words the operator can act on.
+ *
+ * `app.rs` answers a preview with one of three things and they mean different
+ * things to the person reading: the store was not open yet, the bytes are not
+ * there, or something else went wrong. "This file could not be read" covered
+ * all three and told nobody which, so the one failure anybody has hit was also
+ * the one nobody could diagnose.
+ */
+export function whyNot(status: number): string {
+  if (status === 404) return "its contents are not in this workspace's file store";
+  if (status === 503) return "the file store was still opening";
+  return `the file store answered ${status}`;
 }
 
 /** What was read of a text file, and whether that was all of it. */
@@ -131,7 +172,7 @@ export function readFileText(file: Attachment, limit: number): Promise<FileText>
 async function read(file: Attachment, limit: number): Promise<FileText> {
   const response = await fetch(fileUrl(file), { headers: { Range: `bytes=0-${limit - 1}` } });
   if (!response.ok && response.status !== 206) {
-    throw new Error(`could not read ${file.name}`);
+    throw new Error(whyNot(response.status));
   }
   const text = await response.text();
   // Against the file's own size rather than the text's: a character can be

--- a/src/lib/toolArgs.ts
+++ b/src/lib/toolArgs.ts
@@ -7,7 +7,14 @@
  * recover enough to show the operator what was sent.
  */
 
-function asRecord(value: unknown): Record<string, unknown> {
+/**
+ * A tool call's arguments, read as an object.
+ *
+ * Exported because the trail reads the same arguments back from the same
+ * messages: an argument list that is not an object is a call with no arguments
+ * worth showing, and both readers have to agree on that.
+ */
+export function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};

--- a/src/lib/trail.test.ts
+++ b/src/lib/trail.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+
+import { foldTrail, hasDetail, readSpent, type Step, trailStep } from "./trail";
+import type { Part, ToolOutcome } from "./types";
+
+type ToolCall = Extract<Part, { type: "toolCall" }>;
+
+const ok = (summary: string): ToolOutcome => ({ status: "ok", summary });
+
+function call(name: string, args: unknown, outcome: ToolOutcome = ok("done")): ToolCall {
+  return { type: "toolCall", name, arguments: args, outcome };
+}
+
+function steps(...calls: ToolCall[]): Step[] {
+  return calls.map((call, position) => trailStep(call, `m1:${position}`));
+}
+
+describe("what one call was", () => {
+  it("names the site a browser was pointed at, not the tool", () => {
+    // `used browse` is the name of a function in a file the operator does not
+    // have. Where it went is the thing they opened the channel to find out.
+    const [step] = steps(call("browse", { action: "open", url: "https://www.cnn.com/world" }));
+    expect(step?.title).toBe("Opened cnn.com");
+    expect(step?.target).toBe("https://www.cnn.com/world");
+  });
+
+  it("shows a url that will not parse exactly as it was written", () => {
+    // An agent that browsed to `cnn.com` browsed to cnn.com. Reporting nothing
+    // because `new URL` threw describes a different session.
+    const [step] = steps(call("browse", { action: "open", url: "cnn.com" }));
+    expect(step?.title).toBe("Opened cnn.com");
+  });
+
+  it("keeps the command, which is the only interesting part of running one", () => {
+    const [step] = steps(
+      call("run_command", { command: "curl -s wttr.in" }, ok("exit 0, 8 bytes out")),
+    );
+    expect(step?.title).toBe("Ran a command");
+    expect(step?.target).toBe("curl -s wttr.in");
+    expect(step?.said).toBe("exit 0, 8 bytes out");
+  });
+
+  it("reads a screen action as the place it happened", () => {
+    const [step] = steps(call("use_screen", { action: "click", x: 412, y: 96 }));
+    expect(step?.title).toBe("Clicked on its screen");
+    expect(step?.target).toBe("412, 96");
+  });
+
+  it("names a tool it has never heard of rather than guessing", () => {
+    const [step] = steps(call("run_code", { source: "print(1)" }, ok("exit 0")));
+    expect(step?.title).toBe("Used run_code");
+    expect(step?.target).toBeNull();
+  });
+
+  it("carries the reason a call was refused, not the fact that it happened", () => {
+    const [step] = steps(
+      call(
+        "send_message",
+        { text: "hello?" },
+        { status: "refused", reason: "Refused: name a recipient." },
+      ),
+    );
+    expect(step?.failed).toBe(true);
+    expect(step?.said).toBe("Refused: name a recipient.");
+  });
+});
+
+describe("credentials a command spent", () => {
+  // Mirrors `credentials_named_in` in `runtime/mod.rs`. If that wording changes
+  // this test is where it is noticed, rather than a transcript quietly losing
+  // the operator's audit trail for their own tokens.
+  it("reads the names the runtime wrote, and leaves the rest of the summary", () => {
+    const read = readSpent("used Mistral ($MISTRAL_API_KEY) · exit 0, 812 bytes out");
+    expect(read.spent).toEqual(["Mistral ($MISTRAL_API_KEY)"]);
+    expect(read.rest).toBe("exit 0, 812 bytes out");
+  });
+
+  it("reads several", () => {
+    const read = readSpent("used Mistral ($A), GitHub ($B) · exit 0, 4 bytes out");
+    expect(read.spent).toEqual(["Mistral ($A)", "GitHub ($B)"]);
+  });
+
+  it("leaves an ordinary summary alone", () => {
+    expect(readSpent("exit 0, 812 bytes out")).toEqual({
+      spent: [],
+      rest: "exit 0, 812 bytes out",
+    });
+  });
+
+  it("never lets one be folded into a count", () => {
+    // Two commands would ordinarily read as "Ran 2 commands". The one that
+    // spent a token keeps its own chip, because that is the row the operator
+    // audits their own credentials from.
+    const groups = foldTrail(
+      steps(
+        call("run_command", { command: "ls" }, ok("exit 0, 4 bytes out")),
+        call("run_command", { command: "curl $X" }, ok("used Stripe ($X) · exit 0, 9 bytes out")),
+      ),
+    );
+    expect(groups).toHaveLength(2);
+    expect(groups[1]?.spent).toEqual(["Stripe ($X)"]);
+  });
+});
+
+describe("folding a turn's work", () => {
+  it("says what a single call was, in full", () => {
+    const groups = foldTrail(steps(call("run_command", { command: "ls" }, ok("exit 0"))));
+    expect(groups.map((group) => group.label)).toEqual(["Ran a command"]);
+  });
+
+  it("counts several of one kind instead of listing them", () => {
+    // The row this replaced: twenty-four lines of `Chef used browse` between
+    // the operator's question and the answer to it.
+    const groups = foldTrail(
+      steps(
+        call("run_command", { command: "ls" }, ok("exit 0")),
+        call("run_command", { command: "pwd" }, ok("exit 0")),
+        call("run_command", { command: "whoami" }, ok("exit 0")),
+      ),
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.label).toBe("Ran 3 commands");
+    expect(groups[0]?.steps).toHaveLength(3);
+  });
+
+  it("names the site when a browsing turn only visited one", () => {
+    // A count that names nothing hides what the operator opened the channel to
+    // find out, which is the same reason a burst draws one chip per peer.
+    const groups = foldTrail(
+      steps(
+        call("browse", { action: "open", url: "https://cnn.com" }),
+        call("browse", { action: "read" }),
+        call("browse", { action: "click", id: 12 }),
+      ),
+    );
+    expect(groups[0]?.label).toBe("3 steps on cnn.com");
+  });
+
+  it("names the site from the step and not from the words on the chip", () => {
+    // The label used to be recovered by slicing the title back apart, so
+    // rewording "Opened cnn.com" silently cost the group its name.
+    const [step] = steps(call("browse", { action: "open", url: "https://cnn.com/world" }));
+    expect(step?.where).toBe("cnn.com");
+    expect(steps(call("browse", { action: "read" }))[0]?.where).toBeNull();
+  });
+
+  it("does not name a site when the turn moved between several", () => {
+    const groups = foldTrail(
+      steps(
+        call("browse", { action: "open", url: "https://cnn.com" }),
+        call("browse", { action: "open", url: "https://bbc.co.uk" }),
+      ),
+    );
+    expect(groups[0]?.label).toBe("2 steps in the browser");
+  });
+
+  it("gathers calls of one kind that a call of another came between", () => {
+    // What the turn did, rather than the order a model happened to interleave
+    // its tools in, which is not something anybody asked about.
+    const groups = foldTrail(
+      steps(
+        call("browse", { action: "read" }),
+        call("run_command", { command: "ls" }, ok("exit 0")),
+        call("browse", { action: "read" }),
+      ),
+    );
+    expect(groups.map((group) => group.label)).toEqual(["2 steps in the browser", "Ran a command"]);
+  });
+
+  it("keeps a failure out of the count, in the place it happened", () => {
+    const groups = foldTrail(
+      steps(
+        call("run_command", { command: "ls" }, ok("exit 0")),
+        call("run_command", { command: "boom" }, { status: "failed", error: "no machine" }),
+        call("run_command", { command: "pwd" }, ok("exit 0")),
+      ),
+    );
+    expect(groups.map((group) => group.label)).toEqual(["Ran 2 commands", "Ran a command"]);
+    expect(groups[1]?.failed).toBe(true);
+    expect(groups[1]?.steps[0]?.said).toBe("no machine");
+  });
+});
+
+describe("whether a chip opens anything", () => {
+  it("does not offer a control over a lookup with nothing behind it", () => {
+    // A button that opens nothing is one the operator stops trusting the rest
+    // of.
+    const groups = foldTrail(steps(call("directory", {}, ok("2 agent(s): Chef, Scribe"))));
+    expect(hasDetail(groups[0]!)).toBe(false);
+  });
+
+  it("opens a command, because the command is not on the chip", () => {
+    const groups = foldTrail(steps(call("run_command", { command: "ls" }, ok("exit 0"))));
+    expect(hasDetail(groups[0]!)).toBe(true);
+  });
+
+  it("opens what an agent wrote to its own memory", () => {
+    const groups = foldTrail(
+      steps(call("update_notes", { content: "Smith handles verification." }, ok("Memory saved."))),
+    );
+    expect(hasDetail(groups[0]!)).toBe(true);
+    expect(groups[0]?.steps[0]?.target).toBe("Smith handles verification.");
+  });
+});

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -1,0 +1,380 @@
+/**
+ * What an agent did on its own turn, arranged the way it is read.
+ *
+ * A turn's tool calls arrive as one envelope, and a turn may make two dozen of
+ * them: the round limit is 24 and a browsing turn legitimately spends most of
+ * it. Drawn a line each, that is two dozen rows of `Chef used browse` between
+ * the operator's question and the answer to it, which is the same burial that
+ * peer traffic was collapsed to fix. So this does to a turn's own work what
+ * `transcript.ts` does to its peer traffic: several calls of one kind become
+ * one chip saying which kind and how many, and the calls themselves are one
+ * click away.
+ *
+ * Two things never fold, for the same reason a refusal never joins a burst.
+ * A call the runtime refused or that failed is the row's whole point. And a
+ * command that spent one of the operator's credentials is their audit trail
+ * for their own tokens, which is not a thing to put behind a click.
+ *
+ * A single call still says exactly what it was. `Opened cnn.com` and
+ * `Ran a command` are what the operator wanted to know; `used browse` is the
+ * name of a function in a file they do not have.
+ */
+
+import { asRecord, sendRecipients } from "./toolArgs";
+import type { Part, ToolOutcome } from "./types";
+
+type ToolCall = Extract<Part, { type: "toolCall" }>;
+type Args = Record<string, unknown>;
+
+/** One tool call, as the row draws it. */
+export interface Step {
+  key: string;
+  tool: string;
+  /** What this one call was, in words. */
+  title: string;
+  /**
+   * What it acted on, drawn as machine text: a command, a URL, the memory it
+   * wrote. Null where there is nothing behind the title, which is also what
+   * makes a chip unclickable.
+   */
+  target: string | null;
+  /**
+   * The place this call happened, where it has one a group can be named after.
+   * A browsing turn that stayed on one site is a turn that can say which site.
+   */
+  where: string | null;
+  /** What came back, in the runtime's own words. */
+  said: string;
+  /** True when the runtime refused the call or it failed outright. */
+  failed: boolean;
+  /** Credentials this call spent, by name. Never a value. */
+  spent: string[];
+}
+
+/** A run of steps the row draws as one chip. */
+export interface TrailGroup {
+  key: string;
+  label: string;
+  steps: Step[];
+  failed: boolean;
+  spent: string[];
+}
+
+/**
+ * Credentials a command spent, read back off the summary the runtime wrote.
+ *
+ * Mirrors `credentials_named_in` in `runtime/mod.rs`, which prefixes a
+ * `run_command` summary with `used Mistral ($MISTRAL_API_KEY) · `. The two have
+ * to agree, and the test holds this side to that exact wording. If the prefix
+ * ever stops matching, the names stay legible inside the summary and lose only
+ * their own place on the collapsed row.
+ */
+const SPENT = /^used (.+?) · /;
+
+export function readSpent(summary: string): { spent: string[]; rest: string } {
+  const found = SPENT.exec(summary);
+  if (!found) return { spent: [], rest: summary };
+  return {
+    spent: found[1]!.split(", ").filter(Boolean),
+    rest: summary.slice(found[0].length),
+  };
+}
+
+/** What came back, whatever became of the call. */
+function outcomeText(outcome: ToolOutcome): string {
+  switch (outcome.status) {
+    case "ok":
+    case "partial":
+      return outcome.summary;
+    case "refused":
+      return outcome.reason;
+    case "failed":
+      return outcome.error;
+  }
+}
+
+function text(args: Args, key: string): string | null {
+  const value = args[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function whole(args: Args, key: string): number | null {
+  const value = args[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * A URL as somewhere you have heard of.
+ *
+ * A chip is a few words wide and a real URL is not, so the host is what fits
+ * and it is also the part that answers "where did it go". Anything that will
+ * not parse is shown as written: a model that browsed to `cnn.com` should read
+ * as having browsed to cnn.com, not as having browsed to nothing.
+ */
+function place(url: string): string {
+  try {
+    return new URL(url).host.replace(/^www\./, "") || url;
+  } catch {
+    return url;
+  }
+}
+
+/** Cuts machine text to something a chip can hold, saying that it was cut. */
+function clip(value: string, at = 60): string {
+  const flat = value.replace(/\s+/g, " ").trim();
+  return flat.length > at ? `${flat.slice(0, at - 1)}…` : flat;
+}
+
+/** What one call was, what it acted on, and where. */
+interface Described {
+  title: string;
+  target: string | null;
+  where?: string;
+}
+
+function describe(tool: string, args: Args): Described {
+  switch (tool) {
+    case "directory":
+      return { title: "Checked who is available", target: null };
+
+    case "update_notes":
+      return { title: "Updated its memory", target: text(args, "content") };
+
+    case "create_agent": {
+      const name = text(args, "name");
+      return { title: name ? `Asked to add ${name}` : "Asked to add an agent", target: null };
+    }
+
+    case "request_permission":
+      return { title: "Asked for permission", target: text(args, "summary") };
+
+    case "run_command":
+      return { title: "Ran a command", target: text(args, "command") };
+
+    case "open_on_desktop": {
+      const command = text(args, "command");
+      return {
+        title: command
+          ? `Opened ${clip(command.split(/\s+/)[0]!, 24)} on its screen`
+          : "Opened a program on its screen",
+        target: command,
+      };
+    }
+
+    // Only ever reaches here naming nobody: a send with recipients is peer
+    // traffic and `transcriptRows` has already lifted it into a burst.
+    case "send_message": {
+      const named = sendRecipients(args);
+      return {
+        title: named.length > 0 ? `Sent to ${named.join(", ")}` : "Sent a message to nobody",
+        target: null,
+      };
+    }
+
+    case "schedule": {
+      const action = text(args, "action");
+      if (action === "cancel") return { title: "Cancelled a routine", target: null };
+      if (action === "list") return { title: "Checked its schedule", target: null };
+      const what = text(args, "name") ?? text(args, "what");
+      return { title: what ? `Scheduled ${clip(what, 40)}` : "Changed its schedule", target: what };
+    }
+
+    case "browse": {
+      const action = text(args, "action");
+      const id = whole(args, "id");
+      switch (action) {
+        case "open": {
+          const url = text(args, "url");
+          if (!url) return { title: "Opened a page", target: null };
+          return { title: `Opened ${place(url)}`, target: url, where: place(url) };
+        }
+        case "read":
+          return { title: "Read the page", target: null };
+        case "click":
+          return { title: "Clicked on the page", target: id === null ? null : `element ${id}` };
+        case "type": {
+          const typed = text(args, "text");
+          return { title: "Typed on the page", target: typed };
+        }
+        case "scroll":
+          return { title: "Scrolled the page", target: null };
+        case "back":
+          return { title: "Went back a page", target: null };
+        default:
+          return { title: "Used the browser", target: null };
+      }
+    }
+
+    case "use_screen": {
+      const action = text(args, "action");
+      const x = whole(args, "x");
+      const y = whole(args, "y");
+      const at = x !== null && y !== null ? `${x}, ${y}` : null;
+      switch (action) {
+        case "look":
+          return { title: "Looked at its screen", target: null };
+        case "click":
+        case "double_click":
+        case "right_click":
+          return { title: "Clicked on its screen", target: at };
+        case "move":
+          return { title: "Moved the pointer", target: at };
+        case "type":
+          return { title: "Typed on its screen", target: text(args, "text") };
+        case "key":
+          return { title: "Pressed a key", target: text(args, "keys") };
+        case "scroll":
+          return { title: "Scrolled its screen", target: null };
+        default:
+          return { title: "Used its screen", target: null };
+      }
+    }
+
+    // A tool this build does not know about reads as a tool nobody has
+    // explained yet. Guessing at it is how `update_notes` once drew as a
+    // message sent to no one.
+    default:
+      return { title: `Used ${tool}`, target: null };
+  }
+}
+
+/** One tool call, read out of a stored message. */
+export function trailStep(part: ToolCall, key: string): Step {
+  const { title, target, where } = describe(part.name, asRecord(part.arguments));
+  const { spent, rest } = readSpent(outcomeText(part.outcome));
+  return {
+    key,
+    tool: part.name,
+    title,
+    target,
+    where: where ?? null,
+    said: rest,
+    failed: part.outcome.status === "refused" || part.outcome.status === "failed",
+    spent,
+  };
+}
+
+/**
+ * How several calls of one kind read as one.
+ *
+ * Named rather than counted wherever the group can name something, for the
+ * reason a burst draws one chip per peer rather than "5 messages with 2
+ * agents": a count that names nothing hides what the operator opened the
+ * channel to find out. Browsing is the case that has an answer, because a
+ * turn spent on one site can say which site.
+ */
+function manyLabel(group: TrailGroup): string {
+  const count = group.steps.length;
+  switch (group.steps[0]!.tool) {
+    case "run_command":
+      return `Ran ${count} commands`;
+    case "browse": {
+      const places = new Set(group.steps.map((step) => step.where).filter(Boolean));
+      const only = places.size === 1 ? [...places][0] : null;
+      return only ? `${count} steps on ${only}` : `${count} steps in the browser`;
+    }
+    case "use_screen":
+      return `${count} actions on its screen`;
+    case "open_on_desktop":
+      return `Opened ${count} programs`;
+    case "schedule":
+      return `${count} changes to its schedule`;
+    case "update_notes":
+      return `Updated its memory ${count} times`;
+    case "directory":
+      return `Checked who is available ${count} times`;
+    default:
+      return `Used ${group.steps[0]!.tool} ${count} times`;
+  }
+}
+
+/**
+ * A turn's steps, folded into the chips a row draws.
+ *
+ * Grouped by tool across the whole run of calls rather than only where they
+ * are adjacent: the order a model happens to interleave `browse` and
+ * `run_command` in is not something the operator asked about, and reading
+ * "4 steps on cnn.com · ran 2 commands" is the answer to what the turn did.
+ * Failures and credential spends keep their own chips, in place.
+ */
+export function foldTrail(steps: Step[]): TrailGroup[] {
+  const groups: TrailGroup[] = [];
+  const open = new Map<string, TrailGroup>();
+
+  for (const step of steps) {
+    if (step.failed || step.spent.length > 0) {
+      groups.push({
+        key: step.key,
+        label: step.title,
+        steps: [step],
+        failed: step.failed,
+        spent: step.spent,
+      });
+      continue;
+    }
+    const held = open.get(step.tool);
+    if (held) {
+      held.steps.push(step);
+      continue;
+    }
+    const group: TrailGroup = {
+      key: step.key,
+      label: step.title,
+      steps: [step],
+      failed: false,
+      spent: [],
+    };
+    open.set(step.tool, group);
+    groups.push(group);
+  }
+
+  return groups.map((group) =>
+    group.steps.length === 1 ? group : { ...group, label: manyLabel(group) },
+  );
+}
+
+/**
+ * Tools whose summary is the call again, in the runtime's words.
+ *
+ * `browse` answers `read in the browser` beside a step that already says "Read
+ * the page". `open_on_desktop` answers with the command it was handed.
+ * `use_screen` answers `clicked at (412, 96)` beside a step that says where it
+ * clicked. `update_notes` answers with a character count printed directly above
+ * the characters. None of them is wrong; all of them are the line above read
+ * back, and nine of those turned a row into a paragraph of grey monospace,
+ * which is the shape this was collapsed to get away from.
+ *
+ * A failure is never an echo. Whatever went wrong is not something the title
+ * could have said.
+ */
+const ECHOES = new Set(["browse", "use_screen", "open_on_desktop", "update_notes"]);
+
+/** Whether what came back is worth reading beside the call it came from. */
+export function tellsMore(step: Step): boolean {
+  return step.failed || !ECHOES.has(step.tool);
+}
+
+/**
+ * Whether it earns a place on the collapsed chip, where space is scarcest.
+ *
+ * Stricter, because a chip is one line shared with everything else the turn
+ * did. A call with something to open keeps its answer behind the click, where
+ * an exit code is worth reading and a byte count can be ignored in peace. What
+ * is left is the call that has nothing else to show, where the summary is the
+ * whole of what came back: `2 agents: Chef, Scribe` is the answer to a
+ * directory lookup, not a restatement of it.
+ */
+export function saysMore(step: Step): boolean {
+  return step.failed || (step.target === null && tellsMore(step));
+}
+
+/**
+ * Whether a chip has anything behind it.
+ *
+ * A directory lookup is one call with nothing to show but the sentence already
+ * on the chip, and a button that opens nothing is a button the operator learns
+ * to distrust.
+ */
+export function hasDetail(group: TrailGroup): boolean {
+  return group.steps.length > 1 || group.steps[0]!.target !== null;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2400,9 +2400,32 @@ button {
   text-decoration: underline;
 }
 
-.file__size {
+/* Never wraps and never shrinks. This is three or four characters carrying the
+   one fact the name does not, and a size broken across two lines is the row
+   telling the operator its own layout gave up. */
+.file__meta {
   font-size: 0.66rem;
   color: var(--muted);
+  flex: none;
+  white-space: nowrap;
+}
+
+/* A file the app has and could not read. Says which reason it was and offers
+   the two ways forward: the store answers 503 while it is opening, so the
+   commonest failure here is one that has already stopped being true. */
+.file__failed {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.6rem 0.7rem;
+}
+
+.file__failed-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
   flex: none;
 }
 
@@ -2420,26 +2443,69 @@ button {
   max-height: calc(100vh - 3rem);
 }
 
+/* Two rows in one grid rather than one row of four things. The name is the
+   only part allowed to run out of room; everything else states a fact in a
+   fixed number of characters and is placed where running out cannot happen to
+   it. */
 .file-view__head {
-  display: flex;
-  align-items: baseline;
-  gap: 0.6rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: 0.9rem;
   margin-bottom: 0.9rem;
-  min-width: 0;
 }
 
 .file-view__head .dialog__title {
+  grid-column: 1;
+  margin: 0;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+/* What it is and how big, under the name. Its own line because it is the line
+   that used to be squeezed between a name that wanted the whole row and a pair
+   of buttons that would not give any of it up: `48 KB` came out as `48` over
+   `KB`, which is a dialog admitting it cannot lay out five characters. */
+.file-view__what {
+  grid-column: 1;
+  margin: 0.1rem 0 0;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
 .file-view__actions {
+  grid-column: 2;
+  grid-row: 1 / span 2;
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  margin-left: auto;
+  gap: 0.5rem;
+}
+
+/* Its own corner. Beside `Save a copy` it read as the second half of a pair of
+   answers, which is part of why the first one looked like it might change the
+   file rather than copy it out. */
+.file-view__close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
   flex: none;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: none;
+  color: var(--muted);
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.file-view__close:hover {
+  background: var(--sunken);
+  color: var(--text);
 }
 
 .file-view__body {

--- a/src/styles.css
+++ b/src/styles.css
@@ -61,6 +61,21 @@
   box-sizing: border-box;
 }
 
+/* Said, never drawn. `display: none` and `visibility: hidden` both take an
+   element out of the accessibility tree along with the page, which for a live
+   region means it announces nothing at all. */
+.offscreen {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
 html,
 body,
 #root {
@@ -1723,6 +1738,176 @@ button {
 
 .wire--notice {
   justify-content: center;
+}
+
+/* ==========================================================================
+   The trail: what an agent did on its own turn
+
+   The quietest thing a channel draws, and by volume it used to be the loudest:
+   a browsing turn spends most of its twenty-four rounds in the browser, and
+   every one of those was a line reading `Chef used browse`. Now a run of calls
+   is chips, one per kind of work, and the calls open underneath in place.
+
+   Deliberately not the burst's shape, even though both collapse. A burst is a
+   conversation with somebody, so it is centred and bracketed by rules like the
+   rest of the traffic. This is the agent's own working, so it sits under the
+   left margin where the agent's words are, at the size of a footnote.
+   ========================================================================== */
+
+.trail {
+  padding: 0.2rem 1.5rem 0.2rem 1.15rem;
+}
+
+/* Wide gaps between chips and tight ones inside. Four of these on a line with
+   the same space either side of every word read as one paragraph of grey
+   monospace, which is exactly the shape the row was collapsed to get away
+   from. */
+.trail__chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.3rem 1.1rem;
+  /* In line with the message bodies beside it: the gutter is 2.1rem of avatar
+     and 0.75rem of gap, and a footnote that starts at the margin instead reads
+     as a different column of the page. */
+  padding-left: 2.85rem;
+}
+
+.trail__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+  max-width: 100%;
+  padding: 0.08rem 0.3rem;
+  margin: 0 -0.3rem;
+  border: 1px solid transparent;
+  border-radius: 99px;
+  background: none;
+  font-family: var(--font-mono);
+  font-size: 0.63rem;
+  letter-spacing: 0.01em;
+  color: var(--faint);
+  text-align: left;
+  transition: border-color 130ms ease, color 130ms ease, background-color 130ms ease;
+}
+
+/* As with a burst chip: "you can open this" is only worth saying to somebody
+   already pointing at it. */
+.trail__chip--open:hover,
+.trail__chip--open[aria-expanded="true"] {
+  background: var(--sunken);
+  border-color: var(--edge);
+  color: var(--text);
+}
+
+.trail__caret {
+  flex: none;
+  font-size: 0.62rem;
+  line-height: 1;
+  color: var(--faint);
+}
+
+.trail__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* What came back. Present on a chip only where it belongs to one call: several
+   calls have several answers, and a chip carrying the first of them is a chip
+   that is wrong about the rest. */
+.trail__said {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.72;
+}
+
+/* A credential this command spent, by name. The operator's audit trail for
+   their own tokens, so it is never folded into a count and never behind a
+   click. Pit brown, because it is Guaca saying something rather than the agent.
+   The value is not here and there is no field it could arrive in. */
+.trail__spent {
+  flex: none;
+  padding: 0 0.3rem;
+  border-radius: 99px;
+  background: var(--pit-soft);
+  color: var(--pit);
+  font-size: 0.6rem;
+}
+
+/* Something went wrong, and the row it is on is otherwise a list of things
+   that went right. Given a shape rather than only a colour, for the same reason
+   a refused send is louder than the traffic around it: this is the one chip on
+   the row the operator may have to do something about. */
+.trail__chip[data-failed] {
+  padding: 0.08rem 0.45rem;
+  margin: 0;
+  border-color: color-mix(in oklab, var(--pit) 32%, transparent);
+  background: var(--pit-soft);
+  color: var(--pit);
+}
+
+.trail__chip[data-failed] .trail__said {
+  opacity: 1;
+}
+
+/* Opened. Indented under the chips rather than centred, because these are the
+   calls behind one chip and not a new kind of row. */
+.trail__steps {
+  list-style: none;
+  margin: 0.3rem 0 0.2rem;
+  padding: 0.35rem 0 0.35rem 0.7rem;
+  margin-left: 2.85rem;
+  max-width: 42rem;
+  border-left: 2px solid var(--edge);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.trail__step[data-failed] {
+  color: var(--pit);
+}
+
+.trail__step-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 0.63rem;
+  color: var(--faint);
+}
+
+.trail__step-title {
+  color: var(--muted);
+}
+
+.trail__step[data-failed] .trail__step-title,
+.trail__step[data-failed] .trail__said {
+  color: var(--pit);
+}
+
+/* The command, the URL, the memory that was written: exactly as it was.
+   Never markdown, because this is a record of what happened rather than
+   something written to be read, and a model that could format it could
+   describe a command as something other than the command it ran. */
+.trail__target {
+  margin: 0.15rem 0 0;
+  padding: 0.35rem 0.5rem;
+  max-height: 11rem;
+  overflow: auto;
+  border-radius: var(--radius-sm);
+  background: var(--sunken);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  line-height: 1.5;
+  color: var(--text);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
A turn can make two dozen tool calls, and every one of them drew a line reading `Chef used browse` between the operator's question and the answer to it; a run of calls is now one row of chips per kind of work with the calls one click away, and neither a failure nor a command that spent one of the operator's credentials is ever folded away. The transcript is also a `log` now, and a message addressed to the operator is announced once when it settles, by a region of its own rather than by the log's own politeness, because a live transcript reads three hundred rows aloud when a channel is opened. File cards were the other half: `48 KB` broke across two lines in the full view, `Save` read as a button that might change the file rather than copy it out, a file with no preview was a name and a size and no other fact, and "This file could not be read" was the same sentence whether the store was still opening, the bytes are missing, or the renderer threw before it ever asked. `.claude/skills/run-guaca` records how any of this gets looked at: the harness that draws a component in seconds with no Rust build, no key and no spend, the migration guard that stops a branch behind `main` from opening a real workspace, and a `seed.py` that fills a scratch one with a transcript covering every row a channel draws. Full CI is green: 533 frontend tests, the Rust suite, cascade, the scripted evals and trajectory.
