### PR TITLE
feat: settings is eight places, and a conversation can be stopped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@ src/                  React + TypeScript. A view over the runtime, nothing more.
   lib/trail.ts        A turn's own tool calls: what folds into one chip.
   lib/cafeteria.ts    Preset agents, waiting to be hired. Content, not runtime.
   lib/ipc.ts          Every call into Rust.
+  lib/prefs.ts        What the operator sets and the runtime never reads.
+  lib/appearance.ts   Scale and surface, as one write to the root element.
+  lib/notify.ts       When an interruption is warranted. Mostly when it is not.
+  lib/announce.ts     What that interruption would say. One event in, one line out.
+  lib/keybinds.ts     Every key the app answers to, in one list.
   components/         One file per surface.
 src-tauri/src/
   domain/             AgentCard, Envelope, Routine, Connector, Signin, Approval,
@@ -55,6 +60,7 @@ repo: the frontend renders state and forwards intent.
 | Messaging, replies, cascades, hop limits, the guard | `runtime/guard.rs`, then *Cascades terminate because of one asymmetry* and *The five limits* in `docs/ARCHITECTURE.md` |
 | What a turn is told it was asked for: `expects_reply`, `intent`, `ReplyMode` | *Cascades terminate because of one asymmetry*, and `runtime/prompt.rs`, which has to agree with it |
 | Streaming, retries, the budget, when a run settles | *A failed model call is retried*, *A thought is shown and never kept*, *The budget counts model calls* |
+| Stopping a conversation: what a stop marks, wakes, and must never release | *A stop marks the run and releases nothing*, then `Runtime::stop_run` |
 | Permission prompts, parked turns, acting in the operator's name | *A protected action parks the turn that asked for it* |
 | What an agent may do with a page it has just read | *A page that was read this turn cannot quietly press a button* |
 | Screenshots, coordinates, what a screen action answers with | *A computer is looked at, never asked* in `docs/MACHINES.md` |
@@ -69,6 +75,7 @@ repo: the frontend renders state and forwards intent.
 | Anything announced to a screen reader, or a live region | *A transcript is a log, and says one thing out loud* in `docs/WORKSPACE.md` |
 | The rail's order, dragging a row, groups as places you go inside | *The rail is arranged by hand*, *A drop is one call* and *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/rail.ts` |
 | Preset agents, hiring a crew | *The cafeteria is a copy machine* in `docs/WORKSPACE.md`, then `src/lib/cafeteria.ts` |
+| Settings, the surface, the scale, what may interrupt the operator | *Settings is eight places*, *The reading column has two surfaces* and *An interruption has to earn it* in `docs/WORKSPACE.md` |
 | A prompt, or anything that changes how much a crew talks | *Three test suites, asking different questions*, then run the live evals |
 
 Unqualified section names are headings in `docs/ARCHITECTURE.md`.
@@ -132,6 +139,31 @@ the model takes a screenshot to see what `browse` did.
 - **`Routine::next_run_at` is an `Option` because some triggers have no next
   run.** A sentinel date would be shown to the operator, and it is one bad
   comparison away from firing something that was waiting on a connector.
+- **A stop marks a run and releases nothing.** `track_inflight` reads a negative
+  delta against a run it is no longer counting as that run reaching zero, and
+  emits a second `RunSettled` for it. So a stop that helpfully released the
+  envelopes it was ending would report the run finished twice, which fails the
+  trajectory suite and double-counts its spend. Marking is the whole mechanism:
+  each of the three boundaries releases through `finish_turn`, exactly as an
+  ordinary turn does.
+- **The stop check sits before `reserve_step`, not after it.** One line later and
+  a run reports a model call that a stop prevented, for the rest of its life.
+- **The checks inside the round loop do not cover the way out of it.** A turn
+  whose last call returns text and no tool calls leaves by the break at the
+  bottom, so there is a fourth check after the loop and before the reply is
+  decided. Without it a stop that landed during a single-round reply turn — the
+  whole turn, in that shape — still wrote to the peer that was waiting.
+- **An actor only ever examines the envelope it is holding.** A paused agent
+  parked on one run therefore cannot see that another run's work is queued behind
+  it, which is why the pause park drains the queue whenever anything is stopped.
+  Survivors go to a holding queue and stay counted in `depth`.
+- **`--flesh` and `--flesh-soft` are pinned on `.rail`.** The rail is dark in
+  both surfaces and reads both tokens, so a dark value for either would repaint
+  it and no test would notice. Pinning them on the one element every rail rule
+  descends from makes the rail a colour scope rather than a naming convention.
+- **`data-surface` is only ever `light` or `dark`.** `system` is resolved before
+  it reaches the document. A stylesheet rule keyed on `system` would have to
+  duplicate the one keyed on `dark`, and CSS has no way to share them.
 
 ## Conventions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -166,6 +166,87 @@ permitted up to 48 billable calls. The unit is now the model call, because that
 is the thing that costs money. A cascade test caught this; the fix is one line
 and the test that found it is still there.
 
+## A stop marks the run and releases nothing
+
+The limits above decide when a conversation ends on its own. A stop is the
+operator deciding, and the two are the same mechanism seen from different ends:
+a run that has been called off is a run with no budget left, except that it is
+the person paying who said so.
+
+The mark is on the `RunId`, in the same structure that already decides
+settlement, and there is no second generation of a run. `RunId` is minted once
+per operator action and every envelope the action causes inherits it, so "this
+conversation" is already a value the runtime can name; `retry_turn` is already
+how the operator sends the same thing again, as a new run.
+
+**A stop releases nothing.** This is the part that is easy to get wrong and hard
+to notice. Every envelope booked against a run is released by whatever consumes
+it, and `track_inflight` reads a negative delta against a run it is no longer
+counting as that run reaching zero. So a stop that tidily released the envelopes
+it was ending would emit a second `RunSettled`, report the run finished twice and
+reconcile its spend twice. Marking and waking is the whole of what `stop_run`
+does. Each boundary that notices the mark releases through `finish_turn`, the
+same call an ordinary turn ends with.
+
+There are four boundaries, and between them they cover every place a turn can
+be:
+
+- **After an envelope is dequeued, inside the pause park.** The only case
+  `run_turn` cannot reach: an agent that is not accepting work never gets there,
+  so its booking would be held until somebody resumed it. The check is inside
+  the park rather than above it because an agent that was already asleep when
+  the stop arrived has to see it on the wake-up, which is why `stop_run` also
+  notifies every inbox.
+
+  The actor only ever examines the envelope it is holding, which is why the same
+  place also drains the queue behind it whenever anything at all is stopped. A
+  paused agent parked on one conversation would otherwise never notice that a
+  different one, sitting behind it in the same inbox, had been called off — and
+  that run would wait on a turn that cannot happen until somebody resumes an
+  agent the operator has already stopped. What survives the drain keeps its place
+  in line in a holding queue, and stays counted in the depth the rail reads,
+  because an envelope set aside is as queued as one still in the channel.
+- **At the top of the turn**, before the prompt, the placeholder and the first
+  call. This catches the whole queued half of a stopped cascade, so a fan-out
+  that reached eight agents leaves eight channels each saying why nothing came
+  back rather than eight messages nobody answered.
+- **Inside the turn**, before each model call and between tool calls. Before the
+  call and not after: a step reserved for a call that a stop then prevents would
+  leave the run reporting a call it never made, for the rest of its life. Between
+  tool calls is the finest boundary that exists, because one tool call is a
+  single unbounded await into a sandbox or a browser.
+- **After the turn's rounds, before its reply is decided.** The one that is easy
+  to leave out, because the two checks above look like they cover the loop. They
+  do not cover the way out of it: a turn whose last call comes back with text and
+  no tool calls leaves by the ordinary break at the bottom of the round, and a
+  stop that landed during that call — which for a single-round reply is the whole
+  turn — would reach the reply with the mode it started in and write to the peer
+  that was waiting. One lock read per turn closes it.
+
+A stop does not interrupt the model call in flight. The streaming client has no
+cancellation handle, so the turn that is talking finishes talking and stops
+before it would have called again. That is also what keeps the accounting
+honest: a call that was paid for is a call that completed. The same reasoning is
+why a stop is not looked at inside the retry loop either, which is the one place
+it costs something: a step is claimed for the whole call before the first
+attempt, so abandoning it between attempts would leave the run reporting a step
+against no call. A stop landing during a backoff waits it out.
+
+A stopped turn keeps its words and sends them nowhere. It reports as a note, so
+whatever it managed to say lands in its own channel where the operator can read
+how far it got, and the peer that was waiting is not written to. Not sending on
+is the whole of what a stop is for.
+
+Two things a stop has to answer for that nothing else does. A turn parked on a
+permission request is holding its envelope inside a ten-minute window, so the
+stop closes those rows itself — expired rather than denied, because the operator
+stopped a conversation and did not refuse an action, and that difference is what
+a standing grant would be read out of later. The row moves before the turn is
+woken, because the turn reads its verdict back off the row. And a stop of a run
+that has already finished returns false and writes nothing: a line in the
+transcript saying a conversation was stopped, in a conversation that ended on its
+own, describes something that did not happen.
+
 ## A failed model call is retried before the operator hears about it
 
 `stream_with_retries` is the loop and `LlmError::is_transient` decides. Rate

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -287,3 +287,132 @@ not in that window. `channel_messages` takes a `through` so the window reaches
 back to the message being opened, bounded at a thousand; past that the operator
 lands in the right channel at its newest end. Anything that jumps to a message
 goes through `openMessage` rather than `select`.
+
+## Settings is eight places, because it stopped being one subject
+
+An endpoint, a set of limits, a machine's credentials, how large the window
+draws and what is allowed to interrupt you are five different questions, and one
+scroll made the operator read all five to change one. So it is a nav and a pane,
+on the Cafeteria's shape: a panel that owns its own height, a head and a foot
+pinned to it, one scrolling half.
+
+Every value lives in the shell rather than in the pane that draws it, and that is
+not tidiness. The shell is unmounted when the dialog closes, so a pane holding
+its own state would discard it on every section change: typing an endpoint,
+glancing at Limits and coming back would silently lose the endpoint. Save and
+Test stay in the foot for the same reason they used to be at the bottom of the
+one column — they act on the whole panel, not on the section that happens to be
+open — and Save still does not close, because the point of Test is to press it
+next.
+
+Two things open onto a named section rather than onto the top. The banner that
+says there is no API key opens Provider, because landing on General with the key
+two sections away was a step nobody wanted, and the shortcuts key opens
+Shortcuts. The palette's own row opens the surface rather than a section: it
+lists what is in there, so the row is found by searching for "notifications" or
+"appearance", and the nav is the first thing under the cursor once it is open.
+
+The provider list is presets, not a registry. Guaca speaks one protocol and the
+field is a text box, so the failure it exists to prevent is an endpoint that is
+off by a path segment and fails on every turn of every agent with an error from
+somebody else's server. A local endpoint is marked as local because that changes
+what the key field means: an empty key beside a warning about a missing key is a
+state an operator will try to fix forever.
+
+## The reading column has two surfaces; the rail has one
+
+`styles.css` used to say the surface never follows the OS, and the argument was
+sound as far as it went: a chat log is read for minutes at a time and white wins
+that in a lit room. It does not win it in a dark one. So the reading column is a
+token block behind `data-surface` — the same seven neutrals, four accents, a
+scrim and a shadow, and nothing else.
+
+The rail is not part of the question. It is dark in both surfaces, which is what
+makes the column read as a surface rather than as another panel, and it pins the
+two accents it draws with on `.rail` itself. That last part is load-bearing: the
+rail reads `--flesh` in twelve rules and `--flesh-soft` in two, so a dark value
+for either would have repainted it silently and no test in this repo would have
+caught it. Pinning them on the one element every rail rule descends from turns
+the rail into a colour scope instead of a naming convention.
+
+`system` is resolved before it reaches the document, so `data-surface` is only
+ever `light` or `dark`. A rule keyed on `system` would have to duplicate the one
+keyed on `dark`, and CSS has no way to share the two.
+
+Scale is the same idea from the other side: every length in the stylesheet is
+already a `rem`, so the whole interface is one root font size. It is anchored at
+16px because that is what a `rem` already resolved to — nothing had ever set a
+root font size — and `body` moved from `15px` to `0.9375rem` so that everything
+inheriting from it grows too. The rail and the inspector are capped against the
+viewport as well as scaled: both grow with the scale and the window's own minimum
+does not, so at the largest scale in the smallest window they would otherwise
+leave the reading column narrower than a message can draw.
+
+Neither preference goes anywhere near the runtime. They are `localStorage`, the
+way the inspector's open-or-closed already is, because the runtime would carry
+them across IPC only to hand them straight back.
+
+## An interruption has to earn it
+
+Guaca keeps working while nobody is looking, which is the only time a
+notification is worth anything: routines fire on a schedule, a parked turn waits
+ten minutes for an answer, a cascade settles long after the message that started
+it. All of that matters when you are elsewhere and none of it is worth a badge
+while you watch it happen.
+
+So "away" is not one condition, because the four kinds are not the same news.
+
+- **A permission request** blocks a turn until it is answered. It reaches the
+  operator when the window is not in front of them, *and* when it is but the
+  request belongs to a channel they are not looking at. Nobody finds a parked
+  turn by noticing a row change colour three screens up the rail.
+- **A routine firing** was addressed to nobody and implies no channel: it goes
+  where it was pointed, which is almost never where the operator is. It reaches
+  them whenever they are away, with no channel to match against.
+- **A conversation finishing, or failing**, is the end of something they started.
+  It reaches them only when they are away *and* it is the channel they were last
+  looking at, because a busy runtime settles runs in channels nobody has ever
+  opened and one badge each would make the whole mechanism worth turning off.
+
+Two more refusals, both of which would otherwise read as a bug. Nothing fires for
+the first few seconds after a launch: a routine whose slot passed while the app
+was closed is overdue and fires on the first tick, which is correct, but starting
+Guaca after a weekend away should not announce a weekend of schedule at once. And
+the same kind about the same channel is said once a second at most, so two agents
+failing together are two notifications while one agent failing twice is one.
+
+There is a button that sends a test notification, which is the only way to tell a
+refused operating-system permission from a working one.
+
+## Every key the app answers to is in one list
+
+The app answered to a dozen keys and said so nowhere, which is the same as not
+having them. The Shortcuts pane is that list.
+
+It is a reference rather than a rebinding system, deliberately. Nine of these
+keys are handled by the component that owns the surface they act on — Escape by
+whatever is open, Enter and the arrows by the composer and the palette — so
+rebinding would mean routing all nine through one dispatcher, and a setting that
+appears to rebind a key while only moving one of them is worse than no setting.
+The fixed ones are listed as fixed, and the three that are genuinely global are
+matched from the same table the pane draws, so a key listed there is a key that
+works.
+
+`mod` means Command or Control on every platform, both accepted. Only the label
+follows the platform: a label naming a key the keyboard does not have is worse
+than none.
+
+## Stop is a control on the conversation, not on the agent
+
+It sits in the working line, always visible rather than on hover, because a
+control that appears on hover is a control nobody knows is there and this is the
+one thing on screen that costs money to leave alone.
+
+What it stops is the run. A message that reached four agents is one conversation,
+and stopping only the one on screen would leave the other three working on the
+operator's bill. The button knows which run to name because the runtime already
+said so: a placeholder opening in an agent's channel is the runtime's own
+statement that this agent is working on that run, and the entry is dropped when
+the run settles. Not read from what `sendMessage` returned, which only knows
+about conversations the operator started — a routine's work and a peer's request
+are exactly as worth stopping.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@fontsource-variable/space-grotesk": "^5.3.0",
     "@tauri-apps/api": "^2.9.0",
     "@tauri-apps/plugin-dialog": "^2.4.0",
+    "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2.5.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@tauri-apps/plugin-dialog':
         specifier: ^2.4.0
         version: 2.7.2
+      '@tauri-apps/plugin-notification':
+        specifier: ^2.3.3
+        version: 2.3.3
       '@tauri-apps/plugin-opener':
         specifier: ^2.5.0
         version: 2.5.4
@@ -792,6 +795,9 @@ packages:
 
   '@tauri-apps/plugin-dialog@2.7.2':
     resolution: {integrity: sha512-pX0IGm1I3I6wc+zeKYcq1GSqogK6okCNX5fOdaNU5ab1AjGS6l1E5wFNjEb7meg7ZFSp0JUs+0jQGQNyOvLrsg==}
+
+  '@tauri-apps/plugin-notification@2.3.3':
+    resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
@@ -2249,6 +2255,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
 
   '@tauri-apps/plugin-dialog@2.7.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-notification@2.3.3':
     dependencies:
       '@tauri-apps/api': 2.11.1
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -543,7 +543,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1422,7 +1422,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -1591,6 +1591,7 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tempfile",
  "thiserror 2.0.20",
@@ -2261,6 +2262,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2393,20 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2548,6 +2577,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2873,6 +2903,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2978,7 +3017,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -3050,13 +3089,42 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3071,7 +3139,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4047,6 +4115,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.5",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4166,6 +4253,17 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.4+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.20",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]
@@ -4626,7 +4724,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.10.2",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -4754,7 +4852,7 @@ checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
- "rand",
+ "rand 0.10.2",
  "serde_core",
  "wasm-bindgen",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,6 +66,7 @@ sha2 = "0.10"
 parking_lot = "0.12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tauri-plugin-notification = "2.3.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capabilities for the single Guac window. Guac talks to the network only from Rust, so the webview gets no HTTP or filesystem access. Opening a link in the operating system browser needs both the command and the url scope: the command alone is granted and then refuses every url.",
+  "description": "Capabilities for the single Guac window. Guac talks to the network only from Rust, so the webview gets no HTTP or filesystem access. Opening a link in the operating system browser needs both the command and the url scope: the command alone is granted and then refuses every url. Raising an operating system notification is granted as three named commands rather than the plugin's default set, because the default also carries the mobile channel and batch surface, which this app has no use for and should not be able to reach.",
   "windows": [
     "main"
   ],
@@ -10,6 +10,9 @@
     "core:event:default",
     "core:window:allow-start-dragging",
     "opener:allow-open-url",
-    "opener:allow-default-urls"
+    "opener:allow-default-urls",
+    "notification:allow-is-permission-granted",
+    "notification:allow-request-permission",
+    "notification:allow-notify"
   ]
 }

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -122,6 +122,7 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_notification::init())
         .register_uri_scheme_protocol(FILE_SCHEME, serve_file)
         .setup(move |app| {
             let data_dir = app.path().app_data_dir()?;
@@ -270,6 +271,7 @@ pub fn run() {
             commands::save_file,
             commands::send_message,
             commands::retry_turn,
+            commands::stop_run,
             commands::clear_channel,
             commands::clear_group,
             commands::agent_routines,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -849,6 +849,21 @@ pub fn retry_turn(
     Ok(state.runtime.retry_turn(agent_id, message_id)?)
 }
 
+/// Stops a conversation and everything it set off.
+///
+/// A run rather than an agent: what the operator wants to end reached however
+/// many agents it reached, and stopping only the one they happen to be looking
+/// at would leave the rest of it running on their bill.
+///
+/// False when the run had already finished, which is the ordinary outcome of a
+/// stop that arrives a moment too late. It is not an error and there is nothing
+/// for the operator to do about it: the answer they were waiting for is already
+/// on screen.
+#[tauri::command]
+pub fn stop_run(state: State<'_, AppState>, run_id: RunId) -> Reply<bool> {
+    Ok(state.runtime.stop_run(run_id))
+}
+
 #[tauri::command]
 pub fn clear_channel(state: State<'_, AppState>, channel_id: AgentId) -> Reply<usize> {
     Ok(state.runtime.store().delete_channel_messages(channel_id)?)

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -908,6 +908,24 @@ impl Store {
         Ok(out)
     }
 
+    /// What one run is still waiting on the operator to answer.
+    ///
+    /// Read from the row rather than from the runtime's map of waiters, because
+    /// the map is keyed by request and carries no run: the row is where the two
+    /// are related, and it is the record everywhere else in this subsystem.
+    pub fn pending_approvals_for_run(&self, run: RunId) -> Result<Vec<ApprovalId>, StoreError> {
+        let conn = self.conn()?;
+        let mut stmt =
+            conn.prepare("SELECT id FROM approvals WHERE run_id=?1 AND state='pending'")?;
+        let rows = stmt.query_map(params![run.to_string()], |row| row.get::<_, String>(0))?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?.parse::<ApprovalId>().map_err(|e| StoreError::Corrupt(e.to_string()))?);
+        }
+        Ok(out)
+    }
+
     /// Expires everything still waiting. Called at startup.
     ///
     /// The turn that raised a request is holding a channel in memory, so a

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -13,7 +13,7 @@ pub mod events;
 pub mod guard;
 pub mod prompt;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -345,8 +345,27 @@ struct Inbox {
     tx: mpsc::UnboundedSender<Envelope>,
     /// Queue depth, so the sidebar can show a backlog without draining it.
     depth: Arc<AtomicUsize>,
-    /// Woken when a paused agent is resumed.
+    /// Woken when a paused agent is resumed, or when a run it may be holding is
+    /// stopped.
     resume: Arc<Notify>,
+}
+
+/// What is still owed, per run, and which runs the operator has called off.
+///
+/// One structure behind one lock rather than two, because the two facts are
+/// read and written together. A stop is only meaningful for a run with work
+/// outstanding, and a run that settles has to forget it was stopped in the same
+/// critical section it stops being counted in: split across two mutexes there
+/// would be a lock-ordering rule to remember against the guard, and a window in
+/// which a run is marked stopped and already gone.
+#[derive(Default)]
+struct Runs {
+    /// Booked envelopes per run. A run has settled when its count reaches zero.
+    outstanding: HashMap<RunId, usize>,
+    /// Stopped runs, held exactly as long as they are still outstanding, so
+    /// this is the size of what is live rather than of everything this process
+    /// has ever stopped.
+    stopped: HashSet<RunId>,
 }
 
 struct Inner {
@@ -360,8 +379,9 @@ struct Inner {
     guard: Mutex<GuardRegistry>,
     inboxes: Mutex<HashMap<AgentId, Inbox>>,
     activity: Mutex<HashMap<AgentId, Activity>>,
-    /// Outstanding work per run, used to decide when a cascade has settled.
-    inflight: Mutex<HashMap<RunId, usize>>,
+    /// Outstanding work per run, used to decide when a cascade has settled, and
+    /// which of those runs the operator has stopped.
+    runs: Mutex<Runs>,
     /// Turns parked on a permission request, by request id. The row in SQLite
     /// is the record; this is the way back to the agent that is holding.
     waiting: Mutex<HashMap<ApprovalId, tokio::sync::oneshot::Sender<()>>>,
@@ -426,7 +446,7 @@ impl Runtime {
                 guard: Mutex::new(GuardRegistry::new(limits)),
                 inboxes: Mutex::new(HashMap::new()),
                 activity: Mutex::new(HashMap::new()),
-                inflight: Mutex::new(HashMap::new()),
+                runs: Mutex::new(Runs::default()),
                 waiting: Mutex::new(HashMap::new()),
                 workspace,
                 files,
@@ -1126,15 +1146,16 @@ impl Runtime {
 
     fn track_inflight(&self, run: RunId, delta: i64) {
         let settled = {
-            let mut map = self.inner.inflight.lock();
-            let entry = map.entry(run).or_insert(0);
+            let mut runs = self.inner.runs.lock();
+            let entry = runs.outstanding.entry(run).or_insert(0);
             if delta >= 0 {
                 *entry += delta as usize;
             } else {
                 *entry = entry.saturating_sub((-delta) as usize);
             }
             if *entry == 0 {
-                map.remove(&run);
+                runs.outstanding.remove(&run);
+                runs.stopped.remove(&run);
                 true
             } else {
                 false
@@ -1210,6 +1231,117 @@ impl Runtime {
         Ok(approval)
     }
 
+    /// True while a stop the operator asked for is still in force.
+    ///
+    /// Read into a `bool` and the lock dropped, because every caller is about
+    /// to await something.
+    fn stopped(&self, run: RunId) -> bool {
+        self.inner.runs.lock().stopped.contains(&run)
+    }
+
+    /// True when any run at all has been stopped and not yet settled.
+    ///
+    /// Asked before doing anything expensive on behalf of a stop, so the
+    /// ordinary case — nothing stopped, which is almost always — costs one
+    /// uncontended lock and no work.
+    fn anything_stopped(&self) -> bool {
+        !self.inner.runs.lock().stopped.is_empty()
+    }
+
+    /// Ends a conversation, and everything it set off, at the next boundary.
+    ///
+    /// **This marks and wakes. It releases nothing.** Every envelope booked
+    /// against a run is released by whatever consumes it, and a stop that
+    /// released as well would settle the run twice over: `track_inflight` reads
+    /// a negative delta against a run it is no longer counting as that run
+    /// reaching zero, and emits a second `RunSettled`. So the mark is the whole
+    /// mechanism, and each of the three boundaries that notice it releases
+    /// through `finish_turn` exactly as an ordinary turn does.
+    ///
+    /// After marking, two things have to be woken, because they are the only
+    /// places a turn waits on something that will otherwise never arrive: a
+    /// permission request nobody is going to answer, and a pause nobody is
+    /// going to lift. Everything else is either running, and will reach a
+    /// boundary on its own, or queued, and will reach one when it is read.
+    ///
+    /// A stop does not interrupt the model call in flight. There is no
+    /// cancellation handle on the streaming client, so the turn that is talking
+    /// finishes talking and stops before it would have called again. That is
+    /// the honest boundary and it is also the one that keeps the budget
+    /// truthful: a call that was paid for is a call that completed.
+    ///
+    /// False when the run has nothing outstanding, which is every run that has
+    /// already finished. That is not an error, and it deliberately writes
+    /// nothing: a notice about a conversation that ended on its own would be a
+    /// line in the transcript describing something that did not happen.
+    pub fn stop_run(&self, run: RunId) -> bool {
+        {
+            let mut runs = self.inner.runs.lock();
+            if !runs.outstanding.contains_key(&run) {
+                return false;
+            }
+            runs.stopped.insert(run);
+        }
+
+        self.release_parked(run);
+
+        // Collected under the lock and notified outside it: `notify_waiters`
+        // is cheap but this is the one place that touches every inbox, and
+        // nothing holds a lock across anything it does not have to.
+        let notifiers: Vec<Arc<Notify>> =
+            self.inner.inboxes.lock().values().map(|inbox| inbox.resume.clone()).collect();
+        for resume in notifiers {
+            resume.notify_waiters();
+        }
+
+        true
+    }
+
+    /// Closes, on the operator's behalf, every permission request a stopped run
+    /// is holding.
+    ///
+    /// A parked turn is waiting on a channel with a ten-minute window and its
+    /// envelope is still booked, so without this the run cannot settle until
+    /// that window runs out. The row moves first and the wake follows: waking
+    /// the turn while the row is still pending leaves a request that nothing
+    /// will ever answer and no event to say it was closed, which is exactly
+    /// what the trajectory suite calls a turn parked without an answer.
+    ///
+    /// Expired rather than denied. The operator stopped a conversation; they
+    /// did not refuse this action, and that difference is what a standing grant
+    /// would be read out of later.
+    fn release_parked(&self, run: RunId) {
+        let pending = match self.inner.store.pending_approvals_for_run(run) {
+            Ok(ids) => ids,
+            Err(err) => {
+                // The stop still stands. The turn comes back on its own window
+                // instead of at once, which is slow rather than wrong.
+                tracing::warn!(%err, "could not read what a stopped run was waiting on");
+                return;
+            }
+        };
+
+        for id in pending {
+            match self.inner.store.settle_approval(id, ApprovalState::Expired) {
+                Ok(approval) => self
+                    .inner
+                    .events
+                    .emit(UiEvent::ApprovalSettled { approval_id: id, state: approval.state }),
+                Err(err) => {
+                    // Leave the waiter alone. A turn woken against a row that
+                    // is still pending reads the row back as its verdict and
+                    // would act on a request nobody answered.
+                    tracing::warn!(%err, %id, "could not close a stopped run's request");
+                    continue;
+                }
+            }
+
+            if let Some(waiter) = self.inner.waiting.lock().remove(&id) {
+                let _ = waiter.send(());
+            }
+        }
+    }
+
     /// Puts a request to the operator and holds the turn until it is answered.
     ///
     /// The verdict is read back from the row rather than from the channel the
@@ -1244,6 +1376,26 @@ impl Runtime {
 
         let (waker, wait) = tokio::sync::oneshot::channel();
         self.inner.waiting.lock().insert(approval.id, waker);
+
+        // After the row exists and the waker is registered, which is what makes
+        // this airtight rather than merely narrow. `stop_run` marks the run
+        // before it sweeps the pending rows, so a request recorded before that
+        // sweep is closed by it, and one recorded after it reads the mark here.
+        // Without this a request created in the instant after the sweep would
+        // park a run the operator has already called off for the full ten
+        // minutes, holding its booking the whole time.
+        if self.stopped(run_id) {
+            self.inner.waiting.lock().remove(&approval.id);
+            if let Ok(expired) =
+                self.inner.store.settle_approval(approval.id, ApprovalState::Expired)
+            {
+                self.inner.events.emit(UiEvent::ApprovalSettled {
+                    approval_id: approval.id,
+                    state: expired.state,
+                });
+            }
+            return Permission::Unanswered;
+        }
 
         self.record_for(
             card.id,
@@ -1341,6 +1493,28 @@ impl Runtime {
             _ if assigned => ReplyMode::Assigned,
             _ => ReplyMode::NoteOnly,
         };
+
+        // Before the prompt, the placeholder and the first call, for the same
+        // reason as the budget check below it: an agent handed work that has
+        // been called off should cost nothing at all. This is the boundary that
+        // catches the whole queued half of a stopped cascade, so a fan-out that
+        // reached eight agents leaves eight channels each saying plainly why
+        // nothing came back, rather than eight messages nobody answered.
+        if self.stopped(run_id) {
+            self.notice(
+                agent_id,
+                run_id,
+                cause,
+                NoticeKind::GuardStop,
+                format!(
+                    "You stopped this conversation, so {} never started this. Nothing was sent on. \
+                     Send it again if you want it done.",
+                    card.name
+                ),
+            );
+            self.finish_turn(agent_id, run_id, batch.len());
+            return;
+        }
 
         // Peek rather than claim: the budget is spent per model call inside the
         // loop below, but there is no point building a prompt or telling the UI
@@ -1455,9 +1629,21 @@ impl Runtime {
         let mut failure: Option<LlmError> = None;
         let mut hit_tool_ceiling = false;
         let mut budget_exhausted = false;
+        let mut called_off = false;
 
         let max_rounds = config.limits.sanitized().max_tool_rounds as usize;
         for round in 0..max_rounds {
+            // Before the step is claimed, and that ordering is the whole reason
+            // this check is here rather than a line lower. A run's steps have to
+            // equal the calls it actually made; a step reserved for a call that
+            // a stop then prevents would leave the two disagreeing for the rest
+            // of the run's life, which is the one thing the trajectory suite
+            // reads the budget for.
+            if self.stopped(run_id) {
+                called_off = true;
+                break;
+            }
+
             // One claim per model call. Claiming per turn instead would let a
             // tool-looping turn bill max_rounds times against one unit of
             // budget, which is how a bounded run still runs up a bill.
@@ -1503,6 +1689,16 @@ impl Runtime {
             });
 
             for call in &completion.tool_calls {
+                // Between tool calls, so a turn holding a browse, a send and a
+                // note does not work through all three after being called off.
+                // This is the finest boundary there is: one tool call is a
+                // single unbounded await into a sandbox or a browser, with no
+                // cancellation handle of its own.
+                if self.stopped(run_id) {
+                    called_off = true;
+                    break;
+                }
+
                 let outcome = self
                     .execute_tool(
                         &card,
@@ -1537,12 +1733,34 @@ impl Runtime {
                 }
             }
 
+            if called_off {
+                break;
+            }
+
             if round == max_rounds - 1 {
                 hit_tool_ceiling = true;
             }
         }
 
+        // Every way out of the loop above, not only the two that look on the
+        // way round. A turn whose last call came back with text and no tool
+        // calls leaves by the `break` at the bottom of the round, and a stop
+        // that landed during that call would otherwise reach `emit_reply` with
+        // the mode it started with and write to the peer that was waiting —
+        // which is the one thing a stop exists to prevent. Costs one lock read
+        // per turn.
+        if !called_off && self.stopped(run_id) {
+            called_off = true;
+        }
+
         stream.close(&*self.inner.events);
+
+        // A turn that was called off did not reach the ceiling; it stopped
+        // short of it. Saying both would tell the operator their own stop was
+        // a limit they could raise.
+        if called_off {
+            hit_tool_ceiling = false;
+        }
 
         if hit_tool_ceiling {
             tool_parts.push(Part::Notice {
@@ -1563,6 +1781,17 @@ impl Runtime {
                 ),
             });
         }
+        if called_off {
+            tool_parts.push(Part::Notice {
+                kind: NoticeKind::GuardStop,
+                text: format!(
+                    "You stopped this conversation. {} finished the model call it was already in \
+                     and started nothing else, and nothing was sent on. Send it again if you want \
+                     it finished.",
+                    card.name
+                ),
+            });
+        }
 
         if let Some(err) = failure {
             tracing::warn!(agent = %card.name, error = %err, "inference failed");
@@ -1579,7 +1808,13 @@ impl Runtime {
                 run_id,
                 inbound_hop,
                 cause,
-                mode,
+                // A stopped turn keeps its words and sends them nowhere. As a
+                // note they land in this agent's own channel, where the
+                // operator can read how far it got; as a reply they would go to
+                // the peer that was waiting, book another envelope against a
+                // run that is being wound down, and hand the cascade one more
+                // hop. Not sending on is the whole of what a stop is.
+                if called_off { ReplyMode::NoteOnly } else { mode },
                 reply_target,
                 &addressed,
                 collected_text,
@@ -1596,6 +1831,14 @@ impl Runtime {
     /// The budget is not touched here. A call is one call however many times
     /// the network dropped it, and reserving a step per attempt would bill a
     /// run for requests that never reached a provider.
+    ///
+    /// A stop is not looked at here either, and that is the one place it costs
+    /// something. A step is claimed for the whole call before this is entered,
+    /// so abandoning it partway through would leave the run reporting a step
+    /// against no call and the two would disagree for the rest of its life. A
+    /// stop that lands during a backoff therefore waits it out — up to
+    /// `MAX_RETRY_AFTER` when a provider asked for that long — and is noticed
+    /// at the boundary after the call returns.
     async fn stream_with_retries(
         &self,
         inference: &InferenceConfig,
@@ -3362,12 +3605,14 @@ async fn actor_loop(
     depth: Arc<AtomicUsize>,
     resume: Arc<Notify>,
 ) {
-    // Carries an envelope that was pulled but does not belong in the current
-    // batch, so nothing is lost between iterations.
-    let mut carry: Option<Envelope> = None;
+    // Envelopes pulled off the inbox that do not belong in the current batch,
+    // in the order they arrived, so nothing is lost or reordered between
+    // iterations. `depth` deliberately still counts these: a held envelope is
+    // as queued as one still in the channel, and the rail says so.
+    let mut carry: VecDeque<Envelope> = VecDeque::new();
 
     loop {
-        let first = match carry.take() {
+        let first = match carry.pop_front() {
             Some(envelope) => envelope,
             None => match rx.recv().await {
                 Some(envelope) => envelope,
@@ -3384,6 +3629,7 @@ async fn actor_loop(
         // would wait for a wake-up that can never come, leaking the task and
         // the envelope it is holding for the life of the process.
         let mut abandoned = false;
+        let mut called_off = false;
         loop {
             match runtime.inner.store.get_agent(id).ok().flatten() {
                 None => {
@@ -3395,17 +3641,99 @@ async fn actor_loop(
                     break;
                 }
                 Some(card) if card.lifecycle.accepts_work() => break,
-                Some(_) => {
+                Some(card) => {
+                    // Registered before the stop is read, and that ordering is
+                    // the whole of it. `notify_waiters` only wakes futures that
+                    // are already waiting, so a stop landing between the check
+                    // below and the await at the bottom would be lost and the
+                    // actor would sleep holding a booking nobody can release.
+                    // Enabling the future first closes that window — and closes
+                    // the same one `pause_agent` and `resume_agent` have always
+                    // had, where a resume between the card read and the await
+                    // left an agent parked until the next message arrived.
+                    let waiter = resume.notified();
+                    tokio::pin!(waiter);
+                    waiter.as_mut().enable();
+
+                    // The only place a stopped run has to be noticed before the
+                    // turn: an agent that is not accepting work cannot reach
+                    // `run_turn`, where every other boundary lives, so its
+                    // booking would be held until somebody resumed it.
+                    //
+                    // Inside the loop rather than above it, so an agent that
+                    // was already parked when the stop arrived sees it on the
+                    // wake-up. `stop_run` notifies every inbox for exactly
+                    // this: otherwise the actor re-reads its card, finds itself
+                    // still paused, and parks again holding the booking.
+                    if runtime.stopped(first.run_id) {
+                        runtime.notice(
+                            id,
+                            first.run_id,
+                            Some(first.id),
+                            NoticeKind::GuardStop,
+                            format!(
+                                "You stopped this conversation while {} was paused, so this never ran. Resume {} and send it again if you still want it.",
+                                card.name, card.name
+                            ),
+                        );
+                        called_off = true;
+                        break;
+                    }
+                    // A paused agent holds one envelope and lets the rest
+                    // queue behind it, which is right until one of those queued
+                    // runs is stopped. Nothing else will ever look at them: the
+                    // actor only examines what it is holding, so a stopped run
+                    // whose work is sitting behind somebody else's waits on a
+                    // turn that cannot happen until an agent the operator has
+                    // already called off is resumed.
+                    //
+                    // Only entered when something really is stopped, so an
+                    // ordinary pause moves nothing. Whatever survives keeps its
+                    // place in line in the holding queue.
+                    if runtime.anything_stopped() {
+                        while let Ok(queued) = rx.try_recv() {
+                            if runtime.stopped(queued.run_id) {
+                                depth.fetch_sub(1, Ordering::SeqCst);
+                                runtime.notice(
+                                    id,
+                                    queued.run_id,
+                                    Some(queued.id),
+                                    NoticeKind::GuardStop,
+                                    format!(
+                                        "You stopped this conversation while {} was paused, so this never ran. Resume {} and send it again if you still want it.",
+                                        card.name, card.name
+                                    ),
+                                );
+                                runtime.finish_turn(id, queued.run_id, 1);
+                            } else {
+                                carry.push_back(queued);
+                            }
+                        }
+                    }
+
                     runtime.set_activity(id, Activity::Paused);
-                    resume.notified().await;
+                    waiter.await;
                 }
             }
+        }
+        if called_off {
+            // `finish_turn`, not `abandon`: it resets the badge as well as
+            // releasing the booking, and a badge left reading "1 queued" for a
+            // queue that is now empty outlives the run for the rest of the
+            // session. The row still reads as paused, which is a lifecycle and
+            // not an activity.
+            runtime.finish_turn(id, first.run_id, 1);
+            continue;
         }
         if abandoned {
             // Everything this inbox is holding dies with the agent, and the
             // run counting on it has to be told. `first` was already taken off
             // the queue; the rest would go silently when `rx` drops.
             runtime.abandon(first.run_id, 1);
+            for held in carry.drain(..) {
+                depth.fetch_sub(1, Ordering::SeqCst);
+                runtime.abandon(held.run_id, 1);
+            }
             while let Ok(orphan) = rx.try_recv() {
                 depth.fetch_sub(1, Ordering::SeqCst);
                 runtime.abandon(orphan.run_id, 1);
@@ -3430,14 +3758,21 @@ async fn actor_loop(
             let run = batch[0].run_id;
             let patience = Instant::now() + BURST_WINDOW;
             while batch.len() < MAX_BATCH {
-                match rx.try_recv() {
+                // The holding queue first: anything in it arrived before
+                // whatever is still in the channel, and batching around it
+                // would put a later message ahead of an earlier one.
+                let pulled = match carry.pop_front() {
+                    Some(held) => Ok(held),
+                    None => rx.try_recv(),
+                };
+                match pulled {
                     Ok(next) if !next.expects_reply && next.run_id == run => {
                         depth.fetch_sub(1, Ordering::SeqCst);
                         batch.push(next);
                         continue;
                     }
                     Ok(next) => {
-                        carry = Some(next);
+                        carry.push_front(next);
                         break;
                     }
                     Err(mpsc::error::TryRecvError::Disconnected) => break,

--- a/src-tauri/tests/trajectory.rs
+++ b/src-tauri/tests/trajectory.rs
@@ -24,7 +24,8 @@ use std::time::Duration;
 
 use guac_lib::domain::agent::Lifecycle;
 use guac_lib::domain::approval::{ApprovalState, Decision};
-use guac_lib::runtime::events::Activity;
+use guac_lib::domain::envelope::NoticeKind;
+use guac_lib::runtime::events::{Activity, UiEvent};
 use guac_lib::runtime::guard::GuardLimits;
 use guac_lib::trajectory::{Anomaly, Record};
 
@@ -417,4 +418,275 @@ async fn a_message_nobody_is_left_to_read_ends_its_run_rather_than_hanging() {
         h.trajectory(run).ledger
     );
     assert_eq!(h.trajectory(run).steps(), Some(0), "and nothing was spent on it");
+}
+
+// ---- work the operator called off ------------------------------------------
+//
+// A stop marks the run and wakes what is asleep on it. It releases nothing:
+// every envelope is released by whatever consumes it, and a stop that released
+// as well would take a run's count below zero, which `track_inflight` reads as
+// the run reaching zero and reports as a second ending.
+//
+// So what these ask is whether every boundary that notices a stop still leaves
+// the run exactly as accountable as an ordinary turn does: settled once, every
+// placeholder closed, every parked turn answered, and a budget that names the
+// calls that actually happened.
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stopping_a_run_ends_it_and_bills_only_the_calls_it_made() {
+    // A model that never stops asking for another round is the case a stop
+    // exists for. The accounting is the part worth pinning: the check sits
+    // before the step is claimed, and moved one line later it would leave the
+    // run reporting a call that a stop then prevented.
+    let stub = serve(|_| Script::SendTo {
+        recipients: vec!["Chef".into()],
+        text: "and another thing".into(),
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager", "Chef"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "Talk to Chef.").unwrap();
+
+    h.wait_until("a call has been made and paid for", |h| {
+        h.sink.count_of(|e| matches!(e, UiEvent::TokensUsed { run_id, .. } if *run_id == run)) > 0
+    })
+    .await;
+
+    assert!(h.runtime.stop_run(run), "a run with work outstanding can be stopped");
+    assert!(
+        h.settled_within(run, 10).await,
+        "a stopped run still owes the operator an ending:\n{}",
+        h.trajectory(run).ledger
+    );
+
+    let t = h.expect_normal(run, "a conversation the operator stopped");
+    assert_eq!(
+        t.steps().map(|steps| steps as usize),
+        Some(t.calls()),
+        "a stopped run must not report a call it never made:\n{}",
+        t.ledger
+    );
+    assert!(
+        t.records.iter().any(|r| matches!(
+            r,
+            Record::Noticed { kind: NoticeKind::GuardStop, text, .. } if text.contains("stopped")
+        )),
+        "the transcript has to say why it ended, in the agent's own channel:\n{}",
+        t.ledger
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stopping_a_run_a_paused_agent_is_holding_still_ends_it() {
+    // The same shape as deleting an agent mid-hold, and the reason a stop wakes
+    // every inbox. A paused agent parks inside an await that only a resume
+    // reaches, holding the one booking the run is waiting on, so a stop that
+    // only marked the run would wait for somebody to resume an agent they had
+    // just called off. The check has to sit inside that park, not above it: the
+    // agent is already asleep by the time the stop arrives.
+    let stub = serve(|_| Script::Say("on it".into())).await;
+    let h = harness(&stub, &["Manager", "Chef"], GuardLimits::default());
+
+    h.pause("Chef");
+    let run = h.runtime.send_from_human(h.id("Chef"), "start the prep").unwrap();
+    h.wait_until("Chef parks holding the message", |h| {
+        matches!(h.runtime.activity_snapshot().get(&h.id("Chef")), Some(Activity::Paused))
+    })
+    .await;
+
+    assert!(h.runtime.stop_run(run), "the run is outstanding, so there is something to stop");
+    assert!(
+        h.settled_within(run, 5).await,
+        "work a paused agent was holding outlived the stop:\n{}",
+        h.trajectory(run).ledger
+    );
+
+    let t = h.expect_normal(run, "stopping work a paused agent was holding");
+    assert_eq!(t.calls(), 0, "nothing ran, so nothing was billed:\n{}", t.ledger);
+    assert!(
+        t.records.iter().any(|r| matches!(
+            r,
+            Record::Noticed { kind: NoticeKind::GuardStop, text, .. } if text.contains("paused")
+        )),
+        "and the channel says why nothing happened:\n{}",
+        t.ledger
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stopping_a_run_closes_the_request_it_was_waiting_on() {
+    // A parked turn holds its envelope inside a ten-minute window, so a stop
+    // that does not reach it leaves the run outstanding for ten minutes. Both
+    // halves are needed and the order matters: waking the turn while the row is
+    // still pending leaves a request nothing will ever answer, and the turn
+    // reads its verdict back off that row.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Say("Scout is set up.".into())
+        } else {
+            Script::Hire {
+                name: "Scout".into(),
+                instructions: "You look things up.".into(),
+                notes: String::new(),
+            }
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "Hire a scout.").unwrap();
+
+    let request = h.awaited_request().await;
+    assert!(h.runtime.stop_run(run), "a turn parked on the operator is still outstanding work");
+    assert!(
+        h.settled_within(run, 10).await,
+        "a stopped run sat waiting on a request nobody was going to answer:\n{}",
+        h.trajectory(run).ledger
+    );
+
+    let t = h.expect_normal(run, "stopping a turn that was waiting on the operator");
+    assert!(
+        t.records
+            .iter()
+            .any(|r| matches!(r, Record::Answered { state: ApprovalState::Expired, .. })),
+        "the request has to be closed, and as expired rather than refused:\n{}",
+        t.ledger
+    );
+    assert_eq!(
+        h.runtime.store().get_approval(request).unwrap().map(|a| a.state),
+        Some(ApprovalState::Expired),
+        "the row is the record, and a row left pending draws live buttons that answer nothing"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stopping_a_run_that_has_already_finished_changes_nothing() {
+    // The ordinary outcome of a stop pressed a moment too late. It is not an
+    // error, and it must write nothing: a line saying a conversation was
+    // stopped, in a conversation that ended on its own, describes something
+    // that did not happen. `settled_within` also asserts a run ends exactly
+    // once, which is what a stop that released work of its own would break.
+    let stub = serve(|_| Script::Say("The kitchen is ready.".into())).await;
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "are we set?").unwrap();
+    h.settle(run).await;
+
+    assert!(!h.runtime.stop_run(run), "there is nothing left to stop");
+    assert!(h.settled_within(run, 1).await, "and the run still ended exactly once");
+
+    let t = h.expect_normal(run, "a stop that arrived after the answer");
+    assert!(
+        !t.records.iter().any(|r| matches!(r, Record::Noticed { kind: NoticeKind::GuardStop, .. })),
+        "a run that finished on its own must not gain a line saying it was stopped:\n{}",
+        t.ledger
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stopping_a_run_mid_call_does_not_let_the_answer_reach_the_peer() {
+    // Found by review. Every other stop test drives a model that asks for
+    // another tool call, so the turn always comes back round to the check at the
+    // top of the round. A turn whose last call returns text and no tool calls
+    // leaves by the break at the bottom instead, and nothing there was looking:
+    // the reply went to the peer that was waiting, booking another envelope
+    // against a run the operator had already called off.
+    //
+    // The 503 is what makes that window wide enough to aim at. Chef's first
+    // attempt fails, the runtime waits out its backoff before trying again, and
+    // the stop lands inside that wait — so the second attempt returns text the
+    // turn then has to decide what to do with, which is exactly the state no
+    // other test can reach.
+    let chef_calls = Arc::new(AtomicUsize::new(0));
+    let counted = chef_calls.clone();
+    let stub = serve(move |body| {
+        if speaker(body) == "Chef" {
+            if counted.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Script::Unavailable;
+            }
+            return Script::Say("the prep is done".into());
+        }
+        if has_tool_result(body) {
+            Script::Say("asked Chef.".into())
+        } else {
+            Script::SendTo { recipients: vec!["Chef".into()], text: "how is the prep".into() }
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager", "Chef"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "Ask Chef about the prep.").unwrap();
+
+    h.wait_until("Chef's first attempt has been refused", |_| {
+        chef_calls.load(Ordering::SeqCst) >= 1
+    })
+    .await;
+
+    assert!(h.runtime.stop_run(run), "Chef's envelope is still outstanding");
+    assert!(
+        h.settled_within(run, 10).await,
+        "a run stopped between a turn's attempts never ended:\n{}",
+        h.trajectory(run).ledger
+    );
+
+    let t = h.expect_normal(run, "a stop that landed while an agent was talking");
+    assert!(
+        !h.channel_texts("Manager").iter().any(|line| line.contains("the prep is done")),
+        "Chef's answer was sent on after the stop:\n{:?}",
+        h.channel_texts("Manager")
+    );
+    assert!(
+        t.records.iter().any(|r| matches!(
+            r,
+            Record::Noticed { kind: NoticeKind::GuardStop, text, .. } if text.contains("stopped")
+        )),
+        "and the transcript has to say why nothing was sent on:\n{}",
+        t.ledger
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stopping_a_run_queued_behind_another_at_a_paused_agent_still_ends_it() {
+    // Found by review, and the nastiest shape a stop has. The actor only ever
+    // looks at the envelope it is holding, so a paused agent parked on run A
+    // never notices that run B — sitting behind it in the same inbox — has been
+    // stopped. B waited on a turn that could not happen until somebody resumed
+    // an agent the operator had already called off, which is the leak this
+    // whole suite exists to catch.
+    let stub = serve(|_| Script::Say("on it".into())).await;
+    let h = harness(&stub, &["Manager", "Chef"], GuardLimits::default());
+
+    h.pause("Chef");
+    let held = h.runtime.send_from_human(h.id("Chef"), "start the prep").unwrap();
+    h.wait_until("Chef parks holding the first message", |h| {
+        matches!(h.runtime.activity_snapshot().get(&h.id("Chef")), Some(Activity::Paused))
+    })
+    .await;
+
+    // Queued behind the one being held, and belonging to a different run.
+    let behind = h.runtime.send_from_human(h.id("Chef"), "and the stock").unwrap();
+
+    assert!(h.runtime.stop_run(behind), "the queued run is outstanding");
+    assert!(
+        h.settled_within(behind, 5).await,
+        "work queued behind a held envelope outlived the stop:\n{}",
+        h.trajectory(behind).ledger
+    );
+
+    // And the run that was NOT stopped is untouched: still held, still waiting
+    // for a resume, and it finishes when one arrives. Stopping one conversation
+    // must not end another that happens to share an inbox.
+    assert!(
+        !h.settled_within(held, 1).await,
+        "the run nobody stopped ended anyway:\n{}",
+        h.trajectory(held).ledger
+    );
+    h.resume("Chef");
+    assert!(
+        h.settled_within(held, 10).await,
+        "the held run never resumed:\n{}",
+        h.trajectory(held).ledger
+    );
+
+    h.expect_normal(behind, "stopping work queued behind a held envelope");
+    h.expect_normal(held, "the conversation that was not stopped");
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { AgentAvatar } from "./avatars/AgentAvatar";
 import { AgentEditor } from "./components/AgentEditor";
@@ -8,11 +8,15 @@ import { ChannelView } from "./components/ChannelView";
 import { GroupEditor } from "./components/GroupEditor";
 import { Inspector } from "./components/Inspector";
 import { Search } from "./components/Search";
-import { SettingsDialog } from "./components/SettingsDialog";
+import { type Section, SettingsDialog } from "./components/SettingsDialog";
 import { Sidebar } from "./components/Sidebar";
-import { api, onRuntimeEvent } from "./lib/ipc";
+import { announcementFor } from "./lib/announce";
+import { applyAppearance, watchSystemSurface } from "./lib/appearance";
+import { api, notifyOperator, onRuntimeEvent } from "./lib/ipc";
+import { bindingFor } from "./lib/keybinds";
+import { away, burst, markQuiet, quiet, shouldNotify } from "./lib/notify";
 import { ACTIVITY_CHANNEL, useLiveAgents, useStore } from "./lib/store";
-import { type AgentCard, errorMessage, type Group } from "./lib/types";
+import { type AgentCard, errorMessage, type Group, type UiEvent } from "./lib/types";
 
 export default function App() {
   const agents = useLiveAgents();
@@ -28,28 +32,71 @@ export default function App() {
   const groups = useStore((s) => s.groups);
   const nudgeAgent = useStore((s) => s.nudgeAgent);
   const dropAgent = useStore((s) => s.dropAgent);
+  const prefs = useStore((s) => s.prefs);
+
+  /**
+   * Raises an operating system notification, when one is warranted.
+   *
+   * Reads the store at the moment of the event rather than closing over it. The
+   * subscription below is made once, on purpose, and a preference or a
+   * selection that has changed since then is the one that has to apply; a
+   * dependency on either would tear the event listener down and rebuild it
+   * every time the operator clicked a different agent.
+   */
+  const announce = useCallback((event: UiEvent) => {
+    const state = useStore.getState();
+    const said = announcementFor(
+      event,
+      (id) => state.agents.find((agent) => agent.id === id)?.name ?? "An agent",
+    );
+    if (!said) return;
+
+    const warranted = shouldNotify(said.kind, state.prefs.notify, {
+      away: away(),
+      // An announcement about no channel in particular is never held back for
+      // being about the wrong one.
+      onScreen: said.channel === null || said.channel === state.selected,
+      quiet: quiet(),
+    });
+    if (!warranted || burst(said.key)) return;
+
+    void notifyOperator(said.title, said.body);
+  }, []);
 
   const [editing, setEditing] = useState<AgentCard | "new" | null>(null);
   const [editingGroup, setEditingGroup] = useState<Group | "new" | null>(null);
   const [menu, setMenu] = useState<MenuTarget | null>(null);
-  const [showSettings, setShowSettings] = useState(false);
+  const [showSettings, setShowSettings] = useState<Section | true | null>(null);
   const [searching, setSearching] = useState(false);
   const [ready, setReady] = useState(false);
   const [showCafeteria, setShowCafeteria] = useState(false);
 
-  // Both modifiers, on every platform. The app is one window with one find
-  // shortcut, and an operator who learned it on a laptop should not have to
-  // learn it again on a desktop.
+  // The three shortcuts that work wherever the operator is, matched against
+  // the same table the Shortcuts pane draws from, so a key listed there is a key
+  // that works. Everything else in that table belongs to the surface it acts
+  // on: see `lib/keybinds`.
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
-      if (event.key.toLowerCase() === "k" && (event.metaKey || event.ctrlKey)) {
-        event.preventDefault();
-        setSearching(true);
-      }
+      const binding = bindingFor(event);
+      if (!binding) return;
+      event.preventDefault();
+
+      if (binding.id === "search") setSearching(true);
+      if (binding.id === "settings") setShowSettings(true);
+      if (binding.id === "shortcuts") setShowSettings("shortcuts");
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, []);
+
+  // The scale and the surface, written to the root element. Done here rather
+  // than where they are chosen so a reload draws them before the first paint of
+  // anything else, and re-run when the OS changes its mind, which only matters
+  // while the surface is set to follow it.
+  useEffect(() => {
+    applyAppearance(prefs.uiScale, prefs.surface);
+    return watchSystemSurface(() => applyAppearance(prefs.uiScale, prefs.surface));
+  }, [prefs.uiScale, prefs.surface]);
 
   useEffect(() => {
     let unlisten: (() => void) | undefined;
@@ -63,12 +110,22 @@ export default function App() {
     void (async () => {
       // Subscribe before the first read so nothing that happens during startup
       // is missed.
-      const stop = await onRuntimeEvent(applyEvent);
+      const stop = await onRuntimeEvent((event) => {
+        applyEvent(event);
+        announce(event);
+      });
       if (cancelled) {
         stop();
         return;
       }
       unlisten = stop;
+
+      // Nothing interrupts the operator for the first few seconds. A routine
+      // whose slot passed while the app was closed is overdue and fires on the
+      // first tick, which is correct, but launching after a weekend away should
+      // not announce a weekend of schedule at once. All of it is on screen
+      // immediately either way; only the interruption waits.
+      markQuiet();
 
       try {
         await bootstrap();
@@ -83,7 +140,7 @@ export default function App() {
       cancelled = true;
       unlisten?.();
     };
-  }, [applyEvent, bootstrap, setBanner]);
+  }, [announce, applyEvent, bootstrap, setBanner]);
 
   /**
    * Runs something on one agent and re-reads the roster.
@@ -123,7 +180,9 @@ export default function App() {
         {needsKey && (
           <div className="banner">
             <span>Add an API key before your agents can reply.</span>
-            <button type="button" className="btn" onClick={() => setShowSettings(true)}>
+            {/* Onto the pane that holds the key, rather than onto the first one
+                with the key two sections away. */}
+            <button type="button" className="btn" onClick={() => setShowSettings("provider")}>
               Open settings
             </button>
           </div>
@@ -226,7 +285,12 @@ export default function App() {
         />
       )}
       {showCafeteria && <Cafeteria onClose={() => setShowCafeteria(false)} />}
-      {showSettings && <SettingsDialog onClose={() => setShowSettings(false)} />}
+      {showSettings && (
+        <SettingsDialog
+          onClose={() => setShowSettings(null)}
+          section={showSettings === true ? undefined : showSettings}
+        />
+      )}
       {searching && (
         <Search
           onClose={() => setSearching(false)}

--- a/src/components/ActivityFlow.tsx
+++ b/src/components/ActivityFlow.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { AgentAvatar } from "../avatars/AgentAvatar";
+import { ROOT_PX } from "../lib/appearance";
 import { api } from "../lib/ipc";
+import { useStore } from "../lib/store";
 import type { WirePeer } from "../lib/transcript";
 import type { AgentCard, AgentId, Envelope, Participant, RunId, Tokens } from "../lib/types";
 import { plainText } from "../lib/types";
@@ -32,8 +34,16 @@ import { MessageModal } from "./WireRow";
  * newest is first and open. History is still all here, one line each.
  */
 
-/** Width of one participant column. */
-const LANE_W = 72;
+/**
+ * Width of one participant column, as a multiple of the root font size.
+ *
+ * A number rather than a `rem` string because the wires between the lanes are
+ * SVG coordinates in the same space, so the whole board has to be measured in
+ * one unit and that unit has to be pixels. Resolved against the interface scale
+ * at render time instead: the names inside these columns are sized in `rem` and
+ * a column that did not grow with them would crop them.
+ */
+const LANE_REM = 4.5;
 
 const YOU: WirePeer = { id: "human", name: "You", color: "#5b665e", avatar: "plain" };
 
@@ -90,6 +100,10 @@ export function ActivityFlow({ messages, byId }: Props) {
   // for the rest. Storing the exception rather than the state means a new run
   // arriving does not have to be reconciled with anything.
   const [toggled, setToggled] = useState<Record<string, boolean>>({});
+  // Derived from the scale rather than measured off the document: it is the same
+  // arithmetic the stylesheet's root font size does, and doing it here keeps a
+  // layout read out of a render.
+  const laneW = (LANE_REM * ROOT_PX * useStore((s) => s.prefs.uiScale)) / 100;
 
   const blocks = useMemo(() => buildBlocks(messages, byId), [messages, byId]);
 
@@ -138,8 +152,8 @@ export function ActivityFlow({ messages, byId }: Props) {
       <div className="flow__scroll">
         {blocks.map((block, blockIndex) => {
           const isOpen = toggled[block.key] ?? blockIndex === 0;
-          const boardWidth = Math.max(block.lanes.length * LANE_W, LANE_W);
-          const laneX = (i: number) => i * LANE_W + LANE_W / 2;
+          const boardWidth = Math.max(block.lanes.length * laneW, laneW);
+          const laneX = (i: number) => i * laneW + laneW / 2;
           const day = dayLabel(block.startedAt);
 
           return (
@@ -198,7 +212,7 @@ export function ActivityFlow({ messages, byId }: Props) {
                         <div
                           className="flow__lane"
                           key={lane.key}
-                          style={{ width: LANE_W }}
+                          style={{ width: laneW }}
                           data-gone={lane.gone || undefined}
                         >
                           <AgentAvatar

--- a/src/components/ChannelView.tsx
+++ b/src/components/ChannelView.tsx
@@ -304,6 +304,12 @@ export function ChannelView({ channel, onOpenMenu }: Props) {
  */
 function WorkingNote({ agent, state }: { agent: AgentCard; state: Activity | undefined }) {
   const thought = thoughtLine(useStore((s) => s.reasoning[agent.id]));
+  // One string, so this re-renders when the run changes and not when a token
+  // arrives. Subscribing to `streams` here to find it would undo the whole
+  // reason this component exists.
+  const run = useStore((s) => s.activeRun[agent.id]);
+  const setBanner = useStore((s) => s.setBanner);
+  const [stopping, setStopping] = useState(false);
 
   // Queued counts: the agent has work it has not read yet, and to the operator
   // that is the same thing as working. Awaiting approval does not: it is
@@ -330,6 +336,32 @@ function WorkingNote({ agent, state }: { agent: AgentCard; state: Activity | und
         title={`${agent.name} is working`}
       />
       <span className="working__label">{thought || `${agent.name} is working`}</span>
+      {run && (
+        // Stops the conversation, not the agent. A message that reached four
+        // agents is one run, and stopping only the one on screen would leave
+        // the other three working on the operator's bill: hence the wording,
+        // which is the same distinction the button actually makes.
+        <button
+          type="button"
+          className="btn btn--ghost btn--small working__stop"
+          disabled={stopping}
+          title="Stop this conversation and everything it set off"
+          onClick={async () => {
+            setStopping(true);
+            try {
+              // False means it had already finished, which needs no telling:
+              // the answer is on screen.
+              await api.stopRun(run);
+            } catch (error) {
+              setBanner({ tone: "error", text: errorMessage(error) });
+            } finally {
+              setStopping(false);
+            }
+          }}
+        >
+          Stop
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -1,0 +1,716 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Prefs } from "../lib/prefs";
+import type { GuardLimits, Settings, SettingsPatch } from "../lib/types";
+import type { Section } from "./SettingsDialog";
+
+/**
+ * The settings dialog, over a mocked runtime.
+ *
+ * Eight panes, and every field of every one of them held by the shell. That is
+ * where the risk is, and none of it is visible in the markup: the patch the
+ * Save button sends is assembled by omission, so a box left blank has to be
+ * absent from that object rather than present and empty. An empty string sent
+ * as an API key clears a stored key, and a zero sent as a limit is a limit that
+ * refuses all work. The other half is the same state read the other way round:
+ * changing section unmounts a pane, so anything a pane held would be lost by a
+ * glance at Limits and back.
+ *
+ * The runtime is mocked down to the two calls this surface makes, which is
+ * enough to assert the one thing that matters about each: what was on screen
+ * when it was pressed.
+ */
+
+const HELD: GuardLimits = {
+  maxHops: 8,
+  maxStepsPerRun: 60,
+  maxFanoutPerCall: 8,
+  maxSendsPerPair: 6,
+  maxToolRounds: 24,
+};
+
+/** What the runtime is holding when the dialog opens. */
+function stored(over: Partial<Settings> = {}): Settings {
+  return {
+    operatorName: "Robert",
+    e2bKeySet: false,
+    e2bKeyHint: "",
+    computerIdleMinutes: 15,
+    kernelKeySet: false,
+    kernelKeyHint: "",
+    browserIdleMinutes: 60,
+    browserStealth: false,
+    baseUrl: "https://openrouter.ai/api/v1",
+    defaultModel: "anthropic/claude-sonnet-4.5",
+    apiKeySet: true,
+    apiKeyHint: "…9f2c",
+    requestTimeoutSecs: 120,
+    limits: { ...HELD },
+    ...over,
+  };
+}
+
+const updateSettings = vi.fn<(patch: SettingsPatch) => Promise<Settings>>(async () => stored());
+const testConnection = vi.fn<(patch?: SettingsPatch) => Promise<string>>(async () => "Reached it.");
+const notifyOperator = vi.fn<(title: string, body: string) => Promise<boolean>>(async () => true);
+const getVersion = vi.fn<() => Promise<string>>(async () => "0.4.2");
+
+vi.mock("../lib/ipc", () => ({
+  api: {
+    updateSettings: (patch: SettingsPatch) => updateSettings(patch),
+    testConnection: (patch?: SettingsPatch) => testConnection(patch),
+  },
+  notifyOperator: (title: string, body: string) => notifyOperator(title, body),
+}));
+
+// The About pane reads the version through a dynamic import, so the module has
+// to answer here or the whole tree comes down on a webview with no Tauri host.
+vi.mock("@tauri-apps/api/app", () => ({ getVersion: () => getVersion() }));
+
+const { SettingsDialog } = await import("./SettingsDialog");
+const { useStore } = await import("../lib/store");
+const { DEFAULT_PREFS, NOTIFY_KINDS } = await import("../lib/prefs");
+const { BINDINGS, SURFACES } = await import("../lib/keybinds");
+const { PROVIDERS } = await import("../lib/providers");
+
+const onClose = vi.fn();
+
+function open(settings: Settings | null = stored(), prefs: Prefs = DEFAULT_PREFS, on?: Section) {
+  useStore.setState({ settings, prefs });
+  return render(<SettingsDialog onClose={onClose} section={on} />);
+}
+
+function pane(label: string): void {
+  fireEvent.click(screen.getByRole("tab", { name: label }));
+}
+
+/**
+ * One field's input, by the words above it.
+ *
+ * Anchored patterns rather than exact names: every hint on this surface lives
+ * inside its own label, so the accessible name of a box is its label followed
+ * by a sentence of explanation.
+ */
+function field(label: RegExp): HTMLInputElement {
+  return screen.getByLabelText(label) as HTMLInputElement;
+}
+
+function type(label: RegExp, value: string): void {
+  fireEvent.change(field(label), { target: { value } });
+}
+
+function save(): HTMLButtonElement {
+  return screen.getByRole("button", { name: "Save" }) as HTMLButtonElement;
+}
+
+/**
+ * Test connection.
+ *
+ * It lives in the Provider pane rather than in the foot, because it reads the
+ * endpoint, the key and the model and acts on none of the other seven sections.
+ * So every test that presses it opens on that pane first.
+ */
+function probe(): HTMLButtonElement {
+  return screen.getByRole("button", { name: "Test connection" }) as HTMLButtonElement;
+}
+
+/** Whatever the dialog is currently saying about itself. */
+function banner(): HTMLElement {
+  const found = document.querySelector(".banner");
+  if (!found) throw new Error("no banner on screen");
+  return found as HTMLElement;
+}
+
+function sentPatch(): SettingsPatch {
+  const call = updateSettings.mock.calls[0];
+  if (!call) throw new Error("nothing was sent");
+  return call[0];
+}
+
+/**
+ * The switch on the row carrying this label.
+ *
+ * By the row rather than by role: the switches on this pane are named "On" and
+ * "Off" and nothing ties one to the label beside it, so a role query cannot
+ * tell the five of them apart.
+ */
+function switchOn(label: string): HTMLButtonElement {
+  const row = screen.getByText(label).closest(".switch-row");
+  const control = row?.querySelector("button");
+  if (!control) throw new Error(`no switch on the row for ${label}`);
+  return control as HTMLButtonElement;
+}
+
+/** Every kind's switch, in the order the pane lists them. The master is first. */
+function kindSwitches(): HTMLButtonElement[] {
+  return [...document.querySelectorAll(".switch-row")].slice(1).map((row) => {
+    const control = row.querySelector("button");
+    if (!control) throw new Error("a switch row with no switch in it");
+    return control as HTMLButtonElement;
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  updateSettings.mockResolvedValue(stored());
+  testConnection.mockResolvedValue("Reached OpenRouter. 312 models.");
+  notifyOperator.mockResolvedValue(true);
+  // No Tauri host behind this webview, which is the state the About pane is
+  // built to shrug off. The one test that wants a version asks for one.
+  getVersion.mockRejectedValue(new Error("no host"));
+});
+
+describe("when the runtime refuses", () => {
+  it("says what went wrong and stays open, so nothing typed is lost", async () => {
+    updateSettings.mockRejectedValue({ kind: "config", message: "config.json is read-only" });
+    open();
+    type(/^Your name/, "Robert W");
+    fireEvent.click(save());
+
+    await waitFor(() => expect(screen.getByText(/config\.json is read-only/i)).toBeTruthy());
+    expect(banner().className).toContain("banner--error");
+    // Closing on a failed save is the one thing that turns a refusal into lost
+    // work: the operator would reopen the dialog onto the stored values with no
+    // way to tell what had landed.
+    expect(onClose).not.toHaveBeenCalled();
+    expect(field(/^Your name/).value).toBe("Robert W");
+    expect(save().disabled).toBe(false);
+  });
+
+  it("reports a refused endpoint without touching what is stored", async () => {
+    testConnection.mockRejectedValue({ kind: "inference", message: "connection refused" });
+    open(stored(), DEFAULT_PREFS, "provider");
+    fireEvent.click(probe());
+
+    await waitFor(() => expect(screen.getByText(/connection refused/i)).toBeTruthy());
+    expect(banner().className).toContain("banner--error");
+    expect(updateSettings).not.toHaveBeenCalled();
+  });
+
+  it("takes one press while a save is in flight, whatever the operator does", async () => {
+    let settle: (value: Settings) => void = () => {};
+    updateSettings.mockImplementation(
+      () =>
+        new Promise<Settings>((resolve) => {
+          settle = resolve;
+        }),
+    );
+    // On Provider so both of the buttons a press could double up are on screen.
+    open(stored(), DEFAULT_PREFS, "provider");
+    fireEvent.click(save());
+
+    // Two config writes racing each other is the failure this prevents, and the
+    // second one would carry the same patch, so nothing would look wrong after.
+    expect(save().disabled).toBe(true);
+    expect(probe().disabled).toBe(true);
+    fireEvent.click(save());
+    expect(updateSettings).toHaveBeenCalledTimes(1);
+
+    settle(stored());
+    await waitFor(() => expect(save().disabled).toBe(false));
+  });
+});
+
+describe("what a save sends", () => {
+  it("leaves a blank key, timer and timeout out of the patch entirely", async () => {
+    open();
+    fireEvent.click(save());
+
+    await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
+    const patch = sentPatch();
+    // Absent, not empty and not zero. An empty `apiKey` clears the stored key,
+    // and a zero timeout or sleep timer is a setting nobody chose.
+    expect("apiKey" in patch).toBe(false);
+    expect("e2bApiKey" in patch).toBe(false);
+    expect("computerIdleMinutes" in patch).toBe(false);
+    expect("requestTimeoutSecs" in patch).toBe(false);
+    expect(patch).toEqual({
+      operatorName: "Robert",
+      baseUrl: "https://openrouter.ai/api/v1",
+      defaultModel: "anthropic/claude-sonnet-4.5",
+      limits: HELD,
+    });
+  });
+
+  it("does not read a box of spaces as a key", async () => {
+    open();
+    pane("Provider");
+    type(/^API key/, "   ");
+    pane("Machines");
+    type(/^E2B API key/, " ");
+    fireEvent.click(save());
+
+    await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
+    expect("apiKey" in sentPatch()).toBe(false);
+    expect("e2bApiKey" in sentPatch()).toBe(false);
+  });
+
+  it("refuses anything but digits in a duration, so no patch can carry NaN", async () => {
+    open();
+    pane("Machines");
+    type(/^Sleep computers after/, "45 minutes");
+    expect(field(/^Sleep computers after/).value).toBe("45");
+
+    pane("Provider");
+    type(/^Give up on a call after/, "abc");
+    expect(field(/^Give up on a call after/).value).toBe("");
+
+    fireEvent.click(save());
+    await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
+    expect(sentPatch().computerIdleMinutes).toBe(45);
+    expect("requestTimeoutSecs" in sentPatch()).toBe(false);
+  });
+
+  it("sends a cleared limit as that limit's floor rather than as zero", async () => {
+    open();
+    pane("Limits");
+    type(/^Relay depth/, "");
+    // Clearing a number box hands back nothing at all, and a limit of zero
+    // refuses every send the runtime is asked to make.
+    expect(field(/^Relay depth/).value).toBe("1");
+
+    fireEvent.click(save());
+    await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
+    expect(sentPatch().limits).toEqual({ ...HELD, maxHops: 1 });
+  });
+
+  it("sends a limit the runtime will clamp exactly as it was typed", async () => {
+    open();
+    pane("Limits");
+    type(/^Relay depth/, "40");
+
+    fireEvent.click(save());
+    await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
+    // The ceiling in the field's metadata is drawn, not enforced: only the floor
+    // is applied here, and `GuardLimits::sanitized` is what actually holds this
+    // to 16. Recorded rather than endorsed, and the box goes on reading 40.
+    expect(sentPatch().limits?.maxHops).toBe(40);
+  });
+
+  it("trims a typed key and carries the rest of the panes with it", async () => {
+    open();
+    pane("Provider");
+    type(/^API key/, "  sk-or-v1-typed  ");
+    type(/^Inference endpoint/, "http://localhost:1234/v1");
+    type(/^Default model/, "qwen3-coder-30b");
+    type(/^Give up on a call after/, "30");
+    pane("Machines");
+    type(/^E2B API key/, " e2b_typed ");
+    type(/^Sleep computers after/, "45");
+    pane("General");
+    type(/^Your name/, "Robert");
+
+    fireEvent.click(save());
+    await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
+    expect(sentPatch()).toEqual({
+      operatorName: "Robert",
+      baseUrl: "http://localhost:1234/v1",
+      defaultModel: "qwen3-coder-30b",
+      apiKey: "sk-or-v1-typed",
+      e2bApiKey: "e2b_typed",
+      computerIdleMinutes: 45,
+      requestTimeoutSecs: 30,
+      limits: HELD,
+    });
+  });
+
+  it("clears the API key box afterwards and leaves every other box alone", async () => {
+    open();
+    pane("Provider");
+    type(/^API key/, "sk-or-v1-typed");
+    type(/^Give up on a call after/, "30");
+    pane("Machines");
+    type(/^E2B API key/, "e2b_typed");
+    type(/^Sleep computers after/, "45");
+
+    updateSettings.mockResolvedValue(stored({ apiKeySet: true, apiKeyHint: "…yped" }));
+    fireEvent.click(save());
+    await waitFor(() => expect(screen.getByText("Saved.")).toBeTruthy());
+
+    // The asymmetry is asserted as it stands: one secret is dropped from the
+    // webview and the other is left on screen.
+    expect(field(/^E2B API key/).value).toBe("e2b_typed");
+    expect(field(/^Sleep computers after/).value).toBe("45");
+    pane("Provider");
+    expect(field(/^API key/).value).toBe("");
+    expect(field(/^Give up on a call after/).value).toBe("30");
+  });
+
+  it("stays open on a save, because saving is not finishing", async () => {
+    open();
+    fireEvent.click(save());
+    await waitFor(() => expect(screen.getByText("Saved.")).toBeTruthy());
+    expect(banner().className).toContain("banner--ok");
+    expect(onClose).not.toHaveBeenCalled();
+    expect(useStore.getState().settings?.operatorName).toBe("Robert");
+  });
+});
+
+describe("moving between sections", () => {
+  it("keeps typing that has not been saved", () => {
+    open();
+    pane("Provider");
+    type(/^Inference endpoint/, "http://localhost:1234/v1");
+    pane("Machines");
+    type(/^Sleep computers after/, "45");
+    pane("Limits");
+    type(/^Recipients per send/, "3");
+
+    // The whole reason every field is held by the shell. A pane owning its own
+    // state loses it the moment the operator glances at another one, and the
+    // loss is silent: the box is simply back to what is stored.
+    pane("Provider");
+    expect(field(/^Inference endpoint/).value).toBe("http://localhost:1234/v1");
+    pane("Machines");
+    expect(field(/^Sleep computers after/).value).toBe("45");
+    pane("Limits");
+    expect(field(/^Recipients per send/).value).toBe("3");
+  });
+
+  it("marks exactly one section as the one being read", () => {
+    open();
+    const chosen = () =>
+      screen
+        .getAllByRole("tab")
+        .filter((tab) => tab.getAttribute("aria-selected") === "true")
+        .map((tab) => tab.textContent);
+
+    expect(chosen()).toEqual(["General"]);
+    pane("Notifications");
+    expect(chosen()).toEqual(["Notifications"]);
+  });
+
+  it("opens on the section it was pointed at", () => {
+    // The palette and the missing-key banner both point at one, and landing on
+    // General to hunt for it is the step they exist to remove.
+    open(stored(), DEFAULT_PREFS, "shortcuts");
+    expect(screen.getByRole("tab", { name: "Shortcuts" }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    expect(screen.getByText("Every key the app answers to.", { exact: false })).toBeTruthy();
+  });
+});
+
+describe("closing", () => {
+  it("answers Escape while the focus is on a section tab", () => {
+    open();
+    const tab = screen.getByRole("tab", { name: "Limits" });
+    tab.focus();
+    expect(document.activeElement).toBe(tab);
+
+    // Bound to the window rather than to the panel for exactly this: focus is
+    // on a nav button the moment the operator has finished choosing a section,
+    // which is when they reach for Escape.
+    fireEvent.keyDown(tab, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    // And from outside the panel, which is where focus goes after a click on
+    // the scrim. A handler on the panel would never see this one.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("dismisses on the scrim behind it", () => {
+    open();
+    fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("testing the endpoint", () => {
+  it("sends what is on screen, without the name or the limits", async () => {
+    open(stored(), DEFAULT_PREFS, "provider");
+    type(/^Inference endpoint/, "https://api.groq.com/openai/v1");
+    type(/^API key/, "gsk_typed");
+    pane("General");
+    type(/^Your name/, "Somebody else");
+    // Back to the pane the button lives on. The name typed on the way past is
+    // still held by the shell, which is the other half of what this checks.
+    pane("Provider");
+
+    fireEvent.click(probe());
+    await waitFor(() => expect(testConnection).toHaveBeenCalledTimes(1));
+
+    const patch = testConnection.mock.calls[0]?.[0];
+    // Neither a name nor a limit is something an endpoint can be tested
+    // against, and the unsaved key is the whole point: probing the stored one
+    // reports "no API key" for a key the operator can see in front of them.
+    expect(patch).toEqual({
+      baseUrl: "https://api.groq.com/openai/v1",
+      defaultModel: "anthropic/claude-sonnet-4.5",
+      apiKey: "gsk_typed",
+    });
+    expect(updateSettings).not.toHaveBeenCalled();
+  });
+
+  it("says it is working, and then what came back", async () => {
+    let settle: (value: string) => void = () => {};
+    testConnection.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          settle = resolve;
+        }),
+    );
+    open(stored(), DEFAULT_PREFS, "provider");
+    fireEvent.click(probe());
+
+    expect(screen.getByText("Testing…")).toBeTruthy();
+    expect(banner().className).toBe("banner");
+
+    settle("Reached OpenRouter. 312 models.");
+    await waitFor(() => expect(screen.getByText(/312 models/)).toBeTruthy());
+    expect(banner().className).toContain("banner--ok");
+  });
+});
+
+describe("the provider presets", () => {
+  function preset(name: string): HTMLButtonElement {
+    const label = screen.getByText(name, { selector: ".preset__name" });
+    const button = label.closest("button");
+    if (!button) throw new Error(`no preset tile for ${name}`);
+    return button as HTMLButtonElement;
+  }
+
+  it("offers every endpoint that is known to speak the protocol", () => {
+    open();
+    pane("Provider");
+    for (const provider of PROVIDERS) {
+      expect(preset(provider.name), provider.id).toBeTruthy();
+    }
+  });
+
+  it("marks the preset the endpoint currently is, and only that one", () => {
+    open();
+    pane("Provider");
+    expect(preset("OpenRouter").getAttribute("aria-current")).toBe("true");
+    expect(preset("OpenAI").getAttribute("aria-current")).toBe("false");
+
+    // A hand-typed endpoint is chosen, not unrecognised, so nothing is marked.
+    type(/^Inference endpoint/, "https://gateway.example/v1");
+    expect(preset("OpenRouter").getAttribute("aria-current")).toBe("false");
+  });
+
+  it("fills both fields under it, and moves the mark", () => {
+    open();
+    pane("Provider");
+    fireEvent.click(preset("Groq"));
+
+    expect(field(/^Inference endpoint/).value).toBe("https://api.groq.com/openai/v1");
+    expect(field(/^Default model/).value).toBe("llama-3.3-70b-versatile");
+    expect(preset("Groq").getAttribute("aria-current")).toBe("true");
+    expect(preset("OpenRouter").getAttribute("aria-current")).toBe("false");
+    // Filling a box is not saving it.
+    expect(updateSettings).not.toHaveBeenCalled();
+  });
+
+  it("leaves the model alone for a preset that has no opinion about one", () => {
+    open();
+    pane("Provider");
+    type(/^Default model/, "qwen3-coder-30b");
+    fireEvent.click(preset("LM Studio"));
+
+    // A local server serves whatever is loaded into it, so blanking the model
+    // here would be replacing a working answer with a guess.
+    expect(field(/^Inference endpoint/).value).toBe("http://localhost:1234/v1");
+    expect(field(/^Default model/).value).toBe("qwen3-coder-30b");
+  });
+
+  it("does not ask a machine on this desk for a key", () => {
+    open(stored({ apiKeySet: false, apiKeyHint: "" }));
+    pane("Provider");
+    // An empty key field beside a warning about a missing key is the state an
+    // operator running a local model will try to fix forever.
+    expect(preset("LM Studio").textContent).toContain("On this machine");
+    expect(preset("OpenRouter").textContent).toContain("Needs a key");
+  });
+
+  it("says a key is stored once one is", () => {
+    open(stored({ apiKeySet: true, apiKeyHint: "…9f2c" }));
+    pane("Provider");
+    expect(preset("OpenRouter").textContent).toContain("Key stored");
+    expect(field(/^API key/).getAttribute("placeholder")).toBe("Stored …9f2c");
+  });
+
+  it("says nothing about a key on a row that is not the one chosen", () => {
+    // There is one key and it belongs to the endpoint in the field below, so a
+    // hosted row that is not the chosen one has nothing true to say about it.
+    // Reporting on the strength of another provider's key put "Key stored"
+    // against five providers the operator had never used.
+    open(stored({ apiKeySet: true, apiKeyHint: "…9f2c" }));
+    pane("Provider");
+
+    for (const name of ["OpenAI", "Groq", "Together", "Fireworks"]) {
+      expect(preset(name).textContent, name).not.toContain("Key stored");
+      expect(preset(name).textContent, name).not.toContain("Needs a key");
+    }
+    // And a local one still says what is true of the server itself.
+    expect(preset("Ollama").textContent).toContain("On this machine");
+  });
+});
+
+describe("appearance", () => {
+  /**
+   * One of the choice buttons.
+   *
+   * Matched on its accessible name rather than the word printed on it: a button
+   * reading "Ink" or "110%" says nothing about what it is choosing, so each
+   * carries an `aria-label` that does.
+   */
+  function choice(label: string): HTMLButtonElement {
+    return screen.getByRole("button", { name: label }) as HTMLButtonElement;
+  }
+
+  it("keeps a chosen surface and paints it onto the document", () => {
+    open();
+    pane("Appearance");
+    fireEvent.click(choice("Reading surface: Ink"));
+
+    // Both halves matter: the preference is what survives the window closing,
+    // and the attribute is what the stylesheet reads.
+    expect(useStore.getState().prefs.surface).toBe("dark");
+    expect(document.documentElement.dataset.surface).toBe("dark");
+    expect(choice("Reading surface: Ink").getAttribute("aria-pressed")).toBe("true");
+    expect(choice("Reading surface: Paper").getAttribute("aria-pressed")).toBe("false");
+    expect(screen.getByText(/Currently drawing ink/)).toBeTruthy();
+  });
+
+  it("resolves the system's answer rather than handing it on as one", () => {
+    open();
+    pane("Appearance");
+    fireEvent.click(choice("Reading surface: Follow the system"));
+
+    // `system` is a choice the operator makes; it is never what the stylesheet
+    // is given. The stub here reports no preference, which is paper.
+    expect(useStore.getState().prefs.surface).toBe("system");
+    expect(document.documentElement.dataset.surface).toBe("light");
+  });
+
+  it("keeps a chosen scale without disturbing the surface", () => {
+    open(stored(), { ...DEFAULT_PREFS, surface: "dark" });
+    pane("Appearance");
+    fireEvent.click(choice("Interface scale: 110%"));
+
+    expect(useStore.getState().prefs.uiScale).toBe(110);
+    // Each choice writes both, so a scale that read the wrong surface would
+    // flip the column to paper on the way past.
+    expect(useStore.getState().prefs.surface).toBe("dark");
+    expect(document.documentElement.dataset.surface).toBe("dark");
+    expect(document.documentElement.style.getPropertyValue("--ui-scale")).toBe("1.1");
+  });
+});
+
+describe("notifications", () => {
+  const ROUTINE = "A routine fired";
+
+  it("disables every kind while the master switch is off", () => {
+    open();
+    pane("Notifications");
+    fireEvent.click(switchOn("Notify me at all"));
+
+    expect(useStore.getState().prefs.notify.on).toBe(false);
+    expect(kindSwitches()).toHaveLength(NOTIFY_KINDS.length);
+    // Off means none of the below, whatever they say, and a switch that can
+    // still be flipped says the opposite. What each one REPORTS, though, is its
+    // own setting rather than its setting and the master together: the row is
+    // already unreachable, and what it has to say is what will apply when the
+    // master goes back on. Reading them together had the label say On while the
+    // control reported itself unchecked, which is a disagreement a sighted
+    // operator and a screen reader would resolve differently.
+    for (const control of kindSwitches()) {
+      expect(control.disabled).toBe(true);
+      expect(control.getAttribute("aria-checked")).toBe("true");
+    }
+  });
+
+  it("toggles one kind and leaves the others alone", () => {
+    open();
+    pane("Notifications");
+    fireEvent.click(switchOn(ROUTINE));
+
+    expect(useStore.getState().prefs.notify.kinds).toEqual({
+      approval: true,
+      routine: false,
+      settled: true,
+      failed: true,
+    });
+    expect(useStore.getState().prefs.notify.on).toBe(true);
+    expect(switchOn(ROUTINE).textContent).toBe("Off");
+  });
+
+  it("says so when the machine refuses a test notification", async () => {
+    notifyOperator.mockResolvedValue(false);
+    open();
+    pane("Notifications");
+    fireEvent.click(screen.getByRole("button", { name: "Send a test notification" }));
+
+    // A refused permission and a working one look identical from in here, which
+    // is the only reason this button exists.
+    await waitFor(() => expect(screen.getByText(/System Settings, then try again/)).toBeTruthy());
+    expect(banner().className).toContain("banner--error");
+  });
+
+  it("sends something recognisable when the machine allows it", async () => {
+    open();
+    pane("Notifications");
+    fireEvent.click(screen.getByRole("button", { name: "Send a test notification" }));
+
+    await waitFor(() => expect(notifyOperator).toHaveBeenCalledTimes(1));
+    expect(notifyOperator.mock.calls[0]).toEqual([
+      "Guaca",
+      "This is what a notification looks like.",
+    ]);
+    // Neutral, not the success tone, and that is the point. On desktop there is
+    // no per-app grant for the plugin to read, so a machine with notifications
+    // switched off accepts every one of these and shows none: a green "it
+    // worked" would be the one message in the pane that cannot be checked.
+    expect(banner().className).not.toContain("banner--ok");
+    expect(banner().className).not.toContain("banner--error");
+    expect(screen.getByText(/Handed to the operating system/)).toBeTruthy();
+  });
+});
+
+describe("shortcuts", () => {
+  it("lists every key the app answers to", () => {
+    open();
+    pane("Shortcuts");
+
+    // Discoverability is the whole feature: a binding this panel omits is a
+    // shortcut the operator does not have.
+    const rows = [...document.querySelectorAll(".keys__row")];
+    expect(rows).toHaveLength(BINDINGS.length);
+    for (const binding of BINDINGS) {
+      const row = screen.getByText(binding.what).closest(".keys__row");
+      expect(row?.querySelector(".keys__combo")?.textContent, binding.id).toBeTruthy();
+    }
+  });
+
+  it("groups the rows under the surface each one belongs to", () => {
+    open();
+    pane("Shortcuts");
+    const headings = [...document.querySelectorAll(".keys__group")].map((row) => row.textContent);
+    expect(headings).toEqual(
+      SURFACES.filter((where) => BINDINGS.some((binding) => binding.where === where)),
+    );
+  });
+});
+
+describe("about", () => {
+  it("shows a dash rather than a banner when the version cannot be read", async () => {
+    open();
+    pane("About");
+
+    await waitFor(() => expect(getVersion).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("Version —")).toBeTruthy();
+    expect(document.querySelector(".banner")).toBeNull();
+  });
+
+  it("shows the version once the app reports one", async () => {
+    getVersion.mockResolvedValueOnce("0.4.2");
+    open();
+    pane("About");
+
+    expect(await screen.findByText("Version 0.4.2")).toBeTruthy();
+  });
+});

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1,12 +1,58 @@
-import { useEffect, useState } from "react";
+/**
+ * Settings, as eight places rather than one scroll.
+ *
+ * Every piece of state lives here, in the shell, and the panes are given values
+ * and setters. That is not tidiness: the shell is unmounted when the dialog
+ * closes, so state held by a pane would be discarded every time the operator
+ * changed section, and typing an endpoint, glancing at Limits and coming back
+ * would silently lose the endpoint.
+ *
+ * Save and Test stay in the foot, outside the scrolling half, for the same
+ * reason they used to be at the bottom of one column: they act on everything,
+ * not on the section that happens to be open. Test deliberately sends what is
+ * on screen rather than what is stored, and Save deliberately does not close.
+ */
 
+import { useEffect, useRef, useState } from "react";
+
+import { applyAppearance, resolveSurface } from "../lib/appearance";
 import { api } from "../lib/ipc";
+import { BINDINGS, comboLabel, SURFACES } from "../lib/keybinds";
+import { NOTIFY_KINDS, type NotifyKind, type SurfaceMode, UI_SCALES } from "../lib/prefs";
+import { PROVIDERS, providerFor, providerReady } from "../lib/providers";
 import { useStore } from "../lib/store";
 import { errorMessage, type GuardLimits } from "../lib/types";
 
 interface Props {
   onClose: () => void;
+  /** Which pane to open on. The palette and the missing-key banner both point
+   *  at a specific one, and landing on General to hunt for it is a step. */
+  section?: Section;
 }
+
+const SECTIONS = [
+  "general",
+  "provider",
+  "limits",
+  "machines",
+  "appearance",
+  "notifications",
+  "shortcuts",
+  "about",
+] as const;
+
+export type Section = (typeof SECTIONS)[number];
+
+const SECTION_LABELS: Record<Section, string> = {
+  general: "General",
+  provider: "Provider",
+  limits: "Limits",
+  machines: "Machines",
+  appearance: "Appearance",
+  notifications: "Notifications",
+  shortcuts: "Shortcuts",
+  about: "About",
+};
 
 interface LimitField {
   key: keyof GuardLimits;
@@ -54,10 +100,38 @@ const LIMITS: LimitField[] = [
   },
 ];
 
-export function SettingsDialog({ onClose }: Props) {
+const SURFACE_LABELS: Record<SurfaceMode, string> = {
+  light: "Paper",
+  dark: "Ink",
+  system: "Follow the system",
+};
+
+const NOTIFY_COPY: Record<NotifyKind, { label: string; hint: string }> = {
+  approval: {
+    label: "An agent needs permission",
+    hint: "The only one that blocks: the turn that asked is parked until you answer, and gives up after ten minutes. Reaches you even while Guaca is open, if the request is in a channel you are not looking at.",
+  },
+  routine: {
+    label: "A routine fired",
+    hint: "Work that starts on a schedule rather than because you asked. It lands in whichever channel it was pointed at, which is usually not the one on screen.",
+  },
+  settled: {
+    label: "A conversation finished",
+    hint: "Every agent it reached has gone quiet. Only for the channel you were last looking at, so a busy runtime does not announce work you never opened.",
+  },
+  failed: {
+    label: "A turn could not finish",
+    hint: "The model call failed after its retries. Same channel rule as above.",
+  },
+};
+
+export function SettingsDialog({ onClose, section: opening }: Props) {
   const settings = useStore((s) => s.settings);
   const setSettings = useStore((s) => s.setSettings);
+  const prefs = useStore((s) => s.prefs);
+  const setPrefs = useStore((s) => s.setPrefs);
 
+  const [section, setSection] = useState<Section>(opening ?? "general");
   const [operatorName, setOperatorName] = useState(settings?.operatorName ?? "");
   const [baseUrl, setBaseUrl] = useState(settings?.baseUrl ?? "");
   const [model, setModel] = useState(settings?.defaultModel ?? "");
@@ -67,6 +141,7 @@ export function SettingsDialog({ onClose }: Props) {
   const [kernelKey, setKernelKey] = useState("");
   const [browserIdleMinutes, setBrowserIdleMinutes] = useState("");
   const [stealth, setStealth] = useState(settings?.browserStealth ?? false);
+  const [timeout, setTimeoutSecs] = useState("");
   const [limits, setLimits] = useState<GuardLimits>(
     settings?.limits ?? {
       maxHops: 8,
@@ -80,6 +155,8 @@ export function SettingsDialog({ onClose }: Props) {
     null,
   );
   const [busy, setBusy] = useState(false);
+  const [version, setVersion] = useState<string | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
@@ -89,24 +166,52 @@ export function SettingsDialog({ onClose }: Props) {
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
+  // Focus moves into the dialog on open, as it does in every other dialog here.
+  // Onto the panel rather than the first field: the first thing on this surface
+  // is a choice of section, not something to type into.
+  useEffect(() => {
+    panelRef.current?.focus();
+  }, []);
+
+  // Read on mount rather than at startup, so nothing pays for it until the one
+  // pane that shows it is opened.
+  useEffect(() => {
+    let live = true;
+    void import("@tauri-apps/api/app")
+      .then(({ getVersion }) => getVersion())
+      .then((value) => {
+        if (live) setVersion(value);
+      })
+      .catch(() => {
+        // A version nobody can read is worth a dash, not a banner.
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  const patch = () => ({
+    baseUrl,
+    defaultModel: model,
+    // Omitted when blank, so saving without retyping keeps the stored key.
+    ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
+    ...(e2bKey.trim() ? { e2bApiKey: e2bKey.trim() } : {}),
+    ...(idleMinutes.trim() ? { computerIdleMinutes: Number(idleMinutes) } : {}),
+    ...(timeout.trim() ? { requestTimeoutSecs: Number(timeout) } : {}),
+  });
+
   const save = async () => {
     setBusy(true);
     setStatus(null);
     try {
-      const next = await api.updateSettings({
-        operatorName,
-        baseUrl,
-        defaultModel: model,
-        limits,
-        // Omitted when blank, so saving without retyping keeps the stored key.
-        ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
-        ...(e2bKey.trim() ? { e2bApiKey: e2bKey.trim() } : {}),
-        ...(idleMinutes.trim() ? { computerIdleMinutes: Number(idleMinutes) } : {}),
-        ...(kernelKey.trim() ? { kernelApiKey: kernelKey.trim() } : {}),
-        ...(browserIdleMinutes.trim() ? { browserIdleMinutes: Number(browserIdleMinutes) } : {}),
-        browserStealth: stealth,
-      });
+      const next = await api.updateSettings({ operatorName, limits, ...patch() });
       setSettings(next);
+      // Read the limits back rather than leaving what was typed. The `max` on a
+      // number input is advisory — a pasted or typed value sails past it — and
+      // the runtime sanitises what it stores, so a relay depth of 40 is kept as
+      // 16. Saying "Saved." over a box still reading 40 tells the operator
+      // something untrue about what is running.
+      setLimits(next.limits);
       setApiKey("");
       setKernelKey("");
       setStatus({ tone: "ok", text: "Saved." });
@@ -123,16 +228,10 @@ export function SettingsDialog({ onClose }: Props) {
     try {
       // Sends what is on screen, so testing before saving does the obvious
       // thing rather than reporting on a key the operator has already replaced.
-      const result = await api.testConnection({
-        baseUrl,
-        defaultModel: model,
-        ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
-        ...(e2bKey.trim() ? { e2bApiKey: e2bKey.trim() } : {}),
-        ...(idleMinutes.trim() ? { computerIdleMinutes: Number(idleMinutes) } : {}),
-        ...(kernelKey.trim() ? { kernelApiKey: kernelKey.trim() } : {}),
-        ...(browserIdleMinutes.trim() ? { browserIdleMinutes: Number(browserIdleMinutes) } : {}),
-        browserStealth: stealth,
-      });
+      // Deliberately without operatorName and limits: neither is something an
+      // endpoint can be tested against, and a blank model would fail
+      // validation here instead of reporting on the endpoint.
+      const result = await api.testConnection(patch());
       setStatus({ tone: "ok", text: result });
     } catch (error) {
       setStatus({ tone: "error", text: errorMessage(error) });
@@ -141,184 +240,552 @@ export function SettingsDialog({ onClose }: Props) {
     }
   };
 
+  const choose = (provider: (typeof PROVIDERS)[number]) => {
+    setBaseUrl(provider.baseUrl);
+    if (provider.model) setModel(provider.model);
+  };
+
+  const current = providerFor(baseUrl);
+
   return (
     <div className="scrim">
       {/* A real button, so dismissing by clicking away is reachable from the
           keyboard and announced, rather than being an invisible div handler. */}
       <button type="button" className="scrim__close" aria-label="Close dialog" onClick={onClose} />
-      <div className="dialog" role="dialog" aria-modal="true" aria-label="Settings">
-        <h2 className="dialog__title">Settings</h2>
-        <p className="dialog__lede">
-          Guaca runs entirely on this machine. The only thing it sends anywhere is what you and your
-          agents type, to the endpoint below.
-        </p>
+      <div
+        className="dialog dialog--settings"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Settings"
+        tabIndex={-1}
+        ref={panelRef}
+      >
+        <div className="settings__head">
+          <h2 className="dialog__title">Settings</h2>
+          <p className="dialog__lede" style={{ margin: 0 }}>
+            Guaca runs entirely on this machine. The only thing it sends anywhere is what you and
+            your agents type, to the endpoint you choose.
+          </p>
+        </div>
 
-        <label className="field">
-          <span className="field__label">Your name</span>
-          <input
-            className="input"
-            value={operatorName}
-            placeholder="Unnamed"
-            onChange={(event) => setOperatorName(event.target.value)}
-          />
-          <span className="field__hint">
-            What every agent calls you. They are told this on every turn, so you never have to
-            introduce yourself or ask one to remember it. Leave blank and they say "the operator".
-          </span>
-        </label>
+        <div className="settings__body">
+          <div
+            className="settings__nav"
+            role="tablist"
+            aria-orientation="vertical"
+            aria-label="Settings sections"
+          >
+            {SECTIONS.map((key) => (
+              <button
+                key={key}
+                type="button"
+                role="tab"
+                className="settings__tab"
+                aria-selected={section === key}
+                onClick={() => setSection(key)}
+              >
+                {SECTION_LABELS[key]}
+              </button>
+            ))}
+          </div>
 
-        <label className="field">
-          <span className="field__label">Inference endpoint</span>
-          <input
-            className="input input--mono"
-            value={baseUrl}
-            placeholder="https://openrouter.ai/api/v1"
-            onChange={(event) => setBaseUrl(event.target.value)}
-          />
-          <span className="field__hint">
-            Any OpenAI-compatible base URL. Point it at a local server to run without a network.
-          </span>
-        </label>
+          <div className="settings__pane">
+            {section === "general" && (
+              <>
+                <h3 className="settings__title">General</h3>
+                <p className="settings__lede">Who the agents think they are talking to.</p>
 
-        <label className="field">
-          <span className="field__label">API key</span>
-          <input
-            className="input input--mono"
-            type="password"
-            value={apiKey}
-            placeholder={settings?.apiKeySet ? `Stored ${settings.apiKeyHint}` : "sk-or-v1-…"}
-            autoComplete="off"
-            onChange={(event) => setApiKey(event.target.value)}
-          />
-          <span className="field__hint">
-            Stored on this machine in a file only your user account can read. Leave blank to keep
-            the current key.
-          </span>
-        </label>
+                <label className="field">
+                  <span className="field__label">Your name</span>
+                  <input
+                    className="input"
+                    value={operatorName}
+                    placeholder="Unnamed"
+                    onChange={(event) => setOperatorName(event.target.value)}
+                  />
+                  <span className="field__hint">
+                    What every agent calls you. They are told this on every turn, so you never have
+                    to introduce yourself or ask one to remember it. Leave blank and they say "the
+                    operator".
+                  </span>
+                </label>
+              </>
+            )}
 
-        <label className="field">
-          <span className="field__label">E2B API key</span>
-          <input
-            className="input input--mono"
-            type="password"
-            value={e2bKey}
-            placeholder={settings?.e2bKeySet ? `Stored ${settings.e2bKeyHint}` : "e2b_… (optional)"}
-            autoComplete="off"
-            onChange={(event) => setE2bKey(event.target.value)}
-          />
-          <span className="field__hint">
-            Gives every agent its own computer: a desktop and a terminal in a sandbox, shown in the
-            corner of its channel. Without a key that pane stays closed.
-          </span>
-        </label>
+            {section === "provider" && (
+              <>
+                <h3 className="settings__title">Provider</h3>
+                <p className="settings__lede">
+                  Any OpenAI-compatible endpoint. The ones below are spelled correctly; choosing one
+                  fills in the two fields under it, and anything else can be typed in.
+                </p>
 
-        <label className="field">
-          <span className="field__label">Sleep computers after</span>
-          <input
-            className="input input--mono"
-            inputMode="numeric"
-            value={idleMinutes}
-            placeholder={`${settings?.computerIdleMinutes ?? 15} minutes`}
-            onChange={(event) => setIdleMinutes(event.target.value.replace(/[^0-9]/g, ""))}
-          />
-          <span className="field__hint">
-            Idle minutes before a machine sleeps. Sleeping keeps its disk, so a browser stays signed
-            in and wakes where it left off. Only the running time is billed.
-          </span>
-        </label>
+                {PROVIDERS.map((provider) => {
+                  const chosen = current?.id === provider.id;
+                  const ready = providerReady(provider, Boolean(settings?.apiKeySet));
+                  return (
+                    <button
+                      key={provider.id}
+                      type="button"
+                      className="preset"
+                      aria-current={chosen}
+                      onClick={() => choose(provider)}
+                    >
+                      <span className="preset__text">
+                        <span className="preset__name">{provider.name}</span>
+                        <span className="preset__url">{provider.baseUrl}</span>
+                      </span>
+                      {/* Only the row that is actually chosen can say
+                          anything about the key, because there is one key and
+                          it belongs to the endpoint in the field below. Saying
+                          "key stored" against six providers the operator has
+                          never used, on the strength of a seventh provider's
+                          key, is the same sentence repeated until it means
+                          nothing. Local endpoints are the exception: wanting no
+                          key is a property of the server, not of this setup. */}
+                      {provider.local ? (
+                        <span className="preset__state" data-ready="true">
+                          On this machine
+                        </span>
+                      ) : (
+                        chosen && (
+                          <span className="preset__state" data-ready={ready ? "true" : undefined}>
+                            {ready ? "Key stored" : "Needs a key"}
+                          </span>
+                        )
+                      )}
+                    </button>
+                  );
+                })}
 
-        <label className="field">
-          <span className="field__label">Kernel API key</span>
-          <input
-            className="input input--mono"
-            type="password"
-            value={kernelKey}
-            placeholder={
-              settings?.kernelKeySet ? `Stored ${settings.kernelKeyHint}` : "sk_… (optional)"
-            }
-            autoComplete="off"
-            onChange={(event) => setKernelKey(event.target.value)}
-          />
-          <span className="field__hint">
-            Gives every agent its own browser: a Chrome in the cloud, separate from its computer.
-            This is what agents use for the web, because it tells them where everything on a page is
-            instead of making them aim at pixels. Without a key that pane stays closed and agents
-            have no `browse`.
-          </span>
-        </label>
+                <label className="field" style={{ marginTop: "1.1rem" }}>
+                  <span className="field__label">Inference endpoint</span>
+                  <input
+                    className="input input--mono"
+                    value={baseUrl}
+                    placeholder="https://openrouter.ai/api/v1"
+                    onChange={(event) => setBaseUrl(event.target.value)}
+                  />
+                  <span className="field__hint">
+                    Any OpenAI-compatible base URL. Point it at a local server to run without a
+                    network.
+                  </span>
+                </label>
 
-        <label className="field">
-          <span className="field__label">Close browsers after</span>
-          <input
-            className="input input--mono"
-            inputMode="numeric"
-            value={browserIdleMinutes}
-            placeholder={`${settings?.browserIdleMinutes ?? 60} minutes`}
-            onChange={(event) => setBrowserIdleMinutes(event.target.value.replace(/[^0-9]/g, ""))}
-          />
-          <span className="field__hint">
-            Idle minutes before a browser is thrown away. It stops billing within seconds of going
-            quiet either way, and what it was signed in to is kept, so the next one opens signed in
-            to the same accounts. Longer only saves the seconds a fresh one takes to start.
-          </span>
-        </label>
+                <label className="field">
+                  <span className="field__label">API key</span>
+                  <input
+                    className="input input--mono"
+                    type="password"
+                    value={apiKey}
+                    placeholder={
+                      settings?.apiKeySet ? `Stored ${settings.apiKeyHint}` : "sk-or-v1-…"
+                    }
+                    autoComplete="off"
+                    onChange={(event) => setApiKey(event.target.value)}
+                  />
+                  <span className="field__hint">
+                    Stored on this machine in a file only your user account can read, and never sent
+                    to the webview. Leave blank to keep the current key. A server on this machine
+                    usually wants none.
+                  </span>
+                </label>
 
-        <label className="field field--row">
-          <input
-            type="checkbox"
-            checked={stealth}
-            onChange={(event) => setStealth(event.target.checked)}
-          />
-          <span>
-            <span className="field__label">Hide that browsers are automated</span>
-            <span className="field__hint">
-              For sites that block automation. Kernel disguises the browser and solves captchas.
-              Costs more per browser and needs a plan that includes it, so leave it off until a site
-              turns an agent away.
-            </span>
-          </span>
-        </label>
+                <label className="field">
+                  <span className="field__label">Default model</span>
+                  <input
+                    className="input input--mono"
+                    value={model}
+                    placeholder="anthropic/claude-sonnet-4.5"
+                    onChange={(event) => setModel(event.target.value)}
+                  />
+                  <span className="field__hint">
+                    Used for new agents. Each agent, and each group, can override it.
+                  </span>
+                </label>
 
-        <label className="field">
-          <span className="field__label">Default model</span>
-          <input
-            className="input input--mono"
-            value={model}
-            placeholder="anthropic/claude-sonnet-4.5"
-            onChange={(event) => setModel(event.target.value)}
-          />
-          <span className="field__hint">Used for new agents. Each agent can override it.</span>
-        </label>
+                <label className="field">
+                  <span className="field__label">Give up on a call after</span>
+                  <input
+                    className="input input--mono"
+                    inputMode="numeric"
+                    value={timeout}
+                    placeholder={`${settings?.requestTimeoutSecs ?? 120} seconds`}
+                    onChange={(event) => setTimeoutSecs(event.target.value.replace(/[^0-9]/g, ""))}
+                  />
+                  <span className="field__hint">
+                    Seconds to wait for a model call. A slow local model wants more than a hosted
+                    one; a run that hangs wants less. Blank keeps what is stored.
+                  </span>
+                </label>
 
-        <hr className="divider" />
+                <div className="settings__probe">
+                  <button type="button" className="btn" disabled={busy} onClick={() => void test()}>
+                    Test connection
+                  </button>
+                  <span className="hint">Tests what is on screen. Save to keep it.</span>
+                </div>
+              </>
+            )}
 
-        <h3 className="dialog__title" style={{ fontSize: "0.85rem" }}>
-          Limits
-        </h3>
-        <p className="dialog__lede">
-          Agents that message each other do not stop on their own. These bounds decide when a
-          conversation ends, and every agent is told why when it hits one.
-        </p>
+            {section === "limits" && (
+              <>
+                <h3 className="settings__title">Limits</h3>
+                <p className="settings__lede">
+                  Agents that message each other do not stop on their own. These bounds decide when
+                  a conversation ends, and every agent is told why when it hits one.
+                </p>
 
-        {LIMITS.map((field) => (
-          <label className="field" key={field.key}>
-            <span className="field__label">{field.label}</span>
-            <input
-              className="input input--mono"
-              type="number"
-              min={field.min}
-              max={field.max}
-              value={limits[field.key]}
-              onChange={(event) =>
-                setLimits((current) => ({
-                  ...current,
-                  [field.key]: Number(event.target.value) || field.min,
-                }))
-              }
-            />
-            <span className="field__hint">{field.hint}</span>
-          </label>
-        ))}
+                {LIMITS.map((field) => (
+                  <label className="field" key={field.key}>
+                    <span className="field__label">{field.label}</span>
+                    <input
+                      className="input input--mono input--number"
+                      type="number"
+                      min={field.min}
+                      max={field.max}
+                      value={limits[field.key]}
+                      onChange={(event) =>
+                        setLimits((current) => ({
+                          ...current,
+                          [field.key]: Number(event.target.value) || field.min,
+                        }))
+                      }
+                    />
+                    <span className="field__hint">{field.hint}</span>
+                  </label>
+                ))}
+              </>
+            )}
+
+            {section === "machines" && (
+              <>
+                <h3 className="settings__title">Machines</h3>
+                <p className="settings__lede">
+                  A sandbox each: a desktop and a terminal an agent can actually work in.
+                </p>
+
+                <label className="field">
+                  <span className="field__label">E2B API key</span>
+                  <input
+                    className="input input--mono"
+                    type="password"
+                    value={e2bKey}
+                    placeholder={
+                      settings?.e2bKeySet ? `Stored ${settings.e2bKeyHint}` : "e2b_… (optional)"
+                    }
+                    autoComplete="off"
+                    onChange={(event) => setE2bKey(event.target.value)}
+                  />
+                  <span className="field__hint">
+                    Gives every agent its own computer: a desktop and a terminal in a sandbox, shown
+                    in the corner of its channel. Without a key that pane stays closed.
+                  </span>
+                </label>
+
+                <label className="field">
+                  <span className="field__label">Sleep computers after</span>
+                  <input
+                    className="input input--mono"
+                    inputMode="numeric"
+                    value={idleMinutes}
+                    placeholder={`${settings?.computerIdleMinutes ?? 15} minutes`}
+                    onChange={(event) => setIdleMinutes(event.target.value.replace(/[^0-9]/g, ""))}
+                  />
+                  <span className="field__hint">
+                    Idle minutes before a machine sleeps. Sleeping keeps its disk, so a browser
+                    stays signed in and wakes where it left off. Only the running time is billed.
+                  </span>
+                </label>
+
+                <label className="field">
+                  <span className="field__label">Kernel API key</span>
+                  <input
+                    className="input input--mono"
+                    type="password"
+                    value={kernelKey}
+                    placeholder={
+                      settings?.kernelKeySet
+                        ? `Stored ${settings.kernelKeyHint}`
+                        : "sk_… (optional)"
+                    }
+                    autoComplete="off"
+                    onChange={(event) => setKernelKey(event.target.value)}
+                  />
+                  <span className="field__hint">
+                    Gives every agent its own browser: a Chrome in the cloud, separate from its
+                    computer. This is what agents use for the web, because it tells them where
+                    everything on a page is instead of making them aim at pixels. Without a key that
+                    pane stays closed and agents have no `browse`.
+                  </span>
+                </label>
+
+                <label className="field">
+                  <span className="field__label">Close browsers after</span>
+                  <input
+                    className="input input--mono"
+                    inputMode="numeric"
+                    value={browserIdleMinutes}
+                    placeholder={`${settings?.browserIdleMinutes ?? 60} minutes`}
+                    onChange={(event) =>
+                      setBrowserIdleMinutes(event.target.value.replace(/[^0-9]/g, ""))
+                    }
+                  />
+                  <span className="field__hint">
+                    Idle minutes before a browser is thrown away. It stops billing within seconds of
+                    going quiet either way, and what it was signed in to is kept, so the next one
+                    opens signed in to the same accounts. Longer only saves the seconds a fresh one
+                    takes to start.
+                  </span>
+                </label>
+
+                <label className="field field--row">
+                  <input
+                    type="checkbox"
+                    checked={stealth}
+                    onChange={(event) => setStealth(event.target.checked)}
+                  />
+                  <span>
+                    <span className="field__label">Hide that browsers are automated</span>
+                    <span className="field__hint">
+                      For sites that block automation. Kernel disguises the browser and solves
+                      captchas. Costs more per browser and needs a plan that includes it, so leave
+                      it off until a site turns an agent away.
+                    </span>
+                  </span>
+                </label>
+              </>
+            )}
+
+            {section === "appearance" && (
+              <>
+                <h3 className="settings__title">Appearance</h3>
+                <p className="settings__lede">
+                  Applied as you choose, and kept on this machine. Neither of these is sent anywhere
+                  or known to an agent.
+                </p>
+
+                <div className="field">
+                  <span className="field__label">Reading surface</span>
+                  <div className="choices">
+                    {(Object.keys(SURFACE_LABELS) as SurfaceMode[]).map((mode) => (
+                      <button
+                        key={mode}
+                        type="button"
+                        className="choice"
+                        aria-label={`Reading surface: ${SURFACE_LABELS[mode]}`}
+                        aria-pressed={prefs.surface === mode}
+                        onClick={() => {
+                          setPrefs({ surface: mode });
+                          applyAppearance(prefs.uiScale, mode);
+                        }}
+                      >
+                        {SURFACE_LABELS[mode]}
+                      </button>
+                    ))}
+                  </div>
+                  <span className="field__hint">
+                    The column you read in. The rail stays dark either way: it is what makes the
+                    column read as a surface rather than as another panel. Currently drawing{" "}
+                    {resolveSurface(prefs.surface) === "dark" ? "ink" : "paper"}.
+                  </span>
+                </div>
+
+                <div className="field">
+                  <span className="field__label">Interface scale</span>
+                  <div className="choices">
+                    {UI_SCALES.map((scale) => (
+                      <button
+                        key={scale}
+                        type="button"
+                        className="choice"
+                        aria-label={`Interface scale: ${scale}%`}
+                        aria-pressed={prefs.uiScale === scale}
+                        onClick={() => {
+                          setPrefs({ uiScale: scale });
+                          applyAppearance(scale, prefs.surface);
+                        }}
+                      >
+                        {scale}%
+                      </button>
+                    ))}
+                  </div>
+                  <span className="field__hint">
+                    Everything, not just the type: the rail, the rows and the spacing scale with it.
+                    The rail and the inspector stop growing before they would crowd out the reading
+                    column in a small window.
+                  </span>
+                </div>
+              </>
+            )}
+
+            {section === "notifications" && (
+              <>
+                <h3 className="settings__title">Notifications</h3>
+                <p className="settings__lede">
+                  Guaca keeps working while you are elsewhere, which is the only time any of these
+                  fire. Nothing interrupts you for something already on screen in front of you.
+                </p>
+
+                <div className="switch-row">
+                  <span className="switch-row__text">
+                    <span className="switch-row__label">Notify me at all</span>
+                    <span className="switch-row__hint">
+                      Off means none of the below, whatever they say. The first notification asks
+                      the operating system for permission.
+                    </span>
+                  </span>
+                  <button
+                    type="button"
+                    className="choice"
+                    role="switch"
+                    aria-checked={prefs.notify.on}
+                    aria-label="Notify me at all"
+                    onClick={() => setPrefs({ notify: { ...prefs.notify, on: !prefs.notify.on } })}
+                  >
+                    {prefs.notify.on ? "On" : "Off"}
+                  </button>
+                </div>
+
+                {NOTIFY_KINDS.map((kind) => (
+                  <div
+                    className="switch-row"
+                    key={kind}
+                    data-off={prefs.notify.on ? undefined : "true"}
+                  >
+                    <span className="switch-row__text">
+                      <span className="switch-row__label">{NOTIFY_COPY[kind].label}</span>
+                      <span className="switch-row__hint">{NOTIFY_COPY[kind].hint}</span>
+                    </span>
+                    <button
+                      type="button"
+                      className="choice"
+                      role="switch"
+                      disabled={!prefs.notify.on}
+                      // The kind's own setting, not the master switch and the
+                      // kind together: the row is already disabled, and what it
+                      // has to report is what will apply when the master goes
+                      // back on. Reading them together had the label say On
+                      // while the control reported itself unchecked.
+                      aria-checked={prefs.notify.kinds[kind]}
+                      aria-label={NOTIFY_COPY[kind].label}
+                      onClick={() =>
+                        setPrefs({
+                          notify: {
+                            ...prefs.notify,
+                            kinds: { ...prefs.notify.kinds, [kind]: !prefs.notify.kinds[kind] },
+                          },
+                        })
+                      }
+                    >
+                      {prefs.notify.kinds[kind] ? "On" : "Off"}
+                    </button>
+                  </div>
+                ))}
+
+                <div style={{ marginTop: "1rem" }}>
+                  <button
+                    type="button"
+                    className="btn"
+                    onClick={async () => {
+                      const { notifyOperator } = await import("../lib/ipc");
+                      const sent = await notifyOperator(
+                        "Guaca",
+                        "This is what a notification looks like.",
+                      );
+                      // Deliberately not "it worked". On desktop there is no
+                      // per-app grant for the plugin to read, so a machine with
+                      // notifications switched off accepts this and shows
+                      // nothing: claiming success would be the one message that
+                      // cannot be checked. The refusal branch is reachable on
+                      // the platforms that do answer the question.
+                      setStatus(
+                        sent
+                          ? {
+                              tone: "info",
+                              text: "Handed to the operating system. If nothing appeared, Guaca is not allowed to notify you: check Notifications in System Settings.",
+                            }
+                          : {
+                              tone: "error",
+                              text: "This machine refused outright. Allow Guaca to notify you in System Settings, then try again.",
+                            },
+                      );
+                    }}
+                  >
+                    Send a test notification
+                  </button>
+                  <p className="hint" style={{ marginTop: "0.4rem" }}>
+                    The only way to find out whether this machine will show them.
+                  </p>
+                </div>
+              </>
+            )}
+
+            {section === "shortcuts" && (
+              <>
+                <h3 className="settings__title">Shortcuts</h3>
+                <p className="settings__lede">
+                  Every key the app answers to. The three under Anywhere work wherever you are; the
+                  rest belong to the surface they are listed under.
+                </p>
+
+                <div className="keys">
+                  {SURFACES.map((where) => {
+                    const rows = BINDINGS.filter((binding) => binding.where === where);
+                    if (rows.length === 0) return null;
+                    return (
+                      <div key={where}>
+                        <p className="keys__group">{where}</p>
+                        {rows.map((binding) => (
+                          <div className="keys__row" key={binding.id}>
+                            <span className="keys__what">{binding.what}</span>
+                            <span className="keys__combo">{comboLabel(binding)}</span>
+                          </div>
+                        ))}
+                      </div>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+
+            {section === "about" && (
+              <>
+                <div className="about">
+                  <h3 className="about__name">Guaca</h3>
+                  <p className="about__version">{version ? `Version ${version}` : "Version —"}</p>
+                </div>
+
+                <div className="about__facts">
+                  <div className="field">
+                    <span className="field__label">What this is</span>
+                    <span className="field__hint">
+                      A local desktop app where you talk to LLM agents and they talk to each other.
+                      The agents run here, in this app, not on anybody's server.
+                    </span>
+                  </div>
+
+                  <div className="field">
+                    <span className="field__label">Where it keeps things</span>
+                    <span className="field__hint">
+                      Everything is under this app's data directory: <code>guac.db</code> for the
+                      transcripts, <code>config.json</code> for the settings and your keys, written
+                      so only your user account can read it, <code>workspace/</code> for what each
+                      agent remembers, and <code>files/</code> for anything attached.
+                    </span>
+                  </div>
+
+                  <div className="field">
+                    <span className="field__label">Licence</span>
+                    <span className="field__hint">
+                      GNU Affero General Public License v3 or later.
+                    </span>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
 
         {status && (
           <div
@@ -329,32 +796,24 @@ export function SettingsDialog({ onClose }: Props) {
                   ? "banner banner--ok"
                   : "banner"
             }
-            style={{ margin: "0 0 0.9rem" }}
+            style={{ margin: "0.75rem 1.35rem 0" }}
           >
             <span>{status.text}</span>
           </div>
         )}
 
-        <div style={{ display: "flex", gap: "0.5rem" }}>
-          <button type="button" className="btn" disabled={busy} onClick={() => void test()}>
-            Test connection
+        <div className="settings__foot">
+          <button type="button" className="btn" onClick={onClose}>
+            Close
           </button>
-          <span className="hint" style={{ alignSelf: "center" }}>
-            Tests what is on screen. Save to keep it.
-          </span>
-          <div style={{ marginLeft: "auto", display: "flex", gap: "0.5rem" }}>
-            <button type="button" className="btn" onClick={onClose}>
-              Close
-            </button>
-            <button
-              type="button"
-              className="btn btn--primary"
-              disabled={busy}
-              onClick={() => void save()}
-            >
-              Save
-            </button>
-          </div>
+          <button
+            type="button"
+            className="btn btn--primary"
+            disabled={busy}
+            onClick={() => void save()}
+          >
+            Save
+          </button>
         </div>
       </div>
     </div>

--- a/src/lib/announce.test.ts
+++ b/src/lib/announce.test.ts
@@ -1,0 +1,312 @@
+/**
+ * What an interruption would say, decided one event at a time.
+ *
+ * `notify` owns whether the operator hears anything and has its own tests; this
+ * decides what would be said and which channel it is about. Both ways of
+ * getting that wrong are quiet. An announcement per event rather than per thing
+ * that happened is a badge for every token of a reply, and the operator's only
+ * answer to that is the master switch. And the channel is not decoration:
+ * `notify` holds a completion back unless the operator was already looking at
+ * that channel, so a kind labelled with the wrong one reaches nobody, or
+ * reaches them for a run they have never opened.
+ *
+ * The one piece of state here, a run's channel, is module-level and outlives a
+ * render, so what it forgets matters as much as what it learns.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { announcementFor, resetChannels } from "./announce";
+import type { AgentId, Envelope, Part, RunId, UiEvent } from "./types";
+
+const CHEF: AgentId = "agent-chef";
+const SCRIBE: AgentId = "agent-scribe";
+const RUN: RunId = "run-1";
+
+const NAMES = new Map<AgentId, string>([
+  [CHEF, "Chef"],
+  [SCRIBE, "Scribe"],
+]);
+
+/** The lookup `App` hands in: a name when it has one, a stand-in when it does not. */
+function nameOf(id: AgentId): string {
+  return NAMES.get(id) ?? "An agent";
+}
+
+function envelope(over: Partial<Envelope> = {}): Envelope {
+  return {
+    id: "m1",
+    runId: RUN,
+    channelId: CHEF,
+    from: { kind: "agent", id: CHEF },
+    to: { kind: "human" },
+    parts: [{ type: "text", text: "the listings are up to date" }],
+    trust: "peer",
+    hop: 1,
+    expectsReply: false,
+    intent: "work",
+    cause: null,
+    createdAt: 1,
+    ...over,
+  };
+}
+
+function appended(parts: Part[], over: Partial<Envelope> = {}): UiEvent {
+  return { type: "messageAppended", message: envelope({ parts, ...over }) };
+}
+
+/** The event a run's channel is learned from, which is the only reason it is passed here. */
+function opened(runId: RunId, channelId: AgentId): UiEvent {
+  return {
+    type: "streamStarted",
+    messageId: `stream-${runId}`,
+    channelId,
+    agentId: channelId,
+    runId,
+    to: { kind: "human" },
+  };
+}
+
+function ended(runId: RunId, stepsUsed: number): UiEvent {
+  return { type: "runSettled", runId, stepsUsed };
+}
+
+beforeEach(() => {
+  resetChannels();
+});
+
+describe("events nobody should be told about", () => {
+  it("says nothing about the traffic a turn is made of", () => {
+    // Every one of these arrives many times inside a single reply. A kind read
+    // off the event stream rather than off the thing that happened is how a
+    // finished conversation becomes forty notifications.
+    const ignored: UiEvent[] = [
+      { type: "agentsChanged" },
+      { type: "streamDelta", messageId: "m1", channelId: CHEF, text: "the list" },
+      { type: "reasoningDelta", messageId: "m1", text: "weighing it up" },
+      { type: "streamEnded", messageId: "m1", channelId: CHEF },
+      { type: "activityChanged", agentId: CHEF, activity: { state: "thinking" } },
+      {
+        type: "tokensUsed",
+        agentId: CHEF,
+        groupId: "group-1",
+        runId: RUN,
+        prompt: 900,
+        completion: 40,
+        cost: null,
+      },
+      { type: "approvalSettled", approvalId: "approval-1", state: "allow" },
+      { type: "channelsCleared", agents: [CHEF, SCRIBE] },
+    ];
+
+    expect(ignored.map((event) => [event.type, announcementFor(event, nameOf)])).toEqual(
+      ignored.map((event) => [event.type, null]),
+    );
+  });
+
+  it("says nothing about a message that is only what an agent said", () => {
+    // A reply in a channel is the app working, not news. The operator is told
+    // when the conversation it belongs to finishes, once.
+    expect(announcementFor(appended([{ type: "text", text: "done" }]), nameOf)).toBeNull();
+  });
+
+  it("says nothing about a message carrying the permission request itself", () => {
+    // `approvalRequested` already announced this one. Announcing the part too
+    // would put the same parked turn in front of the operator twice.
+    const request = appended([
+      {
+        type: "approval",
+        id: "approval-1",
+        action: "actOnBehalf",
+        summary: "Send the owner an email",
+        detail: [{ label: "To", value: "owner@example.com" }],
+      },
+    ]);
+    expect(announcementFor(request, nameOf)).toBeNull();
+  });
+
+  it("says nothing when the guard stopped a cascade", () => {
+    // A limit doing its job is not a failure, and the operator usually caused
+    // it by asking a crew to talk to itself. Treating it as one would announce
+    // the machinery working correctly.
+    const stopped = appended([
+      { type: "notice", kind: "guardStop", text: "hop limit reached, nothing was sent" },
+    ]);
+    expect(announcementFor(stopped, nameOf)).toBeNull();
+  });
+
+  it("says nothing about a run that spent nothing", () => {
+    // An envelope nobody read, or an agent that was already gone. Nothing ran,
+    // so there is nothing the operator was waiting for.
+    expect(announcementFor(opened(RUN, CHEF), nameOf)).toBeNull();
+    expect(announcementFor(ended(RUN, 0), nameOf)).toBeNull();
+  });
+});
+
+describe("the channel a run turns out to have been in", () => {
+  it("is null for a run whose stream was never seen", () => {
+    // Normal, not corrupt: runs are already in flight when the window
+    // subscribes. The title has to be built without a channel rather than
+    // interpolating one that is not there.
+    const said = announcementFor(ended("run-elsewhere", 3), nameOf);
+    expect(said?.channel).toBeNull();
+    expect(said?.title).toBe("A conversation has finished");
+    expect(said?.title).not.toMatch(/undefined/);
+  });
+
+  it("is forgotten even on the settle that announces nothing", () => {
+    // The zero-step return is above the delete in an easy version of this
+    // function, and then every quiet run leaks an entry for the life of the
+    // process.
+    announcementFor(opened(RUN, CHEF), nameOf);
+    expect(announcementFor(ended(RUN, 0), nameOf)).toBeNull();
+    expect(announcementFor(ended(RUN, 2), nameOf)?.channel).toBeNull();
+  });
+
+  it("is forgotten once the settle it was kept for has used it", () => {
+    announcementFor(opened(RUN, CHEF), nameOf);
+    expect(announcementFor(ended(RUN, 2), nameOf)?.channel).toBe(CHEF);
+    expect(announcementFor(ended(RUN, 2), nameOf)?.channel).toBeNull();
+  });
+
+  it("belongs to one run and not to the process", () => {
+    // Several runs are in flight at once by design, so a single "last channel
+    // seen" would tag a settle with whichever run streamed most recently.
+    announcementFor(opened("run-a", CHEF), nameOf);
+    announcementFor(opened("run-b", SCRIBE), nameOf);
+    expect(announcementFor(ended("run-b", 2), nameOf)?.channel).toBe(SCRIBE);
+    expect(announcementFor(ended("run-a", 2), nameOf)?.channel).toBe(CHEF);
+  });
+
+  it("is learned from the stream that opened in it, which announces nothing itself", () => {
+    expect(announcementFor(opened(RUN, SCRIBE), nameOf)).toBeNull();
+    const said = announcementFor(ended(RUN, 3), nameOf);
+    expect(said?.channel).toBe(SCRIBE);
+    expect(said?.title).toBe("Scribe has finished");
+  });
+});
+
+describe("the name the operator reads", () => {
+  it("is asked for, never the agent's id", () => {
+    const lookup = vi.fn(nameOf);
+    const said = announcementFor(
+      { type: "approvalRequested", approvalId: "approval-1", agentId: CHEF },
+      lookup,
+    );
+    expect(lookup).toHaveBeenCalledWith(CHEF);
+    expect(said?.title).toBe("Chef needs your permission");
+    // A uuid in a notification tells the operator nothing about who is waiting.
+    expect(said?.title).not.toContain(CHEF);
+  });
+
+  it("falls back to a stand-in for an agent nobody can name", () => {
+    // An agent terminated between the event and the notification is not in the
+    // store any more, and every one of these strings is user-facing.
+    const gone: AgentId = "agent-gone";
+    const said = [
+      announcementFor(
+        { type: "approvalRequested", approvalId: "approval-1", agentId: gone },
+        nameOf,
+      ),
+      announcementFor(
+        appended([{ type: "notice", kind: "upstreamError", text: "no route to host" }], {
+          channelId: gone,
+        }),
+        nameOf,
+      ),
+    ];
+    expect(said[0]?.title).toBe("An agent needs your permission");
+    for (const one of said) {
+      expect(one?.title).not.toMatch(/undefined/);
+      expect(one?.body).not.toMatch(/undefined/);
+    }
+  });
+});
+
+describe("what each interruption says", () => {
+  it("names the agent whose turn is parked, and the channel to answer in", () => {
+    const said = announcementFor(
+      { type: "approvalRequested", approvalId: "approval-1", agentId: SCRIBE },
+      nameOf,
+    );
+    expect(said?.kind).toBe("approval");
+    expect(said?.title).toBe("Scribe needs your permission");
+    // `notify` lets an approval through when the operator is away *or* looking
+    // at another channel, and it can only tell the second case from the channel.
+    expect(said?.channel).toBe(SCRIBE);
+  });
+
+  it("keys a permission request on the agent rather than on the request", () => {
+    // Two requests from one agent within the second are one interruption; the
+    // burst check can only collapse them if the approval id is not in the key.
+    const first = announcementFor(
+      { type: "approvalRequested", approvalId: "approval-1", agentId: CHEF },
+      nameOf,
+    );
+    const again = announcementFor(
+      { type: "approvalRequested", approvalId: "approval-2", agentId: CHEF },
+      nameOf,
+    );
+    const other = announcementFor(
+      { type: "approvalRequested", approvalId: "approval-3", agentId: SCRIBE },
+      nameOf,
+    );
+    expect(again?.key).toBe(first?.key);
+    // And two agents parked at once are two, because nothing else says the
+    // second one is waiting.
+    expect(other?.key).not.toBe(first?.key);
+  });
+
+  it("announces a fired routine about no channel at all", () => {
+    const said = announcementFor(
+      appended(
+        [
+          {
+            type: "routine",
+            routineId: "routine-7",
+            name: "Morning sweep",
+            what: "check the listings",
+          },
+        ],
+        { from: { kind: "system" }, trust: "system" },
+      ),
+      nameOf,
+    );
+    expect(said?.kind).toBe("routine");
+    expect(said?.title).toBe("Morning sweep fired");
+    expect(said?.body).toBe("check the listings");
+    expect(said?.key).toBe("routine:routine-7");
+    // Null even though the message has a channel. A routine goes where it was
+    // pointed, almost never where the operator is looking, so carrying the
+    // channel would let `notify` hold back the one kind that only ever happens
+    // while nobody is watching.
+    expect(said?.channel).toBeNull();
+  });
+
+  it("carries the upstream words when an agent could not reply", () => {
+    const said = announcementFor(
+      appended([{ type: "notice", kind: "upstreamError", text: "502 from the endpoint, gave up" }]),
+      nameOf,
+    );
+    expect(said?.kind).toBe("failed");
+    expect(said?.title).toBe("Chef could not reply");
+    // A body of "something went wrong" sends the operator to the transcript to
+    // find out which thing, and the endpoint is usually the answer.
+    expect(said?.body).toBe("502 from the endpoint, gave up");
+    expect(said?.channel).toBe(CHEF);
+    expect(said?.key).toBe(`failed:${CHEF}`);
+  });
+
+  it("counts one model call in the singular", () => {
+    announcementFor(opened(RUN, CHEF), nameOf);
+    expect(announcementFor(ended(RUN, 1), nameOf)?.body).toBe("One model call.");
+  });
+
+  it("says how much a longer conversation took, and that it is over", () => {
+    announcementFor(opened(RUN, CHEF), nameOf);
+    const said = announcementFor(ended(RUN, 4), nameOf);
+    expect(said?.kind).toBe("settled");
+    expect(said?.body).toMatch(/^4 model calls\b/);
+    expect(said?.key).toBe(`settled:${RUN}`);
+  });
+});

--- a/src/lib/announce.ts
+++ b/src/lib/announce.ts
@@ -1,0 +1,132 @@
+/**
+ * Turning runtime events into the four things worth interrupting someone for.
+ *
+ * Kept apart from `notify`, which decides *whether* to interrupt, and from
+ * `App`, which is a view. This decides *what* the interruption would say, and
+ * it is a pure function of one event so it can be argued with in a test rather
+ * than in a running window.
+ *
+ * Three of the four kinds are read out of the event stream directly. The fourth
+ * is not: `runSettled` says which run ended and nothing about where it
+ * happened, and "only tell me about the channel I was looking at" needs a
+ * channel. So the one piece of state here is a run's channel, learned from the
+ * `streamStarted` that opened in it and forgotten when the run ends. It is the
+ * smallest thing that answers the question, and it cleans itself up on the same
+ * event it is needed for.
+ */
+
+import type { NotifyKind } from "./prefs";
+import type { AgentId, RunId, UiEvent } from "./types";
+
+export interface Announcement {
+  kind: NotifyKind;
+  title: string;
+  body: string;
+  /**
+   * The channel this is about, or null when it is about none. Null means the
+   * "was I looking at it" question does not apply, which is only true of the
+   * ambient kinds.
+   */
+  channel: AgentId | null;
+  /** What the one-second burst check is keyed on. */
+  key: string;
+}
+
+/**
+ * Where each live run started talking.
+ *
+ * The FIRST placeholder, not the most recent, and that is the whole point. A
+ * run spans as many channels as it reached, so the last agent to speak in a
+ * cascade is usually one the operator has never opened; judging "was I looking
+ * at this" against that channel answers a question nobody asked. The channel a
+ * run opened in is the one the operator was in when they set it off.
+ *
+ * Bounded by the runs in flight rather than by the runs there have ever been,
+ * because every entry is removed by the `runSettled` that made it interesting.
+ * A run that never settles would leak one entry, and that is a defect the
+ * trajectory suite fails on long before it is a memory problem here.
+ */
+const channels = new Map<RunId, AgentId>();
+
+/** Only tests need this: the map outlives a render. */
+export function resetChannels(): void {
+  channels.clear();
+}
+
+export function announcementFor(
+  event: UiEvent,
+  nameOf: (id: AgentId) => string,
+): Announcement | null {
+  switch (event.type) {
+    case "streamStarted":
+      // Not an announcement. A stream is how a run says where it is, and the
+      // only reason this function sees the event at all. Only the first one
+      // counts: see the note on `channels`.
+      if (!channels.has(event.runId)) channels.set(event.runId, event.channelId);
+      return null;
+
+    case "approvalRequested":
+      return {
+        kind: "approval",
+        title: `${nameOf(event.agentId)} needs your permission`,
+        body: "Its turn is parked until you answer, and gives up after ten minutes.",
+        channel: event.agentId,
+        key: `approval:${event.agentId}`,
+      };
+
+    case "runSettled": {
+      const channel = channels.get(event.runId) ?? null;
+      channels.delete(event.runId);
+      // A run that spent nothing did not do anything worth announcing: an
+      // envelope nobody read, an agent that was already gone. The operator was
+      // not waiting for it.
+      if (event.stepsUsed === 0) return null;
+      return {
+        kind: "settled",
+        title: channel ? `${nameOf(channel)} has finished` : "A conversation has finished",
+        body:
+          event.stepsUsed === 1
+            ? "One model call."
+            : `${event.stepsUsed} model calls, and everyone it reached has gone quiet.`,
+        channel,
+        key: `settled:${event.runId}`,
+      };
+    }
+
+    case "messageAppended": {
+      const message = event.message;
+
+      for (const part of message.parts) {
+        if (part.type === "routine") {
+          return {
+            kind: "routine",
+            title: `${part.name} fired`,
+            body: part.what,
+            // Deliberately null even though the message has a channel: a
+            // routine goes where it was pointed, which is almost never where
+            // the operator is looking, and holding it back for that reason
+            // would be holding back the one kind that only happens while
+            // nobody is watching.
+            channel: null,
+            key: `routine:${part.routineId}`,
+          };
+        }
+
+        if (part.type === "notice" && part.kind === "upstreamError") {
+          return {
+            kind: "failed",
+            title: `${nameOf(message.channelId)} could not reply`,
+            body: part.text,
+            channel: message.channelId,
+            key: `failed:${message.channelId}`,
+          };
+        }
+      }
+
+      return null;
+    }
+
+    default:
+      return null;
+  }
+}

--- a/src/lib/appearance.test.ts
+++ b/src/lib/appearance.test.ts
@@ -1,0 +1,259 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  applyAppearance,
+  prefersDark,
+  ROOT_PX,
+  resolveSurface,
+  watchSystemSurface,
+} from "./appearance";
+import type { UiScale } from "./prefs";
+
+/**
+ * Appearance, as the three things the root element is asked to carry.
+ *
+ * jsdom resolves no `var()` and does no layout, so nothing here can be asked
+ * what colour it drew. What it can be asked is what `styles.css` is keyed on:
+ * the `data-surface` attribute, the `--ui-scale` multiplier, and the
+ * `color-scheme` the engine reads for its own controls. Those three are the
+ * whole contract between this file and the stylesheet, and each has a wrong
+ * value that still draws a window.
+ *
+ * Two of them are load-bearing past the obvious. `system` must never reach the
+ * attribute, because the stylesheet has one dark block and it is keyed on
+ * `dark`: written through verbatim, an operator who asked the OS gets paper in
+ * a dark room. And no `--rail-*` name may be written at all, because the rail
+ * is dark in both surfaces and a surface that quietly repainted it would look
+ * deliberate.
+ */
+
+/** The stub `test-setup.ts` installs, so a test that replaces it can put it back. */
+const REAL_MATCH_MEDIA = globalThis.matchMedia;
+
+/** Every property left on the root, by name. */
+function inlineProperties(): string[] {
+  const { style } = document.documentElement;
+  return Array.from({ length: style.length }, (_, index) => style.item(index));
+}
+
+/**
+ * A `MediaQueryList` that reports one answer and remembers who is listening.
+ *
+ * It only registers a `change` listener, so a watcher subscribed to any other
+ * event name hears nothing from `flip` and the test fails rather than passing
+ * on a listener that would never fire in a real webview.
+ */
+function fakeQuery(matches: boolean) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  return {
+    matches,
+    listeners,
+    addEventListener(type: string, fn: (event: MediaQueryListEvent) => void) {
+      if (type === "change") listeners.add(fn);
+    },
+    removeEventListener(type: string, fn: (event: MediaQueryListEvent) => void) {
+      if (type === "change") listeners.delete(fn);
+    },
+    /** What the OS changing its mind does. */
+    flip(dark: boolean) {
+      for (const fn of [...listeners]) fn({ matches: dark } as MediaQueryListEvent);
+    },
+  };
+}
+
+/** Puts one query behind `matchMedia`, and collects what was asked for. */
+function stubMatchMedia(query: ReturnType<typeof fakeQuery>): string[] {
+  const asked: string[] = [];
+  globalThis.matchMedia = ((media: string) => {
+    asked.push(media);
+    return query as unknown as MediaQueryList;
+  }) as typeof globalThis.matchMedia;
+  return asked;
+}
+
+/** What a webview with no media queries at all looks like. */
+function withoutMatchMedia(): void {
+  delete (globalThis as { matchMedia?: unknown }).matchMedia;
+}
+
+beforeEach(() => {
+  const root = document.documentElement;
+  root.removeAttribute("style");
+  root.removeAttribute("data-surface");
+});
+
+afterEach(() => {
+  globalThis.matchMedia = REAL_MATCH_MEDIA;
+});
+
+describe("a webview with no media queries", () => {
+  it("reads a light surface rather than throwing", () => {
+    // This is jsdom, and the reason the call is optional. An unguarded
+    // `matchMedia` here is not a wrong colour, it is a window that never draws.
+    withoutMatchMedia();
+    expect(prefersDark()).toBe(false);
+  });
+
+  it("hands back a callable no-op, so the caller needs no branch", () => {
+    withoutMatchMedia();
+    const onChange = vi.fn();
+    const stop = watchSystemSurface(onChange);
+
+    expect(stop).toBeTypeOf("function");
+    expect(() => stop()).not.toThrow();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("still resolves system, and lands the operator on paper", () => {
+    withoutMatchMedia();
+    expect(applyAppearance(100, "system")).toBe("light");
+    expect(document.documentElement.dataset.surface).toBe("light");
+  });
+});
+
+describe("resolving a mode", () => {
+  it("ignores the OS entirely when the operator named a surface", () => {
+    // The named modes exist to override the OS. Reading the preference and
+    // then deferring to `prefers-color-scheme` anyway is the whole bug.
+    expect(resolveSurface("light", true)).toBe("light");
+    expect(resolveSurface("light", false)).toBe("light");
+    expect(resolveSurface("dark", false)).toBe("dark");
+    expect(resolveSurface("dark", true)).toBe("dark");
+  });
+
+  it("follows the OS both ways when the mode is system", () => {
+    expect(resolveSurface("system", true)).toBe("dark");
+    expect(resolveSurface("system", false)).toBe("light");
+  });
+
+  it("asks the OS for the dark-scheme query when no answer is handed in", () => {
+    // A typo in the query string matches nothing, so every operator on system
+    // silently gets paper and no assertion on the returned surface would say why.
+    const asked = stubMatchMedia(fakeQuery(true));
+
+    expect(resolveSurface("system")).toBe("dark");
+    expect(asked).toEqual(["(prefers-color-scheme: dark)"]);
+  });
+});
+
+describe("what applying an appearance writes", () => {
+  it("writes no --rail property, so a surface cannot repaint the rail", () => {
+    applyAppearance(125, "dark");
+
+    // The rail is dark in both surfaces and pins its own accents. A `--rail-*`
+    // override written from here would look like a design decision, and no
+    // colour assertion in jsdom could ever catch it.
+    expect(inlineProperties().filter((name) => name.startsWith("--rail"))).toEqual([]);
+    expect(document.documentElement.getAttribute("style")).not.toContain("--rail");
+  });
+
+  it("never writes the word system, because no rule is keyed on it", () => {
+    expect(applyAppearance(100, "system", true)).toBe("dark");
+    expect(document.documentElement.getAttribute("data-surface")).toBe("dark");
+
+    expect(applyAppearance(100, "system", false)).toBe("light");
+    expect(document.documentElement.getAttribute("data-surface")).toBe("light");
+  });
+
+  it("writes the surface the operator named, whatever the OS thinks", () => {
+    applyAppearance(100, "dark", false);
+    expect(document.documentElement.dataset.surface).toBe("dark");
+
+    applyAppearance(100, "light", true);
+    expect(document.documentElement.dataset.surface).toBe("light");
+  });
+
+  it("reports the surface that won, so the caller need not resolve it again", () => {
+    expect(applyAppearance(90, "light", true)).toBe("light");
+    expect(applyAppearance(90, "dark", false)).toBe("dark");
+    expect(applyAppearance(90, "system", true)).toBe("dark");
+  });
+
+  it("sets the scale as a unitless multiplier, not a percentage and not a length", () => {
+    // The stylesheet says `calc(16px * var(--ui-scale))`. A percentage or a px
+    // there is an invalid length, the declaration is dropped, and the operator
+    // gets an interface that ignores the slider.
+    const cases: [UiScale, string][] = [
+      [90, "0.9"],
+      [100, "1"],
+      [110, "1.1"],
+      [125, "1.25"],
+    ];
+
+    for (const [scale, expected] of cases) {
+      applyAppearance(scale, "light");
+      expect(document.documentElement.style.getPropertyValue("--ui-scale")).toBe(expected);
+    }
+  });
+
+  it("tells the engine which scheme to draw its own controls in", () => {
+    // Nothing in the stylesheet reads this, so a wrong value shows up only as a
+    // white scrollbar down the side of a dark window.
+    applyAppearance(100, "system", true);
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+
+    applyAppearance(100, "system", false);
+    expect(document.documentElement.style.colorScheme).toBe("light");
+  });
+});
+
+describe("the anchor the scale multiplies", () => {
+  it("is the number the stylesheet multiplies too", () => {
+    // The anchor exists twice on purpose and is tied together by nothing but
+    // this: `styles.css` is where it takes effect, and `ROOT_PX` is the copy the
+    // activity board needs because it places its lanes as SVG coordinates and
+    // has to do the arithmetic itself. Drift shows up as a board whose columns
+    // disagree with the type inside them, which is not a thing anyone would
+    // think to look at the stylesheet about.
+    const css = readFileSync(resolve(__dirname, "../styles.css"), "utf8");
+    expect(css).toContain(`font-size: calc(${ROOT_PX}px * var(--ui-scale))`);
+  });
+
+  it("is what a rem already resolved to, so scale 100 changes nothing", () => {
+    // Neither `:root` nor Tailwind's preflight had ever set a root font size.
+    // Anchoring on the 15px body instead would have shrunk the whole interface
+    // by 6.25% for an operator who changed nothing.
+    expect(ROOT_PX).toBe(16);
+  });
+});
+
+describe("watching the OS", () => {
+  it("asks for the dark-scheme query, since a typo subscribes to nothing", () => {
+    const asked = stubMatchMedia(fakeQuery(false));
+    watchSystemSurface(vi.fn());
+    expect(asked).toEqual(["(prefers-color-scheme: dark)"]);
+  });
+
+  it("reports what the event says changed, not what the query said when it was made", () => {
+    // A handler that read the query back instead of the event would report the
+    // answer from before the change, so the surface would lag one flip behind.
+    const query = fakeQuery(false);
+    stubMatchMedia(query);
+    const onChange = vi.fn();
+    watchSystemSurface(onChange);
+
+    query.flip(true);
+    expect(onChange).toHaveBeenLastCalledWith(true);
+
+    query.flip(false);
+    expect(onChange).toHaveBeenLastCalledWith(false);
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("hears nothing more once the returned function is called", () => {
+    // The caller rebuilds this on every preference change, so a listener that
+    // outlives its teardown means every change adds another one.
+    const query = fakeQuery(false);
+    stubMatchMedia(query);
+    const onChange = vi.fn();
+
+    watchSystemSurface(onChange)();
+    expect(query.listeners.size).toBe(0);
+
+    query.flip(true);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/appearance.ts
+++ b/src/lib/appearance.ts
@@ -1,0 +1,88 @@
+/**
+ * How large the interface draws, and whether the reading column is paper or ink.
+ *
+ * Both are one write to the root element, because both are already expressed in
+ * `styles.css` as one thing: every size in the stylesheet is a `rem`, so scale
+ * is a root font size, and every colour the reading column uses is a custom
+ * property, so the surface is a token block behind an attribute.
+ *
+ * The rail is not part of either question. It owns `--rail-*`, it is dark in
+ * both surfaces by design, and nothing here names those tokens. What scale does
+ * to it is what scale does to everything: it grows.
+ *
+ * `system` is resolved here rather than in a media query. A media query would
+ * mean the dark token block written twice, once for the chosen mode and once
+ * inside `prefers-color-scheme`, with no way for CSS to share it; two copies of
+ * eighteen colours that must agree is a worse bargain than one listener.
+ */
+
+import type { SurfaceMode, UiScale } from "./prefs";
+
+/**
+ * What `1rem` resolves to before scaling.
+ *
+ * Neither `:root` nor Tailwind's preflight had ever set a root font size, so
+ * 16px is what every `rem` in the stylesheet is already measured against;
+ * anchoring on the 15px `body` instead would have shrunk the whole interface at
+ * scale 100.
+ *
+ * The same number appears in `styles.css` as `calc(16px * var(--ui-scale))`,
+ * which is where it takes effect. This copy exists for the one thing that has
+ * to do the arithmetic itself: the activity board draws its lanes as SVG
+ * coordinates, so it needs a width in pixels rather than in `rem`. If either
+ * changes, both have to.
+ */
+export const ROOT_PX = 16;
+
+/** The surface actually drawn. `system` is not one of these. */
+export type Surface = "light" | "dark";
+
+/** True when the OS has asked for a dark interface. */
+export function prefersDark(): boolean {
+  // Optional call: jsdom ships no media queries at all, and a preference that
+  // cannot be read is the light default rather than a thrown render.
+  return window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
+}
+
+export function resolveSurface(mode: SurfaceMode, dark = prefersDark()): Surface {
+  if (mode === "system") return dark ? "dark" : "light";
+  return mode;
+}
+
+/**
+ * Puts both onto the document, and reports which surface won.
+ *
+ * The attribute carries the resolved surface, never `system`: the stylesheet
+ * should not have to know that a third choice exists, and a rule keyed on
+ * `system` would have to duplicate the one keyed on `dark`.
+ */
+export function applyAppearance(scale: UiScale, mode: SurfaceMode, dark = prefersDark()): Surface {
+  const surface = resolveSurface(mode, dark);
+  const root = document.documentElement;
+
+  root.style.setProperty("--ui-scale", `${scale / 100}`);
+  root.dataset.surface = surface;
+  // So the webview draws its own scrollbars and form controls to match. Nothing
+  // in the stylesheet reads this; the engine does.
+  root.style.colorScheme = surface;
+
+  return surface;
+}
+
+/**
+ * Calls back when the OS changes its mind, for as long as the returned function
+ * is not called.
+ *
+ * Only `system` cares, but subscribing unconditionally keeps the caller from
+ * having to tear down and rebuild a listener every time the mode changes. A
+ * webview with no media queries subscribes to nothing and returns a no-op, so
+ * the caller needs no branch either.
+ */
+export function watchSystemSurface(onChange: (dark: boolean) => void): () => void {
+  const query = window.matchMedia?.("(prefers-color-scheme: dark)");
+  if (!query) return () => {};
+
+  const handle = (event: MediaQueryListEvent) => onChange(event.matches);
+  query.addEventListener("change", handle);
+  return () => query.removeEventListener("change", handle);
+}

--- a/src/lib/choreography.test.ts
+++ b/src/lib/choreography.test.ts
@@ -137,6 +137,33 @@ describe("pacing", () => {
     expect(done).toHaveBeenCalledTimes(1);
   });
 
+  it("waits on nothing while there is nothing to animate", () => {
+    // A poll would keep the renderer awake for the life of the window to look
+    // at an empty queue several times a second, and a renderer that never goes
+    // idle never stops drawing.
+    const interval = vi.spyOn(window, "setInterval");
+    renderHook(() => usePulseChoreography([], vi.fn()));
+
+    expect(interval).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("stops waiting once the last message has played", () => {
+    const done = vi.fn();
+    const only = [pulse(1, "a", "b")];
+    const { rerender } = renderHook(({ pulses }) => usePulseChoreography(pulses, done), {
+      initialProps: { pulses: only },
+    });
+    rerender({ pulses: only });
+
+    act(() => {
+      vi.advanceTimersByTime(AIM_MS + FLIGHT_MS + CATCH_MS + STAGGER_MS);
+    });
+
+    expect(done).toHaveBeenCalledWith(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it("drops the animation, never the message, when a backlog builds", () => {
     // Delivery already happened. A queue longer than anyone will watch just
     // means some throws go undrawn.

--- a/src/lib/choreography.ts
+++ b/src/lib/choreography.ts
@@ -66,28 +66,17 @@ export function usePulseChoreography(pulses: Pulse[], onDone: (id: number) => vo
   const seen = useRef(new Set<number>());
   const lastStart = useRef(0);
   const timers = useRef(new Set<number>());
-  // Kept in a ref so the pump does not need `onDone` in its dependencies, which
-  // would restart the scheduler on every render.
+  /** The wait for the next throw, or null when there is nothing left to play. */
+  const wait = useRef<number | null>(null);
+  // Kept in a ref so the scheduler does not need `onDone` in its dependencies,
+  // which would rebuild it on every render.
   const done = useRef(onDone);
   done.current = onDone;
 
-  useEffect(() => {
-    for (const pulse of pulses) {
-      if (seen.current.has(pulse.id)) continue;
-      seen.current.add(pulse.id);
-
-      if (prefersReducedMotion()) {
-        done.current(pulse.id);
-        continue;
-      }
-      if (queue.current.length >= MAX_QUEUE) {
-        // Dropped from the animation only. The message itself arrived.
-        done.current(pulse.id);
-        continue;
-      }
-      queue.current.push(pulse);
-    }
-  }, [pulses]);
+  // Set by the effect below, and declared before the effect that fills the
+  // queue so the scheduler exists by the time the first pulses arrive: effects
+  // run in the order they are written.
+  const schedule = useRef<() => void>(() => {});
 
   useEffect(() => {
     const after = (ms: number, run: () => void) => {
@@ -111,25 +100,57 @@ export function usePulseChoreography(pulses: Pulse[], onDone: (id: number) => vo
       });
     };
 
-    // A single interval is enough: it only ever starts the next throw once the
-    // stagger has elapsed, so the cost is one cheap check per tick.
-    const pump = window.setInterval(() => {
-      if (queue.current.length === 0) return;
-      const now = Date.now();
-      if (now - lastStart.current < STAGGER_MS) return;
+    // Each throw books the wait for the next one, so a window with nothing
+    // crossing it holds no timer at all. Polling for work instead costs a
+    // wakeup several times a second for the life of the app to find an empty
+    // queue, and a renderer that never goes idle never stops drawing.
+    const book = () => {
+      if (wait.current !== null || queue.current.length === 0) return;
 
-      const next = queue.current.shift();
-      if (!next) return;
-      lastStart.current = now;
-      start(next);
-    }, 80);
+      wait.current = window.setTimeout(
+        () => {
+          wait.current = null;
+
+          const next = queue.current.shift();
+          if (next) {
+            lastStart.current = Date.now();
+            start(next);
+          }
+          book();
+        },
+        Math.max(0, STAGGER_MS - (Date.now() - lastStart.current)),
+      );
+    };
+
+    schedule.current = book;
 
     return () => {
-      window.clearInterval(pump);
+      if (wait.current !== null) window.clearTimeout(wait.current);
+      wait.current = null;
       for (const id of timers.current) window.clearTimeout(id);
       timers.current.clear();
     };
   }, []);
+
+  useEffect(() => {
+    for (const pulse of pulses) {
+      if (seen.current.has(pulse.id)) continue;
+      seen.current.add(pulse.id);
+
+      if (prefersReducedMotion()) {
+        done.current(pulse.id);
+        continue;
+      }
+      if (queue.current.length >= MAX_QUEUE) {
+        // Dropped from the animation only. The message itself arrived.
+        done.current(pulse.id);
+        continue;
+      }
+      queue.current.push(pulse);
+    }
+
+    schedule.current();
+  }, [pulses]);
 
   return { staged, inFlight: staged.filter((p) => p.phase === "flight") };
 }

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -8,6 +8,11 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { listen, TauriEvent, type UnlistenFn } from "@tauri-apps/api/event";
+import {
+  isPermissionGranted,
+  requestPermission,
+  sendNotification,
+} from "@tauri-apps/plugin-notification";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
 import type {
@@ -239,6 +244,16 @@ export const api = {
    */
   retryTurn: (agentId: AgentId, messageId: MessageId) =>
     invoke<RunId>("retry_turn", { agentId, messageId }),
+
+  /**
+   * Stops a conversation and everything it set off. False when there was
+   * nothing left to stop.
+   *
+   * A run, not an agent: the thing the operator wants to end reached however
+   * many agents it reached, and stopping only the one on screen would leave the
+   * rest of the cascade running.
+   */
+  stopRun: (runId: RunId) => invoke<boolean>("stop_run", { runId }),
   /** Resets a whole group: transcripts, routines, memories and spend. */
   clearGroup: (groupId: GroupId) => invoke<GroupReset>("clear_group", { groupId }),
   agentRoutines: (id: AgentId) => invoke<Routine[]>("agent_routines", { id }),
@@ -281,6 +296,37 @@ export const api = {
  */
 export function openExternal(url: string): Promise<void> {
   return openUrl(url);
+}
+
+/**
+ * Raises an operating system notification, if the operator has ever allowed it.
+ *
+ * Permission is asked for at the moment the first notification would be shown
+ * rather than at launch, so the prompt arrives attached to something the
+ * operator can see a reason for.
+ *
+ * True means it was handed to the operating system, which is not the same as
+ * shown. On desktop the permission question is answered yes unconditionally —
+ * there is no per-app grant for the plugin to read — so a machine with
+ * notifications switched off in System Settings accepts every one of these and
+ * displays none. Nothing here can tell the difference, and any copy built on
+ * this return value has to be worded so that it does not claim to.
+ *
+ * Every failure is swallowed. A refused permission, a plugin that is not there,
+ * a platform with no notification centre: none of them are worth a banner,
+ * because the thing being announced is already on screen in the rail and the
+ * transcript. This is the redundant copy, not the record.
+ */
+export async function notifyOperator(title: string, body: string): Promise<boolean> {
+  try {
+    const granted = (await isPermissionGranted()) || (await requestPermission()) === "granted";
+    if (!granted) return false;
+
+    sendNotification({ title, body });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** Subscribes to runtime events. Returns an unsubscribe function. */

--- a/src/lib/keybinds.test.ts
+++ b/src/lib/keybinds.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  BINDINGS,
+  type Binding,
+  bindingFor,
+  type Combo,
+  comboLabel,
+  formatCombo,
+  GLOBAL,
+  matches,
+  SURFACES,
+} from "./keybinds";
+
+/**
+ * The key table, under the two questions the app asks it.
+ *
+ * The table is both a reference the panel draws and a dispatch list the one
+ * global handler reads, and only three of its ten rows are the second thing. So
+ * most of what is worth testing here is refusal: Escape, Enter, Tab and the
+ * arrows are listed for the operator's benefit and must never come back from
+ * `bindingFor`, because the global handler calls `preventDefault` on whatever it
+ * is handed and would take those keys away from the surfaces that own them.
+ *
+ * The other half is the rule the table exists to write down once: `mod` is
+ * Command or Control on every platform, both accepted. The glyphs are the one
+ * thing that does follow the platform, and `IS_MAC` is read once at import, so
+ * the glyph test loads its own copies of the module and everything else asserts
+ * only what holds either way.
+ */
+
+/** A keystroke, the shape the window hands one to the global handler in. */
+function press(key: string, held: Partial<KeyboardEventInit> = {}): KeyboardEvent {
+  return new KeyboardEvent("keydown", { key, ...held });
+}
+
+function row(table: Binding[], id: string): Binding {
+  const found = table.find((binding) => binding.id === id);
+  if (!found) throw new Error(`no binding named ${id}`);
+  return found;
+}
+
+/** How the same keystroke would be written down by a keybinding. */
+function signature(combo: Combo): string {
+  return [combo.mod ? "mod" : "", combo.shift ? "shift" : "", combo.key].join("+");
+}
+
+/** A fresh copy of the module, loaded as it would be on the platform named. */
+async function loadedOn(platform: string): Promise<typeof import("./keybinds")> {
+  vi.resetModules();
+  vi.stubGlobal("navigator", { platform, userAgent: platform });
+  try {
+    return await import("./keybinds");
+  } finally {
+    vi.unstubAllGlobals();
+  }
+}
+
+describe("a keystroke that is not the shortcut", () => {
+  it("refuses the bare key when the shortcut names a modifier", () => {
+    expect(matches(press("k"), { key: "k", mod: true })).toBe(false);
+  });
+
+  it("refuses the modified keystroke when the shortcut names no modifier", () => {
+    // Both directions have to hold, or Command+K would fire search and whatever
+    // plain K is bound to on the same keystroke.
+    expect(matches(press("k", { metaKey: true }), { key: "k" })).toBe(false);
+    expect(matches(press("k", { ctrlKey: true }), { key: "k" })).toBe(false);
+  });
+
+  it("refuses a named key written in the wrong case", () => {
+    // Letters are lowercased before comparison and named keys are not, so a row
+    // added as `escape` never fires. Better a failing test than a dead listing.
+    expect(matches(press("Escape"), { key: "escape" })).toBe(false);
+    expect(matches(press("Escape"), { key: "Escape" })).toBe(true);
+  });
+
+  it("refuses the plain keystroke when the shortcut names shift", () => {
+    expect(matches(press("Enter"), { key: "Enter", shift: true })).toBe(false);
+  });
+
+  it("refuses the shifted keystroke for a shortcut that names shift false", () => {
+    // The only way to say "this one, and not the shifted one". Naming no shift
+    // at all takes both, which is the next case.
+    expect(matches(press("Enter", { shiftKey: true }), { key: "Enter", shift: false })).toBe(false);
+    expect(matches(press("Enter"), { key: "Enter", shift: false })).toBe(true);
+  });
+});
+
+describe("a keystroke that is", () => {
+  it("takes Command or Control for mod, on either kind of keyboard", () => {
+    // The rule the table was written down to state. An operator who learned the
+    // shortcut on a laptop should not have to learn it again on a desktop.
+    const combo: Combo = { key: "k", mod: true };
+    expect(matches(press("k", { metaKey: true }), combo)).toBe(true);
+    expect(matches(press("k", { ctrlKey: true }), combo)).toBe(true);
+    expect(matches(press("k", { metaKey: true, ctrlKey: true }), combo)).toBe(true);
+  });
+
+  it("reads a capital letter as the letter it is", () => {
+    // Caps lock or a shifted layout reports "K". A shortcut that quietly stops
+    // working under caps lock is indistinguishable from a broken build.
+    expect(matches(press("K", { metaKey: true }), { key: "k", mod: true })).toBe(true);
+    expect(matches(press("K", { metaKey: true, shiftKey: true }), { key: "k", mod: true })).toBe(
+      true,
+    );
+  });
+
+  it("ignores shift entirely when the shortcut does not mention it", () => {
+    expect(matches(press("Enter"), { key: "Enter" })).toBe(true);
+    expect(matches(press("Enter", { shiftKey: true }), { key: "Enter" })).toBe(true);
+  });
+});
+
+describe("which binding a keystroke is", () => {
+  it("hands back nothing for the keys their own surface owns", () => {
+    // Every one of these is in the table and every one is fixed. If any came
+    // back, the global handler would call preventDefault on it: Escape would
+    // stop closing what is open and Enter would stop sending the message.
+    expect(bindingFor(press("Escape"))).toBeUndefined();
+    expect(bindingFor(press("Enter"))).toBeUndefined();
+    expect(bindingFor(press("Enter", { shiftKey: true }))).toBeUndefined();
+    expect(bindingFor(press("ArrowUp"))).toBeUndefined();
+    expect(bindingFor(press("ArrowDown"))).toBeUndefined();
+    expect(bindingFor(press("Tab"))).toBeUndefined();
+  });
+
+  it("hands back nothing for a letter typed without a modifier", () => {
+    expect(bindingFor(press("k"))).toBeUndefined();
+    expect(bindingFor(press(","))).toBeUndefined();
+    expect(bindingFor(press("/"))).toBeUndefined();
+  });
+
+  it("answers with the three that work wherever the operator is", () => {
+    expect(bindingFor(press("k", { metaKey: true }))?.id).toBe("search");
+    expect(bindingFor(press(",", { metaKey: true }))?.id).toBe("settings");
+    expect(bindingFor(press("/", { metaKey: true }))?.id).toBe("shortcuts");
+    expect(bindingFor(press("k", { ctrlKey: true }))?.id).toBe("search");
+    expect(bindingFor(press(",", { ctrlKey: true }))?.id).toBe("settings");
+    expect(bindingFor(press("/", { ctrlKey: true }))?.id).toBe("shortcuts");
+  });
+});
+
+describe("the table", () => {
+  it("lists every binding once, in a section the panel draws", () => {
+    // The panel groups rows by SURFACES, so a `where` outside that list is a
+    // shortcut that exists and cannot be found.
+    const ids = BINDINGS.map((binding) => binding.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const binding of BINDINGS) {
+      expect(SURFACES).toContain(binding.where);
+      expect(binding.what.trim()).not.toBe("");
+    }
+  });
+
+  it("leaves no global shortcut shadowed by an earlier one", () => {
+    // `bindingFor` takes the first row that matches, so two non-fixed rows on
+    // one combo make the second unreachable and the panel lists a key that
+    // does something else.
+    const global = BINDINGS.filter((binding) => !binding.fixed);
+    const combos = global.map((binding) => signature(binding.combo));
+    expect(new Set(combos).size).toBe(combos.length);
+
+    for (const binding of global) {
+      const event = press(binding.combo.key, {
+        metaKey: Boolean(binding.combo.mod),
+        shiftKey: Boolean(binding.combo.shift),
+      });
+      expect(bindingFor(event)?.id).toBe(binding.id);
+    }
+  });
+
+  it("offers the one global handler exactly the three ids it dispatches", () => {
+    // App.tsx switches on these by name. A fourth non-fixed row is a shortcut
+    // the panel promises and nothing answers, and it works everywhere or it is
+    // not global, so its section has to say so.
+    expect(GLOBAL).toEqual(["search", "settings", "shortcuts"]);
+    for (const id of GLOBAL) {
+      expect(row(BINDINGS, id).where).toBe("Anywhere");
+    }
+  });
+});
+
+describe("how a shortcut is written down", () => {
+  it("writes something legible for every row the panel draws", () => {
+    // The label is the whole feature, so no row may render empty, and none may
+    // render "undefined": a named key with no glyph falls back to the raw
+    // `event.key`, and a row whose combo lost its key would print the word.
+    for (const binding of BINDINGS) {
+      const label = comboLabel(binding);
+      expect(label.trim()).not.toBe("");
+      expect(label).not.toContain("undefined");
+      expect(formatCombo(binding.combo).trim()).not.toBe("");
+      expect(formatCombo(binding.combo)).not.toContain("undefined");
+    }
+  });
+
+  it("draws the arrow pair as the one shortcut it reads as", () => {
+    // Neither arrow takes a modifier, so this holds on both platforms.
+    expect(comboLabel(row(BINDINGS, "mention"))).toBe("↑↓");
+    expect(comboLabel(row(BINDINGS, "hit"))).toBe("↑↓");
+  });
+
+  it("uses the glyphs of the machine it was imported on", async () => {
+    // A label naming a key the keyboard does not have is worse than no label.
+    // IS_MAC is read once at import, so each platform needs its own copy.
+    const mac = await loadedOn("MacIntel");
+    expect(mac.formatCombo({ key: "k", mod: true })).toBe("⌘K");
+    expect(mac.formatCombo({ key: ",", mod: true })).toBe("⌘,");
+    expect(mac.formatCombo({ key: "Enter", shift: true })).toBe("⇧↩");
+    expect(mac.comboLabel(row(mac.BINDINGS, "scope"))).toBe("Tab / ⇧Tab");
+
+    const pc = await loadedOn("Win32");
+    expect(pc.formatCombo({ key: "k", mod: true })).toBe("Ctrl+K");
+    expect(pc.formatCombo({ key: ",", mod: true })).toBe("Ctrl+,");
+    expect(pc.formatCombo({ key: "Enter", shift: true })).toBe("Shift+↩");
+    expect(pc.comboLabel(row(pc.BINDINGS, "scope"))).toBe("Tab / Shift+Tab");
+  });
+
+  it("matches the same keystroke on the platform whose glyphs it does not use", async () => {
+    // The glyphs follow the machine and the matching deliberately does not, so
+    // a Control-holding operator on a Mac still gets search.
+    const mac = await loadedOn("MacIntel");
+    expect(mac.bindingFor(press("k", { ctrlKey: true }))?.id).toBe("search");
+    expect(mac.bindingFor(press("k", { metaKey: true }))?.id).toBe("search");
+  });
+});

--- a/src/lib/keybinds.ts
+++ b/src/lib/keybinds.ts
@@ -1,0 +1,178 @@
+/**
+ * Every key the app answers to, in one list.
+ *
+ * The list exists because the app already answered to a dozen keys and said so
+ * nowhere. Discoverability is the whole feature: an operator who cannot find a
+ * shortcut does not have it.
+ *
+ * It is a reference, not a rebinding system, and the difference is deliberate.
+ * Nine of these are handled by the component that owns the surface they work
+ * on: Escape by whatever is open, Enter and the arrows by the composer and the
+ * palette. Rebinding would mean routing all nine through one dispatcher, and a
+ * setting that appeared to rebind a key and only moved one of them is worse
+ * than no setting at all. So the fixed ones are listed as fixed, and only the
+ * three that are genuinely global are matched from this table.
+ *
+ * What that buys, beyond the panel: `mod` here means Command or Control on
+ * every platform, both accepted, which is the rule the one existing shortcut
+ * already followed and the reason it is written down once now.
+ */
+
+export interface Combo {
+  /** `event.key`, lowercased for letters and verbatim for named keys. */
+  key: string;
+  /** Command or Control. Either one, on every platform. */
+  mod?: boolean;
+  shift?: boolean;
+}
+
+/** The surfaces a binding belongs to, in the order the panel lists them. */
+export const SURFACES = ["Anywhere", "A channel", "Search", "Anything open"] as const;
+
+export type Surface = (typeof SURFACES)[number];
+
+export interface Binding {
+  id: string;
+  /** What it does, in the operator's words. */
+  what: string;
+  combo: Combo;
+  where: Surface;
+  /**
+   * True when the key is owned by the surface it works on rather than by the
+   * one global handler, and therefore cannot be changed from here. Listing it
+   * anyway is the point: the panel is a map of what the app responds to, not of
+   * what happens to be configurable.
+   */
+  fixed?: boolean;
+}
+
+const IS_MAC = /mac/i.test(navigator.platform || navigator.userAgent);
+
+export const BINDINGS: Binding[] = [
+  {
+    id: "search",
+    what: "Search agents, messages and actions",
+    combo: { key: "k", mod: true },
+    where: "Anywhere",
+  },
+  { id: "settings", what: "Open settings", combo: { key: ",", mod: true }, where: "Anywhere" },
+  {
+    id: "shortcuts",
+    what: "Open this list",
+    combo: { key: "/", mod: true },
+    where: "Anywhere",
+  },
+  {
+    id: "send",
+    what: "Send the message",
+    combo: { key: "Enter" },
+    where: "A channel",
+    fixed: true,
+  },
+  {
+    id: "newline",
+    what: "Start a new line instead of sending",
+    combo: { key: "Enter", shift: true },
+    where: "A channel",
+    fixed: true,
+  },
+  {
+    id: "mention",
+    what: "Choose which agent to mention",
+    combo: { key: "ArrowUp" },
+    where: "A channel",
+    fixed: true,
+  },
+  {
+    id: "hit",
+    what: "Move through the results",
+    combo: { key: "ArrowDown" },
+    where: "Search",
+    fixed: true,
+  },
+  {
+    id: "scope",
+    what: "Change what is being searched",
+    combo: { key: "Tab" },
+    where: "Search",
+    fixed: true,
+  },
+  {
+    id: "open",
+    what: "Open the result",
+    combo: { key: "Enter" },
+    where: "Search",
+    fixed: true,
+  },
+  {
+    id: "close",
+    what: "Close it",
+    combo: { key: "Escape" },
+    where: "Anything open",
+    fixed: true,
+  },
+];
+
+/** The ids the one global handler dispatches. Everything else is `fixed`. */
+export const GLOBAL = BINDINGS.filter((binding) => !binding.fixed).map((binding) => binding.id);
+
+/**
+ * True when this keystroke is that binding.
+ *
+ * Either modifier satisfies `mod`, on every platform: an operator who learned
+ * the shortcut on a laptop should not have to learn it again on a desktop.
+ * `shift` is checked only when the binding names it, because a shortcut that
+ * silently stopped working with caps lock or a shifted layout would be
+ * indistinguishable from a broken build.
+ *
+ * Alt never matches anything, and that is not fussiness. On Windows and Linux
+ * AltGr arrives as Control *and* Alt, so on a layout where AltGr and a key
+ * produce a character, typing that character would look exactly like a
+ * shortcut: the global handler calls `preventDefault`, the character never
+ * arrives, and a dialog opens instead. No binding here wants Alt, so the
+ * cheapest correct rule is that none of them tolerate it.
+ */
+export function matches(event: KeyboardEvent, combo: Combo): boolean {
+  const key = combo.key.length === 1 ? event.key.toLowerCase() : event.key;
+  if (key !== combo.key) return false;
+  if (event.altKey) return false;
+  if (Boolean(combo.mod) !== (event.metaKey || event.ctrlKey)) return false;
+  if (combo.shift !== undefined && combo.shift !== event.shiftKey) return false;
+  return true;
+}
+
+/** Which binding this keystroke is, if any. Only the global ones can match. */
+export function bindingFor(event: KeyboardEvent): Binding | undefined {
+  return BINDINGS.find((binding) => !binding.fixed && matches(event, binding.combo));
+}
+
+const NAMED: Record<string, string> = {
+  Enter: "↩",
+  Escape: "Esc",
+  Tab: "Tab",
+  ArrowUp: "↑",
+  ArrowDown: "↓",
+};
+
+/**
+ * How this machine writes a shortcut.
+ *
+ * A label naming a key the keyboard does not have is worse than no label, so
+ * the glyphs follow the platform even though the matching does not.
+ */
+export function formatCombo(combo: Combo): string {
+  const parts: string[] = [];
+  if (combo.mod) parts.push(IS_MAC ? "⌘" : "Ctrl");
+  if (combo.shift) parts.push(IS_MAC ? "⇧" : "Shift");
+  parts.push(NAMED[combo.key] ?? combo.key.toUpperCase());
+  return IS_MAC ? parts.join("") : parts.join("+");
+}
+
+/** The arrow pair reads as one shortcut, so the panel draws it as one. */
+export function comboLabel(binding: Binding): string {
+  if (binding.id === "mention" || binding.id === "hit")
+    return formatCombo({ key: "ArrowUp" }) + formatCombo({ key: "ArrowDown" });
+  if (binding.id === "scope")
+    return `${formatCombo({ key: "Tab" })} / ${formatCombo({ key: "Tab", shift: true })}`;
+  return formatCombo(binding.combo);
+}

--- a/src/lib/notify.test.ts
+++ b/src/lib/notify.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  away,
+  burst,
+  classOf,
+  type Moment,
+  markQuiet,
+  QUIET_MS,
+  quiet,
+  resetBurst,
+  resetQuiet,
+  shouldNotify,
+} from "./notify";
+import { NOTIFY_KINDS, type NotifyKind, type NotifyPrefs } from "./prefs";
+
+/**
+ * The gates a notification has to pass, read from the refusals inward.
+ *
+ * Every interesting assertion in this file is about silence. Raising a
+ * notification is one call; the work is declining to, and each way of getting
+ * that wrong costs the operator the whole feature, because nobody who turns
+ * notifications off turns them back on again. A badge for a routine that fired
+ * in the channel they were watching, a second badge for the same failure, a
+ * weekend of overdue schedule announced at launch: any one of those and the
+ * switch goes off for good.
+ *
+ * The judgement is in `Moment`. "Away" is graded, not binary, so the same three
+ * booleans mean three different things depending on the kind, and the class
+ * table is the only thing that says which. A kind that quietly changes class is
+ * a permission request nobody is told about, or a settled run announced from a
+ * channel that has never been opened.
+ *
+ * `away` itself is two conditions rather than one. A window sitting behind a
+ * browser on the same screen is visible and unfocused, which is exactly the
+ * case worth interrupting for and the one `document.hidden` misses.
+ */
+
+/** The master switch on and all four kinds wanted: prefs are never the refusal. */
+function wanted(): NotifyPrefs {
+  return {
+    on: true,
+    kinds: { approval: true, routine: true, settled: true, failed: true },
+  };
+}
+
+/** Everything wanted but one, so that kind's own switch is the only refusal. */
+function except(kind: NotifyKind): NotifyPrefs {
+  const prefs = wanted();
+  prefs.kinds[kind] = false;
+  return prefs;
+}
+
+/**
+ * The moment that lets every class through: away, looking at the channel it
+ * concerns, past the quiet window. Each test overrides only what should refuse.
+ */
+function moment(over: Partial<Moment> = {}): Moment {
+  return { away: true, onScreen: true, quiet: false, ...over };
+}
+
+/** A launch, in wall-clock milliseconds, so the quiet window has a real edge. */
+const LAUNCH = 1_756_000_000_000;
+
+beforeEach(() => {
+  // Both windows are module state that outlives a render, and therefore a test.
+  resetQuiet();
+  resetBurst();
+});
+
+describe("the switches", () => {
+  it("says nothing at all when the master switch is off, whatever the kinds ask for", () => {
+    for (const kind of NOTIFY_KINDS) {
+      expect(shouldNotify(kind, { ...wanted(), on: false }, moment())).toBe(false);
+    }
+  });
+
+  it("refuses a kind the operator switched off while the master switch is still on", () => {
+    // The dialog leaves the four kind switches enabled and readable with the
+    // master on, so the kind's own answer has to be the one that counts.
+    for (const kind of NOTIFY_KINDS) {
+      expect(shouldNotify(kind, except(kind), moment())).toBe(false);
+    }
+  });
+
+  it("holds one kind back without silencing the other three", () => {
+    expect(shouldNotify("approval", except("routine"), moment())).toBe(true);
+    expect(shouldNotify("routine", except("routine"), moment())).toBe(false);
+  });
+});
+
+describe("the quiet window after a launch", () => {
+  it("refuses every kind inside it, however much the moment favours them", () => {
+    markQuiet(LAUNCH);
+    // Away, on the channel, and wanted: the one moment where all three classes
+    // fire. A routine whose slot passed over a weekend arrives overdue on the
+    // first tick, and a weekend of schedule at once is why this gate outranks
+    // the rest of them.
+    for (const kind of NOTIFY_KINDS) {
+      expect(shouldNotify(kind, wanted(), moment({ quiet: quiet(LAUNCH + QUIET_MS - 1) }))).toBe(
+        false,
+      );
+    }
+  });
+
+  it("stops holding anything back the instant the window is up", () => {
+    markQuiet(LAUNCH);
+    expect(quiet(LAUNCH + QUIET_MS - 1)).toBe(true);
+    expect(quiet(LAUNCH + QUIET_MS)).toBe(false);
+    expect(shouldNotify("approval", wanted(), moment({ quiet: quiet(LAUNCH + QUIET_MS) }))).toBe(
+      true,
+    );
+  });
+
+  it("is not open before a launch has been marked", () => {
+    // The mark lands when the first read of state does. Anything arriving
+    // before that has to reach the operator, not fall into a window that was
+    // opened by module load.
+    expect(quiet(LAUNCH)).toBe(false);
+  });
+});
+
+describe("the class of news a kind is", () => {
+  it("makes a permission request the only thing that can break through", () => {
+    expect(classOf("approval")).toBe("attention");
+  });
+
+  it("treats a schedule firing as ambient, because it was pointed somewhere else", () => {
+    expect(classOf("routine")).toBe("ambient");
+  });
+
+  it("treats both ends of a run as completion, success or failure", () => {
+    // A failure is still the end of something the operator started. It gets no
+    // wider a hearing than a settle: a busy runtime fails runs in channels
+    // nobody has opened.
+    expect(classOf("settled")).toBe("completion");
+    expect(classOf("failed")).toBe("completion");
+  });
+});
+
+describe("attention", () => {
+  it("stays quiet when the operator is watching the channel that is asking", () => {
+    expect(shouldNotify("approval", wanted(), moment({ away: false, onScreen: true }))).toBe(false);
+  });
+
+  it("reaches an operator who is elsewhere, even from the channel on screen", () => {
+    expect(shouldNotify("approval", wanted(), moment({ away: true, onScreen: true }))).toBe(true);
+  });
+
+  it("breaks through a focused window when the request is on a channel that is not on screen", () => {
+    // The one rule that survives a window the operator is looking at. Nobody
+    // finds a parked turn by noticing a row change colour three screens up the
+    // rail, and the turn stays parked until it is answered.
+    expect(shouldNotify("approval", wanted(), moment({ away: false, onScreen: false }))).toBe(true);
+  });
+});
+
+describe("ambient", () => {
+  it("stays quiet while the operator is at the window, on screen or not", () => {
+    expect(shouldNotify("routine", wanted(), moment({ away: false, onScreen: true }))).toBe(false);
+    expect(shouldNotify("routine", wanted(), moment({ away: false, onScreen: false }))).toBe(false);
+  });
+
+  it("reaches an operator who is away without asking which channel is on screen", () => {
+    // A routine fires wherever it was pointed and `announcementFor` hands it no
+    // channel, so `onScreen` is whatever the caller happened to compute. Read
+    // it here and half of every schedule goes missing.
+    expect(shouldNotify("routine", wanted(), moment({ away: true, onScreen: true }))).toBe(true);
+    expect(shouldNotify("routine", wanted(), moment({ away: true, onScreen: false }))).toBe(true);
+  });
+});
+
+describe("completion", () => {
+  it("stays quiet about a run in a channel the operator was not looking at", () => {
+    // The gate that keeps a busy runtime from announcing work nobody opened.
+    for (const kind of ["settled", "failed"] as const) {
+      expect(shouldNotify(kind, wanted(), moment({ away: true, onScreen: false }))).toBe(false);
+    }
+  });
+
+  it("stays quiet while the operator is at the window watching it happen", () => {
+    for (const kind of ["settled", "failed"] as const) {
+      expect(shouldNotify(kind, wanted(), moment({ away: false, onScreen: true }))).toBe(false);
+    }
+  });
+
+  it("reaches an operator who stepped away from the conversation they were waiting on", () => {
+    for (const kind of ["settled", "failed"] as const) {
+      expect(shouldNotify(kind, wanted(), moment({ away: true, onScreen: true }))).toBe(true);
+    }
+  });
+});
+
+describe("away", () => {
+  const realHidden = Object.getOwnPropertyDescriptor(document, "hidden");
+
+  /** Both are inherited getters in jsdom, so an own property shadows them. */
+  function put(where: { hidden: boolean; focused?: boolean }): void {
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => where.hidden });
+    if (where.focused !== undefined) {
+      document.hasFocus = vi.fn(() => where.focused === true);
+    }
+  }
+
+  afterEach(() => {
+    if (realHidden) Object.defineProperty(document, "hidden", realHidden);
+    else Reflect.deleteProperty(document, "hidden");
+    Reflect.deleteProperty(document, "hasFocus");
+  });
+
+  it("does not claim a webview without hasFocus is away", () => {
+    // A host that does not implement it would otherwise throw here, on the
+    // first event of the session, inside a subscription made once.
+    Object.defineProperty(document, "hasFocus", { configurable: true, value: undefined });
+    put({ hidden: false });
+    expect(away()).toBe(false);
+  });
+
+  it("is false with the window visible and focused, which is the operator watching", () => {
+    put({ hidden: false, focused: true });
+    expect(away()).toBe(false);
+  });
+
+  it("is true for a window that is visible but not focused", () => {
+    // The alt-tabbed case: a Guaca window uncovered on the same screen as the
+    // browser being typed into. `document.hidden` never flips for it, and it is
+    // the case the whole mechanism exists for.
+    put({ hidden: false, focused: false });
+    expect(away()).toBe(true);
+  });
+
+  it("is true for a minimised or fully covered window without consulting focus", () => {
+    const hasFocus = vi.fn(() => true);
+    put({ hidden: true });
+    document.hasFocus = hasFocus;
+    expect(away()).toBe(true);
+    expect(hasFocus).not.toHaveBeenCalled();
+  });
+});
+
+describe("the burst window", () => {
+  it("says the same thing once, not twice, inside the same second", () => {
+    expect(burst("failed:Cook", LAUNCH)).toBe(false);
+    expect(burst("failed:Cook", LAUNCH + 200)).toBe(true);
+  });
+
+  it("does not let a repeat extend its own silence", () => {
+    // The window runs from what was said, not from the last thing suppressed. A
+    // stream retrying just inside the second would otherwise be muted forever.
+    expect(burst("failed:Cook", LAUNCH)).toBe(false);
+    expect(burst("failed:Cook", LAUNCH + 900)).toBe(true);
+    expect(burst("failed:Cook", LAUNCH + 1_000)).toBe(false);
+  });
+
+  it("treats two agents failing at once as two things worth saying", () => {
+    expect(burst("failed:Cook", LAUNCH)).toBe(false);
+    expect(burst("failed:Scribe", LAUNCH)).toBe(false);
+    expect(burst("approval:Cook", LAUNCH)).toBe(false);
+  });
+
+  it("forgets a key once its second is up, which is all that keeps the map bounded", () => {
+    expect(burst("failed:Cook", LAUNCH)).toBe(false);
+    // Chatter under other keys must not keep the first key alive, and must not
+    // outlive its own second either.
+    expect(burst("failed:Scribe", LAUNCH + 400)).toBe(false);
+    expect(burst("failed:Cook", LAUNCH + 1_000)).toBe(false);
+    expect(burst("failed:Scribe", LAUNCH + 1_500)).toBe(false);
+    // The entry the prune replaced is the current one, so the reprieve is not
+    // permanent: this is still the same thing said twice in a second.
+    expect(burst("failed:Cook", LAUNCH + 1_500)).toBe(true);
+  });
+});

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -1,0 +1,139 @@
+/**
+ * Telling the operator something happened while they were not looking.
+ *
+ * The hard part is not raising a notification, it is refusing to. Guaca runs
+ * unattended: routines fire on a schedule, an agent parks on a permission
+ * request and waits ten minutes for an answer, a cascade settles long after the
+ * message that started it. All of that is worth knowing about when you are
+ * elsewhere and none of it is worth a badge when you are watching it happen.
+ *
+ * So a notification has to pass three gates, and they are not the same gate:
+ *
+ *   the kind      is this something you asked to hear about
+ *   the moment    are you actually elsewhere, and elsewhere from what
+ *   the burst     has this already been said in the last second
+ *
+ * The second is where the judgement is. "Away" is not one condition, because a
+ * permission request and a finished conversation are not the same news:
+ *
+ *   attention   an agent is blocked on you. Reaches you when the window is not
+ *               in front of you, and also when it is but the request belongs to
+ *               a channel you are not looking at. Nobody finds a parked turn by
+ *               noticing a row change colour three screens up the rail.
+ *   ambient     nothing was addressed to you and no channel is implied. A
+ *               routine fires wherever it was pointed. Reaches you whenever you
+ *               are away, with no channel to match against.
+ *   completion  the end of something you started. Reaches you only when you are
+ *               away AND it is the channel you were last looking at, because a
+ *               busy runtime settles runs in channels you have never opened and
+ *               one badge each would make the whole mechanism worth turning off.
+ */
+
+import type { NotifyKind, NotifyPrefs } from "./prefs";
+
+export type NotifyClass = "attention" | "ambient" | "completion";
+
+export function classOf(kind: NotifyKind): NotifyClass {
+  switch (kind) {
+    case "approval":
+      return "attention";
+    case "routine":
+      return "ambient";
+    default:
+      return "completion";
+  }
+}
+
+/** Where the operator is, at the instant something happened. */
+export interface Moment {
+  /** The window is not the thing in front of the operator. */
+  away: boolean;
+  /**
+   * The channel this concerns is the one on screen. Meaningless for `ambient`,
+   * which has no channel to be about.
+   */
+  onScreen: boolean;
+  /** Inside the quiet window that follows a launch. */
+  quiet: boolean;
+}
+
+export function shouldNotify(kind: NotifyKind, prefs: NotifyPrefs, moment: Moment): boolean {
+  if (!prefs.on || !prefs.kinds[kind]) return false;
+  if (moment.quiet) return false;
+
+  switch (classOf(kind)) {
+    case "attention":
+      return moment.away || !moment.onScreen;
+    case "ambient":
+      return moment.away;
+    case "completion":
+      return moment.away && moment.onScreen;
+  }
+}
+
+/**
+ * True when the window is not the thing the operator is looking at.
+ *
+ * `document.hidden` alone is not enough: it flips when the window is minimised
+ * or fully covered, and a window sitting behind a browser on the same screen is
+ * visible-but-unfocused, which is exactly the case worth notifying for.
+ */
+export function away(): boolean {
+  if (document.hidden) return true;
+  return typeof document.hasFocus === "function" && !document.hasFocus();
+}
+
+/**
+ * How long after a launch nothing may interrupt.
+ *
+ * A routine whose slot passed while the app was closed reaches the scheduler
+ * overdue and fires on the first tick, which is correct: the work is owed. But
+ * it did not just happen, and launching after a weekend away should not
+ * announce a weekend of schedule at once. The transcript and the rail show all
+ * of it immediately; only the interruption waits.
+ */
+export const QUIET_MS = 4000;
+
+let quietUntil = 0;
+
+/** Opens the quiet window. Called once, when the first read of state lands. */
+export function markQuiet(now = Date.now()): void {
+  quietUntil = now + QUIET_MS;
+}
+
+export function quiet(now = Date.now()): boolean {
+  return now < quietUntil;
+}
+
+/** Only tests need this: the window is process-wide and outlives a render. */
+export function resetQuiet(): void {
+  quietUntil = 0;
+}
+
+const BURST_MS = 1000;
+
+const spoken = new Map<string, number>();
+
+/**
+ * True when this has already been said in the last second.
+ *
+ * Keyed on kind and channel, so two agents failing at once are two
+ * notifications and one agent failing twice is one. The map prunes on every
+ * call rather than on a timer, which is what keeps it from being a leak: an
+ * entry older than the window is dropped by the next thing that asks.
+ */
+export function burst(key: string, now = Date.now()): boolean {
+  for (const [seen, at] of spoken) {
+    if (now - at >= BURST_MS) spoken.delete(seen);
+  }
+
+  if (spoken.has(key)) return true;
+
+  spoken.set(key, now);
+  return false;
+}
+
+/** Only tests need this, for the same reason as `resetQuiet`. */
+export function resetBurst(): void {
+  spoken.clear();
+}

--- a/src/lib/prefs.test.ts
+++ b/src/lib/prefs.test.ts
@@ -1,0 +1,224 @@
+/**
+ * The one preferences blob, read back out of a file the operator can edit.
+ *
+ * `readPrefs` validates field by field, and the reason is that every route this
+ * blob takes into the app is a route it can arrive wrong on: an older build
+ * wrote fewer fields, a newer one wrote more, a webview torn down mid-write
+ * left half a string, and a curious operator edited it by hand. What is under
+ * test here is that each of those costs exactly the fields it got wrong and
+ * never the window. A scale that is not one of the offered scales becomes a CSS
+ * length no button can turn back off; a notify flag that was coerced rather
+ * than checked is either an interruption the operator never switched off or one
+ * they asked for and will not get.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_PREFS,
+  loadPrefs,
+  NOTIFY_KINDS,
+  type Prefs,
+  readPrefs,
+  savePrefs,
+  UI_SCALES,
+} from "./prefs";
+
+/**
+ * The key the blob lives under, written out again rather than imported.
+ *
+ * It is not exported, and it is the whole of the contract with every operator
+ * who already has preferences: a rename strands all of them silently. Spelling
+ * it here means a rename fails this suite instead.
+ */
+const KEY = "guac.prefs";
+
+/**
+ * The defaults, written out independently of the module's own constant.
+ *
+ * 100 and light are what the app has always drawn, and every notification is on
+ * because a blob that cannot be read must not be able to switch interruptions
+ * off. Asserting against the module constant would pass whatever it said.
+ */
+const DEFAULTS: Prefs = {
+  uiScale: 100,
+  surface: "light",
+  notify: {
+    on: true,
+    kinds: { approval: true, routine: true, settled: true, failed: true },
+  },
+};
+
+/** Runs `body` against a storage that behaves the way a hardened webview does. */
+function withStorage(stub: Partial<Storage>, body: () => void): void {
+  const held = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: stub });
+  try {
+    body();
+  } finally {
+    if (held) Object.defineProperty(globalThis, "localStorage", held);
+    else Reflect.deleteProperty(globalThis, "localStorage");
+  }
+}
+
+beforeEach(() => {
+  // One Map backs storage for the whole file, so a leftover blob from the test
+  // above is a first launch that is not one.
+  localStorage.clear();
+});
+
+describe("a blob that cannot be trusted", () => {
+  it("takes the defaults from anything that is not an object", () => {
+    // The last two are the ones that actually happen: a blob stringified twice
+    // parses back to a string, and a truncated file can parse to a bare number.
+    for (const raw of [null, undefined, true, 7, "", '{"uiScale":125}']) {
+      expect(readPrefs(raw)).toEqual(DEFAULTS);
+    }
+  });
+
+  it("takes the defaults from a JSON array, which is an object holding nothing", () => {
+    // `typeof [] === "object"`, so an array walks past the guard and into the
+    // field reads. Nothing it carries is a field this build ever wrote.
+    expect(readPrefs([])).toEqual(DEFAULTS);
+    expect(readPrefs([{ uiScale: 125, surface: "dark" }])).toEqual(DEFAULTS);
+  });
+
+  it("defaults every field whose type is wrong and keeps the ones that are not", () => {
+    // The hand-edited case. A `Boolean(value)` check would read the 0 as an
+    // operator switching the blocking approval prompts off, and the quoted 110
+    // would reach `styles.css` as a length; a flag copied through unchecked puts
+    // a string where every reader of the record expects a boolean.
+    expect(
+      readPrefs({
+        uiScale: "110",
+        surface: 1,
+        notify: { on: false, kinds: { approval: 0, settled: "yes", routine: false } },
+      }),
+    ).toEqual({
+      uiScale: 100,
+      surface: "light",
+      notify: {
+        on: false,
+        kinds: { approval: true, routine: false, settled: true, failed: true },
+      },
+    });
+  });
+
+  it("defaults the whole notify block when the block itself is not an object", () => {
+    // A valid field beside a ruined one survives: the blob is not all or nothing.
+    expect(readPrefs({ uiScale: 125, notify: "off" })).toEqual({ ...DEFAULTS, uiScale: 125 });
+    expect(readPrefs({ notify: [] })).toEqual(DEFAULTS);
+    expect(readPrefs({ notify: null })).toEqual(DEFAULTS);
+    // A switch and a kinds record that are both present and both unreadable.
+    expect(readPrefs({ notify: { on: 0, kinds: "all" } })).toEqual(DEFAULTS);
+  });
+
+  it("refuses a scale that is a number nobody offers", () => {
+    // The value drives a CSS length and the preset row the settings dialog
+    // highlights, so an unoffered number draws a window with no button lit that
+    // would return it to something legible.
+    for (const uiScale of [137, 0, 100.5, -100, Number.NaN, 1e9]) {
+      expect(readPrefs({ uiScale }).uiScale).toBe(DEFAULTS.uiScale);
+    }
+  });
+
+  it("ignores a notify kind this build has never heard of", () => {
+    // A blob from a newer build carries kinds this one cannot draw a row for.
+    // Copied through, they persist on the next write forever, and a stale value
+    // under a name a later build reuses is a preference nobody set.
+    const prefs = readPrefs({ notify: { kinds: { approval: false, chatter: false } } });
+    expect(prefs.notify.kinds.approval).toBe(false);
+    expect(Object.keys(prefs.notify.kinds)).toEqual([...NOTIFY_KINDS]);
+  });
+
+  it("fills in what an older build never wrote and keeps what it did", () => {
+    expect(readPrefs({ surface: "dark" })).toEqual({ ...DEFAULTS, surface: "dark" });
+    expect(readPrefs({ notify: { kinds: { failed: false } } })).toEqual({
+      ...DEFAULTS,
+      notify: { on: true, kinds: { ...DEFAULTS.notify.kinds, failed: false } },
+    });
+  });
+
+  it("leaves the defaults it fell back on alone for the next read", () => {
+    // The kinds record is copied before anything is written into it. Writing
+    // into `DEFAULT_PREFS.notify.kinds` instead would work once and then hand
+    // every later read in the process the last blob's answer.
+    expect(readPrefs({ notify: { kinds: { approval: false } } }).notify.kinds.approval).toBe(false);
+    expect(readPrefs({}).notify.kinds.approval).toBe(true);
+    expect(DEFAULT_PREFS).toEqual(DEFAULTS);
+  });
+});
+
+describe("storage that will not cooperate", () => {
+  it("reads the defaults when the stored blob will not parse", () => {
+    // A write cut short by a webview going away leaves exactly this.
+    localStorage.setItem(KEY, '{"uiScale":125,"surface":"da');
+    expect(loadPrefs()).toEqual(DEFAULTS);
+  });
+
+  it("reads the defaults when storage refuses to be read at all", () => {
+    // Private modes and hardened webviews throw on access rather than returning
+    // null. A forgotten preference is a far smaller problem than no window.
+    withStorage(
+      {
+        getItem: () => {
+          throw new Error("access to storage is not allowed from this context");
+        },
+      },
+      () => {
+        expect(loadPrefs()).toEqual(DEFAULTS);
+      },
+    );
+  });
+
+  it("swallows a save that storage refuses", () => {
+    // Over quota is the common one. The operator's choice holds for the session
+    // either way, and there is nothing for them to do about it.
+    const refused = vi.fn(() => {
+      throw new Error("exceeded the quota");
+    });
+    withStorage({ getItem: () => null, setItem: refused }, () => {
+      expect(() => savePrefs({ ...DEFAULTS, surface: "dark" })).not.toThrow();
+    });
+    expect(refused).toHaveBeenCalledOnce();
+  });
+});
+
+describe("a preference that outlives the window", () => {
+  it("is the defaults on a first launch, with nothing stored", () => {
+    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(loadPrefs()).toEqual(DEFAULTS);
+  });
+
+  it("reads back exactly what was written", () => {
+    const chosen: Prefs = {
+      uiScale: 125,
+      surface: "dark",
+      notify: {
+        on: false,
+        kinds: { approval: true, routine: false, settled: false, failed: true },
+      },
+    };
+    savePrefs(chosen);
+    expect(loadPrefs()).toEqual(chosen);
+    // One blob under one key: a key per field is a read per field, and a set of
+    // them half written by an interrupted save.
+    expect(localStorage.length).toBe(1);
+  });
+
+  it("keeps every scale the picker offers", () => {
+    // `isScale` and `UI_SCALES` are two lists that have to stay one. A scale the
+    // dialog offers and the reader rejects is a button that does not hold.
+    for (const scale of UI_SCALES) {
+      expect(readPrefs({ uiScale: scale }).uiScale).toBe(scale);
+    }
+  });
+
+  it("keeps every surface, including the one that is not a colour", () => {
+    // System is the one worth naming: dropped from the reader, it reverts to
+    // light, and the operator's window stops following the OS at every launch.
+    for (const surface of ["light", "dark", "system"] as const) {
+      expect(readPrefs({ surface }).surface).toBe(surface);
+    }
+  });
+});

--- a/src/lib/prefs.ts
+++ b/src/lib/prefs.ts
@@ -1,0 +1,146 @@
+/**
+ * Preferences the operator sets and the runtime never reads.
+ *
+ * Everything else the operator can change lives in `config.json` and reaches
+ * the webview as `Settings`, because the runtime acts on it: an endpoint, a
+ * key, a limit. None of what is here means anything to an agent. How large the
+ * interface draws, whether the reading column is paper or ink, which of four
+ * things is worth interrupting you for: the runtime would carry these across
+ * IPC only to hand them straight back.
+ *
+ * So they stay on this side, in `localStorage`, the way the inspector's
+ * open-or-closed already does. That is a deliberate exception to "the frontend
+ * holds nothing durable" and it is narrow on purpose: nothing in here survives
+ * being lost, and none of it is worth a migration.
+ *
+ * One blob under one key rather than a key each, so a read is one parse and a
+ * write is one string. Every field is validated on the way in: this file is a
+ * text file an operator can edit, a webview can truncate and an older build can
+ * have written, and a preference that cannot be read should cost the default
+ * rather than the window.
+ */
+
+export type SurfaceMode = "light" | "dark" | "system";
+
+/**
+ * What an agent doing something can interrupt you for.
+ *
+ * Four kinds rather than one switch, because they are not the same question.
+ * A permission request is blocking and stays blocking until you answer it. A
+ * routine fires in a channel you were never looking at. A conversation
+ * finishing is only interesting if you were waiting for it.
+ */
+export type NotifyKind = "approval" | "routine" | "settled" | "failed";
+
+export const NOTIFY_KINDS: readonly NotifyKind[] = ["approval", "routine", "settled", "failed"];
+
+export interface NotifyPrefs {
+  /** The master switch. Off means no kind fires, whatever the kinds say. */
+  on: boolean;
+  kinds: Record<NotifyKind, boolean>;
+}
+
+/**
+ * The scales offered, as percentages.
+ *
+ * 100 is what the app has always drawn, so an existing operator sees no change
+ * until they ask for one. It stops at 125 because the rail and the inspector
+ * are measured in `rem` and therefore grow too: past that they eat a small
+ * window rather than making it legible. Both are capped against the viewport in
+ * `styles.css` so the worst case is a narrow reading column, not a lost one.
+ */
+export const UI_SCALES = [90, 100, 110, 125] as const;
+
+export type UiScale = (typeof UI_SCALES)[number];
+
+export interface Prefs {
+  uiScale: UiScale;
+  surface: SurfaceMode;
+  notify: NotifyPrefs;
+}
+
+/**
+ * Frozen, all the way down.
+ *
+ * `readPrefs` hands this back by identity when there is nothing legible to
+ * read, so a caller that wrote a preference into it in place rather than
+ * copying would poison the defaults for the life of the process. Every caller
+ * copies today; freezing is what keeps that from being something to remember.
+ */
+export const DEFAULT_PREFS: Prefs = Object.freeze({
+  uiScale: 100,
+  surface: "light",
+  notify: Object.freeze({
+    on: true,
+    kinds: Object.freeze({ approval: true, routine: true, settled: true, failed: true }),
+  }),
+}) as Prefs;
+
+const KEY = "guac.prefs";
+
+const SURFACES: readonly SurfaceMode[] = ["light", "dark", "system"];
+
+function isScale(value: unknown): value is UiScale {
+  return UI_SCALES.some((scale) => scale === value);
+}
+
+function isSurface(value: unknown): value is SurfaceMode {
+  return SURFACES.some((mode) => mode === value);
+}
+
+/**
+ * Reads one stored blob, keeping whatever is legible and defaulting the rest.
+ *
+ * Field by field rather than an object spread: a blob written by an older build
+ * is missing fields a spread would leave undefined, and one written by a newer
+ * one carries fields this build must not trust. Both are the same case as a
+ * hand-edited file, and all three should cost exactly the fields they got wrong.
+ */
+export function readPrefs(raw: unknown): Prefs {
+  if (typeof raw !== "object" || raw === null) return DEFAULT_PREFS;
+
+  const stored = raw as Partial<Prefs>;
+  const kinds = { ...DEFAULT_PREFS.notify.kinds };
+  const storedKinds = stored.notify?.kinds;
+  if (typeof storedKinds === "object" && storedKinds !== null) {
+    for (const kind of NOTIFY_KINDS) {
+      const value = (storedKinds as Record<string, unknown>)[kind];
+      if (typeof value === "boolean") kinds[kind] = value;
+    }
+  }
+
+  return {
+    uiScale: isScale(stored.uiScale) ? stored.uiScale : DEFAULT_PREFS.uiScale,
+    surface: isSurface(stored.surface) ? stored.surface : DEFAULT_PREFS.surface,
+    notify: {
+      on: typeof stored.notify?.on === "boolean" ? stored.notify.on : DEFAULT_PREFS.notify.on,
+      kinds,
+    },
+  };
+}
+
+/**
+ * Loads the stored preferences, or the defaults.
+ *
+ * Private modes and hardened webviews can refuse storage, and a truncated write
+ * leaves JSON that will not parse. A forgotten preference is a much smaller
+ * problem than a window that will not draw.
+ */
+export function loadPrefs(): Prefs {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (raw === null) return DEFAULT_PREFS;
+    return readPrefs(JSON.parse(raw));
+  } catch {
+    return DEFAULT_PREFS;
+  }
+}
+
+/** As above: not worth telling the operator about. */
+export function savePrefs(prefs: Prefs): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(prefs));
+  } catch {
+    // Nothing to do and nothing to say. The preference holds for this session.
+  }
+}

--- a/src/lib/providers.test.ts
+++ b/src/lib/providers.test.ts
@@ -1,0 +1,256 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { Provider } from "./providers";
+import { PROVIDERS, providerFor, providerReady } from "./providers";
+
+/**
+ * The preset list is data, and both of its jobs are answered from one string.
+ *
+ * `providerFor` decides which row the dialog draws as chosen, so it has to
+ * survive the two ways an operator's paste differs from the same URL and it
+ * has to refuse everything else: a hand-typed endpoint must read as chosen,
+ * not as one of these with the highlight on the wrong row. And because the
+ * Rust side normalises a base URL before it stores one, a preset that is not
+ * already in that canonical form saves fine and comes back unrecognised, which
+ * looks like the app forgetting the choice that was just made.
+ *
+ * Nothing here needs a running app. A preset the backend would rewrite, or one
+ * that cannot find itself, is wrong the moment it is written.
+ */
+
+const root = resolve(__dirname, "../..");
+const read = (path: string) => readFileSync(resolve(root, path), "utf8");
+
+/** A constant from `src-tauri/src/config.rs`, read rather than copied. */
+function rustConst(name: string): string {
+  const source = read("src-tauri/src/config.rs");
+  const match = source.match(new RegExp(`${name}: &str = "([^"]+)"`));
+  if (!match) throw new Error(`could not find ${name} in config.rs`);
+  return match[1]!;
+}
+
+/** What the endpoint box suggests when it is empty. */
+function endpointPlaceholder(): string {
+  const source = read("src/components/SettingsDialog.tsx");
+  const match = source.match(/Inference endpoint[\s\S]{0,400}?placeholder="([^"]+)"/);
+  if (!match) throw new Error("could not find the endpoint field in SettingsDialog.tsx");
+  return match[1]!;
+}
+
+function preset(id: string): Provider {
+  const found = PROVIDERS.find((provider) => provider.id === id);
+  if (!found) throw new Error(`no preset called ${id}`);
+  return found;
+}
+
+describe("an endpoint that is not a preset", () => {
+  it("reads as no preset at all rather than as the first one in the list", () => {
+    // First run hands this an empty setting. Falling back to PROVIDERS[0] would
+    // draw OpenRouter as chosen before anyone chose anything, and the operator
+    // would be looking at a highlighted row beside an empty box.
+    expect(providerFor("")).toBeUndefined();
+  });
+
+  it("reads as no preset when the box holds nothing but whitespace", () => {
+    expect(providerFor("   ")).toBeUndefined();
+    expect(providerFor("\n\t ")).toBeUndefined();
+    // Trimming leaves a bare separator empty too, so it must not match either.
+    expect(providerFor("/")).toBeUndefined();
+    expect(providerFor("///")).toBeUndefined();
+  });
+
+  it("leaves an endpoint nobody ships unrecognised, because that is what chosen means", () => {
+    // `Custom` is the absence of an entry. Answering with the nearest preset
+    // would put the highlight on a row that is not what the app would call.
+    expect(providerFor("https://llm.internal.example.com/v1")).toBeUndefined();
+    expect(providerFor("http://localhost:8080/v1")).toBeUndefined();
+  });
+
+  it("refuses a near miss on a preset's own host", () => {
+    // The comparison has to be the whole string. A `startsWith` or `endsWith`
+    // implementation would claim both of these, and an endpoint one path
+    // segment off fails on every turn of every agent.
+    const openai = preset("openai");
+    expect(providerFor(`${openai.baseUrl}/beta`)).toBeUndefined();
+    expect(providerFor("https://api.openai.com")).toBeUndefined();
+    expect(providerFor("https://api.openai.com/v2")).toBeUndefined();
+  });
+});
+
+describe("the same endpoint, pasted the way a provider prints it", () => {
+  it("resolves a base that still names the completions path", () => {
+    // The most common paste there is, because it is the URL in a provider's own
+    // documentation. The Rust normaliser strips it before storing, so
+    // recognising it here is what stops the chosen row flipping across a save:
+    // the box read as unrecognised, the backend trimmed the path, and the very
+    // same setting then read as the preset.
+    for (const provider of PROVIDERS) {
+      expect(providerFor(`${provider.baseUrl}/chat/completions`), provider.name).toBe(provider);
+    }
+  });
+
+  it("resolves it with a trailing slash on top, and in the wrong case", () => {
+    const openai = preset("openai");
+    expect(providerFor(`${openai.baseUrl}/chat/completions/`)).toBe(openai);
+    expect(providerFor(`${openai.baseUrl.toUpperCase()}/CHAT/COMPLETIONS`)).toBe(openai);
+  });
+
+  it("still refuses a path that only looks like it", () => {
+    // Only a trailing `/chat/completions` is a known paste error. Anything else
+    // after the base is a different endpoint and must read as chosen.
+    expect(providerFor(`${preset("openai").baseUrl}/chat`)).toBeUndefined();
+    expect(providerFor(`${preset("openai").baseUrl}/completions`)).toBeUndefined();
+    expect(providerFor(`${preset("openai").baseUrl}/chat/completions/extra`)).toBeUndefined();
+  });
+});
+
+describe("the same endpoint, pasted differently", () => {
+  it("resolves a trailing slash, however many were pasted", () => {
+    // A copied base URL arrives with one; a hand-assembled one arrives with
+    // two. Neither is a different endpoint, and the Rust side stores them the
+    // same way, so every preset has to survive both.
+    for (const provider of PROVIDERS) {
+      expect(providerFor(`${provider.baseUrl}/`), provider.name).toBe(provider);
+      expect(providerFor(`${provider.baseUrl}//`), provider.name).toBe(provider);
+      expect(providerFor(`${provider.baseUrl}///`), provider.name).toBe(provider);
+    }
+  });
+
+  it("resolves an endpoint typed in a different case", () => {
+    // Local endpoints get typed out by hand rather than pasted, which is where
+    // the case comes from, and a host is case-insensitive anyway.
+    for (const provider of PROVIDERS) {
+      expect(providerFor(provider.baseUrl.toUpperCase()), provider.name).toBe(provider);
+    }
+    expect(providerFor("Https://Api.OpenAI.com/v1")).toBe(preset("openai"));
+  });
+
+  it("resolves an endpoint with whitespace around it", () => {
+    // A paste out of a terminal or a docs page brings its own padding.
+    for (const provider of PROVIDERS) {
+      expect(providerFor(`  ${provider.baseUrl}  `), provider.name).toBe(provider);
+      expect(providerFor(`\n${provider.baseUrl}\t`), provider.name).toBe(provider);
+    }
+  });
+
+  it("resolves all three at once", () => {
+    // The realistic paste is not one of these, it is all of them.
+    expect(providerFor("\n  HTTPS://Api.OpenAI.com/v1//  \t")).toBe(preset("openai"));
+  });
+});
+
+describe("whether there is any point pressing Test connection", () => {
+  it("ships both kinds of endpoint, so neither case below passes vacuously", () => {
+    expect(PROVIDERS.some((provider) => provider.local === true)).toBe(true);
+    expect(PROVIDERS.some((provider) => provider.local !== true)).toBe(true);
+  });
+
+  it("says a hosted endpoint is not ready until a key is stored", () => {
+    for (const provider of PROVIDERS.filter((entry) => entry.local !== true)) {
+      expect(providerReady(provider, false), `${provider.name} with no key`).toBe(false);
+    }
+  });
+
+  it("says a local endpoint is ready with no key, because the server wants none", () => {
+    // The reason the flag exists: a server on this machine takes no key, and an
+    // empty key field beside a missing-key warning is a state an operator will
+    // try to fix forever.
+    for (const provider of PROVIDERS.filter((entry) => entry.local === true)) {
+      expect(providerReady(provider, false), `${provider.name} with no key`).toBe(true);
+      // And a key stored for some other endpoint does not change the answer.
+      expect(providerReady(provider, true), `${provider.name} with a key`).toBe(true);
+    }
+  });
+
+  it("says a hosted endpoint is ready once there is a key", () => {
+    for (const provider of PROVIDERS.filter((entry) => entry.local !== true)) {
+      expect(providerReady(provider, true), `${provider.name} with a key`).toBe(true);
+    }
+  });
+});
+
+describe("the preset list", () => {
+  it("has presets to offer", () => {
+    // Without this the loops below pass on an empty array.
+    expect(PROVIDERS.length).toBeGreaterThan(3);
+  });
+
+  it("gives every preset an id nothing else uses", () => {
+    // The id is the key of the rendered row and the answer to "which one is
+    // chosen". Two presets sharing one draws the highlight on both.
+    const ids = PROVIDERS.map((provider) => provider.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("gives every preset a name to show", () => {
+    for (const provider of PROVIDERS) {
+      expect(provider.name.trim(), `${provider.id}'s name`).not.toBe("");
+    }
+  });
+
+  it("gives every preset a base URL that parses", () => {
+    for (const provider of PROVIDERS) {
+      expect(
+        () => new URL(provider.baseUrl),
+        `${provider.name} claims ${provider.baseUrl}`,
+      ).not.toThrow();
+    }
+  });
+
+  it("spells every base URL the way the backend would store it", () => {
+    // `normalize_base_url` in `src-tauri/src/config.rs` refuses anything without
+    // one of these schemes, and strips a trailing slash and a trailing
+    // `/chat/completions`. A preset that is not already in that form is a
+    // choice the operator makes, saves, and watches come back as Custom.
+    for (const provider of PROVIDERS) {
+      const url = provider.baseUrl;
+      expect(url.startsWith("http://") || url.startsWith("https://"), `${url} scheme`).toBe(true);
+      expect(url.endsWith("/"), `${url} ends with a slash`).toBe(false);
+      expect(url.endsWith("/chat/completions"), `${url} names the endpoint`).toBe(false);
+    }
+  });
+
+  it("lets every preset find itself", () => {
+    // The property the rest of this file rests on: whatever `choose` puts in
+    // the box, and whatever the backend gives back after a save, must resolve
+    // to the row that was clicked.
+    for (const provider of PROVIDERS) {
+      expect(providerFor(provider.baseUrl), `${provider.name} lost itself`).toBe(provider);
+    }
+  });
+
+  it("does not have two presets claiming one endpoint", () => {
+    // `providerFor` can only answer with one of them, so the other can never be
+    // drawn as chosen no matter how it was picked.
+    const urls = PROVIDERS.map((provider) => provider.baseUrl.toLowerCase());
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+
+  it("names a model on every hosted preset", () => {
+    // Choosing a preset fills the endpoint and the model, which is what the
+    // dialog promises. A hosted preset with no model leaves the model box
+    // holding whatever the last endpoint used. Local presets carry none on
+    // purpose: the model is whatever that server has loaded.
+    for (const provider of PROVIDERS.filter((entry) => entry.local !== true)) {
+      expect(provider.model.trim(), `${provider.name}'s model`).not.toBe("");
+    }
+  });
+});
+
+describe("what a fresh install starts on", () => {
+  it("starts on a preset, endpoint and model together", () => {
+    // The backend's defaults are what an operator sees before touching
+    // anything. If they are not one of these rows, the dialog opens on Custom
+    // for a configuration nobody typed.
+    const chosen = providerFor(rustConst("DEFAULT_BASE_URL"));
+    expect(chosen, `no preset ships ${rustConst("DEFAULT_BASE_URL")}`).toBeDefined();
+    expect(chosen?.model).toBe(rustConst("DEFAULT_MODEL"));
+  });
+
+  it("suggests that same endpoint in the empty box", () => {
+    // The placeholder is a third copy of the default. One that drifts advertises
+    // an endpoint the app would not actually call.
+    expect(endpointPlaceholder()).toBe(rustConst("DEFAULT_BASE_URL"));
+  });
+});

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -1,0 +1,113 @@
+/**
+ * Endpoints that are known to speak the protocol this app speaks.
+ *
+ * Guaca talks to one shape of API: OpenAI-compatible `/chat/completions`, with
+ * streaming and tool calls. That is a wide field and the field is the problem —
+ * the setting is a text box, and a base URL that is off by a path segment fails
+ * on every turn of every agent with an error from a server rather than from
+ * here. This is a list of the ones worth having spelled correctly.
+ *
+ * It is a starting point, never a restriction. Anything else is typed in, which
+ * is what the box was for; a preset only fills it. `Custom` is not an entry in
+ * the list, it is the absence of one, so a hand-typed endpoint reads as chosen
+ * rather than as unrecognised.
+ *
+ * Local endpoints are marked because they change what the API key field means:
+ * a server on this machine wants no key, and an empty key field beside a
+ * warning about a missing key is the state an operator will try to fix forever.
+ */
+
+export interface Provider {
+  id: string;
+  name: string;
+  baseUrl: string;
+  /** A model id that exists there, for the field beside it. */
+  model: string;
+  /** On this machine, and therefore wanting no key. */
+  local?: boolean;
+}
+
+export const PROVIDERS: Provider[] = [
+  {
+    id: "openrouter",
+    name: "OpenRouter",
+    baseUrl: "https://openrouter.ai/api/v1",
+    model: "anthropic/claude-sonnet-4.5",
+  },
+  {
+    id: "openai",
+    name: "OpenAI",
+    baseUrl: "https://api.openai.com/v1",
+    model: "gpt-4.1",
+  },
+  {
+    id: "groq",
+    name: "Groq",
+    baseUrl: "https://api.groq.com/openai/v1",
+    model: "llama-3.3-70b-versatile",
+  },
+  {
+    id: "together",
+    name: "Together",
+    baseUrl: "https://api.together.xyz/v1",
+    model: "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+  },
+  {
+    id: "fireworks",
+    name: "Fireworks",
+    baseUrl: "https://api.fireworks.ai/inference/v1",
+    model: "accounts/fireworks/models/llama-v3p3-70b-instruct",
+  },
+  {
+    id: "lmstudio",
+    name: "LM Studio",
+    baseUrl: "http://localhost:1234/v1",
+    model: "",
+    local: true,
+  },
+  {
+    id: "ollama",
+    name: "Ollama",
+    baseUrl: "http://localhost:11434/v1",
+    model: "",
+    local: true,
+  },
+];
+
+/**
+ * The preset an endpoint is, if it is one.
+ *
+ * Normalised the same three ways `normalize_base_url` in `config.rs` does,
+ * because the endpoint it stores is the one this has to recognise afterwards.
+ * Whitespace and case are the two ways a pasted URL differs from the same URL;
+ * a trailing `/chat/completions` is the third and the most common, since it is
+ * the URL a provider's own documentation prints. Recognising only two of the
+ * three had the chosen row flip across a save: the box read as unrecognised,
+ * the backend trimmed the path, and the same setting then read as the preset.
+ */
+export function providerFor(baseUrl: string): Provider | undefined {
+  const needle = baseUrl
+    .trim()
+    .toLowerCase()
+    .replace(/\/+$/, "")
+    .replace(/\/chat\/completions$/, "")
+    .replace(/\/+$/, "");
+  if (!needle) return undefined;
+  return PROVIDERS.find((provider) => provider.baseUrl.toLowerCase() === needle);
+}
+
+/**
+ * Whether this endpoint is ready to be used, as far as this side can tell.
+ *
+ * "As far as this side can tell" is the whole caveat: a key that is present can
+ * still be wrong, which is what Test connection is for. This answers the
+ * cheaper question of whether there is any point pressing it.
+ *
+ * The key is one key, app-wide, belonging to whichever endpoint is configured.
+ * So this is only a true statement about the provider currently chosen; asked
+ * about any other row it reports on somebody else's key, which is why the UI
+ * only shows it for the chosen one.
+ */
+export function providerReady(provider: Provider, keySet: boolean): boolean {
+  return provider.local === true || keySet;
+}

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -346,7 +346,7 @@ function actionsFor(agents: AgentCard[], groups: Group[]): Omit<SearchResult, "s
       key: "action:app-settings",
       kind: "actions",
       title: "App settings",
-      detail: "API key, model, limits, computers",
+      detail: "API key, model, limits, computers, appearance, notifications, shortcuts",
       meta: "Action",
       action: { do: "openSettings" },
     },

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -21,6 +21,7 @@ vi.mock("./ipc", () => ({
 }));
 
 const { ACTIVITY_CHANNEL, useStore } = await import("./store");
+const { DEFAULT_PREFS } = await import("./prefs");
 
 function envelope(overrides: Partial<Envelope> = {}): Envelope {
   return {
@@ -85,6 +86,11 @@ function reset(messages: Record<string, Envelope[] | undefined> = {}) {
     activity: {},
     lastActive: {},
     settings: null,
+    // Named explicitly for the same reason as every field above it: zustand's
+    // setState merges, so a slice left out of this list leaks into whichever
+    // test runs next.
+    prefs: DEFAULT_PREFS,
+    activeRun: {},
     selected: "chef",
     messages,
     streams: {},

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -10,6 +10,7 @@ import { useCallback, useMemo } from "react";
 import { create } from "zustand";
 
 import { api } from "./ipc";
+import { loadPrefs, type Prefs, savePrefs } from "./prefs";
 import { type DropTarget, landsBefore, nudgeTarget, railOrder } from "./rail";
 import { keepThought } from "./reasoning";
 import type {
@@ -25,6 +26,7 @@ import type {
   MessageId,
   Participant,
   RoutineId,
+  RunId,
   Settings,
   Tokens,
   UiEvent,
@@ -69,6 +71,22 @@ interface State {
   /** Newest message timestamp per agent. Drives the sidebar order. */
   lastActive: Record<AgentId, number>;
   settings: Settings | null;
+  /** Local preferences. See `lib/prefs`: the runtime never reads these. */
+  prefs: Prefs;
+  /**
+   * The conversation each agent is currently part of, so it can be stopped.
+   *
+   * Learned from the placeholder that opens in the agent's channel, which is
+   * the runtime's own statement that this agent is working on that run, and
+   * dropped when the run settles. Not read from `sendMessage`'s return value:
+   * that only knows about conversations the operator started, and a routine or
+   * a peer's request is exactly as worth stopping.
+   *
+   * Keyed by agent rather than by run because that is the question the button
+   * asks: the operator is looking at one channel and wants what is happening in
+   * it to stop.
+   */
+  activeRun: Record<AgentId, RunId | undefined>;
 
   /** Everything each group has spent, ever. Keyed by group id. */
   usage: Record<GroupId, Tokens | undefined>;
@@ -162,6 +180,13 @@ interface State {
   dismissPulse: (id: number) => void;
   setBanner: (banner: State["banner"]) => void;
   setSettings: (settings: Settings) => void;
+  /**
+   * Merges a change into the local preferences and writes them back.
+   *
+   * The write is here rather than in an effect beside the reader, so there is
+   * one place a preference is persisted and no component has to remember to.
+   */
+  setPrefs: (patch: Partial<Prefs>) => void;
 }
 
 let pulseSeq = 0;
@@ -212,6 +237,8 @@ export const useStore = create<State>((set, get) => ({
   activity: {},
   lastActive: {},
   settings: null,
+  prefs: loadPrefs(),
+  activeRun: {},
   usage: {},
   pulse: {},
   approvals: {},
@@ -502,6 +529,7 @@ export const useStore = create<State>((set, get) => ({
           delete reasoning[event.agentId];
           return {
             reasoning,
+            activeRun: { ...state.activeRun, [event.agentId]: event.runId },
             streams: {
               ...state.streams,
               [event.messageId]: {
@@ -564,9 +592,23 @@ export const useStore = create<State>((set, get) => ({
       }
 
       case "activityChanged": {
-        set((state) => ({
-          activity: { ...state.activity, [event.agentId]: event.activity },
-        }));
+        set((state) => {
+          // An agent that has gone quiet is not working on anything, so the run
+          // it was working on stops being the one to stop. Left behind, the
+          // entry would still be here when the agent was next handed work, and
+          // the Stop button would name the conversation before this one.
+          // Absent is the right kind of wrong: no button beats the wrong one.
+          const activeRun =
+            event.activity.state === "idle" && state.activeRun[event.agentId] !== undefined
+              ? (() => {
+                  const next = { ...state.activeRun };
+                  delete next[event.agentId];
+                  return next;
+                })()
+              : state.activeRun;
+
+          return { activity: { ...state.activity, [event.agentId]: event.activity }, activeRun };
+        });
         break;
       }
 
@@ -628,11 +670,26 @@ export const useStore = create<State>((set, get) => ({
         break;
       }
 
-      case "runSettled":
+      case "runSettled": {
+        // Every agent that was working on this one has stopped, whether it
+        // finished, was refused or was stopped. Cleared by run rather than by
+        // agent because a cascade leaves several entries pointing at it.
+        set((state) => {
+          const activeRun = { ...state.activeRun };
+          let changed = false;
+          for (const [agent, run] of Object.entries(activeRun)) {
+            if (run === event.runId) {
+              delete activeRun[agent as AgentId];
+              changed = true;
+            }
+          }
+          return changed ? { activeRun } : {};
+        });
         // The live totals are additions to a number this corrects. Cheap: one
         // grouped sum over a local table, and only when a run has gone quiet.
         void get().refreshUsage();
         break;
+      }
 
       case "approvalRequested": {
         set((state) => ({
@@ -660,6 +717,14 @@ export const useStore = create<State>((set, get) => ({
 
   setSettings(settings) {
     set({ settings });
+  },
+
+  setPrefs(patch) {
+    set((state) => {
+      const prefs = { ...state.prefs, ...patch };
+      savePrefs(prefs);
+      return { prefs };
+    });
   },
 }));
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,22 @@ import ReactDOM from "react-dom/client";
 
 import App from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { applyAppearance } from "./lib/appearance";
+import { loadPrefs } from "./lib/prefs";
 import "./styles.css";
+
+/**
+ * The operator's scale and surface, before anything is drawn.
+ *
+ * `App` applies these too, and has to: it is what a change while the window is
+ * open goes through, and what follows the OS when the surface is set to. But an
+ * effect runs after the first commit has painted, so doing it only there means
+ * every launch shows one frame of white at 100% before snapping to whatever was
+ * stored. One synchronous write here, before the root is created, and there is
+ * nothing to snap from.
+ */
+const stored = loadPrefs();
+applyAppearance(stored.uiScale, stored.surface);
 
 /**
  * Paints a failure that happened before or outside React.

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,11 +3,16 @@
 /* ==========================================================================
    Guaca design tokens
 
-   A dark rail against a white page. The rail carries the identity — warm
-   olive-black, ripe avocado flesh as the one bright accent, pit brown for
-   anything the system says — and the reading column is paper, because that is
-   what long-form text wants. The surface does not follow the OS; a chat log is
-   read for minutes at a time and white wins that argument.
+   A dark rail against a page. The rail carries the identity — warm olive-black,
+   ripe avocado flesh as the one bright accent, pit brown for anything the
+   system says — and the reading column is the page.
+
+   Paper is what long-form text wants and it is still the default: a chat log is
+   read for minutes at a time and white wins that argument in a lit room. It
+   does not win it in a dark one, which is the whole reason the reading column
+   is a token block behind `data-surface` rather than a set of literals. The
+   rail is not part of that question. It is dark in both surfaces, and it pins
+   its own accents so nothing the reading column does can reach it.
 
    Type is three roles, not one. Space Grotesk carries names and titles, where
    a little character belongs. Inter carries everything you actually read for
@@ -27,10 +32,12 @@
   --rail-muted: #8b9c8d;
   --rail-wire: #2b3c32;
 
-  /* The reading surface is white, deliberately and unconditionally. Messages
-     are long-form text read for minutes at a time, and paper is the right
-     ground for that. The avocado palette stays where it belongs: the rail, the
-     agents, and the accents. */
+  /* The reading surface, and the only half of the app a surface choice moves.
+     Messages are long-form text read for minutes at a time, and paper is the
+     right ground for that in a lit room; the dark block below is the same seven
+     names and nothing else, which is what keeps "dark" from meaning "repaint
+     the app". The avocado palette stays where it belongs: the rail, the agents,
+     and the accents. */
   --ground: #fcfcfa;
   --raised: #ffffff;
   --sunken: #f2f1ea;
@@ -50,11 +57,60 @@
   --font-ui: "Inter Variable", system-ui, -apple-system, "Segoe UI", sans-serif;
   --font-mono: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, monospace;
 
-  --rail-w: 15.5rem;
+  /* Every length in this file is a rem, so the operator's interface scale is
+     one root font size and this is the multiplier behind it. A number rather
+     than a size, because it is also what a script would read back. */
+  --ui-scale: 1;
+
+  /* Capped against the viewport as well as scaled, because both of these grow
+     with the scale and the window's own minimum does not. At the largest scale
+     in the smallest window they would otherwise leave the reading column
+     narrower than a message can draw. */
+  --rail-w: min(15.5rem, 28vw);
   --radius: 0.7rem;
   --radius-sm: 0.4rem;
 
+  /* What a dialog is separated from the page by. A token because the answer is
+     different on dark paper, where a near-black wash over a near-black page
+     separates nothing. */
+  --scrim: rgb(11 17 13 / 0.55);
+
   --shadow-pop: 0 1.5rem 3rem -1rem rgb(24 33 27 / 0.22), 0 0 0 1px var(--edge);
+}
+
+/* Ink instead of paper.
+   Seven neutrals, four accents, a scrim and a shadow. Nothing else, and in
+   particular not one `--rail-*` name: the rail is dark in both surfaces and
+   redefining an accent it drew with would repaint it silently, which no test
+   would catch. `.rail` pins the two accents it does read.
+   The reading column sits lighter than the rail here, which is the same
+   relationship as on paper read the other way round: the rail is still the
+   darker frame and the column is still the surface you read on.
+   The accents are lifted rather than kept, because the product's olive and
+   brown are chosen against white and neither can be read on ink. They stay
+   recognisably the same colours; they are not the same values. */
+:root[data-surface="dark"] {
+  --ground: #1b1e1b;
+  --raised: #222622;
+  --sunken: #161916;
+  --edge: #30362f;
+  --text: #e7ebe2;
+  --muted: #a1aa9f;
+  /* Unchanged from paper on purpose: it is already the lightest of the three
+     greys and it is the one hints are set in, so it has the least contrast to
+     spare. */
+  --faint: #8a938a;
+
+  --flesh: #a8c95f;
+  --flesh-soft: #2b3320;
+  --pit: #c99a6a;
+  --pit-soft: #33281d;
+  --mint: #4fc48c;
+  --alarm: #e8705c;
+
+  --scrim: rgb(0 0 0 / 0.62);
+  /* The drop layer does nothing over a dark page, so the ring does the work. */
+  --shadow-pop: 0 1.5rem 3rem -1rem rgb(0 0 0 / 0.55), 0 0 0 1px var(--edge);
 }
 
 * {
@@ -83,10 +139,22 @@ body,
   margin: 0;
 }
 
+/* The anchor every rem in this file is measured against, and the one place the
+   interface scale is applied. 16px because that is what 1rem already resolved
+   to: nothing here or in Tailwind's preflight had ever set it, so anchoring on
+   the 15px body below would have shrunk the whole app by 6.25% at scale 1. */
+html {
+  font-size: calc(16px * var(--ui-scale));
+}
+
 body {
   font-family: var(--font-ui);
   font-optical-sizing: auto;
-  font-size: 15px;
+  /* The 15px this has always been, said in a unit that scales. Every element
+     that resets with `font: inherit` and names no size of its own falls back to
+     this, so leaving it absolute would freeze them while everything around them
+     grew. */
+  font-size: 0.9375rem;
   background: var(--ground);
   color: var(--text);
   -webkit-font-smoothing: antialiased;
@@ -107,13 +175,13 @@ button {
 }
 
 ::-webkit-scrollbar {
-  width: 11px;
-  height: 11px;
+  width: 0.7rem;
+  height: 0.7rem;
 }
 ::-webkit-scrollbar-thumb {
   background: color-mix(in oklab, var(--muted) 32%, transparent);
   border-radius: 99px;
-  border: 3px solid transparent;
+  border: 0.19rem solid transparent;
   background-clip: content-box;
 }
 ::-webkit-scrollbar-thumb:hover {
@@ -137,7 +205,8 @@ button {
 .rail__body,
 .rail__list,
 .inspector,
-.inspector__body {
+.inspector__body,
+.settings__pane {
   min-height: 0;
 }
 
@@ -157,7 +226,17 @@ button {
    Rail
    ========================================================================== */
 
+/* The rail is dark in both surfaces, so the two accents it draws with are the
+   paper values whatever the reading column is doing. Pinned here, on the one
+   element every rail rule descends from, rather than renamed at the twenty-odd
+   call sites in the reading half: this makes the rail a real colour scope
+   instead of a naming convention, and a new dark value for either token cannot
+   reach it by accident. `:focus-visible` is deliberately not covered — a focus
+   ring is drawn in both halves and should follow the surface it is drawn on. */
 .rail {
+  --flesh: #4e6b16;
+  --flesh-soft: #eef2d8;
+
   width: var(--rail-w);
   background: var(--rail-ground);
   color: var(--rail-text);
@@ -377,14 +456,14 @@ button {
 .pulse {
   position: absolute;
   left: 1.72rem;
-  width: 9px;
-  height: 9px;
-  margin-left: -4.5px;
-  border-radius: 3px;
+  width: 0.58rem;
+  height: 0.58rem;
+  margin-left: -0.29rem;
+  border-radius: 0.19rem;
   background: var(--pulse-color, var(--flesh));
   box-shadow:
-    0 0 0 3px color-mix(in oklab, var(--pulse-color, var(--flesh)) 22%, transparent),
-    0 0 10px color-mix(in oklab, var(--pulse-color, var(--flesh)) 45%, transparent);
+    0 0 0 0.19rem color-mix(in oklab, var(--pulse-color, var(--flesh)) 22%, transparent),
+    0 0 0.64rem color-mix(in oklab, var(--pulse-color, var(--flesh)) 45%, transparent);
   pointer-events: none;
   z-index: 2;
   animation: pulse-travel var(--pulse-duration, 620ms) cubic-bezier(0.35, 0, 0.3, 1) forwards;
@@ -1417,7 +1496,7 @@ button {
   border: 0;
   text-align: left;
   font-size: 0.78rem;
-  color: var(--ink);
+  color: var(--text);
 }
 
 .run__head:hover {
@@ -2177,6 +2256,14 @@ button {
   transform: none;
 }
 
+/* Always visible, unlike the label beside it. A control that appears on hover
+   is a control nobody knows is there, and this is the one thing on screen that
+   costs money to leave alone. */
+.working__stop {
+  margin-left: auto;
+  flex: none;
+}
+
 /* Lighter than the answer it is on the way to, and italic so a glance can tell
    the two apart without reading either: this is the only text in the pane that
    is not something anybody said. */
@@ -2606,13 +2693,13 @@ button {
   inset-block: 0;
   margin-left: 0.4rem;
   display: inline-flex;
-  gap: 2px;
+  gap: 0.13rem;
   align-items: center;
 }
 
 .wire__dots i {
-  width: 3px;
-  height: 3px;
+  width: 0.19rem;
+  height: 0.19rem;
   border-radius: 99px;
   background: currentColor;
   opacity: 0.4;
@@ -2862,6 +2949,14 @@ button {
   line-height: 1;
 }
 
+/* Four of these brands publish a black mark, and black on a dark chip is not
+   there at all. Mixed toward the foreground rather than replaced, so a brand
+   that does have a colour keeps most of it and the row still reads as a set of
+   different companies. The comment above rules out the other obvious fix. */
+:root[data-surface="dark"] .mark {
+  color: color-mix(in oklab, var(--mark, var(--muted)) 62%, var(--text));
+}
+
 .mark__icon {
   width: 0.85rem;
   height: 0.85rem;
@@ -3007,7 +3102,7 @@ button {
 .scrim {
   position: fixed;
   inset: 0;
-  background: rgb(11 17 13 / 0.55);
+  background: var(--scrim);
   display: flex;
   align-items: flex-start;
   justify-content: center;
@@ -3149,13 +3244,6 @@ button {
   color: var(--mint);
 }
 
-.divider {
-  height: 1px;
-  background: var(--edge);
-  margin: 1.1rem 0;
-  border: 0;
-}
-
 /* The animation is charm; someone who has asked the OS to stop moving things
    should still get a usable app. */
 @media (prefers-reduced-motion: reduce) {
@@ -3180,7 +3268,9 @@ button {
    ========================================================================== */
 
 .inspector {
-  width: 20rem;
+  /* Capped for the same reason as `--rail-w`: it scales and the window's
+     minimum does not. */
+  width: min(20rem, 30vw);
   flex: none;
   display: flex;
   flex-direction: column;
@@ -3498,7 +3588,7 @@ button {
   width: 0.85rem;
   height: 0.85rem;
   margin-top: 0.15rem;
-  border: 1.5px solid var(--mint);
+  border: 0.1rem solid var(--mint);
   border-radius: 50%;
   position: relative;
 }
@@ -3509,7 +3599,7 @@ button {
   position: absolute;
   left: 50%;
   bottom: 50%;
-  width: 1.5px;
+  width: 0.1rem;
   background: var(--mint);
   transform-origin: bottom center;
 }
@@ -4230,4 +4320,348 @@ button {
 
 .cafeteria__spacer {
   margin-left: auto;
+}
+
+/* ==========================================================================
+   Settings
+
+   Settings stopped being one column the moment it stopped being one subject.
+   An endpoint, a set of limits, a machine's credentials, how large the window
+   draws and what is allowed to interrupt you are five different questions, and
+   a single scroll made the operator read all five to change one.
+
+   So it is the Cafeteria's shape: a panel that owns its own height with a head
+   and a foot pinned to it, and one scrolling half. The nav is a vertical
+   tablist rather than the palette's horizontal one because there are eight
+   sections and they have names rather than one-word scopes.
+
+   Save and Test live in the foot, outside the scrolling half, because they act
+   on the whole panel and not on the section that happens to be open.
+   ========================================================================== */
+
+/* One height, not a height per section. Sized by its content under a
+   `max-height`, the panel was a different size on every pane — tall on
+   Provider, short on Appearance — so choosing a section resized the window
+   under the cursor and the foot moved out from under the button you were about
+   to press. A stated height, capped by the viewport, means the panes differ in
+   what they scroll and in nothing else. */
+.dialog--settings {
+  width: min(52rem, 100%);
+  display: flex;
+  flex-direction: column;
+  height: min(38rem, calc(100vh - 3rem));
+  padding: 0;
+}
+
+/* Focus lands here on open so the dialog owns the keyboard, but this is a
+   landing spot rather than a control: the ring belongs on the nav and the
+   fields inside. */
+.dialog--settings:focus,
+.dialog--settings:focus-visible {
+  outline: none;
+}
+
+.settings__head {
+  padding: 1.35rem 1.35rem 1rem;
+  border-bottom: 1px solid var(--edge);
+  flex: none;
+}
+
+.settings__body {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+}
+
+.settings__nav {
+  flex: none;
+  width: 11rem;
+  padding: 0.6rem 0.5rem;
+  border-right: 1px solid var(--edge);
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  overflow-y: auto;
+}
+
+.settings__tab {
+  border: 0;
+  background: none;
+  text-align: left;
+  padding: 0.4rem 0.55rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.82rem;
+  color: var(--muted);
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.settings__tab:hover {
+  background: var(--sunken);
+  color: var(--text);
+}
+
+.settings__tab[aria-selected="true"] {
+  background: var(--sunken);
+  color: var(--text);
+  font-weight: 600;
+}
+
+.settings__pane {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.1rem 1.35rem 1.35rem;
+}
+
+.settings__title {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0 0 0.2rem;
+}
+
+.settings__lede {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 0 0 1.1rem;
+  line-height: 1.5;
+  max-width: 34rem;
+}
+
+.settings__foot {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 0.9rem 1.35rem;
+  border-top: 1px solid var(--edge);
+  flex: none;
+}
+
+/* The one action that belongs to a single pane rather than to the panel. It
+   reads the endpoint, the key and the model, which are all in arm's reach of
+   it here and were two sections away when it sat in the foot. */
+.settings__probe {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-top: 1.2rem;
+}
+
+/* A row of choices that are one choice: the surface, the scale. Radio
+   semantics rather than a select, because the whole point is seeing the options
+   at once and the set is always short. */
+.choices {
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+
+.choice {
+  border: 1px solid var(--edge);
+  background: var(--raised);
+  color: var(--muted);
+  border-radius: var(--radius-sm);
+  padding: 0.32rem 0.7rem;
+  font-size: 0.78rem;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+.choice:hover:not([aria-pressed="true"]):not([aria-checked="true"]) {
+  color: var(--text);
+  border-color: color-mix(in oklab, var(--flesh) 40%, var(--edge));
+}
+
+.choice:disabled {
+  color: var(--faint);
+  border-color: color-mix(in oklab, var(--edge) 60%, transparent);
+  background: none;
+  cursor: default;
+}
+
+.choice[aria-pressed="true"],
+.choice[aria-checked="true"] {
+  border-color: var(--flesh);
+  background: color-mix(in oklab, var(--flesh) 10%, var(--raised));
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* One switchable thing with a name and a reason, stacked. Used by the
+   notification kinds, where there are five in a row and a `.field` each would
+   put a third of the pane's height into labels. */
+.switch-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--edge);
+}
+
+.switch-row:last-of-type {
+  border-bottom: 0;
+}
+
+.switch-row__text {
+  min-width: 0;
+  flex: 1;
+}
+
+.switch-row__label {
+  display: block;
+  font-size: 0.84rem;
+  color: var(--text);
+}
+
+.switch-row[data-off="true"] .switch-row__label {
+  color: var(--faint);
+}
+
+.switch-row__hint {
+  display: block;
+  font-size: 0.74rem;
+  color: var(--faint);
+  margin-top: 0.1rem;
+  line-height: 1.45;
+}
+
+/* One provider the operator can pick, with what is known about it. A button
+   rather than a row of radio inputs because choosing one fills in a field
+   rather than setting a value: it is an action with a current state. */
+/* One line each. Stacked over two, at seven presets, the picker filled the
+   whole pane and pushed the endpoint and the key below the fold — a shortcut
+   for filling a field, hiding the field. */
+.preset {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--edge);
+  background: var(--raised);
+  border-radius: var(--radius-sm);
+  padding: 0.34rem 0.6rem;
+  margin-bottom: 0.25rem;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+
+.preset:hover {
+  border-color: color-mix(in oklab, var(--flesh) 40%, var(--edge));
+}
+
+.preset[aria-current="true"] {
+  border-color: var(--flesh);
+  background: color-mix(in oklab, var(--flesh) 8%, var(--raised));
+}
+
+.preset__text {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.preset__name {
+  flex: none;
+  font-size: 0.82rem;
+  color: var(--text);
+}
+
+/* Gives up its room first: the name is what the row is picked by, and a
+   truncated URL still says which host it points at. */
+.preset__url {
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  color: var(--faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Whether this one is usable right now. Never a reason not to choose it: a
+   provider with no key is exactly what somebody about to paste a key is
+   looking at, so the state is information rather than a refusal. */
+.preset__state {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+
+.preset__state[data-ready="true"] {
+  color: var(--mint);
+}
+
+/* The shortcuts table. A definition list, because that is what it is. */
+.keys {
+  margin: 0 0 1.1rem;
+}
+
+.keys__group {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  font-weight: 500;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0.9rem 0 0.35rem;
+}
+
+.keys__row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid var(--edge);
+}
+
+.keys__row:last-child {
+  border-bottom: 0;
+}
+
+.keys__what {
+  flex: 1;
+  font-size: 0.82rem;
+  color: var(--text);
+}
+
+.keys__combo {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted);
+  background: var(--sunken);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  padding: 0.1rem 0.36rem;
+  white-space: nowrap;
+}
+
+/* About. Centred, because it is the one pane that is a statement rather than a
+   set of controls. */
+.about {
+  text-align: center;
+  padding: 1rem 0 0.5rem;
+}
+
+.about__name {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.about__version {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--faint);
+  margin: 0.25rem 0 0;
+}
+
+.about__facts {
+  margin: 1.2rem 0 0;
+  text-align: left;
 }

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -42,6 +42,24 @@ if (!("IntersectionObserver" in globalThis)) {
     IntersectionObserverStub;
 }
 
+// jsdom 27 ships no media queries at all, so every non-optional `matchMedia`
+// call takes the whole tree down. A stub rather than a polyfill: nothing here
+// evaluates a query, so every one of them resolves to not-matching, which is
+// the light-surface, full-motion default the app is built around. A test that
+// wants the other answer overrides this one for the length of that test.
+if (!("matchMedia" in globalThis)) {
+  (globalThis as unknown as { matchMedia: unknown }).matchMedia = (media: string) => ({
+    matches: false,
+    media,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  });
+}
+
 // Tauri injects this into the real webview before the app loads. Only the URL
 // builder is needed: `lib/files.ts` addresses a stored file with it, and every
 // command goes through a mock.


### PR DESCRIPTION
Settings becomes a nav and eight panes — General, Provider, Limits, Machines, Appearance, Notifications, Shortcuts, About — with every value held in the shell so changing section cannot discard typed input, and Test connection moved into Provider beside the three fields it actually reads.

The reading column gains an ink surface and a 90/100/110/125 interface scale, both local to this machine and neither known to an agent; the rail pins `--flesh` and `--flesh-soft` on itself so it stays dark in both, and `system` is resolved before it reaches the document so there is one dark token block rather than two that have to agree.

Notifications arrive as four kinds under three rules about where the operator is looking, plus a four-second quiet window after launch, because an overdue routine fires on the first tick and starting after a weekend should not announce a weekend of schedule at once.

A run can now be stopped: `stop_run` marks the run and wakes what is asleep on it while releasing nothing, since `track_inflight` reads a negative delta against an untracked run as that run settling; four boundaries notice the mark and each releases through `finish_turn`, and every check sits before `reserve_step` so a stopped run still reports the calls it made and no others.

Also a keyboard reference, provider presets, an About pane, and a message animation that no longer polls twelve times a second while nothing is moving — 699 frontend, 511 Rust unit, 54 cascade and 18 trajectory tests pass, though dark mode has so far been verified only on the settings surface and not on the transcript itself.