### PR TITLE
fix: a document in the full view scrolls, and the dialog is the width it claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,15 @@ the model takes a screenshot to see what `browse` did.
   An `img` is exempt and is the only preview that is not a `fetch`, so dropping
   the header shows as pictures drawing and every document, log and PDF failing,
   each with the one error message that cannot say which failure it was.
+- **The full file view resets `overflow`, not just the height cap and the mask.**
+  A clipping flex item has an automatic minimum size of zero, so a document left
+  clipping shrinks to fit and eats the rest of itself, nothing overflows the body
+  and the reading view has no scrollbar. The body is the only thing in that
+  dialog that scrolls, so nothing inside it may clip.
+- **`.dialog.dialog--file` is doubled because `.dialog` is declared after it.**
+  A one-class modifier above the base rule loses every property they share on
+  source order, which is invisible in a diff: the reading view opened at the
+  ordinary 38rem for that reason. `styles.test.ts` walks the modifiers.
 - **`emit_reply` delivers a reply that carries a file and no text.** Handing over
   a document with nothing typed is normal, and judging the reply empty by its
   text alone drops the thing the turn was spent producing.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -522,6 +522,27 @@ installed, and a document off an agent's machine is no more trustworthy than the
 message that carried it. Anything else textual stays source: a log is not prose,
 and markdown rules applied to one eat its punctuation.
 
+The full view reuses the card's classes with the bounds taken off, and one of
+those bounds does not look like a bound. A card clips and fades its preview on
+purpose; the reading view lifts the height cap and the mask, and has to lift
+`overflow` with them. A clipping flex item has an automatic minimum size of
+zero, so a document left clipping shrinks to whatever room is going and
+swallows the rest of itself. Nothing then overflows the body above it, so
+nothing scrolls, and a brief opened to be read stops at the height of the
+window with no scrollbar and no way down. The body is the one thing in that
+dialog that scrolls, which means nothing inside it may clip.
+
+The dialog is also wider than an ordinary one, and the rule saying so is
+declared beside the card it enlarges rather than beside `.dialog`, hundreds of
+lines further down. Two single-class selectors: the base rule won `width` on
+source order alone and the reading view opened at the ordinary 38rem, with
+nothing in the diff to look at. `.dialog.dialog--file` is doubled to out-specify
+it, and the trap is waiting for any other modifier declared above the base.
+
+`styles.test.ts` asserts both against the real cascade, because neither is
+visible anywhere else: jsdom does no layout, so all 700-odd tests in this repo
+passed while the reading view could not be read.
+
 Two exceptions, and both are WebKit's.
 
 The first is CORS, and it cost every preview but the picture. A response on a

--- a/src/styles.css
+++ b/src/styles.css
@@ -2551,8 +2551,13 @@ button {
 }
 
 /* The full view. Wider than an ordinary dialog because the whole point of it
-   is that the bounds are off. */
-.dialog--file {
+   is that the bounds are off.
+
+   `.dialog` is declared further down this file, so a one-class modifier here
+   loses `width` to it on source order alone and the reading view came out at
+   the ordinary 38rem. Doubled rather than moved, because the rest of the full
+   view's rules belong beside the card they enlarge. */
+.dialog.dialog--file {
   width: min(64rem, 100%);
   display: flex;
   flex-direction: column;
@@ -2640,24 +2645,37 @@ button {
   padding: 0.35rem 0.5rem;
 }
 
-/* No mask and no height cap in here: this is the reading view. */
-.file-view__body .file__text {
-  max-height: none;
-  mask-image: none;
-  font-size: 0.75rem;
-}
+/* No mask, no height cap and no clip in here: this is the reading view, and
+   the body above is the one thing in it that scrolls.
 
+   `overflow` is the load-bearing one and is the least obvious. A clipping flex
+   item has an automatic minimum size of zero, so the card's `overflow: hidden`
+   left the document free to shrink to whatever room was going and swallow the
+   rest of itself. Nothing overflowed the body, so nothing scrolled, and a
+   brief opened for reading stopped at the height of the window with no
+   scrollbar and no way down. */
+.file-view__body .file__text,
 .file-view__body .file__doc {
   max-height: none;
+  overflow: visible;
   mask-image: none;
+}
+
+.file-view__body .file__text {
+  font-size: 0.75rem;
 }
 
 /* The one place in the app where a document is read rather than glanced at, so
    the measure is capped the way prose is set. Full width, a heading two lines
-   long crosses the whole window and the eye loses the return. */
+   long crosses the whole window and the eye loses the return.
+
+   Centred, because the cap is narrower than the dialog: left-aligned, the
+   column sits against one edge with the rest of a 64rem window empty beside
+   it, which reads as a layout that ran out rather than one that chose. */
 .file-view__body .file__doc .md {
   font-size: 0.85rem;
   max-width: 44rem;
+  margin-inline: auto;
 }
 
 .file-view__image {

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -1,0 +1,94 @@
+/**
+ * What the stylesheet has to keep being true.
+ *
+ * Every other suite here renders components into jsdom, which does no layout,
+ * so a rule that lays a surface out wrongly passes all of them. Two defects in
+ * the file reading view were exactly that shape: it clipped the document it
+ * existed to show and could not be scrolled, and it opened at the width of an
+ * ordinary dialog. Neither is visible in a DOM assertion and neither is
+ * visible in review, so both are asserted here against the cascade itself.
+ *
+ * Only invariants that survive a redesign belong in this file. A colour, a
+ * spacing or a font size is a decision, not a rule, and locking one down here
+ * would make changing your mind a test failure.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+// From the project root rather than from this module: the jsdom environment
+// rewrites `import.meta.url` to an `http:` URL, which `readFileSync` refuses.
+const css = readFileSync(join(process.cwd(), "src/styles.css"), "utf8");
+
+/** The app's own stylesheet, in the document, so the cascade is the real one. */
+beforeAll(() => {
+  const style = document.createElement("style");
+  style.textContent = css;
+  document.head.append(style);
+});
+
+/** Builds a nesting and hands back the innermost node. */
+function nest(...classes: string[]): HTMLElement {
+  let at: HTMLElement = document.body;
+  for (const className of classes) {
+    const node = document.createElement("div");
+    node.className = className;
+    at.append(node);
+    at = node;
+  }
+  return at;
+}
+
+describe("the file reading view", () => {
+  // The card under a message clips and fades its preview on purpose. The full
+  // view reuses the same classes with the bounds taken off, and `overflow` is
+  // the one that has to come off with them: a clipping flex item has an
+  // automatic minimum size of zero, so a document left clipping shrinks to
+  // whatever room is going and swallows the rest of itself. Nothing then
+  // overflows the body, so nothing scrolls, and a brief opened for reading
+  // stops at the height of the window with no scrollbar and no way down.
+  it.each([
+    ["a document", "file__doc"],
+    ["a log", "file__text"],
+  ])("neither clips nor caps %s", (_what, className) => {
+    const shown = getComputedStyle(nest("file-view__body", className));
+
+    expect(shown.overflow).toBe("visible");
+    expect(shown.maxHeight).toBe("none");
+  });
+
+  it("scrolls in the body, which is the one thing in it that scrolls", () => {
+    expect(getComputedStyle(nest("file-view__body")).overflow).toBe("auto");
+  });
+});
+
+describe("dialog modifiers", () => {
+  /**
+   * A modifier declared above `.dialog` silently loses to it.
+   *
+   * Both selectors carry one class, so the base rule wins every property they
+   * share on source order alone, and the full file view came out at the
+   * ordinary 38rem for that reason. It cannot be asserted through
+   * `getComputedStyle`: jsdom's CSS parser drops any declaration whose value
+   * is a `min()`, which is how every dialog width in this file is written, so
+   * the width never reaches the cascade to be read back. The source order is
+   * what is checkable, and it is also the actual trap.
+   */
+  it("out-specify the base rule, or are declared after it", () => {
+    const base = css.search(/^\.dialog \{$/m);
+    expect(base).toBeGreaterThan(-1);
+
+    // The selector is the whole match rather than a group, so it is a string
+    // under `noUncheckedIndexedAccess` without a cast to say so.
+    const modifiers = [...css.matchAll(/^(?:\.dialog)?\.dialog--[a-z-]+(?= \{$)/gm)];
+    expect(modifiers.length).toBeGreaterThan(0);
+
+    for (const found of modifiers) {
+      const selector = found[0];
+      const wins = selector.startsWith(".dialog.") || found.index > base;
+      expect(wins, `${selector} is declared above .dialog and loses to it`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
A markdown brief opened for reading stopped at the height of the window with no scrollbar: the full view lifted the card's `max-height` and its mask but left `overflow: hidden` on, and a clipping flex item has an automatic minimum size of zero, so the document shrank to whatever room was going and swallowed the rest of itself. `.file__text` carried the same rule, so a log was as unreadable as a brief. The dialog also opened at 38rem rather than the 64rem it asks for, because `.dialog--file` and `.dialog` both carry one class and the base rule is declared six hundred lines further down the same file, so it won `width` on source order alone; `.dialog.dialog--file` out-specifies it now, and the 44rem measure is centred in the room that appears. `styles.test.ts` asserts both against the real cascade, because jsdom does no layout and all 713 tests already here passed while the reading view could not be read. Reproduced and confirmed in the harness against a real renderer, at a 760px window and a 1400px one.