### PR TITLE
fix: a page that moved is read again, and a researcher is sent to the web

### DIFF
--- a/docs/BROWSERS.md
+++ b/docs/BROWSERS.md
@@ -101,6 +101,23 @@ between, and a socket held across that is dead in a way nothing notices until an
 action hangs on it. The only thing that has to persist across actions is the
 element numbering, and that is on the page.
 
+## An action is done once, and the page it produced is read until it answers
+
+A navigation can replace the target a session is attached to, and Chrome then
+fails the *wait* and the *description* rather than the navigation that caused
+them. An `open` that redirects is enough to do it. The wording that came back
+was Chrome's own, `Inspected target navigated or closed`, on a page that had
+loaded perfectly well, and it reads to an agent like a browser that cannot see
+the web: one met it, abandoned `browse` for the rest of the run, and went to
+work the same pages by screenshot on its computer instead. `CdpError::TargetGone`
+exists to keep that wording away from a model and to say what to do instead.
+
+So `browse` attaches again and reads again. It never acts again. That asymmetry
+is the whole design: the action has already happened by the time the target can
+go missing, and a click sent a second time because the answer went astray is the
+one mistake a browser tool must not make. `settle_and_collect` is one function
+for exactly this reason, and it runs at most twice.
+
 ## Sign-ins, and the one thing that is weaker here
 
 Detection is the same rule as the machine's, in `domain/signin.rs`, because "a

--- a/src-tauri/src/cdp.rs
+++ b/src-tauri/src/cdp.rs
@@ -55,6 +55,22 @@ pub enum CdpError {
     /// and the model is the one who has to act on it.
     #[error("{0}")]
     Page(String),
+    /// The page this socket attached to is not there any more.
+    ///
+    /// Separate from `Page` because it is the one protocol error that is about
+    /// this client rather than about the web: a navigation can replace a target,
+    /// which invalidates the session and fails every later call on it. Chrome's
+    /// own wording for that is "Inspected target navigated or closed", which
+    /// reads to a model like the site broke. It reached one that way and went
+    /// off to work the same page through screenshots instead.
+    ///
+    /// Says what to do, because a message that only says no gets retried
+    /// verbatim or abandoned for another tool.
+    #[error(
+        "the page moved on while that was in flight, so this action lost track of it. Read the \
+         page again to get its current state and fresh element numbers, then carry on from there."
+    )]
+    TargetGone,
     #[error("the browser took too long to answer")]
     TimedOut,
     #[error("the browser replied in a form this build does not understand: {0}")]
@@ -180,7 +196,7 @@ impl Page {
                 continue;
             }
             if let Some(error) = message["error"]["message"].as_str() {
-                return Err(CdpError::Page(error.chars().take(300).collect()));
+                return Err(protocol_error(error));
             }
             return Ok(message["result"].clone());
         }
@@ -331,6 +347,31 @@ impl Page {
     }
 }
 
+/// What an error reply from the protocol means.
+///
+/// One distinction, and it is the difference between "the web did something"
+/// and "we lost our handle on it". Chrome has several wordings for the second,
+/// depending on whether the target, the session or the execution context is the
+/// thing that went away, and they all mean the same thing to a caller: attach
+/// again and ask again. Everything else is the page's own answer and is passed
+/// through, which is what `Page` is for.
+fn protocol_error(message: &str) -> CdpError {
+    const GONE: [&str; 6] = [
+        "inspected target navigated or closed",
+        "session with given id not found",
+        "no target with given id found",
+        "target closed",
+        "cannot find context with specified id",
+        "execution context was destroyed",
+    ];
+
+    let lowered = message.to_ascii_lowercase();
+    if GONE.iter().any(|gone| lowered.contains(gone)) {
+        return CdpError::TargetGone;
+    }
+    CdpError::Page(message.chars().take(300).collect())
+}
+
 /// The host part of a URL, or nothing if it has none.
 fn host_of(url: &str) -> Option<String> {
     let rest = url.split_once("://")?.1;
@@ -354,5 +395,32 @@ mod tests {
         assert_eq!(host_of("about:blank"), None);
         assert_eq!(host_of("chrome://newtab"), None);
         assert_eq!(host_of(""), None);
+    }
+
+    #[test]
+    fn a_page_that_went_away_is_told_apart_from_one_that_threw() {
+        // Chrome's own wordings for the same fact, all of which used to reach a
+        // model verbatim as though the site had failed.
+        for message in [
+            "Inspected target navigated or closed",
+            "Session with given id not found.",
+            "No target with given id found",
+            "Target closed",
+            "Cannot find context with specified id",
+            "Execution context was destroyed.",
+        ] {
+            let err = protocol_error(message);
+            assert!(matches!(err, CdpError::TargetGone), "{message} became {err:?}");
+            // The part that matters. A refusal that only says no gets retried
+            // word for word, or the tool gets abandoned for a screenshot.
+            assert!(err.to_string().contains("Read the page again"), "{err}");
+        }
+    }
+
+    #[test]
+    fn what_the_page_itself_said_is_still_passed_through() {
+        let err = protocol_error("Uncaught TypeError: x is not a function");
+        assert!(matches!(err, CdpError::Page(_)), "{err:?}");
+        assert_eq!(err.to_string(), "Uncaught TypeError: x is not a function");
     }
 }

--- a/src-tauri/src/kernel.rs
+++ b/src-tauri/src/kernel.rs
@@ -310,7 +310,11 @@ impl KernelClient {
     ) -> Result<String, KernelError> {
         let mut page = Page::attach(&session.cdp_ws_url).await?;
 
-        match action {
+        // How long the page is given to finish what the action started. Each
+        // arm does its action and says only that, because the wait and the
+        // description that follows it are the same two steps for every action
+        // and have to be able to happen on a page this socket has lost.
+        let settle_ms = match action {
             "open" => {
                 let url = args["url"].as_str().unwrap_or_default().trim().to_string();
                 if url.is_empty() {
@@ -329,10 +333,11 @@ impl KernelClient {
                     format!("https://{url}")
                 };
                 page.navigate(&url).await?;
-                page.settle(SETTLE_NAVIGATE_MS).await?;
+                SETTLE_NAVIGATE_MS
             }
 
-            "read" => {}
+            // Nothing happened, so there is nothing to wait for.
+            "read" => 0,
 
             "click" => {
                 let target = element(args)?;
@@ -342,7 +347,7 @@ impl KernelClient {
                 ))
                 .await?;
                 page.evaluate(&format!("window.__guacEls[{target}].click()")).await?;
-                page.settle(SETTLE_CLICK_MS).await?;
+                SETTLE_CLICK_MS
             }
 
             "type" => {
@@ -365,9 +370,9 @@ impl KernelClient {
                 page.insert_text(text).await?;
                 if args["submit"].as_bool().unwrap_or(false) {
                     page.press_enter().await?;
-                    page.settle(SETTLE_NAVIGATE_MS).await?;
+                    SETTLE_NAVIGATE_MS
                 } else {
-                    page.settle(SETTLE_SCROLL_MS).await?;
+                    SETTLE_SCROLL_MS
                 }
             }
 
@@ -376,12 +381,12 @@ impl KernelClient {
                 let amount =
                     if args["direction"].as_str() == Some("up") { -amount } else { amount };
                 page.evaluate(&format!("scrollBy(0, {amount})")).await?;
-                page.settle(SETTLE_SCROLL_MS).await?;
+                SETTLE_SCROLL_MS
             }
 
             "back" => {
                 page.evaluate("history.back()").await?;
-                page.settle(SETTLE_NAVIGATE_MS).await?;
+                SETTLE_NAVIGATE_MS
             }
 
             other => {
@@ -390,9 +395,25 @@ impl KernelClient {
                      scroll or back."
                 )))
             }
-        }
+        };
 
-        let collected = page.evaluate(COLLECT).await?;
+        // Attaching again is how the ordinary case survives: a navigation can
+        // replace the target this socket attached to, and Chrome then fails the
+        // wait and the description rather than the navigation that caused them.
+        // An `open` that redirects is enough to do it, and the answer used to be
+        // "Inspected target navigated or closed" on a page that had loaded
+        // perfectly well. An agent that reads that concludes the browser cannot
+        // see the web and goes to work the same page through screenshots.
+        //
+        // Read again, never act again. The action has already happened, and a
+        // click sent a second time is the one mistake this must not make.
+        let collected = match settle_and_collect(&mut page, settle_ms).await {
+            Err(CdpError::TargetGone) => {
+                let mut replacement = Page::attach(&session.cdp_ws_url).await?;
+                settle_and_collect(&mut replacement, settle_ms).await?
+            }
+            other => other?,
+        };
         collected
             .as_str()
             .map(str::to_string)
@@ -410,6 +431,19 @@ impl KernelClient {
         let mut page = Page::attach(&session.cdp_ws_url).await?;
         Ok(BrowserState { cookies: page.cookies().await?, visited: page.visited().await? })
     }
+}
+
+/// Waits for the page to finish, then has it describe itself.
+///
+/// One function because the two are never wanted apart, and because both have
+/// to be repeatable against a page that has been replaced: a description taken
+/// before the page settled is a description of the page before the action, and
+/// a wait with no description afterwards answers nothing.
+async fn settle_and_collect(page: &mut Page, settle_ms: u32) -> Result<Value, CdpError> {
+    if settle_ms > 0 {
+        page.settle(settle_ms).await?;
+    }
+    page.evaluate(COLLECT).await
 }
 
 /// The element a `click` or `type` names, refused clearly when it is missing.
@@ -532,6 +566,13 @@ const COLLECT: &str = r#"
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use futures_util::{SinkExt, StreamExt};
+    use parking_lot::Mutex;
+    use tokio_tungstenite::tungstenite::Message;
+
     use super::*;
 
     /// Where a live view is served from, and the port it is served on.
@@ -670,5 +711,159 @@ mod tests {
             browser_live_view_url: Some("  ".into()),
         };
         assert_eq!(Session::from(row).live_view_url, None);
+    }
+
+    /// The page the fake browser describes, in the shape `render_page` reads.
+    const FAKE_PAGE: &str = r#"{"url":"https://example.com/after","title":"After","scroll":0,
+        "height":2000,"text":"arrived","elements":[]}"#;
+
+    /// A browser that speaks enough of the protocol for one action.
+    ///
+    /// A real socket rather than a stubbed client, because what is being tested
+    /// is the protocol's own behaviour: a session stops answering the moment the
+    /// page it names is replaced, and nothing but a connection can express
+    /// that. Every expression it is asked to evaluate is kept, which is how a
+    /// test can say an action was not performed twice.
+    struct FakeBrowser {
+        url: String,
+        evaluated: Arc<Mutex<Vec<String>>>,
+        connections: Arc<AtomicUsize>,
+    }
+
+    impl FakeBrowser {
+        /// `lose_first` connections answer the action and then report their
+        /// target as gone, which is what Chrome does when a navigation replaces
+        /// the target underneath an attached session.
+        async fn start_losing(lose_first: usize) -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("a port");
+            let address = listener.local_addr().expect("an address");
+            let evaluated: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+            let connections = Arc::new(AtomicUsize::new(0));
+
+            let (recorded, counted) = (evaluated.clone(), connections.clone());
+            tokio::spawn(async move {
+                loop {
+                    let Ok((stream, _)) = listener.accept().await else { return };
+                    let lost = counted.fetch_add(1, Ordering::SeqCst) < lose_first;
+                    let recorded = recorded.clone();
+                    tokio::spawn(async move {
+                        let mut socket =
+                            tokio_tungstenite::accept_async(stream).await.expect("a handshake");
+                        while let Some(Ok(frame)) = socket.next().await {
+                            let Message::Text(text) = frame else { continue };
+                            let call: Value = serde_json::from_str(&text).expect("a call");
+                            let id = call["id"].clone();
+                            let expression =
+                                call["params"]["expression"].as_str().unwrap_or_default();
+                            let reply = match call["method"].as_str().unwrap_or_default() {
+                                "Target.getTargets" => json!({"id": id, "result":
+                                    {"targetInfos": [{"type": "page", "targetId": "T"}]}}),
+                                "Target.attachToTarget" => {
+                                    json!({"id": id, "result": {"sessionId": "S"}})
+                                }
+                                "Page.navigate" => json!({"id": id, "result": {}}),
+                                "Runtime.evaluate" => {
+                                    recorded.lock().push(expression.to_string());
+                                    // The settle and the description of the
+                                    // page, which are what a navigation lands
+                                    // on. Everything before them is the action
+                                    // itself, and it goes through.
+                                    let after = expression.contains("setTimeout")
+                                        || expression.contains("location.href");
+                                    if lost && after {
+                                        json!({"id": id, "error":
+                                            {"message": "Inspected target navigated or closed"}})
+                                    } else if expression.contains("location.href") {
+                                        json!({"id": id, "result": {"result": {"value": FAKE_PAGE}}})
+                                    } else if expression.contains("Boolean(") {
+                                        json!({"id": id, "result": {"result": {"value": true}}})
+                                    } else {
+                                        json!({"id": id, "result": {"result": {"value": 1}}})
+                                    }
+                                }
+                                other => panic!("the fake browser was asked for {other}"),
+                            };
+                            socket.send(Message::text(reply.to_string())).await.expect("a reply");
+                        }
+                    });
+                }
+            });
+
+            FakeBrowser { url: format!("ws://{address}"), evaluated, connections }
+        }
+
+        fn session(&self) -> Session {
+            Session { id: "s".into(), cdp_ws_url: self.url.clone(), live_view_url: None }
+        }
+
+        fn connections(&self) -> usize {
+            self.connections.load(Ordering::SeqCst)
+        }
+    }
+
+    #[tokio::test]
+    async fn a_page_that_navigates_underneath_an_action_is_read_again_not_reported_as_broken() {
+        // The failure this exists for: an `open` that redirects loads a page
+        // perfectly well, and every call after the navigation fails on a
+        // session naming a target that is gone. The agent that met it concluded
+        // its browser could not see the web and went to work the same page
+        // through screenshots, which its model could not even accept.
+        let browser = FakeBrowser::start_losing(1).await;
+        let client = KernelClient::new("sk-test").expect("a client");
+
+        let page = client
+            .browse(&browser.session(), "open", &json!({ "url": "https://example.com" }))
+            .await
+            .expect("the page loaded, so the action succeeded");
+
+        assert!(page.contains("https://example.com/after"), "{page}");
+        // One that lost its target, one that read the page. Not a loop.
+        assert_eq!(browser.connections(), 2);
+    }
+
+    #[tokio::test]
+    async fn a_click_that_loses_the_page_is_never_sent_a_second_time() {
+        // The whole reason the recovery re-reads instead of retrying. A button
+        // that navigates is the commonest button there is, and pressing it
+        // again because the answer went missing is the one mistake a browser
+        // tool must not make.
+        let browser = FakeBrowser::start_losing(1).await;
+        let client = KernelClient::new("sk-test").expect("a client");
+
+        let page = client
+            .browse(&browser.session(), "click", &json!({ "id": 3 }))
+            .await
+            .expect("the click went through");
+
+        assert!(page.contains("After"), "{page}");
+        let clicks =
+            browser.evaluated.lock().iter().filter(|seen| seen.contains(".click()")).count();
+        assert_eq!(clicks, 1, "the click was sent again after the page moved");
+    }
+
+    #[tokio::test]
+    async fn an_action_on_a_page_that_stays_put_opens_one_connection() {
+        let browser = FakeBrowser::start_losing(0).await;
+        let client = KernelClient::new("sk-test").expect("a client");
+
+        client.browse(&browser.session(), "read", &json!({})).await.expect("read the page");
+
+        assert_eq!(browser.connections(), 1, "a working page must not pay for a reconnection");
+    }
+
+    #[tokio::test]
+    async fn a_page_that_will_not_stay_still_says_what_to_do_about_it() {
+        let browser = FakeBrowser::start_losing(usize::MAX).await;
+        let client = KernelClient::new("sk-test").expect("a client");
+
+        let err = client
+            .browse(&browser.session(), "open", &json!({ "url": "https://example.com" }))
+            .await
+            .expect_err("nothing could be read");
+
+        // Chrome's own wording reaches nobody. What the agent gets is a way
+        // forward, because a refusal that only says no gets retried verbatim.
+        assert!(err.to_string().contains("Read the page again"), "{err}");
+        assert_eq!(browser.connections(), 2, "one retry, not a loop");
     }
 }

--- a/src/lib/cafeteria.test.ts
+++ b/src/lib/cafeteria.test.ts
@@ -144,6 +144,32 @@ describe("the cafeteria catalog", () => {
       );
     }
   });
+
+  it("never ties a browser to a computer, because they are two places", () => {
+    // A preset prompt is injected above the sections that describe what an
+    // agent has, so a preset that names a surface outranks the runtime's own
+    // account of it. The Market Researcher said "using your computer's
+    // browser", which in this app names the Chrome on the machine's screen:
+    // the agent worked the desktop through screenshots instead of asking the
+    // page, and every screenshot is an image the operator's model may not
+    // accept. A preset describes the work. Which surface it lands on is the
+    // runtime's to say, in `prompt.rs` and the tool descriptions.
+    const conflates = [
+      "computer's browser",
+      "browser on your computer",
+      "browser on your machine",
+      "browser on your screen",
+      "screenshot",
+    ];
+    for (const preset of HIREABLE) {
+      const prompt = preset.systemPrompt.toLowerCase();
+      for (const phrase of conflates) {
+        expect(prompt, `${preset.id} sends its browsing to the wrong surface`).not.toContain(
+          phrase,
+        );
+      }
+    }
+  });
 });
 
 describe("hiring", () => {

--- a/src/lib/cafeteria.ts
+++ b/src/lib/cafeteria.ts
@@ -238,7 +238,7 @@ export const HIREABLE: Hireable[] = [
     color: "#6faa5c",
     skills: ["research", "competitor analysis", "fact checking"],
     systemPrompt:
-      "You research markets, competitors and claims using your computer's browser. Report what the page said and the URL you read it on, and separate what you are confident about from what you are not. Never invent a citation or describe a page you did not open.",
+      "You research markets, competitors and claims by reading the sources on the web yourself. Report what the page said and the URL you read it on, and separate what you are confident about from what you are not. Never invent a citation or describe a page you did not open.",
   },
   {
     id: "data-analyst",


### PR DESCRIPTION
A Market Researcher abandoned `browse` mid-run and worked the same pages by screenshot instead, which its text-only model refused with `No endpoints found that support image input`. Two causes: its cafeteria preset said "using your computer's browser", which names the Chrome on the machine's screen and is reachable only through `use_screen`, and a preset prompt is injected above the sections describing what an agent has; and `browse` handed it Chrome's raw `Inspected target navigated or closed` whenever a navigation replaced the attached target, on pages that had loaded perfectly well. The preset now describes the work and leaves the surface to the runtime, guarded by a test that fails the build on any preset tying a browser to a computer. `browse` classifies that condition as `CdpError::TargetGone`, attaches again and reads the page again, and never repeats the action, covered by four tests against a fake CDP browser on a real socket plus the classifier's own unit tests. One caveat: the preset fix reaches newly hired agents only, so an existing Market Researcher's prompt is already in its database row and still needs editing in the app.