### PR TITLE
feat: a document is handed over rather than named, and read as a document

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ repo: the frontend renders state and forwards intent.
 | Permission prompts, parked turns, acting in the operator's name | *A protected action parks the turn that asked for it* |
 | What an agent may do with a page it has just read | *A page that was read this turn cannot quietly press a button* |
 | Screenshots, coordinates, what a screen action answers with | *A computer is looked at, never asked* in `docs/MACHINES.md` |
-| Attachments, previews, drops | *Files are references, and what a model gets depends on what they are* |
+| Attachments, previews, drops, handing a document to the operator | *Files are references, and what a model gets depends on what they are* |
 | SQLite, the pool, migrations | *Storage*, and the two comments in `Store::open` |
 | Schedules, triggers, what a firing looks like | `docs/ROUTINES.md` |
 | Sandboxes, the desktop, the screen, sign-ins on it | `docs/MACHINES.md` |
@@ -114,6 +114,13 @@ the model takes a screenshot to see what `browse` did.
 - **`FileCard` hands the frame a `blob:` URL on purpose.** WebKit refuses a
   custom scheme in a frame and says nothing. A direct `guacfile:` `src` passes
   every test in this repo and draws an empty rectangle.
+- **`emit_reply` delivers a reply that carries a file and no text.** Handing over
+  a document with nothing typed is normal, and judging the reply empty by its
+  text alone drops the thing the turn was spent producing.
+- **`body_with_files` names a file on an agent's own turns too, not just on
+  incoming ones.** An agent that reads its last turn back without the file it
+  attached has no record of handing anything over, so it attaches the document
+  again and reports it as the first time.
 - **Only the component drawing the live bubbles subscribes to `streams`.** One
   level higher, a single token re-renders every message in the transcript.
 - **The sign-in tests carry real cookie names.** A cookie's presence is not a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -457,6 +457,34 @@ which is where an agent that *produced* a document has it. The operator's end is
 the same pipe: `dragDropEnabled` hands Rust the dropped paths, so the bytes are
 read on the Rust side and never enter the webview.
 
+**A file reaches the operator on the turn's own answer, through `attach_file`.**
+For a while it could not reach them at all. `send_message` carries files to
+another agent; a turn's final message carried text and nothing else, so an agent
+asked for a brief wrote one, saved it, and ended its turn with the path. That
+reads as success and is not: `/home/user/brief.md` is a location on a sandbox
+the operator does not have, in an app with nothing to click. The tool resolves
+its arguments through the same `resolve_files` a send uses, and `emit_reply`
+puts what came back on the reply envelope rather than sending anything of its
+own, so there is no second message, no extra hop and nothing new for the guard
+to judge. Three consequences worth knowing:
+
+- **The reply is delivered when it carries a file and no text.** Handing over a
+  document with nothing typed is normal, and a reply judged empty by its text
+  alone would drop the thing the whole turn was spent producing.
+- **It attaches to whatever the reply is addressed to.** In every mode but
+  `ToPeer` that is the operator's channel, including `Assigned`, where a
+  delegated agent's answer is filed as a note. A peer turn attaches to the peer,
+  which is the honest reading of "attach to your answer".
+- **An agent's own attachments are named back to it.** `body_with_files` runs
+  over own messages as well as incoming ones. Without it an agent reads its last
+  turn back with no file in it, has no record of handing anything over, and
+  attaches the same document again while telling the operator it is the first
+  time.
+
+The prompt states the mistake rather than the feature (*Handing over a
+document*), because the tool schema alone was not enough: a model that has just
+saved a file has no reason to go looking for a tool it does not know it needs.
+
 **A drop is taken into the store before anything is sent.** `stage_files` runs
 on the drop, which is what lets the app refuse a 40 MB archive while the
 operator is still holding it rather than failing the message they went on to
@@ -478,11 +506,21 @@ not 64 hex characters is refused before it is ever joined onto a path. The
 name in the URL decides the type of the answer and nothing else.
 
 A transcript draws what it can of a file rather than naming it: a picture, a
-document's first page in the webview's own viewer, the first lines of anything
-textual, and for the rest a row saying what it is. Each opens a full view, and
-each offers a copy into the downloads folder, whose path is said out loud
-because a file saved somewhere the operator has to go looking for has not really
-been saved.
+document's first page in the webview's own viewer, a markdown file as the
+document it is, the first lines of anything else textual, and for the rest a row
+saying what it is. Each opens a full view, and each offers a copy into the
+downloads folder, whose path is said out loud because a file saved somewhere the
+operator has to go looking for has not really been saved.
+
+Markdown is its own preview kind because it is what the agents write in. A brief
+drawn as monospace `##` is a document the operator reads around rather than
+through, and every message body in this app is already rendered as the prose it
+is: a file is the same prose that happened to arrive as a file. It goes through
+the same `Markdown` component, which means the same trust decision, and that is
+the point rather than a coincidence. Raw HTML is off because `rehype-raw` is not
+installed, and a document off an agent's machine is no more trustworthy than the
+message that carried it. Anything else textual stays source: a log is not prose,
+and markdown rules applied to one eat its punctuation.
 
 One exception, and it is WebKit's. A custom scheme is allowed in an `img` and
 a `fetch` if the CSP names it, and refused in a frame however it is named, as

--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -27,6 +27,7 @@ pub const BROWSE: &str = "browse";
 pub const SCHEDULE: &str = "schedule";
 pub const CREATE_AGENT: &str = "create_agent";
 pub const REQUEST_PERMISSION: &str = "request_permission";
+pub const ATTACH_FILE: &str = "attach_file";
 
 /// Which of the two places an agent has been given, which decides which tools
 /// it is offered.
@@ -484,6 +485,40 @@ fn all_specs() -> Vec<ToolSpec> {
                 "additionalProperties": false
             }),
         },
+        ToolSpec {
+            name: ATTACH_FILE.to_string(),
+            // The eleventh tool, and it earns its place because without it a
+            // document an agent produces has no way to reach the operator at
+            // all. `send_message` carries files to another agent; the answer a
+            // turn ends with carried text and nothing else, so an agent asked
+            // for a brief wrote one and then typed the path to it. The operator
+            // read `/home/user/brief.md`, which is a path on a machine that is
+            // not theirs, in an app with no way to open it.
+            description: "Attach a file to your answer, so whoever reads it can open it. The \
+                          file you made is on your own computer and nobody else can reach that \
+                          machine, so writing its path into your answer hands over nothing: this \
+                          is what actually delivers it. Name it by its path, for example \
+                          `/home/user/brief.md`, or by the name of a file already attached to \
+                          something in your channel. Attach anything you were asked to produce as \
+                          a document and anything easier read as one: a brief, a report, a table, \
+                          a draft. Then say what it is in your answer rather than repeating its \
+                          contents, because the reader has the file itself."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "files": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "minItems": 1,
+                        "description": "The files to attach: a path on your computer, or the \
+                                        name of one already in your channel."
+                    }
+                },
+                "required": ["files"],
+                "additionalProperties": false
+            }),
+        },
     ]
 }
 
@@ -494,6 +529,10 @@ pub enum ToolInvocation {
         to: Vec<String>,
         text: String,
         intent: Intent,
+        files: Vec<String>,
+    },
+    /// Hand files to whoever this turn is answering, on the answer itself.
+    AttachFile {
         files: Vec<String>,
     },
     /// Stop and ask the operator whether to go ahead.
@@ -572,8 +611,8 @@ pub enum ScreenAction {
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum ToolParseError {
     #[error(
-        "unknown tool {name:?}. Available tools: directory, send_message, update_notes, \
-         run_command, open_on_desktop, use_screen, browse, schedule, create_agent."
+        "unknown tool {name:?}. Available tools: directory, send_message, attach_file, \
+         update_notes, run_command, open_on_desktop, use_screen, browse, schedule, create_agent."
     )]
     UnknownTool { name: String },
     #[error("arguments for {name} were not valid JSON: {detail}")]
@@ -582,6 +621,8 @@ pub enum ToolParseError {
     MissingRecipients,
     #[error("send_message needs a non-empty `text`")]
     MissingText,
+    #[error("attach_file needs a non-empty `files` list")]
+    MissingFiles,
     #[error("update_notes needs a `content` string")]
     MissingContent,
     #[error("run_command needs a non-empty `command` string")]
@@ -610,7 +651,7 @@ impl ToolParseError {
             ToolParseError::UnknownTool { name } => {
                 format!(
                     "Error: no tool named {name:?}. You can call `directory`, `send_message`, \
-                     `update_notes` (your memory), or `run_command`."
+                     `attach_file`, `update_notes` (your memory), or `run_command`."
                 )
             }
             ToolParseError::BadJson { name, detail } => format!(
@@ -658,6 +699,12 @@ impl ToolParseError {
             }
             ToolParseError::MissingText => {
                 "Error: `text` must be a non-empty string containing the message body.".to_string()
+            }
+            ToolParseError::MissingFiles => {
+                "Error: `files` must name at least one file, by its path on your computer or by \
+                 the name of one already in your channel, for example \
+                 {\"files\": [\"/home/user/brief.md\"]}."
+                    .to_string()
             }
             ToolParseError::IncompleteAgent { needs } => format!(
                 "Error: to create an agent you need {needs}. For example {{\"name\": \"Chief of \
@@ -1082,6 +1129,27 @@ pub fn parse(call: &ToolCall) -> Result<ToolInvocation, ToolParseError> {
 
             Ok(ToolInvocation::SendMessage { to, text, intent, files })
         }
+        // The aliases are the words a model reaches for when it has just been
+        // told to give the operator a document. Each names this and nothing
+        // else, so refusing one buys a retry and a turn spent on spelling.
+        ATTACH_FILE | "attach" | "attach_files" | "share_file" | "show_file" | "send_file" => {
+            let value = call.parsed_arguments().map_err(|e| ToolParseError::BadJson {
+                name: ATTACH_FILE.to_string(),
+                detail: e.to_string(),
+            })?;
+            let files = normalize_list(
+                value
+                    .get("files")
+                    .or_else(|| value.get("attachments"))
+                    .or_else(|| value.get("paths"))
+                    .or_else(|| value.get("path"))
+                    .or_else(|| value.get("file")),
+            );
+            if files.is_empty() {
+                return Err(ToolParseError::MissingFiles);
+            }
+            Ok(ToolInvocation::AttachFile { files })
+        }
         other => Err(ToolParseError::UnknownTool { name: other.to_string() }),
     }
 }
@@ -1112,8 +1180,15 @@ fn normalize_list(value: Option<&serde_json::Value>) -> Vec<String> {
                         }
                     }
                     serde_json::Value::Object(map) => {
-                        if let Some(serde_json::Value::String(name)) =
-                            map.get("name").or_else(|| map.get("agent"))
+                        // `path` and `file` for an attachment, the other two
+                        // for a recipient. One list serves both callers, and a
+                        // key that means nothing to one of them cannot collide
+                        // with anything the other sends.
+                        if let Some(serde_json::Value::String(name)) = map
+                            .get("name")
+                            .or_else(|| map.get("agent"))
+                            .or_else(|| map.get("path"))
+                            .or_else(|| map.get("file"))
                         {
                             let trimmed = name.trim();
                             if !trimmed.is_empty() {
@@ -1569,9 +1644,9 @@ mod tests {
         let specs = specs(Surfaces::both());
         assert_eq!(
             specs.len(),
-            10,
+            11,
             "directory, run_command, open_on_desktop, use_screen, browse, schedule, \
-             create_agent, request_permission, send_message, update_notes"
+             create_agent, request_permission, send_message, attach_file, update_notes"
         );
         for spec in &specs {
             assert_eq!(
@@ -2016,5 +2091,64 @@ mod tests {
     #[test]
     fn delivery_rendering_handles_an_empty_result() {
         assert_eq!(render_deliveries(&[]), "No messages were sent.");
+    }
+
+    #[test]
+    fn a_file_is_attached_whichever_word_the_model_reached_for() {
+        // An agent that has just been told to give the operator a document
+        // reaches for whatever its training used. Each of these names this and
+        // nothing else, so refusing one costs a turn on spelling.
+        for name in
+            ["attach_file", "attach", "attach_files", "share_file", "show_file", "send_file"]
+        {
+            let parsed = parse(&call(name, r#"{"files":["/home/user/brief.md"]}"#));
+            assert_eq!(
+                parsed,
+                Ok(ToolInvocation::AttachFile { files: vec!["/home/user/brief.md".into()] }),
+                "{name} should attach"
+            );
+        }
+    }
+
+    #[test]
+    fn one_file_arrives_however_a_model_spells_the_argument() {
+        // The schema says an array under `files`. A single path under `path` is
+        // the near miss a model makes when it has exactly one document, and it
+        // is unambiguous.
+        for arguments in [
+            r#"{"files":["brief.md"]}"#,
+            r#"{"files":"brief.md"}"#,
+            r#"{"attachments":["brief.md"]}"#,
+            r#"{"paths":["brief.md"]}"#,
+            r#"{"path":"brief.md"}"#,
+            r#"{"file":"brief.md"}"#,
+            r#"{"files":[{"path":"brief.md"}]}"#,
+        ] {
+            assert_eq!(
+                parse(&call(ATTACH_FILE, arguments)),
+                Ok(ToolInvocation::AttachFile { files: vec!["brief.md".into()] }),
+                "{arguments} should attach one file"
+            );
+        }
+    }
+
+    #[test]
+    fn an_attach_that_names_nothing_is_told_what_a_call_looks_like() {
+        for arguments in ["{}", r#"{"files":[]}"#, r#"{"files":""}"#] {
+            let err = parse(&call(ATTACH_FILE, arguments)).unwrap_err();
+            assert_eq!(err, ToolParseError::MissingFiles, "{arguments}");
+            // A refusal that only says no gets reworded and retried.
+            assert!(err.guidance().contains("/home/user/brief.md"), "{}", err.guidance());
+        }
+    }
+
+    #[test]
+    fn attaching_is_offered_with_no_computer_and_no_browser() {
+        // Forwarding a file already in the channel is host-side and needs no
+        // machine at all, and an operator with no provider configured is
+        // exactly the person who still wants the document.
+        let offered: Vec<String> =
+            specs(Surfaces::none()).into_iter().map(|spec| spec.name).collect();
+        assert!(offered.contains(&ATTACH_FILE.to_string()), "{offered:?}");
     }
 }

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -301,6 +301,17 @@ const INBOX: &str = "/home/user/inbox";
 /// command line, and few enough round trips to be worth it.
 const PLACE_CHUNK: usize = 192 * 1024;
 
+/// What a model is told it has lost when a file it named could not be resolved.
+///
+/// Two sentences, one per caller, because the mistake each is about to make is
+/// different: a send leaves a colleague waiting for a document, an attach
+/// leaves an answer claiming one. Silence is the worst outcome available in
+/// both cases, since agent and reader would each believe the file arrived.
+const UNSENT_FILE: &str = "The recipient did not get it, so do not tell them it is on the way.";
+const UNATTACHED_FILE: &str =
+    "It is not on your answer, so do not tell them it is attached. Check the path with \
+     `run_command` and attach it again, or say plainly that you could not hand it over.";
+
 /// How long an agent will wait for peers that are still answering the same
 /// thing, before reading what it already has.
 ///
@@ -816,10 +827,18 @@ impl Runtime {
     /// Returns what travelled and, for everything that did not, a line worded
     /// for the model: an agent that believes it attached a document will go on
     /// to discuss a file nobody else can see.
+    ///
+    /// `consequence` is what the caller wants said about the failure, because
+    /// the two callers lose different things. A `send_message` that dropped a
+    /// file has a recipient who never received it and is about to be told it is
+    /// on the way; an `attach_file` that dropped one has an answer that is
+    /// about to claim a document is attached to it. Both need the reason and
+    /// then their own sentence about what not to do next.
     async fn resolve_files(
         &self,
         card: &AgentCard,
         wanted: &[String],
+        consequence: &str,
     ) -> (Vec<Attachment>, Vec<String>) {
         let mut found = Vec::new();
         let mut missing = Vec::new();
@@ -837,10 +856,7 @@ impl Runtime {
             // Not something it was sent, so it is something it made.
             match self.pull_file(card, name).await {
                 Ok(file) => found.push(file),
-                Err(why) => missing.push(format!(
-                    "{name} was not attached: {why}. The recipient did not get it, so do not \
-                     tell them it is on the way."
-                )),
+                Err(why) => missing.push(format!("{name} was not attached: {why}. {consequence}")),
             }
         }
         (found, missing)
@@ -1626,6 +1642,11 @@ impl Runtime {
         let mut addressed: HashSet<AgentId> = HashSet::new();
         // What this turn has read off the web, and where from.
         let mut reading = Reading::default();
+        // Files `attach_file` has put on the answer this turn has not written
+        // yet. Collected here rather than sent as they arrive, because they
+        // belong on the message the agent is still composing: a file delivered
+        // the moment it was named would sit above the sentence explaining it.
+        let mut attached: Vec<Attachment> = Vec::new();
         let mut failure: Option<LlmError> = None;
         let mut hit_tool_ceiling = false;
         let mut budget_exhausted = false;
@@ -1708,6 +1729,7 @@ impl Runtime {
                         settled,
                         &mut addressed,
                         &mut reading,
+                        &mut attached,
                         call,
                     )
                     .await;
@@ -1819,6 +1841,7 @@ impl Runtime {
                 &addressed,
                 collected_text,
                 tool_parts,
+                attached,
             );
         }
 
@@ -1918,6 +1941,7 @@ impl Runtime {
         addressed: &HashSet<AgentId>,
         text: String,
         mut tool_parts: Vec<Part>,
+        files: Vec<Attachment>,
     ) {
         let text = text.trim().to_string();
         let me = Participant::Agent { id: card.id };
@@ -2021,7 +2045,11 @@ impl Runtime {
             }
         }
 
-        if text.is_empty() {
+        // A file with nothing typed is still an answer, and the one this app
+        // was missing: "here is the brief" is a courtesy the model often
+        // skips. Judging the reply empty by its text alone would drop the
+        // document the whole turn was spent producing.
+        if text.is_empty() && files.is_empty() {
             return;
         }
 
@@ -2035,7 +2063,7 @@ impl Runtime {
             channel_id,
             from: me,
             to,
-            parts: vec![Part::text(text)],
+            parts: with_files(&text, files),
             trust: Trust::Peer,
             hop,
             // An agent's answer never itself demands an answer. This is the
@@ -2067,6 +2095,8 @@ impl Runtime {
         addressed: &mut HashSet<AgentId>,
         // What this turn has read off the web so far. See `Reading`.
         reading: &mut Reading,
+        // Files this turn has attached to the answer it has not written yet.
+        attached: &mut Vec<Attachment>,
         call: &ToolCall,
     ) -> ToolResult {
         let arguments = call.parsed_arguments().unwrap_or(serde_json::Value::Null);
@@ -2080,6 +2110,7 @@ impl Runtime {
                 settled,
                 addressed,
                 reading,
+                attached,
                 call,
                 arguments,
             )
@@ -2099,6 +2130,7 @@ impl Runtime {
         settled: bool,
         addressed: &mut HashSet<AgentId>,
         reading: &mut Reading,
+        attached: &mut Vec<Attachment>,
         call: &ToolCall,
         arguments: serde_json::Value,
     ) -> (String, Part, Option<String>) {
@@ -2335,7 +2367,7 @@ impl Runtime {
             }
 
             ToolInvocation::SendMessage { to, text, intent, files } => {
-                let (attached, missing) = self.resolve_files(card, &files).await;
+                let (carried, missing) = self.resolve_files(card, &files, UNSENT_FILE).await;
                 let deliveries = self.send_to_peers(
                     card,
                     run_id,
@@ -2346,7 +2378,7 @@ impl Runtime {
                     &to,
                     &text,
                     intent,
-                    &attached,
+                    &carried,
                 );
                 let rendered = tools::render_deliveries(&deliveries);
                 let queued =
@@ -2394,6 +2426,63 @@ impl Runtime {
                 (
                     rendered,
                     Part::ToolCall { name: tools::SEND_MESSAGE.to_string(), arguments, outcome },
+                )
+            }
+
+            ToolInvocation::AttachFile { files } => {
+                let (found, missing) = self.resolve_files(card, &files, UNATTACHED_FILE).await;
+
+                // Deduplicated against the turn rather than the call: a model
+                // that attaches the brief, writes a paragraph, then attaches
+                // the brief again would otherwise put two identical cards under
+                // one message. The digest is the identity, so the same document
+                // named two ways is one attachment.
+                let mut added: Vec<String> = Vec::new();
+                for file in found {
+                    if attached.iter().any(|held| held.digest == file.digest) {
+                        continue;
+                    }
+                    added.push(file.name.clone());
+                    attached.push(file);
+                }
+
+                let outcome = match (added.is_empty(), missing.is_empty()) {
+                    (false, true) => {
+                        ToolOutcome::Ok { summary: format!("attached {}", added.join(", ")) }
+                    }
+                    (false, false) => ToolOutcome::Partial {
+                        summary: format!("attached {} of {}", added.len(), files.len()),
+                        refused: missing
+                            .iter()
+                            .map(|why| RefusedRecipient {
+                                to: "attachment".to_string(),
+                                reason: why.clone(),
+                            })
+                            .collect(),
+                    },
+                    (true, false) => ToolOutcome::Refused { reason: missing.join(" ") },
+                    // Every name resolved to something already attached, which
+                    // is not a failure: the answer carries the file either way.
+                    (true, true) => ToolOutcome::Ok { summary: "already attached".to_string() },
+                };
+
+                let mut rendered = if added.is_empty() {
+                    "Nothing new was attached.".to_string()
+                } else {
+                    format!(
+                        "{} attached to your answer. The reader gets the file itself, so say what \
+                         it is rather than repeating what is in it.",
+                        added.join(", ")
+                    )
+                };
+                if !missing.is_empty() {
+                    rendered.push('\n');
+                    rendered.push_str(&missing.join("\n"));
+                }
+
+                (
+                    rendered,
+                    Part::ToolCall { name: tools::ATTACH_FILE.to_string(), arguments, outcome },
                 )
             }
         };

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -386,6 +386,28 @@ pub fn system_prompt(
          not let you.\n",
     );
 
+    // Said here as well as in the tool schema, and said as the failure rather
+    // than as the feature, because the failure is what actually happened: an
+    // agent wrote a brief, saved it, and ended its turn with the path to it.
+    // Nothing in the app was broken. The operator was handed a location on a
+    // machine they do not have and cannot reach, in a chat window with nothing
+    // to click, and the document may as well not have existed.
+    out.push_str(
+        "\n## Handing over a document\n\
+         Your computer is yours alone. Nobody else can open a path on it, so naming a file you \
+         made, or its directory, or telling the operator it is on screen in an editor, hands over \
+         nothing at all: they cannot reach any of it.\n\
+         - `attach_file` is what delivers it. Give it the path and the file rides on your reply, \
+         where the operator can read it, open it and save it.\n\
+         - Attach anything you were asked to produce as a document, and anything long enough that \
+         a file reads better than a message: a brief, a report, a table, a draft.\n\
+         - Then write your reply as if they are holding it, because they are. Say what it is and \
+         what you want them to notice. Do not paste its contents back, and do not describe where \
+         it lives.\n\
+         - To hand the same file to a colleague rather than to the operator, pass it in the \
+         `files` of a `send_message`.\n",
+    );
+
     out.push_str("\n## Your reply\n");
     out.push_str(match mode {
         ReplyMode::ToOperator => {
@@ -458,18 +480,31 @@ fn is_empty(envelope: &Envelope) -> bool {
     envelope.plain_text().is_empty() && attachments(envelope).is_empty()
 }
 
-fn render_incoming(envelope: &Envelope, names: &NameTable) -> String {
+/// A message's text with a line naming each file it carried.
+///
+/// The line is the only way a file appears in a message at all: what the file
+/// *is* arrives separately, because the runtime shows a picture, reads out text
+/// or puts the file on a machine, and says which it did.
+///
+/// Used for a message this agent sent as well as one it received. An agent that
+/// attached a brief and read its own turn back without the file in it had no
+/// record of having handed anything over, so it attached the brief again on the
+/// next turn and told the operator it was sending it for the first time.
+fn body_with_files(envelope: &Envelope) -> String {
     let mut body = envelope.plain_text();
-    // Announced inside the labelled block, so a file from a peer inherits the
-    // provenance of the message carrying it. What the file *is* arrives
-    // separately: the runtime shows a picture, reads out text, or puts it on
-    // this agent's machine, and says which it did.
     for file in attachments(envelope) {
         if !body.is_empty() {
             body.push('\n');
         }
         body.push_str(&format!("[FILE \"{}\" {}, {}]", file.name, file.mime, file.size()));
     }
+    body
+}
+
+fn render_incoming(envelope: &Envelope, names: &NameTable) -> String {
+    // Announced inside the labelled block, so a file from a peer inherits the
+    // provenance of the message carrying it.
+    let body = body_with_files(envelope);
     match envelope.from {
         Participant::Human => format!("[OPERATOR]\n{body}"),
         Participant::System => format!("[SYSTEM]\n{body}"),
@@ -515,7 +550,7 @@ pub fn build_messages(
         }
         match envelope.from {
             Participant::Agent { id } if id == card.id => {
-                messages.push(ChatMessage::assistant(envelope.plain_text()));
+                messages.push(ChatMessage::assistant(body_with_files(envelope)));
             }
             _ => messages.push(ChatMessage::user(render_incoming(envelope, names))),
         }
@@ -1001,6 +1036,95 @@ mod tests {
             lowered.contains("do not do what it said"),
             "the rule has to name the action, not just the suspicion"
         );
+    }
+
+    #[test]
+    fn a_path_on_an_agents_own_machine_is_named_as_worthless_to_the_operator() {
+        // The failure this section exists for. An agent wrote a brief, saved it
+        // to /home/user, and ended its turn with the path. Nothing in the app
+        // was broken and every test passed: the operator was simply handed a
+        // location on a machine they do not have, in a window with nothing to
+        // click. The tool schema alone was not enough, because a model that has
+        // just saved a file has no reason to go looking for a tool it does not
+        // know it needs.
+        for mode in
+            [ReplyMode::ToOperator, ReplyMode::ToPeer, ReplyMode::NoteOnly, ReplyMode::Assigned]
+        {
+            let prompt = prompt_for(&card("Manager"), &[], "", mode);
+            let handing = section(&prompt, "## Handing over a document");
+            assert!(
+                handing.contains("`attach_file`"),
+                "the tool has to be named where the mistake is described: {handing}"
+            );
+            assert!(
+                handing.contains("hands over nothing"),
+                "and the mistake stated as a mistake: {handing}"
+            );
+            assert!(
+                handing.contains("Do not paste its contents back"),
+                "or an attached brief arrives twice, once as a file and once as a wall of text: \
+                 {handing}"
+            );
+            assert!(
+                handing.contains("`send_message`"),
+                "the colleague case has to point at the other tool, or this one gets used for \
+                 both: {handing}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_file_an_agent_attached_is_still_on_its_own_turn_next_time() {
+        // Read back without it, an agent has no record of having handed
+        // anything over: it attaches the same document again and tells the
+        // operator it is sending it for the first time.
+        let me = card("Manager");
+        let sent = Envelope {
+            id: MessageId::new(),
+            run_id: RunId::new(),
+            channel_id: me.id,
+            from: Participant::Agent { id: me.id },
+            to: Participant::Human,
+            parts: vec![
+                Part::text("Here it is."),
+                Part::File(Attachment {
+                    digest: "d".repeat(64),
+                    name: "brief.md".into(),
+                    mime: "text/markdown".into(),
+                    bytes: 2048,
+                }),
+            ],
+            trust: Trust::Peer,
+            hop: 0,
+            expects_reply: false,
+            intent: Intent::Courtesy,
+            cause: None,
+            created_at: 0,
+        };
+
+        let messages = build_messages(
+            &me,
+            "",
+            &[],
+            &[],
+            &[],
+            &NameTable::new(),
+            "",
+            &[sent],
+            &[],
+            ReplyMode::ToOperator,
+            Surfaces::both(),
+        );
+        let assistant = messages
+            .iter()
+            .filter_map(|m| match m {
+                ChatMessage::Assistant { content, .. } => content.clone(),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(assistant.contains("Here it is."), "{assistant}");
+        assert!(assistant.contains("brief.md"), "its own turn lost the file: {assistant}");
     }
 
     #[test]

--- a/src-tauri/tests/files.rs
+++ b/src-tauri/tests/files.rs
@@ -317,3 +317,191 @@ async fn a_file_never_leaks_into_the_text_of_a_message() {
         .expect("the operator's message is in the channel");
     assert_eq!(stored.plain_text(), "read this");
 }
+
+/// Every file part on a message this agent sent to the operator, oldest first.
+fn handed_over(h: &Harness, agent: &str) -> Vec<String> {
+    h.runtime
+        .store()
+        .channel_messages(h.id(agent), 200)
+        .unwrap()
+        .iter()
+        .filter(|envelope: &&Envelope| envelope.to == Participant::Human)
+        .flat_map(|envelope| {
+            envelope.parts.iter().filter_map(|part| match part {
+                Part::File(file) => Some(file.name.clone()),
+                _ => None,
+            })
+        })
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_document_an_agent_attaches_reaches_the_operator() {
+    // The failure this exists for: an agent wrote a brief, saved it, and ended
+    // its turn with the path. The operator was handed a location on a machine
+    // that is not theirs, in a window with nothing to click, and the document
+    // may as well not have been written.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Say("Tidied up and attached. The second risk is the one to worry about.".into())
+        } else {
+            Script::Attach { tool: "attach_file".into(), files: vec!["notes.md".into()] }
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let notes = h.runtime.files().put("notes.md", b"# Risks\n\n1. cost\n2. the vendor").unwrap();
+    let run = h
+        .runtime
+        .send_from_human_with(h.id("Manager"), "Tidy this up and give it back.", vec![notes])
+        .unwrap();
+    h.settle(run).await;
+
+    assert_eq!(
+        handed_over(&h, "Manager"),
+        vec!["notes.md"],
+        "the operator was told about a file rather than given one:\n{}",
+        h.transcript()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_document_handed_over_with_nothing_said_still_arrives() {
+    // Sending a document with no covering note is a normal thing to do, and
+    // models do it constantly. A reply judged empty by its text alone would
+    // drop the file the whole turn was spent producing, which is the one
+    // failure worse than not having the feature: the agent believes it handed
+    // the document over and the operator never sees it.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Say("".into())
+        } else {
+            Script::Attach { tool: "attach".into(), files: vec!["agenda.txt".into()] }
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let agenda = h.runtime.files().put("agenda.txt", b"1. budget\n2. hiring").unwrap();
+    let run = h
+        .runtime
+        .send_from_human_with(h.id("Manager"), "Hand that back to me.", vec![agenda])
+        .unwrap();
+    h.settle(run).await;
+
+    assert_eq!(
+        handed_over(&h, "Manager"),
+        vec!["agenda.txt"],
+        "a reply with a file and no words is still a reply:\n{}",
+        h.transcript()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_document_that_could_not_be_attached_is_admitted_rather_than_claimed() {
+    // No sandbox in CI, so a path on the agent's own machine cannot be read,
+    // which is exactly the path this has to get right: an agent told nothing
+    // goes on to tell the operator the brief is attached to a message that
+    // carries no file at all.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Say("I could not hand the file over.".into())
+        } else {
+            Script::Attach { tool: "attach_file".into(), files: vec!["/home/user/brief.md".into()] }
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "Write me a brief.").unwrap();
+    h.settle(run).await;
+
+    assert!(
+        handed_over(&h, "Manager").is_empty(),
+        "nothing should have been attached:\n{}",
+        h.transcript()
+    );
+    let told = tool_results(&stub).join("\n");
+    assert!(told.contains("/home/user/brief.md was not attached"), "{told}");
+    assert!(
+        told.contains("do not tell them it is attached"),
+        "the model has to be told what not to claim: {told}"
+    );
+    assert!(
+        told.contains("attach it again"),
+        "and given a way forward, or it rewords the claim and retries: {told}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_same_document_attached_twice_in_one_turn_is_one_file() {
+    // A model that attaches the brief, writes a paragraph, then attaches the
+    // brief again would otherwise put two identical cards under one message.
+    let stub = serve(|body| {
+        let calls = body["messages"]
+            .as_array()
+            .map(|m| m.iter().filter(|msg| msg["role"] == "tool").count())
+            .unwrap_or(0);
+        match calls {
+            0 | 1 => Script::Attach { tool: "attach_file".into(), files: vec!["menu.md".into()] },
+            _ => Script::Say("Attached.".into()),
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let menu = h.runtime.files().put("menu.md", b"soup, then fish").unwrap();
+    let run =
+        h.runtime.send_from_human_with(h.id("Manager"), "Give me the menu.", vec![menu]).unwrap();
+    h.settle(run).await;
+
+    assert_eq!(
+        handed_over(&h, "Manager"),
+        vec!["menu.md"],
+        "the same document arrived twice:\n{}",
+        h.transcript()
+    );
+    let told = tool_results(&stub).join("\n");
+    assert!(told.contains("Nothing new was attached"), "the second call has to say so: {told}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_agent_reads_its_own_attachment_back_on_the_next_turn() {
+    // Without this the agent has no record of having handed anything over: it
+    // attaches the same document again next turn and tells the operator it is
+    // sending it for the first time.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Say("Attached.".into())
+        } else if reading_peer_replies(body) {
+            Script::Say("Already sent.".into())
+        } else {
+            Script::Attach { tool: "attach_file".into(), files: vec!["brief.md".into()] }
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let brief = h.runtime.files().put("brief.md", b"the deadline is the 14th").unwrap();
+    let first =
+        h.runtime.send_from_human_with(h.id("Manager"), "Hand me the brief.", vec![brief]).unwrap();
+    h.settle(first).await;
+
+    let then = h.runtime.send_from_human(h.id("Manager"), "Did you send it?").unwrap();
+    h.settle(then).await;
+
+    let last = stub.transcript.lock().last().cloned().unwrap();
+    let assistant: Vec<String> = last["messages"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|m| m["role"] == "assistant")
+        .map(|m| m["content"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(
+        assistant.iter().any(|turn| turn.contains("brief.md")),
+        "its own turn lost the file it attached: {assistant:?}"
+    );
+}

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -52,6 +52,10 @@ pub enum Script {
     Instruct { recipients: Vec<String>, text: String },
     /// A `send_message` carrying files, named the way a model names them.
     SendFiles { recipients: Vec<String>, text: String, files: Vec<String> },
+    /// An `attach_file` call: files put on the answer rather than sent to a
+    /// peer. The tool name is the one a model actually emitted, so the alias
+    /// path is exercised wherever a scenario asks for it.
+    Attach { tool: String, files: Vec<String> },
     /// Emit a `directory` tool call.
     Directory,
     /// Emit an `update_notes` tool call.
@@ -143,6 +147,16 @@ pub fn render(script: &Script) -> String {
                     {"index":0,"function":{"arguments": piece}}
                 ]}}]})));
             }
+            body.push_str(&frame(
+                serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
+            ));
+        }
+        Script::Attach { tool, files } => {
+            let args = serde_json::json!({ "files": files }).to_string();
+            body.push_str(&frame(serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                {"index":0,"id":"call_attach","type":"function",
+                 "function":{"name": tool,"arguments": args}}
+            ]}}]})));
             body.push_str(&frame(
                 serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
             ));

--- a/src/components/FileCard.test.tsx
+++ b/src/components/FileCard.test.tsx
@@ -100,12 +100,51 @@ describe("FileCard", () => {
   });
 
   it("reads the first lines of a text file into the transcript", async () => {
-    render(<FileCard file={file("notes.md", "text/markdown")} />);
+    const { container } = render(<FileCard file={file("server.log", "text/plain")} />);
 
     await waitFor(() => expect(screen.getByText(/first line/)).toBeTruthy());
+    // As its own source. A log is not prose, and markdown rules applied to one
+    // would eat its punctuation.
+    expect(container.querySelector(".file__text")).toBeTruthy();
     const asked = fetched.mock.calls[0] ?? [];
     expect(asked[0]).toContain("guacfile:");
     expect(asked[1].headers.Range).toBe("bytes=0-2047");
+  });
+
+  it("draws a markdown file as the document it is, not as its source", async () => {
+    // The format the agents actually write in. A brief shown as monospace `##`
+    // is a document the operator reads around rather than through, and this app
+    // already renders every message body as the prose it is.
+    fetched.mockResolvedValue({
+      ok: true,
+      status: 206,
+      text: async () => "# Risks\n\n- the vendor\n- **the deadline**\n",
+    });
+    const { container } = render(<FileCard file={file("brief.md", "text/markdown")} />);
+
+    await waitFor(() => expect(container.querySelector("h1")).toBeTruthy());
+    expect(container.querySelector("h1")?.textContent).toBe("Risks");
+    expect(container.querySelectorAll("li")).toHaveLength(2);
+    expect(container.querySelector("strong")?.textContent).toBe("the deadline");
+    // Never the raw syntax, which is the whole point.
+    expect(container.textContent).not.toContain("**");
+    expect(container.querySelector(".file__text")).toBeNull();
+  });
+
+  it("renders no HTML out of a file, whoever's machine it came off", async () => {
+    // A file from an agent's computer is no more trustworthy than the message
+    // that carried it, and the message renderer has never allowed raw HTML.
+    // `react-markdown` ignores it unless `rehype-raw` is added, and it is not.
+    fetched.mockResolvedValue({
+      ok: true,
+      status: 206,
+      text: async () => '<img src="x" onerror="alert(1)"><script>alert(2)</script>\n\nplain\n',
+    });
+    const { container } = render(<FileCard file={file("hostile.md", "text/markdown")} />);
+
+    await waitFor(() => expect(container.textContent).toContain("plain"));
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.querySelector("img")).toBeNull();
   });
 
   it("names anything it cannot draw and offers no preview it does not have", () => {
@@ -200,7 +239,7 @@ describe("FileCard", () => {
     fireEvent.click(retry);
 
     await waitFor(() =>
-      expect(container.querySelector(".file__text")?.textContent).toContain("first line"),
+      expect(container.querySelector(".file__doc")?.textContent).toContain("first line"),
     );
     expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
   });

--- a/src/components/FileCard.tsx
+++ b/src/components/FileCard.tsx
@@ -13,15 +13,16 @@ import {
 import { api } from "../lib/ipc";
 import { useStore } from "../lib/store";
 import { type Attachment, errorMessage } from "../lib/types";
+import { Markdown } from "./Markdown";
 
 /**
  * A file on a message.
  *
  * Shown rather than named, because a document that arrives as a filename is a
  * document the operator has to open something else to read. A picture is drawn,
- * a PDF gets its first page, a text file gets its first lines, and anything
- * this cannot draw says so and offers the one thing that always works. All four
- * open a full view on a click.
+ * a PDF gets its first page, a markdown file is drawn as the document it is, a
+ * text file gets its first lines, and anything this cannot draw says so and
+ * offers the one thing that always works. All five open a full view on a click.
  *
  * The bytes come over `guacfile:` rather than IPC: see `lib/files.ts`.
  */
@@ -82,6 +83,8 @@ function Thumbnail({ file }: { file: Attachment }) {
       return <img className="file__image" src={fileUrl(file)} alt={file.name} loading="lazy" />;
     case "pdf":
       return <Page file={file} />;
+    case "markdown":
+      return <Snippet file={file} limit={SNIPPET_BYTES} render="markdown" />;
     case "text":
       return <Snippet file={file} limit={SNIPPET_BYTES} />;
     default:
@@ -195,7 +198,17 @@ function Unreadable({
 }
 
 /**
- * The first lines of a text file, as text.
+ * The first lines of a text file.
+ *
+ * `render` decides whether they are drawn as their own source or as the
+ * document they describe. Markdown is drawn: it is what the agents write in,
+ * and a brief shown as monospace `##` is one the operator reads around rather
+ * than through. Everything else is source, because a log is not prose and
+ * markdown rules applied to one would eat its punctuation.
+ *
+ * The same trust as a message body, and the same renderer: no raw HTML, and
+ * links leave through the operator's own browser. A file from an agent's
+ * machine is no more trustworthy than the message that carried it.
  *
  * `sayTrimmed` where the operator would otherwise believe they have read the
  * whole thing. Under a message the cut is plain from the shape of it; in the
@@ -204,10 +217,12 @@ function Unreadable({
 function Snippet({
   file,
   limit,
+  render = "source",
   sayTrimmed,
 }: {
   file: Attachment;
   limit: number;
+  render?: "source" | "markdown";
   sayTrimmed?: boolean;
 }) {
   const [read, setRead] = useState<{ text: string; trimmed: boolean } | null>(null);
@@ -228,7 +243,13 @@ function Snippet({
   if (failed) return <Unreadable file={file} why={failed} onRetry={again} />;
   return (
     <>
-      <pre className="file__text">{read?.text ?? ""}</pre>
+      {render === "markdown" ? (
+        <div className="file__doc">
+          <Markdown>{read?.text ?? ""}</Markdown>
+        </div>
+      ) : (
+        <pre className="file__text">{read?.text ?? ""}</pre>
+      )}
       {sayTrimmed && read?.trimmed && (
         <p className="hint">The first {readableSize(limit)}. Save a copy to read the rest.</p>
       )}
@@ -239,7 +260,7 @@ function Snippet({
 /**
  * The file, as big as the window will allow.
  *
- * The same four shapes as the strip with the bounds taken off. A file with no
+ * The same five shapes as the strip with the bounds taken off. A file with no
  * preview lands here too: the operator clicked something, and an explanation
  * with a way forward beats nothing happening.
  */
@@ -291,6 +312,8 @@ export function FilePreview({ file, onClose }: { file: Attachment; onClose: () =
             <img className="file-view__image" src={fileUrl(file)} alt={file.name} />
           ) : kind === "pdf" ? (
             <Document file={file} />
+          ) : kind === "markdown" ? (
+            <Snippet file={file} limit={PREVIEW_BYTES} render="markdown" sayTrimmed />
           ) : kind === "text" ? (
             <Snippet file={file} limit={PREVIEW_BYTES} sayTrimmed />
           ) : (

--- a/src/lib/files.test.ts
+++ b/src/lib/files.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { fileUrl, previewKind, readableSize, readFileText } from "./files";
+import { fileUrl, kindLabel, previewKind, readableSize, readFileText } from "./files";
 import type { Attachment } from "./types";
 
 /**
@@ -16,8 +16,26 @@ describe("previewKind", () => {
     expect(previewKind("image/png")).toBe("image");
     expect(previewKind("image/webp")).toBe("image");
     expect(previewKind("application/pdf")).toBe("pdf");
-    expect(previewKind("text/markdown")).toBe("text");
     expect(previewKind("application/json")).toBe("text");
+  });
+
+  it("gives markdown its own kind, because that is what the agents write in", () => {
+    // A brief drawn as monospace `##` is a document the operator reads around
+    // rather than through, and the app already renders every message body as
+    // the prose it is. A file is the same prose that arrived as a file.
+    expect(previewKind("text/markdown")).toBe("markdown");
+    // Everything else textual stays source. A log is not prose, and markdown
+    // rules applied to one would eat its punctuation.
+    expect(previewKind("text/plain")).toBe("text");
+    expect(previewKind("text/csv")).toBe("text");
+    expect(previewKind("text/html")).toBe("text");
+  });
+
+  it("says Markdown rather than shouting it", () => {
+    // The generic `text/` rule upcases the subtype, which reads as MARKDOWN
+    // in the one heading an operator sees while reading the document.
+    expect(kindLabel("text/markdown")).toBe("Markdown");
+    expect(kindLabel("text/csv")).toBe("CSV");
   });
 
   it("refuses to guess at anything else", () => {

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -28,19 +28,25 @@ export const SNIPPET_BYTES = 2048;
 export const PREVIEW_BYTES = 256 * 1024;
 
 /** What can be drawn of a file, decided by its type and nothing else. */
-export type PreviewKind = "image" | "pdf" | "text" | "none";
+export type PreviewKind = "image" | "pdf" | "markdown" | "text" | "none";
 
 /**
- * Which of the four a file is.
+ * Which of the five a file is.
  *
  * By type, never by sniffing the bytes, which is the same rule the runtime
  * follows when it decides what to show a model. A file that is only mostly text
  * renders as a screenful of replacement characters, and the operator is better
  * served by a row saying what it is and a button that saves it.
+ *
+ * Markdown is its own kind because it is the format the agents actually write
+ * in. A brief drawn as monospace source is a document the operator reads around
+ * the syntax rather than through it, and the app already renders every message
+ * body the same way: a file is the same prose that arrived without one.
  */
 export function previewKind(mime: string): PreviewKind {
   if (mime.startsWith("image/")) return "image";
   if (mime === "application/pdf") return "pdf";
+  if (mime === "text/markdown") return "markdown";
   if (mime.startsWith("text/") || mime === "application/json") return "text";
   return "none";
 }
@@ -62,6 +68,8 @@ export function previewKind(mime: string): PreviewKind {
 export function kindLabel(mime: string): string {
   if (mime === "application/pdf") return "PDF";
   if (mime === "application/zip") return "ZIP archive";
+  // Ahead of the `text/` rule below, which would shout it.
+  if (mime === "text/markdown") return "Markdown";
   if (mime.startsWith("image/")) return `${mime.slice("image/".length).toUpperCase()} image`;
   if (mime.startsWith("text/")) return mime.slice("text/".length).toUpperCase();
   if (mime === "application/json") return "JSON";

--- a/src/lib/toolArgs.test.ts
+++ b/src/lib/toolArgs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { sendBody, sendRecipients } from "./toolArgs";
+import { attachedNames, sendBody, sendRecipients } from "./toolArgs";
 
 describe("sendRecipients", () => {
   it("reads the specified array shape", () => {
@@ -40,6 +40,34 @@ describe("sendBody", () => {
   it("returns an empty string when there is nothing to show", () => {
     for (const junk of [null, undefined, 42, "plain", { text: 7 }]) {
       expect(sendBody(junk)).toBe("");
+    }
+  });
+});
+
+describe("attachedNames", () => {
+  it("reads the specified shape, and the aliases a model reaches for", () => {
+    // The same set `tools.rs` accepts, because both sides read the same call.
+    expect(attachedNames({ files: ["brief.md"] })).toEqual(["brief.md"]);
+    expect(attachedNames({ attachments: ["brief.md"] })).toEqual(["brief.md"]);
+    expect(attachedNames({ paths: ["brief.md"] })).toEqual(["brief.md"]);
+    expect(attachedNames({ path: "brief.md" })).toEqual(["brief.md"]);
+    expect(attachedNames({ file: "brief.md" })).toEqual(["brief.md"]);
+    expect(attachedNames({ files: [{ path: "brief.md" }] })).toEqual(["brief.md"]);
+  });
+
+  it("keeps the file and drops the machine it was on", () => {
+    // What the model passes is a path on its own computer, and the directory is
+    // the one fact about it the operator has no use for: they cannot reach that
+    // disk, which is why the file was attached instead of named.
+    expect(attachedNames({ files: ["/home/user/work/exec-brief.md"] })).toEqual(["exec-brief.md"]);
+    expect(attachedNames({ files: ["C:\\Users\\bob\\notes.txt"] })).toEqual(["notes.txt"]);
+    // A name that was never a path is already the answer.
+    expect(attachedNames({ files: ["brief.md"] })).toEqual(["brief.md"]);
+  });
+
+  it("returns nothing for shapes it cannot read", () => {
+    for (const junk of [null, undefined, 42, "plain", { files: 7 }, { files: [1, 2] }]) {
+      expect(attachedNames(junk)).toEqual([]);
     }
   });
 });

--- a/src/lib/toolArgs.ts
+++ b/src/lib/toolArgs.ts
@@ -20,11 +20,15 @@ export function asRecord(value: unknown): Record<string, unknown> {
     : {};
 }
 
-/** Recipient names, from any of the shapes models actually emit. */
-export function sendRecipients(args: unknown): string[] {
-  const record = asRecord(args);
-  const raw = record.to ?? record.agent;
-
+/**
+ * A list of names out of whatever the model sent, given the keys an object
+ * entry might hide one under.
+ *
+ * The shapes are the ones `normalize_list` in `tools.rs` accepts, because both
+ * sides are reading the same call: a bare string, a comma-separated string, an
+ * array of strings, an array of objects.
+ */
+function nameList(raw: unknown, nested: string[]): string[] {
   if (typeof raw === "string") {
     return raw
       .split(",")
@@ -35,13 +39,35 @@ export function sendRecipients(args: unknown): string[] {
     return raw
       .map((entry) => {
         if (typeof entry === "string") return entry.trim();
-        const nested = asRecord(entry);
-        const name = nested.name ?? nested.agent;
-        return typeof name === "string" ? name.trim() : "";
+        const record = asRecord(entry);
+        const found = nested.map((key) => record[key]).find((v) => typeof v === "string");
+        return typeof found === "string" ? found.trim() : "";
       })
       .filter(Boolean);
   }
   return [];
+}
+
+/** Recipient names, from any of the shapes models actually emit. */
+export function sendRecipients(args: unknown): string[] {
+  const record = asRecord(args);
+  return nameList(record.to ?? record.agent, ["name", "agent"]);
+}
+
+/**
+ * The files a call named, as a person would say them.
+ *
+ * Leaf names only. What a model passes is a path on its own machine, and the
+ * directory it kept the file in is the one fact about it the operator has no
+ * use for: they cannot reach that disk, which is the whole reason the file was
+ * attached instead of named.
+ */
+export function attachedNames(args: unknown): string[] {
+  const record = asRecord(args);
+  const raw = record.files ?? record.attachments ?? record.paths ?? record.path ?? record.file;
+  return nameList(raw, ["name", "path", "file"]).map(
+    (path) => path.split(/[/\\]/).filter(Boolean).pop() ?? path,
+  );
 }
 
 /** The message body that was sent, or an empty string. */

--- a/src/lib/trail.test.ts
+++ b/src/lib/trail.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { foldTrail, hasDetail, readSpent, type Step, trailStep } from "./trail";
+import { foldTrail, hasDetail, readSpent, type Step, tellsMore, trailStep } from "./trail";
 import type { Part, ToolOutcome } from "./types";
 
 type ToolCall = Extract<Part, { type: "toolCall" }>;
@@ -50,6 +50,35 @@ describe("what one call was", () => {
     const [step] = steps(call("run_code", { source: "print(1)" }, ok("exit 0")));
     expect(step?.title).toBe("Used run_code");
     expect(step?.target).toBeNull();
+  });
+
+  it("names the document that was attached, since the operator can see the card", () => {
+    // The file itself is drawn under the message. The chip's job is to say
+    // which call put it there, and the path it came from is on a machine the
+    // operator has never seen.
+    const [step] = steps(
+      call("attach_file", { files: ["/home/user/exec-brief.md"] }, ok("attached exec-brief.md")),
+    );
+    expect(step?.title).toBe("Attached exec-brief.md");
+    // Nothing behind the chip: the summary is the title again, and the document
+    // is already on screen.
+    expect(step?.target).toBeNull();
+    expect(tellsMore(step as Step)).toBe(false);
+  });
+
+  it("says what could not be attached, because that is not on screen anywhere", () => {
+    const [step] = steps(
+      call(
+        "attach_file",
+        { files: ["/home/user/brief.md"] },
+        { status: "refused", reason: "brief.md was not attached: there is no file at it." },
+      ),
+    );
+    expect(step?.failed).toBe(true);
+    // A failure is never an echo. Whatever went wrong is not something the
+    // title could have said.
+    expect(tellsMore(step as Step)).toBe(true);
+    expect(step?.said).toContain("was not attached");
   });
 
   it("carries the reason a call was refused, not the fact that it happened", () => {

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -20,7 +20,7 @@
  * name of a function in a file they do not have.
  */
 
-import { asRecord, sendRecipients } from "./toolArgs";
+import { asRecord, attachedNames, sendRecipients } from "./toolArgs";
 import type { Part, ToolOutcome } from "./types";
 
 type ToolCall = Extract<Part, { type: "toolCall" }>;
@@ -171,6 +171,17 @@ function describe(tool: string, args: Args): Described {
       };
     }
 
+    // Named, because the file itself is drawn under the message and the chip's
+    // job is to say which call put it there. `2 files attached` beside two
+    // cards is a count of what the operator is already looking at.
+    case "attach_file": {
+      const named = attachedNames(args);
+      return {
+        title: named.length > 0 ? `Attached ${named.join(", ")}` : "Attached a file",
+        target: null,
+      };
+    }
+
     case "schedule": {
       const action = text(args, "action");
       if (action === "cancel") return { title: "Cancelled a routine", target: null };
@@ -279,6 +290,8 @@ function manyLabel(group: TrailGroup): string {
       return `Opened ${count} programs`;
     case "schedule":
       return `${count} changes to its schedule`;
+    case "attach_file":
+      return `Attached ${count} files`;
     case "update_notes":
       return `Updated its memory ${count} times`;
     case "directory":
@@ -340,14 +353,16 @@ export function foldTrail(steps: Step[]): TrailGroup[] {
  * the page". `open_on_desktop` answers with the command it was handed.
  * `use_screen` answers `clicked at (412, 96)` beside a step that says where it
  * clicked. `update_notes` answers with a character count printed directly above
- * the characters. None of them is wrong; all of them are the line above read
- * back, and nine of those turned a row into a paragraph of grey monospace,
- * which is the shape this was collapsed to get away from.
+ * the characters. `attach_file` answers `attached brief.md` beside a chip that
+ * says "Attached brief.md" and a card drawing brief.md. None of them is wrong;
+ * all of them are the line above read back, and nine of those turned a row into
+ * a paragraph of grey monospace, which is the shape this was collapsed to get
+ * away from.
  *
  * A failure is never an echo. Whatever went wrong is not something the title
  * could have said.
  */
-const ECHOES = new Set(["browse", "use_screen", "open_on_desktop", "update_notes"]);
+const ECHOES = new Set(["browse", "use_screen", "open_on_desktop", "update_notes", "attach_file"]);
 
 /** Whether what came back is worth reading beside the call it came from. */
 export function tellsMore(step: Step): boolean {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2461,6 +2461,24 @@ button {
   mask-image: linear-gradient(to bottom, #000 70%, transparent);
 }
 
+/* A markdown file drawn as the document it is, cut and faded exactly as its
+   source would have been. Markdown is what the agents write in, so this is the
+   preview that gets used: a brief shown as monospace `##` is one the operator
+   reads around rather than through. Same renderer as a message body, because a
+   file is the same prose that happened to arrive as one. */
+.file__doc {
+  padding: 0.6rem 0.7rem;
+  max-height: 11rem;
+  overflow: hidden;
+  mask-image: linear-gradient(to bottom, #000 70%, transparent);
+}
+
+/* The heading a document opens with is not a heading in a conversation: at
+   message size it shouts across the transcript, and a card is a glance. */
+.file__doc .md {
+  font-size: 0.78rem;
+}
+
 .file__foot {
   display: flex;
   align-items: center;
@@ -2605,7 +2623,8 @@ button {
   background: var(--ground);
 }
 
-.file-view__body[data-kind="text"] {
+.file-view__body[data-kind="text"],
+.file-view__body[data-kind="markdown"] {
   flex-direction: column;
   padding: 0.35rem 0.5rem;
 }
@@ -2615,6 +2634,19 @@ button {
   max-height: none;
   mask-image: none;
   font-size: 0.75rem;
+}
+
+.file-view__body .file__doc {
+  max-height: none;
+  mask-image: none;
+}
+
+/* The one place in the app where a document is read rather than glanced at, so
+   the measure is capped the way prose is set. Full width, a heading two lines
+   long crosses the whole window and the eye loses the return. */
+.file-view__body .file__doc .md {
+  font-size: 0.85rem;
+  max-width: 44rem;
 }
 
 .file-view__image {


### PR DESCRIPTION
An agent's answer to the operator could only carry text, so an agent asked for a brief wrote one and ended its turn with `/home/user/brief.md`: a path on a sandbox the operator cannot reach, in a window with nothing to click.

`attach_file` puts the file on the turn's own reply through the same `resolve_files` a send uses, so there is no second message, no extra hop and nothing new for the guard to judge; a reply carrying a file and no text is now delivered, and `body_with_files` names a file on an agent's own turns so it does not hand the same document over twice. The prompt states the mistake rather than the feature, because a model that has just saved a file has no reason to hunt for a tool it does not know it needs.

Markdown gets its own preview kind, drawn through the same renderer as a message body and so under the same no-raw-HTML trust decision; anything else textual stays source, since a log is not prose.

`./scripts/ci.sh` is green with six new integration tests in `src-tauri/tests/files.rs`, but this changes a prompt and the live evals are still owed: `./scripts/evals.sh` has not been run.