### PR TITLE
feat: a routine is changed rather than duplicated, and the panel notices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ repo: the frontend renders state and forwards intent.
 | Attachments, previews, drops, handing a document to the operator | *Files are references, and what a model gets depends on what they are* |
 | SQLite, the pool, migrations | *Storage*, and the two comments in `Store::open` |
 | Schedules, triggers, what a firing looks like | `docs/ROUTINES.md` |
+| What an agent knows about its own schedule, and how it changes one | *An agent reads its own schedule before it decides to write another one* and *Changing a routine is `update`* in `docs/ROUTINES.md` |
 | Sandboxes, the desktop, the screen, sign-ins on it | `docs/MACHINES.md` |
 | Hosted browsers, CDP, `browse`, live view, browser profiles | `docs/BROWSERS.md` |
 | Which of the two a piece of work belongs on, and credentials | *Connectors* in `docs/PROTOCOL.md`, then both files above |
@@ -146,6 +147,12 @@ the model takes a screenshot to see what `browse` did.
 - **`Routine::next_run_at` is an `Option` because some triggers have no next
   run.** A sentinel date would be shown to the operator, and it is one bad
   comparison away from firing something that was waiting on a connector.
+- **An agent's standing routines are in its prompt, and that is not a duplicate
+  of `schedule` with `list`.** A list behind a tool call arrives after the model
+  has decided what to do, so an agent asked to change something it already keeps
+  wrote a second routine beside the first and reported the change as made. Both
+  fired. `docs/ROUTINES.md` before you take the section out, and note that
+  `update` is what the ids in it are for.
 - **A stop marks a run and releases nothing.** `track_inflight` reads a negative
   delta against a run it is no longer counting as that run reaching zero, and
   emits a second `RunSettled` for it. So a stop that helpfully released the

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -88,6 +88,70 @@ reason: a time on its own can only ever mean the next 24 hours.
 holding, and the scheduler fires an overdue slot once. Parking it behind a Save
 the operator has not pressed means a routine they think they stopped still runs.
 
+## An agent reads its own schedule before it decides to write another one
+
+Every routine an agent has standing is in its system prompt, with the id of
+each, its cadence and the first line of its instruction. `schedule` with `list`
+still gives the full text, and the prompt says so.
+
+It is in the prompt rather than behind that tool call because of when the two
+arrive. An operator books something, comes back half an hour later and asks for
+it differently without saying which routine they mean: "make that every day".
+The agent had no idea it kept anything, so nothing in the turn prompted it to go
+and look, and it wrote a second routine beside the first with a name one word
+different. It reported that it had made the change. Both fired from then on, and
+the operator found out by reading the panel. A list an agent has to ask for is a
+list it reads *after* deciding what to do; a list in the prompt is one it reads
+before.
+
+What is in the row is chosen for recognition rather than for reading. An
+instruction is written to be acted on with no other context, so it runs to
+several sentences, and ten of them drawn in full would be the largest section of
+the prompt with the rule underneath them the part that got skimmed. A routine
+the operator has switched off says so instead of counting down: it still holds
+the slot it was holding, and an agent told a dead routine fires in an hour
+reports work as in hand that nobody is going to do.
+
+## Changing a routine is `update`, and adding a second one is not
+
+`schedule` had `list`, `add` and `cancel`. There was no verb for "the routine
+you already have, differently", so an agent asked for one could only add, or
+cancel and add, and cancelling first means losing the wording it was keeping if
+the second call is refused. `update` takes an id and any of a name, an
+instruction, a repeat or a delay, and leaves every field it was not sent alone.
+That last part is the whole point: making an agent restate the instruction in
+order to move the clock is how a second routine gets written.
+
+Where the next firing lands after an edit is `next_slot_for`, in `domain`, and
+it is the same function the operator's panel uses. Two answers to "when is this
+next due" would be two schedules.
+
+An `add` that lands beside a routine already doing the same job says so, in the
+tool's own answer, naming both ids. It is a notice and not a refusal, and it
+must not become one: nothing in the runtime can tell "move the sweep to ten"
+from "sweep at ten as well", because both arrive as the same instruction on a
+different clock. A guard would refuse honest work, and an agent's way around a
+refusal is to reword the instruction until it gets through. Saying it out loud
+reaches the one party that knows which was meant, while the turn is still
+running. `same_job` is deliberately loose for the same reason: a false positive
+costs a sentence the turn can ignore.
+
+## A schedule changing is its own event, and the panel was not listening for one
+
+Every path that writes a routine row emits `RoutinesChanged`, carrying the agent
+whose schedule it was: the agent's own `schedule` tool, the operator's commands,
+and the scheduler advancing a routine it has just fired. `RoutineList` reads
+itself again when the id it is drawing comes up.
+
+The operator commands used to emit `AgentsChanged`, which is a claim about the
+roster, and nothing drawing a schedule was listening for it: the list survived
+on being remounted by its key when the detail panel closed. So an agent that
+booked a routine mid-turn left the operator reading a list drawn before the
+routine existed, and the only way to see it was to close the panel and open it
+again. The same held for a firing: a routine that had just run still showed the
+countdown it had before, and a one-shot that fired stayed on the list until
+something else redrew it.
+
 ## A test run is the scheduler's own path with the schedule left alone
 
 Same delivery, same fresh run, so what the button shows is what Tuesday will do.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -908,29 +908,6 @@ impl RoutineDraft {
     }
 }
 
-/// Where an edited routine's next firing lands.
-///
-/// Three cases, and the difference between them is what the operator did. A
-/// stated time is honoured. An untouched time keeps the slot it was holding,
-/// because correcting a typo must not push the schedule to tomorrow. And a
-/// trigger swapped for one that would never fire at that moment has to move:
-/// "every hour" turned into "every weekday" keeps its hour but cannot keep its
-/// Saturday, or the label and the firing disagree from the moment it is saved.
-///
-/// A trigger that is not a clock lands nowhere at all, whatever was asked for.
-fn next_slot_for(trigger: &Trigger, existing: &Routine, in_secs: Option<u32>) -> Option<i64> {
-    let cadence = trigger.cadence()?;
-    let now = now_ms();
-    match (in_secs, existing.next_run_at) {
-        (Some(_), _) => Some(cadence.first_run(now, in_secs)),
-        // Coming back to the clock from a trigger that held no slot: there is
-        // nothing to keep, so it starts one interval out like a new routine.
-        (None, None) => Some(cadence.first_run(now, None)),
-        (None, Some(slot)) if cadence.accepts(slot) => Some(slot),
-        (None, Some(slot)) => Some(cadence.next_after(slot, now).unwrap_or(slot)),
-    }
-}
-
 #[tauri::command]
 pub fn create_routine(
     state: State<'_, AppState>,
@@ -941,7 +918,7 @@ pub fn create_routine(
     let first = trigger.first_run(now_ms(), draft.in_secs);
     let routine =
         state.runtime.store().create_routine(agent_id, &draft.name, &draft.what, trigger, first)?;
-    state.runtime.emit(UiEvent::AgentsChanged);
+    state.runtime.emit(UiEvent::RoutinesChanged { agent_id });
     Ok(routine)
 }
 
@@ -958,11 +935,11 @@ pub fn update_routine(
         .store()
         .get_routine(id)?
         .ok_or_else(|| CommandError::new("notFound", format!("no routine with id {id}")))?;
-    let next = next_slot_for(&trigger, &existing, draft.in_secs);
+    let next = routine::next_slot_for(&trigger, &existing, draft.in_secs);
 
     let routine =
         state.runtime.store().update_routine(id, &draft.name, &draft.what, trigger, next)?;
-    state.runtime.emit(UiEvent::AgentsChanged);
+    state.runtime.emit(UiEvent::RoutinesChanged { agent_id: routine.agent_id });
     Ok(routine)
 }
 
@@ -978,7 +955,7 @@ pub fn set_routine_active(
     active: bool,
 ) -> Reply<Routine> {
     let routine = state.runtime.store().set_routine_active(id, active)?;
-    state.runtime.emit(UiEvent::AgentsChanged);
+    state.runtime.emit(UiEvent::RoutinesChanged { agent_id: routine.agent_id });
     Ok(routine)
 }
 
@@ -1007,8 +984,13 @@ pub fn routine_runs(state: State<'_, AppState>, id: RoutineId) -> Reply<Vec<Rout
 
 #[tauri::command]
 pub fn delete_routine(state: State<'_, AppState>, id: RoutineId) -> Reply<()> {
+    // Read before the delete, because the event names the agent whose schedule
+    // changed and afterwards there is nothing left to ask.
+    let whose = state.runtime.store().get_routine(id)?.map(|routine| routine.agent_id);
     state.runtime.store().delete_routine(id)?;
-    state.runtime.emit(UiEvent::AgentsChanged);
+    if let Some(agent_id) = whose {
+        state.runtime.emit(UiEvent::RoutinesChanged { agent_id });
+    }
     Ok(())
 }
 

--- a/src-tauri/src/domain/routine.rs
+++ b/src-tauri/src/domain/routine.rs
@@ -492,6 +492,26 @@ impl Routine {
         }
     }
 
+    /// The same, cut down to something that fits one line of a list.
+    ///
+    /// An agent naming its own routine is optional, so the title is often the
+    /// instruction, and an instruction is written to be acted on with no other
+    /// context: several sentences. Whoever is reading a list is recognising a
+    /// routine rather than reading it, and the whole instruction is what the
+    /// `list` action is for. Cut to the width a name is already held to, so a
+    /// named row and an unnamed one are the same shape.
+    pub fn short_title(&self) -> String {
+        let title = self.title().trim();
+        if title.chars().count() <= MAX_NAME_LEN {
+            return title.to_string();
+        }
+        let cut: String = title.chars().take(MAX_NAME_LEN).collect();
+        match cut.rfind(char::is_whitespace) {
+            Some(space) => format!("{}…", cut[..space].trim_end()),
+            None => format!("{cut}…"),
+        }
+    }
+
     /// What happens to its slot, given that it just ran at `now`.
     pub fn after_running(&self, now: i64) -> NextSlot {
         match self.trigger.cadence() {
@@ -507,7 +527,16 @@ impl Routine {
     }
 
     /// How it reads back to the agent that set it.
+    ///
+    /// A routine the operator has switched off says so instead of claiming a
+    /// next firing. It still holds the slot it was holding, so the countdown
+    /// is there to be printed, and an agent told "every weekday, next in 15
+    /// hours" about a row that will not fire reports work as being in hand
+    /// that nobody is going to do.
     pub fn describe(&self) -> String {
+        if !self.active {
+            return format!("{}, switched off by the operator", self.trigger.describe());
+        }
         match self.next_run_at {
             Some(at) => format!("{}, next {}", self.trigger.describe(), when(at)),
             // Nothing to promise: it happens when the event does.
@@ -544,7 +573,45 @@ fn when(at: i64) -> String {
     if seconds <= 0 {
         return "now".to_string();
     }
-    format!("in {}", human_gap(seconds as u32))
+    format!("in {}", rough_gap(seconds as u32))
+}
+
+/// A gap to a moment, as the nearest whole unit of something.
+///
+/// [`human_gap`] is exact because a repeat is a number somebody chose: "every 2
+/// hours" has to read back as that and not as an approximation of it. The gap
+/// to a next firing is not a number anybody chose, and it is almost never a
+/// round multiple of anything, so exactness there produced "next in 51823
+/// seconds": the true answer to a question nobody asked, in every prompt and
+/// every reply that mentions a schedule.
+fn rough_gap(secs: u32) -> String {
+    const MINUTE: u32 = 60;
+    const HOUR: u32 = 60 * MINUTE;
+    const DAY: u32 = 24 * HOUR;
+
+    if secs < MINUTE {
+        return "under a minute".to_string();
+    }
+    // Which unit to use is decided on the rounded number rather than on the raw
+    // seconds, or a slot 59 and a half minutes out reads as 60 minutes. The
+    // boundaries sit where the larger unit starts being the easier read: 30
+    // hours is clearer than a day and a bit.
+    let minutes = (secs + MINUTE / 2) / MINUTE;
+    let hours = (secs + HOUR / 2) / HOUR;
+    let (n, unit) = if minutes < 60 {
+        (minutes, "minute")
+    } else if hours < 48 {
+        (hours, "hour")
+    } else {
+        ((secs + DAY / 2) / DAY, "day")
+    };
+    // "in minute" is what a bare unit reads as here, unlike in "every minute",
+    // which is the wording `human_gap` is for.
+    match (n, unit) {
+        (1, "hour") => "an hour".to_string(),
+        (1, unit) => format!("a {unit}"),
+        (n, unit) => format!("{n} {unit}s"),
+    }
 }
 
 /// The shortest gap a routine may repeat on.
@@ -611,6 +678,71 @@ pub fn validate(
         return Err(RoutineError::TooFar);
     }
     Ok(())
+}
+
+/// Where an edited routine's next firing lands.
+///
+/// Three cases, and the difference between them is what was asked for. A stated
+/// time is honoured. An untouched time keeps the slot it was holding, because
+/// correcting a typo must not push the schedule to tomorrow. And a trigger
+/// swapped for one that would never fire at that moment has to move: "every
+/// hour" turned into "every weekday" keeps its hour but cannot keep its
+/// Saturday, or the label and the firing disagree from the moment it is saved.
+///
+/// A trigger that is not a clock lands nowhere at all, whatever was asked for.
+///
+/// One rule for both editors. An operator editing in the panel and an agent
+/// calling `schedule` with `update` are changing the same row, and two answers
+/// to "when is it next due" would be two schedules.
+pub fn next_slot_for(trigger: &Trigger, existing: &Routine, in_secs: Option<u32>) -> Option<i64> {
+    let cadence = trigger.cadence()?;
+    let now = super::now_ms();
+    match (in_secs, existing.next_run_at) {
+        (Some(_), _) => Some(cadence.first_run(now, in_secs)),
+        // Coming back to the clock from a trigger that held no slot: there is
+        // nothing to keep, so it starts one interval out like a new routine.
+        (None, None) => Some(cadence.first_run(now, None)),
+        (None, Some(slot)) if cadence.accepts(slot) => Some(slot),
+        (None, Some(slot)) => Some(cadence.next_after(slot, now).unwrap_or(slot)),
+    }
+}
+
+/// Words that carry the subject of an instruction, for [`same_job`].
+///
+/// Anything shorter than four characters is grammar rather than subject
+/// matter: left in, "check the listings" and "email the operator" score on
+/// `the` and every pair of instructions looks related.
+fn subject_words(text: &str) -> std::collections::HashSet<String> {
+    text.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|word| word.chars().count() >= 4)
+        .map(str::to_string)
+        .collect()
+}
+
+/// Whether two instructions read like the same job.
+///
+/// Deliberately loose, and deliberately only ever used to say something out
+/// loud. An agent that has just written a second routine for work it already
+/// had standing is told so, with both ids, while it still knows which one it
+/// meant; a false positive costs a sentence it can ignore.
+///
+/// It is not a refusal, and it must not become one. Nothing here can tell
+/// "move the sweep to ten" from "sweep at ten as well": both arrive as the
+/// same instruction on a different clock, so a guard that refused the second
+/// would refuse honest work, and the agent's way around it would be to reword
+/// the instruction until it got through.
+pub fn same_job(a: &str, b: &str) -> bool {
+    let (a, b) = (subject_words(a), subject_words(b));
+    let fewer = a.len().min(b.len());
+    if fewer == 0 {
+        // Two instructions with no subject words between them. Nothing to
+        // compare, so nothing is claimed.
+        return false;
+    }
+    // Three subject words in five. Below that, two routines that both mention
+    // the listings are usually two jobs; at or above it they are usually one.
+    a.intersection(&b).count() * 5 >= fewer * 3
 }
 
 #[cfg(test)]
@@ -940,5 +1072,83 @@ mod tests {
         assert_eq!(json["kind"], serde_json::json!("scheduled"));
         assert_eq!(json["spent"]["calls"], serde_json::json!(2));
         assert_eq!(json["spent"]["cost"], serde_json::json!(0.002));
+    }
+
+    #[test]
+    fn a_next_firing_is_described_in_a_unit_a_reader_can_use() {
+        // A slot is a moment on the clock, not a gap somebody chose, so it is
+        // almost never a round number of anything. Printed exactly, an agent
+        // was told "next in 51823 seconds" on every turn.
+        let now = crate::domain::now_ms();
+        assert_eq!(when(now + 51_823_000), "in 14 hours");
+        assert_eq!(when(now + 3_599_000), "in an hour");
+        assert_eq!(when(now + 86_400_000 * 3), "in 3 days");
+        assert_eq!(when(now + 30_000), "in under a minute");
+        assert_eq!(when(now - 1_000), "now");
+        // And a single unit reads as one. "next in minute" was the shape a
+        // bare unit takes here, which is not the shape "every minute" takes.
+        assert_eq!(when(now + 70_000), "in a minute");
+        assert_eq!(when(now + 5_500_000), "in 2 hours");
+        // A repeat is still exact: it reads back as the number that was set.
+        assert_eq!(human_gap(7200), "2 hours");
+    }
+
+    #[test]
+    fn correcting_a_routine_leaves_the_slot_it_was_holding_alone() {
+        // The edit an operator makes most: a typo in the instruction. Moving
+        // the next firing to an interval from now would quietly cancel this
+        // morning's run.
+        let slot = at(2025, 6, 10, 9, 0);
+        let existing = routine(clock(Cadence::Daily), Some(slot));
+        assert_eq!(next_slot_for(&clock(Cadence::Daily), &existing, None), Some(slot));
+    }
+
+    #[test]
+    fn a_trigger_that_would_never_fire_at_that_moment_moves_the_slot() {
+        // Saturday at nine, told to run on weekdays. It keeps the hour and
+        // gives up the day, or the row says "every weekday" and fires on a
+        // Saturday.
+        let saturday = at(2025, 6, 14, 9, 0);
+        let existing = routine(clock(Cadence::Daily), Some(saturday));
+        let moved = next_slot_for(&clock(Cadence::Weekdays), &existing, None).unwrap();
+        assert_ne!(moved, saturday);
+        assert!(Cadence::Weekdays.accepts(moved), "it moved to a day it would actually fire on");
+    }
+
+    #[test]
+    fn coming_back_to_the_clock_from_an_event_starts_like_a_new_routine() {
+        // An event trigger holds no slot, so there is nothing to keep and
+        // nothing to compute a next firing from.
+        let existing = routine(event("stripe", "invoice.paid"), None);
+        assert!(next_slot_for(&clock(Cadence::Daily), &existing, None).is_some());
+        // And going the other way lands nowhere at all, whatever was asked for.
+        let clocked = routine(clock(Cadence::Daily), Some(at(2025, 6, 10, 9, 0)));
+        assert_eq!(next_slot_for(&event("stripe", "invoice.paid"), &clocked, Some(60)), None);
+    }
+
+    #[test]
+    fn a_second_routine_for_work_already_standing_is_recognised_as_the_same_job() {
+        // The failure this exists for: an operator asks for an adjustment to
+        // something the agent already keeps, and the agent writes a second
+        // routine beside the first. Both fire, and the work happens twice.
+        assert!(same_job(
+            "Check the new listings and email me a summary.",
+            "Check Zillow listings and send me a summary of what is new.",
+        ));
+        // Reworded down to nothing recognisable in common is not the same job,
+        // and neither is a routine that merely works on the same subject.
+        assert!(!same_job(
+            "Check the new listings and email me a summary.",
+            "Write up this week's market activity and file it in the drive.",
+        ));
+        assert!(!same_job("Check the listings.", "Pay the invoices."));
+    }
+
+    #[test]
+    fn two_instructions_of_pure_grammar_are_not_claimed_to_match() {
+        // Nothing to compare is not evidence of a match. An empty subject set
+        // divided into is also how this would have panicked.
+        assert!(!same_job("do it now", "do it now"));
+        assert!(!same_job("", "check the listings"));
     }
 }

--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -178,23 +178,31 @@ fn all_specs() -> Vec<ToolSpec> {
                           instruction back as a new \
                           message and work as usual, so write it as something you will be able \
                           to act on with no other context. Nothing is running while you wait, \
-                          and a routine outlives restarts. Never schedule a check for a reply, a \
-                          result, or anything else you are waiting on: those arrive as new \
-                          messages on their own, so a routine that fires to look for one only \
-                          spends a turn finding nothing."
+                          and a routine outlives restarts. What you already have standing is in \
+                          your system prompt, with the id of each: when one of those already \
+                          does the job you are being asked about, `update` that one and leave \
+                          the rest of it alone. A second routine does not replace the first, so \
+                          both fire and the work happens twice. Never schedule a check for a \
+                          reply, a result, or anything else you are waiting on: those arrive as \
+                          new messages on their own, so a routine that fires to look for one \
+                          only spends a turn finding nothing."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "action": { "type": "string", "enum": ["list", "add", "cancel"] },
+                    "action": { "type": "string", "enum": ["list", "add", "update", "cancel"] },
                     "what": {
                         "type": "string",
-                        "description": "The instruction to give yourself when it fires."
+                        "description": "The instruction to give yourself when it fires. On \
+                                        `update`, the instruction that replaces the old one; \
+                                        leave it out to keep what the routine already says."
                     },
                     "name": {
                         "type": "string",
                         "description": "A short label for it, three or four words, so the \
-                                        operator can see at a glance what you have standing."
+                                        operator can see at a glance what you have standing. On \
+                                        `update`, a new label; leave it out to keep the one it \
+                                        already has."
                     },
                     "repeat": {
                         "type": "string",
@@ -213,9 +221,17 @@ fn all_specs() -> Vec<ToolSpec> {
                         "type": "integer",
                         "description": "How long until the first run, which is also the time of \
                                         day a `repeat` lands on. Defaults to one interval away, \
-                                        or immediately for a one-off."
+                                        or immediately for a one-off. On `update` it moves the \
+                                        next firing; leave it out to change the wording without \
+                                        moving the schedule."
                     },
-                    "id": { "type": "string", "description": "For `cancel`, from `list`." }
+                    "id": {
+                        "type": "string",
+                        "description": "The routine to `update` or `cancel`. Every routine you \
+                                        have standing is listed with its id in your system \
+                                        prompt, and `list` shows them with their full \
+                                        instructions."
+                    }
                 },
                 "required": ["action"],
                 "additionalProperties": false
@@ -590,6 +606,19 @@ pub enum ScheduleAction {
         trigger: Trigger,
         in_secs: Option<u32>,
     },
+    /// Changes a routine that already stands.
+    ///
+    /// Every field is optional, and an absent one is left as it was. The
+    /// commonest edit is a new time on an instruction that has not changed,
+    /// and making an agent restate the instruction to move the clock is how a
+    /// second routine for the same job gets written.
+    Update {
+        id: String,
+        name: Option<String>,
+        what: Option<String>,
+        trigger: Option<Trigger>,
+        in_secs: Option<u32>,
+    },
     Cancel {
         id: String,
     },
@@ -635,7 +664,7 @@ pub enum ToolParseError {
     UnknownBrowseAction,
     #[error("schedule needs a known `action`")]
     UnknownScheduleAction,
-    #[error("schedule add needs {needs}")]
+    #[error("schedule needs {needs}")]
     IncompleteSchedule { needs: String },
     #[error("use_screen {action} needs {needs}")]
     IncompleteScreenAction { action: String, needs: String },
@@ -659,14 +688,16 @@ impl ToolParseError {
                  well-formed JSON object."
             ),
             ToolParseError::UnknownScheduleAction => {
-                "Error: `action` must be list, add or cancel. Use \
+                "Error: `action` must be list, add, update or cancel. Use \
                  {\"action\": \"list\"} to see what you have already set."
                     .to_string()
             }
             ToolParseError::IncompleteSchedule { needs } => format!(
-                "Error: to add a routine you need {needs}. For example \
+                "Error: that `schedule` call needs {needs}. To add one: \
                  {{\"action\": \"add\", \"name\": \"Listings sweep\", \"what\": \"check the \
-                 listings\", \"repeat\": \"weekdays\"}}."
+                 listings\", \"repeat\": \"weekdays\"}}. To change one you already have, \
+                 which is what a routine that needs a new time or new wording wants: \
+                 {{\"action\": \"update\", \"id\": \"3\", \"repeat\": \"daily\"}}."
             ),
             ToolParseError::UnknownBrowseAction => {
                 "Error: `action` must be one of open, read, click, type, scroll or back. \
@@ -905,46 +936,54 @@ pub fn parse(call: &ToolCall) -> Result<ToolInvocation, ToolParseError> {
             let secs = |name: &str| {
                 value.get(name).and_then(|v| v.as_i64()).filter(|n| *n > 0).map(|n| n as u32)
             };
+            // One reading of a repeat, for `add` and `update` both. A named
+            // repeat beats a gap in seconds when both arrive: it is the more
+            // specific of the two, and a model that sends "weekdays" alongside
+            // 86400 means the weekdays.
+            //
+            // Read as a cadence rather than as any trigger: this tool sets a
+            // clock, and a model that improvised `event:...` here would be
+            // handed a routine nothing can fire.
+            let clock = |repeat: Option<&str>, every: Option<u32>| match (repeat, every) {
+                (Some(named), _) => {
+                    Cadence::parse(named).map(Trigger::Clock).map(Some).ok_or_else(|| {
+                        ToolParseError::IncompleteSchedule {
+                            needs: "`repeat` to be one of daily, weekdays, weekly or monthly"
+                                .to_string(),
+                        }
+                    })
+                }
+                (None, Some(gap)) => Ok(Some(Trigger::Clock(Cadence::Every(gap)))),
+                (None, None) => Ok(None),
+            };
+            // A blank string is a model padding out the arguments, not an
+            // instruction to blank the field: on an update it would wipe the
+            // label or the instruction of a routine that was only being
+            // retimed.
+            let words = |key: &str| {
+                value
+                    .get(key)
+                    .and_then(|v| v.as_str())
+                    .map(|text| text.trim().to_string())
+                    .filter(|text| !text.is_empty())
+            };
             match value.get("action").and_then(|v| v.as_str()).unwrap_or("list") {
                 "list" => Ok(ToolInvocation::Schedule { action: ScheduleAction::List }),
                 "add" | "create" => {
-                    let what = value
-                        .get("what")
-                        .or_else(|| value.get("prompt"))
-                        .and_then(|v| v.as_str())
-                        .unwrap_or_default()
-                        .to_string();
-                    let name = value
-                        .get("name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or_default()
-                        .trim()
-                        .to_string();
-                    let repeat = value.get("repeat").and_then(|v| v.as_str());
-                    let every = secs("every_secs");
-                    let delay = secs("in_secs");
-                    if what.trim().is_empty() {
+                    let Some(what) = words("what").or_else(|| words("prompt")) else {
                         return Err(ToolParseError::IncompleteSchedule {
                             needs: "a `what` to do".to_string(),
                         });
-                    }
-                    // A named repeat beats a gap in seconds when both arrive:
-                    // it is the more specific of the two, and a model that
-                    // sends "weekdays" alongside 86400 means the weekdays.
-                    //
-                    // Read as a cadence rather than as any trigger: this tool
-                    // sets a clock, and a model that improvised `event:...`
-                    // here would be handed a routine nothing can fire.
-                    let trigger = match (repeat, every, delay) {
-                        (Some(named), _, _) => Cadence::parse(named)
-                            .map(Trigger::Clock)
-                            .ok_or_else(|| ToolParseError::IncompleteSchedule {
-                                needs: "`repeat` to be one of daily, weekdays, weekly or monthly"
-                                    .to_string(),
-                            })?,
-                        (None, Some(gap), _) => Trigger::Clock(Cadence::Every(gap)),
-                        (None, None, Some(_)) => Trigger::Clock(Cadence::Once),
-                        (None, None, None) => {
+                    };
+                    // Blank is legal here, unlike on an update: a routine an
+                    // agent did not name is titled by what it does.
+                    let name = words("name").unwrap_or_default();
+                    let repeat = value.get("repeat").and_then(|v| v.as_str());
+                    let delay = secs("in_secs");
+                    let trigger = match (clock(repeat, secs("every_secs"))?, delay) {
+                        (Some(trigger), _) => trigger,
+                        (None, Some(_)) => Trigger::Clock(Cadence::Once),
+                        (None, None) => {
                             return Err(ToolParseError::IncompleteSchedule {
                                 needs: "`repeat` or `every_secs` to keep doing it, or `in_secs` \
                                         to do it once"
@@ -956,12 +995,41 @@ pub fn parse(call: &ToolCall) -> Result<ToolInvocation, ToolParseError> {
                         action: ScheduleAction::Add { name, what, trigger, in_secs: delay },
                     })
                 }
+                "update" | "edit" | "change" | "modify" => {
+                    let Some(id) = words("id") else {
+                        return Err(ToolParseError::IncompleteSchedule {
+                            needs: "the `id` of the routine to change, which is listed with \
+                                    every routine you have standing"
+                                .to_string(),
+                        });
+                    };
+                    let trigger =
+                        clock(value.get("repeat").and_then(|v| v.as_str()), secs("every_secs"))?;
+                    let delay = secs("in_secs");
+                    let what = words("what").or_else(|| words("prompt"));
+                    let name = words("name");
+                    // Nothing to change is a call that would report success and
+                    // do nothing, which reads to the agent as the edit having
+                    // landed.
+                    if what.is_none() && name.is_none() && trigger.is_none() && delay.is_none() {
+                        return Err(ToolParseError::IncompleteSchedule {
+                            needs: "something to change: a new `what`, `name`, `repeat`, \
+                                    `every_secs` or `in_secs`"
+                                .to_string(),
+                        });
+                    }
+                    Ok(ToolInvocation::Schedule {
+                        action: ScheduleAction::Update { id, name, what, trigger, in_secs: delay },
+                    })
+                }
                 "cancel" | "remove" | "delete" => match value.get("id").and_then(|v| v.as_str()) {
                     Some(id) if !id.trim().is_empty() => Ok(ToolInvocation::Schedule {
                         action: ScheduleAction::Cancel { id: id.to_string() },
                     }),
                     _ => Err(ToolParseError::IncompleteSchedule {
-                        needs: "the `id` of the routine, from `list`".to_string(),
+                        needs: "the `id` of the routine, which is listed with every routine \
+                                you have standing"
+                            .to_string(),
                     }),
                 },
                 _ => Err(ToolParseError::UnknownScheduleAction),
@@ -1388,6 +1456,90 @@ mod tests {
                     in_secs: None
                 }
             })
+        );
+    }
+
+    #[test]
+    fn changing_a_routine_is_an_update_that_leaves_the_rest_of_it_alone() {
+        // The verb that was missing. Without it, an agent asked for a routine
+        // at a different time can only add a second one, and both fire.
+        assert_eq!(
+            parse(&call(SCHEDULE, "{\"action\":\"update\",\"id\":\"r7\",\"repeat\":\"daily\"}")),
+            Ok(ToolInvocation::Schedule {
+                action: ScheduleAction::Update {
+                    id: "r7".into(),
+                    name: None,
+                    what: None,
+                    trigger: Some(Trigger::Clock(Cadence::Daily)),
+                    in_secs: None,
+                }
+            }),
+            "an absent field is a field to leave as it is, not one to blank"
+        );
+        // And the spellings a model reaches for instead.
+        for verb in ["edit", "change", "modify"] {
+            let parsed = parse(&call(
+                SCHEDULE,
+                &format!("{{\"action\":\"{verb}\",\"id\":\"r7\",\"what\":\"check twice\"}}"),
+            ));
+            assert!(matches!(
+                parsed,
+                Ok(ToolInvocation::Schedule { action: ScheduleAction::Update { .. } })
+            ));
+        }
+    }
+
+    #[test]
+    fn a_blank_field_on_an_update_is_padding_rather_than_an_erasure() {
+        // Models fill out every field in a schema. A routine being retimed must
+        // not lose the name and the instruction it already had because the call
+        // carried empty strings for them.
+        assert_eq!(
+            parse(&call(
+                SCHEDULE,
+                "{\"action\":\"update\",\"id\":\"r7\",\"name\":\"\",\"what\":\"  \",\
+                  \"in_secs\":3600}"
+            )),
+            Ok(ToolInvocation::Schedule {
+                action: ScheduleAction::Update {
+                    id: "r7".into(),
+                    name: None,
+                    what: None,
+                    trigger: None,
+                    in_secs: Some(3600),
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn an_update_that_would_change_nothing_is_refused_rather_than_reporting_success() {
+        // It would answer "updated" and do nothing, which the agent reads as
+        // the change having landed.
+        let err = parse(&call(SCHEDULE, "{\"action\":\"update\",\"id\":\"r7\"}")).unwrap_err();
+        assert!(matches!(err, ToolParseError::IncompleteSchedule { .. }));
+        assert!(err.guidance().contains("update"), "the way out has to be in the message");
+    }
+
+    #[test]
+    fn an_update_without_an_id_is_told_where_the_id_is() {
+        let err =
+            parse(&call(SCHEDULE, "{\"action\":\"update\",\"repeat\":\"daily\"}")).unwrap_err();
+        assert!(matches!(err, ToolParseError::IncompleteSchedule { .. }));
+        assert!(err.guidance().contains("\"id\""), "{}", err.guidance());
+    }
+
+    #[test]
+    fn the_schedule_tool_says_what_a_second_routine_for_one_job_costs() {
+        // The tool schema is read at the moment of the decision, which is where
+        // the consequence has to be: an agent that thinks adding replaces has
+        // no reason to look for `update`.
+        let spec = description(SCHEDULE);
+        assert!(spec.contains("`update`"), "{spec}");
+        assert!(spec.contains("both fire"), "a rule without its consequence: {spec}");
+        assert!(
+            spec.contains("system prompt"),
+            "and it has to know where the ids it needs already are: {spec}"
         );
     }
 

--- a/src-tauri/src/runtime/events.rs
+++ b/src-tauri/src/runtime/events.rs
@@ -132,6 +132,18 @@ pub enum UiEvent {
         approval_id: ApprovalId,
         state: ApprovalState,
     },
+
+    /// One agent's schedule changed: it set a routine, edited one, cancelled
+    /// one, or one came due and moved to its next slot.
+    ///
+    /// Not `AgentsChanged`, which is what this used to borrow. The roster did
+    /// not change, and the panel drawing the schedule was not listening for it
+    /// anyway: an agent that scheduled something for itself left the operator
+    /// reading a list that was drawn before the routine existed, which they
+    /// could only fix by closing the panel and opening it again.
+    RoutinesChanged {
+        agent_id: AgentId,
+    },
 }
 
 pub trait EventSink: Send + Sync + 'static {

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -1065,6 +1065,10 @@ impl Runtime {
                         tracing::error!(%err, "could not advance a routine; skipping it");
                         continue;
                     }
+                    // The row moved: to its next slot, or off the list
+                    // altogether if it was a one-shot. Either way the panel is
+                    // showing a firing that has already happened.
+                    runtime.emit(UiEvent::RoutinesChanged { agent_id: routine.agent_id });
 
                     tracing::info!(
                         agent = %routine.agent_id.short(),
@@ -1569,6 +1573,14 @@ impl Runtime {
             .collect::<Vec<_>>();
 
         let notes = self.inner.workspace.read(agent_id);
+        // What this agent already keeps, read fresh for the same reason the
+        // sign-ins below are: the turn that is about to be asked to change a
+        // routine has to know it has one. A read that fails is an empty
+        // schedule in the prompt, which is what the tool would have said too.
+        let routines = self.inner.store.agent_routines(agent_id).unwrap_or_else(|err| {
+            tracing::warn!(%err, "could not read this agent's schedule for its prompt");
+            Vec::new()
+        });
         // Refreshed before the prompt is built, not after, because the whole
         // point is that an agent knows what it can reach *when it is asked*.
         // Hanging this off the editor panel alone meant the first time anyone
@@ -1597,6 +1609,7 @@ impl Runtime {
             &signins,
             &names,
             &notes,
+            &routines,
             &history,
             &batch,
             mode,
@@ -3459,12 +3472,18 @@ impl Runtime {
     ///
     /// Answers in the words the agent used rather than in seconds, because the
     /// reply is the only record it keeps of what it set.
+    ///
+    /// Every path that writes a row emits [`UiEvent::RoutinesChanged`]. The
+    /// panel beside the transcript is where the operator reads a schedule, and
+    /// it was drawn before the agent wrote to it.
     fn keep_schedule(
         &self,
         card: &AgentCard,
         action: &tools::ScheduleAction,
     ) -> Result<String, crate::db::StoreError> {
-        use crate::domain::routine::{human_gap, validate, MIN_EVERY_SECS};
+        use crate::domain::routine::{
+            human_gap, next_slot_for, same_job, validate, MIN_EVERY_SECS,
+        };
 
         match action {
             tools::ScheduleAction::List => {
@@ -3474,14 +3493,20 @@ impl Runtime {
                 }
                 let mut out = String::from("Your schedule:\n");
                 for routine in routines {
+                    let name = routine.name.trim();
+                    let label = if name.is_empty() { String::new() } else { format!(" · {name}") };
                     out.push_str(&format!(
-                        "  {} — {} ({})\n",
+                        "  {}{label} — {} ({})\n",
                         routine.id,
                         routine.what,
                         routine.describe()
                     ));
                 }
-                out.push_str("Cancel one with its id.");
+                out.push_str(
+                    "`update` and an id changes one of these: a new time, a new instruction, or \
+                     both, leaving whatever you do not send alone. `cancel` and an id takes one \
+                     off.",
+                );
                 Ok(out)
             }
 
@@ -3493,31 +3518,99 @@ impl Runtime {
                     ));
                 }
 
+                // Read before the write, so the answer can say what this now
+                // stands beside.
+                let standing = self.inner.store.agent_routines(card.id)?;
                 let first = trigger.first_run(now_ms(), *in_secs);
                 let routine =
                     self.inner.store.create_routine(card.id, name, what, trigger.clone(), first)?;
+                self.emit(UiEvent::RoutinesChanged { agent_id: card.id });
 
-                Ok(format!(
+                let mut answer = format!(
                     "Scheduled: {} ({}). Its id is {}.",
                     routine.what,
                     routine.describe(),
                     routine.id
-                ))
+                );
+                // Said, never refused. Nothing here can tell "move the sweep to
+                // ten" from "sweep at ten as well", so the turn that knows
+                // which it meant is the one that has to decide, and it only
+                // knows while it is still running.
+                let twins: Vec<String> = standing
+                    .iter()
+                    // Only the ones that are going to fire. A routine the
+                    // operator switched off is their decision, and "both will
+                    // fire" about one of those is simply untrue.
+                    .filter(|other| other.active && same_job(&other.what, &routine.what))
+                    .map(|other| format!("{} ({})", other.id, other.short_title()))
+                    .collect();
+                if !twins.is_empty() {
+                    answer.push_str(&format!(
+                        " Note: {} already stands for what looks like the same job, and both will \
+                         fire, so the work happens twice. If this was meant to replace one of \
+                         them, `cancel` it — or `cancel` this one and `update` the routine you \
+                         already had.",
+                        twins.join(", ")
+                    ));
+                }
+                Ok(answer)
+            }
+
+            tools::ScheduleAction::Update { id, name, what, trigger, in_secs } => {
+                let Some(existing) = self.my_routine(card, id)? else {
+                    return Ok(format!(
+                        "You have no routine with the id {id}. Your own are listed with their \
+                         ids in front of you; `add` is how a new one starts."
+                    ));
+                };
+
+                // An absent field keeps what the row already says. Making an
+                // agent restate the instruction to move the clock is how a
+                // second routine for the same job gets written.
+                let name = name.clone().unwrap_or_else(|| existing.name.clone());
+                let what = what.clone().unwrap_or_else(|| existing.what.clone());
+                let trigger = trigger.clone().unwrap_or_else(|| existing.trigger.clone());
+                if let Err(err) = validate(&name, &what, &trigger, *in_secs) {
+                    return Ok(format!(
+                        "Refused: {err}. {} is unchanged, and the shortest repeat is {}.",
+                        existing.id,
+                        human_gap(MIN_EVERY_SECS)
+                    ));
+                }
+
+                let next = next_slot_for(&trigger, &existing, *in_secs);
+                let routine =
+                    self.inner.store.update_routine(existing.id, &name, &what, trigger, next)?;
+                self.emit(UiEvent::RoutinesChanged { agent_id: card.id });
+                Ok(format!("Updated {}: {} ({}).", routine.id, routine.what, routine.describe()))
             }
 
             tools::ScheduleAction::Cancel { id } => {
-                let Ok(parsed) = id.trim().parse() else {
-                    return Ok(format!("There is no routine with the id {id}."));
-                };
-                // Only its own: an id is guessable and a schedule is not shared.
-                let mine = self.inner.store.agent_routines(card.id)?;
-                if !mine.iter().any(|r| r.id == parsed) {
+                let Some(existing) = self.my_routine(card, id)? else {
                     return Ok(format!("You have no routine with the id {id}."));
-                }
-                self.inner.store.delete_routine(parsed)?;
-                Ok(format!("Cancelled {id}."))
+                };
+                self.inner.store.delete_routine(existing.id)?;
+                self.emit(UiEvent::RoutinesChanged { agent_id: card.id });
+                Ok(format!("Cancelled {}: {}.", existing.id, existing.short_title()))
             }
         }
+    }
+
+    /// One of this agent's own routines, by the id it was given.
+    ///
+    /// Only its own, and that is the point rather than tidiness. An id can
+    /// arrive from anywhere an agent reads — a peer's message, a page, a file —
+    /// and a schedule is not shared, so one agent must never be able to retime
+    /// or cancel another's.
+    fn my_routine(
+        &self,
+        card: &AgentCard,
+        id: &str,
+    ) -> Result<Option<Routine>, crate::db::StoreError> {
+        let Ok(parsed) = id.trim().parse() else {
+            return Ok(None);
+        };
+        Ok(self.inner.store.agent_routines(card.id)?.into_iter().find(|r| r.id == parsed))
     }
 
     /// The inference settings one agent's turn should use.

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -13,6 +13,7 @@ use crate::domain::attachment::Attachment;
 use crate::domain::connector::Connector;
 use crate::domain::envelope::{Envelope, Part, Participant};
 use crate::domain::ids::AgentId;
+use crate::domain::routine::Routine;
 use crate::domain::signin::Signin;
 use crate::llm::openrouter::ChatMessage;
 use crate::llm::tools::Surfaces;
@@ -54,6 +55,11 @@ pub fn system_prompt(
     // places. Nobody typed these: they were read off whatever holds the cookies.
     signins: &[Signin],
     notes: &str,
+    // What this agent already has standing, newest firing first. In the prompt
+    // rather than behind a tool call: an agent asked to change something it
+    // keeps has to know it keeps it before it decides what to do, and a list it
+    // has to go and ask for is a list it asks for after deciding.
+    routines: &[Routine],
     mode: ReplyMode,
     // Which of the two places this agent has. Not a preference: a section
     // describing a machine that is not configured is a promise the app cannot
@@ -252,6 +258,38 @@ pub fn system_prompt(
          reach you as new messages by themselves. A routine that fires to go looking finds \
          nothing, because whatever you were waiting for would already have arrived.\n",
     );
+
+    // The whole list, every turn, and the id of each. An agent asked half an
+    // hour later to change something it already keeps decides what to do before
+    // it calls anything, so a schedule it could have gone and asked for is a
+    // schedule it reads after the decision: it wrote a second routine beside
+    // the first, told the operator it had made the change, and both fired.
+    if routines.is_empty() {
+        out.push_str("\nYou have nothing standing.\n");
+    } else {
+        out.push_str("\nYou have these standing already:\n\n");
+        for routine in routines {
+            // The name only when there is one. An agent naming its own routine
+            // is optional, and a row that fell back to the instruction would
+            // then print it twice, in two different lengths.
+            let name = routine.name.trim();
+            let label = if name.is_empty() { String::new() } else { format!(" · {name}") };
+            out.push_str(&format!(
+                "- {}{label} — {} — {}\n",
+                routine.id,
+                routine.describe(),
+                one_line(&routine.what)
+            ));
+        }
+        out.push_str(
+            "\nThese are yours to keep in order, and the id is how you reach one. When you are \
+             asked for something that one of them already does, change that one: `update` with \
+             its id takes a new time, a new instruction or a new name and leaves the rest of it \
+             as it was. Adding a second routine does not replace the first — both fire, and the \
+             operator gets the work twice — so `cancel` is what retires one. `list` gives you \
+             the full instruction of each, which is cut short above.\n",
+        );
+    }
 
     // Placed before the roster and the rules: an agent's own accumulated
     // understanding of itself should colour how it reads everything after.
@@ -458,6 +496,29 @@ pub fn system_prompt(
     out
 }
 
+/// A routine's instruction as one line of a list.
+///
+/// The instruction is written to be acted on with no other context, which is
+/// several sentences, and this list is read to recognise a job rather than to
+/// carry it out: `schedule` with `list` hands over the whole thing. Ten
+/// routines drawn in full would be the largest section of the prompt, and the
+/// rule underneath them the part that got skimmed.
+fn one_line(what: &str) -> String {
+    /// Enough to tell two routines apart. Well under the shortest instruction
+    /// worth writing, which is why the full text is a tool call away.
+    const WIDTH: usize = 100;
+
+    let what = what.split_whitespace().collect::<Vec<_>>().join(" ");
+    if what.chars().count() <= WIDTH {
+        return what;
+    }
+    let cut: String = what.chars().take(WIDTH).collect();
+    match cut.rfind(char::is_whitespace) {
+        Some(space) => format!("{}…", cut[..space].trim_end()),
+        None => format!("{cut}…"),
+    }
+}
+
 /// The files a message carries, in the order it carries them.
 pub fn attachments(envelope: &Envelope) -> Vec<&Attachment> {
     envelope
@@ -528,6 +589,7 @@ pub fn build_messages(
     signins: &[Signin],
     names: &NameTable,
     notes: &str,
+    routines: &[Routine],
     history: &[Envelope],
     inbound: &[Envelope],
     mode: ReplyMode,
@@ -540,6 +602,7 @@ pub fn build_messages(
         credentials,
         signins,
         notes,
+        routines,
         mode,
         surfaces,
     ))];
@@ -578,7 +641,22 @@ mod tests {
         notes: &str,
         mode: ReplyMode,
     ) -> String {
-        system_prompt(card, "", roster, &[], &[], notes, mode, Surfaces::both())
+        system_prompt(card, "", roster, &[], &[], notes, &[], mode, Surfaces::both())
+    }
+
+    /// The prompt for an agent that already keeps a schedule.
+    fn prompt_keeping(card: &AgentCard, routines: &[Routine]) -> String {
+        system_prompt(
+            card,
+            "",
+            &[],
+            &[],
+            &[],
+            "",
+            routines,
+            ReplyMode::ToOperator,
+            Surfaces::both(),
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -599,6 +677,7 @@ mod tests {
             &[],
             names,
             notes,
+            &[],
             history,
             inbound,
             mode,
@@ -640,7 +719,8 @@ mod tests {
     use crate::domain::attachment::Attachment;
     use crate::domain::envelope::Intent;
     use crate::domain::envelope::{Part, Trust};
-    use crate::domain::ids::{GroupId, MessageId, RunId};
+    use crate::domain::ids::{GroupId, MessageId, RoutineId, RunId};
+    use crate::domain::routine::{Cadence, Trigger};
     use crate::domain::signin::Surface;
 
     fn card(name: &str) -> AgentCard {
@@ -799,6 +879,7 @@ mod tests {
             &[credential("GitHub", "madebywelch", "GITHUB_TOKEN")],
             &[signed_in(c.id, "LinkedIn")],
             "",
+            &[],
             ReplyMode::ToOperator,
             Surfaces::both(),
         );
@@ -832,8 +913,17 @@ mod tests {
         let mut hedged = signed_in(c.id, "intranet.example");
         hedged.recognised = false;
 
-        let prompt =
-            system_prompt(&c, "", &[], &[], &[hedged], "", ReplyMode::ToOperator, Surfaces::both());
+        let prompt = system_prompt(
+            &c,
+            "",
+            &[],
+            &[],
+            &[hedged],
+            "",
+            &[],
+            ReplyMode::ToOperator,
+            Surfaces::both(),
+        );
         assert!(prompt.contains("may also be signed in"), "a guess has to read as one");
         assert!(
             !prompt.contains("Your browser is signed in to these"),
@@ -853,8 +943,17 @@ mod tests {
         let c = card("Researcher");
         let mut token = credential("GitHub", "madebywelch", "GITHUB_TOKEN");
         token.secret_hint = "...ter2".into();
-        let prompt =
-            system_prompt(&c, "", &[], &[token], &[], "", ReplyMode::ToOperator, Surfaces::both());
+        let prompt = system_prompt(
+            &c,
+            "",
+            &[],
+            &[token],
+            &[],
+            "",
+            &[],
+            ReplyMode::ToOperator,
+            Surfaces::both(),
+        );
 
         assert!(prompt.contains("GITHUB_TOKEN"), "the name is what it needs");
         assert!(!prompt.contains("ghp_"), "no value, not even a hint of one");
@@ -884,6 +983,7 @@ mod tests {
             &[],
             &[signed_in(c.id, "LinkedIn")],
             "",
+            &[],
             ReplyMode::ToOperator,
             Surfaces::both(),
         );
@@ -911,6 +1011,7 @@ mod tests {
             &[],
             &[],
             "",
+            &[],
             ReplyMode::ToOperator,
             Surfaces::both(),
         );
@@ -993,6 +1094,117 @@ mod tests {
             !section(&prompt, "## Your computer").contains("schedule"),
             "the computer section is about the machine"
         );
+    }
+
+    /// A routine as the store would hand one back.
+    fn standing(id: RoutineId, name: &str, what: &str, trigger: Trigger) -> Routine {
+        Routine {
+            id,
+            agent_id: AgentId::new(),
+            name: name.to_string(),
+            what: what.to_string(),
+            trigger,
+            active: true,
+            next_run_at: Some(crate::domain::now_ms() + 3_600_000),
+            last_run_at: None,
+            created_at: 0,
+        }
+    }
+
+    #[test]
+    fn an_agent_reads_its_own_schedule_before_it_writes_another_one() {
+        // The failure this is for: an operator asks half an hour later for a
+        // change to something the agent already keeps, the agent has no idea it
+        // keeps it, and writes a second routine beside the first. Both fire.
+        // Behind a tool call this arrives after the decision, not before it, so
+        // it is in the prompt.
+        let id = RoutineId::new();
+        let prompt = prompt_keeping(
+            &card("Watcher"),
+            &[standing(
+                id,
+                "Listings sweep",
+                "Check the new listings and email me a summary.",
+                Trigger::Clock(Cadence::Weekdays),
+            )],
+        );
+        let schedule = section(&prompt, "## Your schedule");
+        assert!(schedule.contains("Listings sweep"), "it has to know what it keeps: {schedule}");
+        assert!(
+            schedule.contains(&id.to_string()),
+            "and the id, or it has nothing to change the routine by: {schedule}"
+        );
+        assert!(schedule.contains("every weekday"), "with what it is standing for: {schedule}");
+        assert!(
+            schedule.contains("`update`"),
+            "knowing it exists is only useful with the way to change it: {schedule}"
+        );
+        assert!(
+            schedule.contains("does not replace"),
+            "and the reason not to add a second one has to be the consequence: {schedule}"
+        );
+    }
+
+    #[test]
+    fn an_agent_with_nothing_standing_is_told_that_plainly() {
+        // Silence here reads as "no schedule section applies to me", and an
+        // empty list is the ordinary case.
+        let schedule = {
+            let prompt = prompt_keeping(&card("Watcher"), &[]);
+            section(&prompt, "## Your schedule").to_string()
+        };
+        assert!(schedule.contains("nothing standing"), "{schedule}");
+        assert!(!schedule.contains("`update`"), "nothing to update yet: {schedule}");
+    }
+
+    #[test]
+    fn a_switched_off_routine_does_not_claim_a_next_firing_in_the_prompt() {
+        // It still holds the slot it was holding, so the countdown is there to
+        // be printed. An agent told a routine fires in an hour reports work as
+        // in hand that nobody is going to do.
+        let mut off = standing(
+            RoutineId::new(),
+            "Listings sweep",
+            "Check the listings.",
+            Trigger::Clock(Cadence::Daily),
+        );
+        off.active = false;
+        let prompt = prompt_keeping(&card("Watcher"), &[off]);
+        let schedule = section(&prompt, "## Your schedule");
+        assert!(schedule.contains("switched off"), "{schedule}");
+        assert!(!schedule.contains("next in"), "{schedule}");
+    }
+
+    #[test]
+    fn a_long_instruction_is_cut_down_to_a_line_rather_than_drawn_in_full() {
+        // An instruction is written to be acted on with no other context, so it
+        // runs to several sentences. Ten of them in full would be the largest
+        // section in the prompt, and the rule underneath them the part that got
+        // skimmed. `list` is where the whole thing lives.
+        let long = "Check the listings on both sites, compare them against the ones you                     reported yesterday, and email the operator a summary of anything new,                     including the asking price and the agent's name.";
+        let prompt = prompt_keeping(
+            &card("Watcher"),
+            &[standing(RoutineId::new(), "Sweep", long, Trigger::Clock(Cadence::Daily))],
+        );
+        let schedule = section(&prompt, "## Your schedule");
+        assert!(schedule.contains("Check the listings on both sites"), "{schedule}");
+        assert!(!schedule.contains("the asking price"), "{schedule}");
+        assert!(schedule.contains('…'), "a cut has to look like one: {schedule}");
+        assert!(schedule.contains("`list`"), "and the full text has to be reachable: {schedule}");
+    }
+
+    #[test]
+    fn an_unnamed_routine_is_titled_by_what_it_does_without_filling_the_list() {
+        // Naming a routine is optional, and an agent that skipped it still has
+        // to be able to tell one row from another.
+        let long = "Publish the queued posts on the day only, in America/New_York, after                     checking the feed for anything the manager has already cleared.";
+        let prompt = prompt_keeping(
+            &card("Watcher"),
+            &[standing(RoutineId::new(), "", long, Trigger::Clock(Cadence::Daily))],
+        );
+        let schedule = section(&prompt, "## Your schedule");
+        assert!(schedule.contains("Publish the queued posts"), "{schedule}");
+        assert!(!schedule.contains("America/New_York — "), "the title is cut: {schedule}");
     }
 
     #[test]
@@ -1110,6 +1322,7 @@ mod tests {
             &[],
             &NameTable::new(),
             "",
+            &[],
             &[sent],
             &[],
             ReplyMode::ToOperator,
@@ -1181,6 +1394,7 @@ mod tests {
             &[],
             &[],
             "",
+            &[],
             ReplyMode::ToOperator,
             Surfaces::both(),
         );
@@ -1194,6 +1408,7 @@ mod tests {
             &[],
             &[],
             "",
+            &[],
             ReplyMode::ToOperator,
             Surfaces::both(),
         );
@@ -1334,6 +1549,7 @@ mod tests {
             &[],
             &[],
             "",
+            &[],
             ReplyMode::ToOperator,
             Surfaces::none(),
         );
@@ -1350,6 +1566,7 @@ mod tests {
             &[],
             &[],
             "",
+            &[],
             ReplyMode::ToOperator,
             Surfaces { computer: true, browser: false },
         );

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -1658,6 +1658,176 @@ async fn a_standing_request_becomes_one_routine_that_does_the_job_when_it_fires(
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_change_to_a_routine_changes_the_one_that_stands_rather_than_adding_a_second() {
+    // The failure this exists for. An operator books something, comes back half
+    // an hour later and asks for it at a different time without saying which
+    // routine they mean. The agent had no way to know it already kept one, and
+    // no verb for changing it: it wrote a second beside the first, said it had
+    // made the change, and both fired from then on.
+    //
+    // The id is read out of the agent's own prompt, so this asserts the whole
+    // path rather than the tool: what it keeps is in front of it, and the way
+    // to change it takes that id.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            return Script::Say("Moved it to every morning.".into());
+        }
+        match standing_id(body) {
+            Some(id) => Script::Retime { id, repeat: "daily".into() },
+            // No id in the prompt is the bug: an agent that cannot see what it
+            // keeps books a second routine instead.
+            None => Script::Book {
+                name: "Listings check".into(),
+                what: "Check the listings and say what is new.".into(),
+                repeat: "daily".into(),
+            },
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Watcher"], GuardLimits::default());
+    h.runtime
+        .store()
+        .create_routine(
+            h.id("Watcher"),
+            "Listings sweep",
+            "Check the listings and say what is new.",
+            Trigger::Clock(Cadence::Weekdays),
+            Some(now_ms() + 3_600_000),
+        )
+        .unwrap();
+
+    let asked = h
+        .runtime
+        .send_from_human(h.id("Watcher"), "Actually make that every day, not just weekdays.")
+        .unwrap();
+    h.settle(asked).await;
+
+    let standing = h.runtime.store().agent_routines(h.id("Watcher")).unwrap();
+    assert_eq!(
+        standing.len(),
+        1,
+        "a change to a standing job is one routine, not two competing ones: {:?}",
+        standing.iter().map(|r| (r.title().to_string(), r.describe())).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        standing[0].trigger,
+        Trigger::Clock(Cadence::Daily),
+        "and it is the change asked for"
+    );
+    assert_eq!(
+        standing[0].name, "Listings sweep",
+        "a field nobody sent is left alone, or retiming a routine loses its name"
+    );
+    assert!(
+        tool_results(&stub).iter().any(|r| r.contains("Updated")),
+        "the reply is the agent's only record of what it did: {:?}",
+        tool_results(&stub)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn one_agent_cannot_retime_or_cancel_another_agents_routine() {
+    // A schedule is not shared. `update` reaches a row by id, and an id that
+    // arrives from anywhere other than this agent's own list has to miss.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            return Script::Say("Could not change it.".into());
+        }
+        // The id is passed in through the instruction, which is the only way an
+        // agent could come by a peer's: read out of a message.
+        let id = body["messages"]
+            .as_array()
+            .and_then(|m| m.last())
+            .and_then(|m| m["content"].as_str())
+            .and_then(|text| text.split("id ").nth(1))
+            .map(|rest| rest.trim().trim_end_matches('.').to_string())
+            .unwrap_or_default();
+        Script::Retime { id, repeat: "monthly".into() }
+    })
+    .await;
+
+    let h = harness(&stub, &["Watcher", "Scribe"], GuardLimits::default());
+    let theirs = h
+        .runtime
+        .store()
+        .create_routine(
+            h.id("Scribe"),
+            "Filing",
+            "File yesterday's notes.",
+            Trigger::Clock(Cadence::Weekdays),
+            Some(now_ms() + 3_600_000),
+        )
+        .unwrap();
+
+    let asked = h
+        .runtime
+        .send_from_human(h.id("Watcher"), &format!("Move the filing routine, id {}.", theirs.id))
+        .unwrap();
+    h.settle(asked).await;
+
+    assert_eq!(
+        h.runtime.store().get_routine(theirs.id).unwrap().unwrap().trigger,
+        Trigger::Clock(Cadence::Weekdays),
+        "one agent retimed another's routine"
+    );
+    assert!(
+        tool_results(&stub).iter().any(|r| r.contains("no routine with the id")),
+        "and the refusal has to say so rather than reporting success: {:?}",
+        tool_results(&stub)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_second_routine_for_a_job_already_standing_is_named_while_the_turn_can_still_fix_it() {
+    // The backstop for the same failure, for a turn that books anyway. Not a
+    // refusal: nothing here can tell "move the sweep" from "sweep twice a day",
+    // and refusing the second would refuse honest work. Said, with both ids,
+    // while the turn that knows which it meant is still running.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            return Script::Say("Booked.".into());
+        }
+        Script::Book {
+            name: "Listings check".into(),
+            what: "Check Zillow listings and email me a summary of anything new.".into(),
+            repeat: "daily".into(),
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Watcher"], GuardLimits::default());
+    let first = h
+        .runtime
+        .store()
+        .create_routine(
+            h.id("Watcher"),
+            "Listings sweep",
+            "Check the new listings and email me a summary.",
+            Trigger::Clock(Cadence::Weekdays),
+            Some(now_ms() + 3_600_000),
+        )
+        .unwrap();
+
+    let asked = h
+        .runtime
+        .send_from_human(h.id("Watcher"), "Check the listings daily and email me.")
+        .unwrap();
+    h.settle(asked).await;
+
+    let told = tool_results(&stub).join("\n");
+    assert!(
+        told.contains("same job"),
+        "the turn has to be told it now has two routines doing one job: {told}"
+    );
+    assert!(
+        told.contains(&first.id.to_string()),
+        "with the id of the one it already had, or there is nothing it can act on: {told}"
+    );
+    assert!(told.contains("cancel"), "and the way out: {told}");
+}
+
 #[tokio::test]
 async fn a_routine_that_is_switched_off_stays_quiet_and_starts_again_when_asked() {
     let stub = serve(|_| Script::Say("checked".into())).await;

--- a/src-tauri/tests/evals.rs
+++ b/src-tauri/tests/evals.rs
@@ -1201,10 +1201,28 @@ mod live {
         instruction: &str,
         secs: u64,
     ) -> Option<(Harness, Eval)> {
+        run_live_prepared(crew, instruction, secs, |_| {}).await
+    }
+
+    /// The same, with something already true of the workspace before the crew
+    /// is asked anything.
+    ///
+    /// A scenario about what an agent does with what it already keeps cannot
+    /// arrange that with an instruction: it would be asking for the thing under
+    /// test. `setup` runs against the live store, and everything after it is
+    /// the ordinary path, including the machine cleanup an early assertion must
+    /// not be able to skip.
+    async fn run_live_prepared(
+        crew: &[LiveAgent],
+        instruction: &str,
+        secs: u64,
+        setup: impl FnOnce(&Harness),
+    ) -> Option<(Harness, Eval)> {
         let config = configured()?;
         let before = machines_now(&config).await;
         let h = live_crew(config.clone(), crew);
         let names: Vec<&str> = crew.iter().map(|a| a.name).collect();
+        setup(&h);
 
         // Started before the instruction, because the first turn can park.
         let (answering, asked) = answer_permission_requests(&h);
@@ -1713,6 +1731,71 @@ mod live {
             booked[0].what
         );
         eval.expect_told_operator("Watcher", 1, "a standing weekday job");
+    }
+
+    #[tokio::test]
+    #[ignore = "live: costs money, needs a configured key"]
+    async fn live_a_change_to_a_standing_job_changes_it_rather_than_adding_a_second() {
+        // The one this whole path exists for, and it is a question about
+        // judgement rather than about machinery: half an hour after booking
+        // something, the operator asks for it differently without saying which
+        // routine they mean. An agent that cannot see what it keeps writes a
+        // second one, tells the operator it has made the change, and both fire
+        // from then on. Nothing in the scripted suite can see this: the model
+        // decides it.
+        let crew = vec![LiveAgent::skilled("Watcher", &["monitoring", "reporting"])];
+        let Some((h, eval)) = run_live_prepared(
+            &crew,
+            "Actually, do the listings sweep every day rather than just weekdays.",
+            240,
+            |h| {
+                // Booked in an earlier conversation, which is the only place
+                // this can come from: the turn under test must not be the turn
+                // that created it.
+                h.runtime
+                    .store()
+                    .create_routine(
+                        h.id("Watcher"),
+                        "Listings sweep",
+                        "Check the new listings on both sites and email the operator anything \
+                         new, with the asking price.",
+                        guac_lib::domain::routine::Trigger::Clock(
+                            guac_lib::domain::routine::Cadence::Weekdays,
+                        ),
+                        Some(guac_lib::domain::now_ms() + 3_600_000),
+                    )
+                    .unwrap();
+            },
+        )
+        .await
+        else {
+            eprintln!("no configured model; skipping");
+            return;
+        };
+        report("a change to a standing job", &eval);
+
+        let standing = h.runtime.store().agent_routines(h.id("Watcher")).unwrap();
+        println!(
+            "standing: {:?}",
+            standing.iter().map(|r| (r.title().to_string(), r.describe())).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            standing.len(),
+            1,
+            "a change to a standing job is one routine, not two that both fire: {:?}",
+            standing.iter().map(|r| (r.title().to_string(), r.describe())).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            standing[0].trigger,
+            guac_lib::domain::routine::Trigger::Clock(guac_lib::domain::routine::Cadence::Daily),
+            "and it is the change that was asked for"
+        );
+        assert!(
+            standing[0].what.len() > 40,
+            "the instruction it already had must survive being retimed: {:?}",
+            standing[0].what
+        );
+        eval.expect_told_operator("Watcher", 1, "a change to a standing job");
     }
 
     #[tokio::test]

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -67,6 +67,9 @@ pub enum Script {
     Hire { name: String, instructions: String, notes: String },
     /// Emit a `schedule` tool call that books a repeat on the calendar.
     Book { name: String, what: String, repeat: String },
+    /// A `schedule` call that retimes a routine the agent already has, which is
+    /// the whole of what it should do when asked to change one.
+    Retime { id: String, repeat: String },
     /// Emit a `request_permission` tool call.
     AskOperator { action: String, because: String },
     /// Answer with a 503.
@@ -195,6 +198,17 @@ pub fn render(script: &Script) -> String {
                 serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
             ));
         }
+        Script::Retime { id, repeat } => {
+            let args =
+                serde_json::json!({ "action": "update", "id": id, "repeat": repeat }).to_string();
+            body.push_str(&frame(serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                {"index":0,"id":"call_retime","type":"function",
+                 "function":{"name":"schedule","arguments": args}}
+            ]}}]})));
+            body.push_str(&frame(
+                serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
+            ));
+        }
         Script::Hire { name, instructions, notes } => {
             let args =
                 serde_json::json!({ "name": name, "instructions": instructions, "notes": notes })
@@ -238,6 +252,21 @@ pub fn speaker(body: &serde_json::Value) -> String {
         .and_then(|rest| rest.split(',').next())
         .unwrap_or("unknown")
         .to_string()
+}
+
+/// The id of the first routine this agent's own prompt says it has standing.
+///
+/// Read out of the prompt rather than handed to the stub, because that is the
+/// thing under test: an agent asked to change something it keeps has to be able
+/// to find it without going to look, or it writes a second one instead.
+pub fn standing_id(body: &serde_json::Value) -> Option<String> {
+    let system = body["messages"][0]["content"].as_str().unwrap_or_default();
+    let schedule = system.split("## Your schedule").nth(1)?.split("\n## ").next()?;
+    schedule
+        .lines()
+        .find_map(|line| line.strip_prefix("- "))
+        .and_then(|line| line.split_whitespace().next())
+        .map(str::to_string)
 }
 
 /// True when the newest user turn carries peer messages, meaning this agent is

--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -51,8 +51,6 @@ function remembered(): boolean {
 export function Inspector({ agent, onEditProfile }: Props) {
   const [open, setOpen] = useState(remembered);
   const [routine, setRoutine] = useState<RoutineId | "new" | null>(null);
-  // Bumped to make the list read itself again after a routine was edited.
-  const [listVersion, setListVersion] = useState(0);
 
   useEffect(() => {
     try {
@@ -150,11 +148,11 @@ export function Inspector({ agent, onEditProfile }: Props) {
         {/* Hidden rather than unmounted while a routine is open. The screen
             holds a live connection to the agent's desktop, and rebuilding it
             every time somebody looked at a schedule would drop and reconnect
-            it. The list beside it is remounted deliberately, by its key. */}
+            it. */}
         <div className="inspector__level" hidden={routine !== null}>
           <ComputerScreen agent={agent} key={agent.id} />
           <BrowserScreen agent={agent} key={`browser:${agent.id}`} />
-          <RoutineList agentId={agent.id} onOpen={setRoutine} key={`${agent.id}:${listVersion}`} />
+          <RoutineList agentId={agent.id} onOpen={setRoutine} key={agent.id} />
         </div>
 
         {routine !== null && (
@@ -162,12 +160,10 @@ export function Inspector({ agent, onEditProfile }: Props) {
             key={`${agent.id}:${routine}`}
             agentId={agent.id}
             routineId={routine}
-            onBack={() => {
-              setRoutine(null);
-              // A routine can come back renamed, retimed, switched off or
-              // gone, and the list behind this was drawn before any of that.
-              setListVersion((n) => n + 1);
-            }}
+            // A routine can come back renamed, retimed, switched off or gone.
+            // The list behind this reads itself again on the event every one of
+            // those emits, so there is nothing to bump here.
+            onBack={() => setRoutine(null)}
           />
         )}
       </div>

--- a/src/components/RoutineList.test.tsx
+++ b/src/components/RoutineList.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { useStore } from "../lib/store";
 import type { Routine } from "../lib/types";
 import { RoutineList } from "./RoutineList";
 
@@ -32,6 +33,7 @@ describe("RoutineList", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     agentRoutines.mockResolvedValue([]);
+    useStore.setState({ routineVersion: {} });
   });
 
   it("reads a routine as a name and a cadence, and nothing else", async () => {
@@ -110,5 +112,34 @@ describe("RoutineList", () => {
   it("says so when there is nothing standing", async () => {
     render(<RoutineList agentId="a1" onOpen={vi.fn()} />);
     expect(await screen.findByText(/Nothing standing/)).toBeTruthy();
+  });
+
+  it("reads itself again when the agent it belongs to changes its own schedule", async () => {
+    // An agent sets a routine for itself mid-turn, with the operator looking at
+    // this panel. Until the runtime said so, the list stayed as it was drawn and
+    // the only way to see the routine was to close the panel and open it again.
+    render(<RoutineList agentId="a1" onOpen={vi.fn()} />);
+    expect(await screen.findByText(/Nothing standing/)).toBeTruthy();
+
+    agentRoutines.mockResolvedValue([routine()]);
+    act(() => {
+      useStore.getState().applyEvent({ type: "routinesChanged", agentId: "a1" });
+    });
+
+    expect(await screen.findByText("Boss commitment nudge")).toBeTruthy();
+  });
+
+  it("ignores a schedule change belonging to another agent", async () => {
+    // Every agent's panel would otherwise refetch on every firing anywhere in
+    // the workspace.
+    render(<RoutineList agentId="a1" onOpen={vi.fn()} />);
+    expect(await screen.findByText(/Nothing standing/)).toBeTruthy();
+    expect(agentRoutines).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useStore.getState().applyEvent({ type: "routinesChanged", agentId: "a2" });
+    });
+
+    expect(agentRoutines).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/RoutineList.tsx
+++ b/src/components/RoutineList.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { api } from "../lib/ipc";
 import { describeTrigger, parseTrigger, routineTitle } from "../lib/routine";
+import { useStore } from "../lib/store";
 import { relativeTime, useNow } from "../lib/time";
 import { type AgentId, errorMessage, type Routine, type RoutineId } from "../lib/types";
 
@@ -51,6 +52,11 @@ export function RoutineList({ agentId, onOpen }: Props) {
   const [routines, setRoutines] = useState<Routine[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const now = useNow(30_000);
+  // A routine set, retimed, cancelled or fired since this was drawn. The
+  // operator watching an agent work is the one most likely to be looking at
+  // this list while it changes, and until this existed the only way to see the
+  // change was to close the panel and open it again.
+  const changed = useStore((state) => state.routineVersion[agentId] ?? 0);
 
   const load = useCallback(async () => {
     try {
@@ -64,7 +70,7 @@ export function RoutineList({ agentId, onOpen }: Props) {
 
   useEffect(() => {
     void load();
-  }, [load]);
+  }, [load, changed]);
 
   return (
     <section className="routines">

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -150,6 +150,19 @@ interface State {
    */
   openingRoutine: RoutineId | null;
 
+  /**
+   * How many times each agent's schedule has changed since the window opened.
+   *
+   * A counter rather than the routines themselves: the panel reads them from
+   * Rust when it draws, and holding a second copy here would be a cache to keep
+   * in step with the one the component already has. What the component cannot
+   * work out for itself is *when* to read again, and an agent that sets a
+   * routine mid-turn is exactly when: the list was drawn before the routine
+   * existed, and closing the panel and opening it again was the only way to see
+   * it.
+   */
+  routineVersion: Record<AgentId, number | undefined>;
+
   /** Non-blocking surface for the last thing that went wrong. */
   banner: { tone: "error" | "info" | "ok"; text: string } | null;
 
@@ -250,6 +263,7 @@ export const useStore = create<State>((set, get) => ({
   pulses: [],
   focused: null,
   openingRoutine: null,
+  routineVersion: {},
   banner: null,
 
   async bootstrap() {
@@ -701,6 +715,16 @@ export const useStore = create<State>((set, get) => ({
       case "approvalSettled": {
         set((state) => ({
           approvals: { ...state.approvals, [event.approvalId]: event.state },
+        }));
+        break;
+      }
+
+      case "routinesChanged": {
+        set((state) => ({
+          routineVersion: {
+            ...state.routineVersion,
+            [event.agentId]: (state.routineVersion[event.agentId] ?? 0) + 1,
+          },
         }));
         break;
       }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -379,7 +379,13 @@ export type UiEvent =
     }
   | { type: "runSettled"; runId: RunId; stepsUsed: number }
   | { type: "approvalRequested"; approvalId: ApprovalId; agentId: AgentId }
-  | { type: "approvalSettled"; approvalId: ApprovalId; state: ApprovalState };
+  | { type: "approvalSettled"; approvalId: ApprovalId; state: ApprovalState }
+  /**
+   * One agent's schedule changed: it set a routine, edited one, cancelled one,
+   * or one came due and moved. The list refetches; nothing here is patched,
+   * because a schedule is a handful of rows.
+   */
+  | { type: "routinesChanged"; agentId: AgentId };
 
 /** Tokens spent, as the provider counted them. Never estimated. */
 export interface Tokens {


### PR DESCRIPTION
An agent asked to change a routine it already kept had no way to see that it kept one and no verb for changing one, so it wrote a second routine beside the first, reported the change as made, and both fired. Standing routines are now in the agent's prompt with the id of each, `schedule` gained an `update` action that leaves every field it was not sent alone, and an add that lands beside a routine already doing the same job says so with both ids rather than refusing, because nothing here can tell "move the sweep to ten" from "sweep at ten as well". Every path that writes a routine row now emits `RoutinesChanged`, so the panel stops showing a schedule drawn before the agent changed it and no longer has to be closed and reopened. Cascade, unit and frontend tests cover each half, including one that can only pass if the agent found the id in its own prompt, and `./scripts/ci.sh` is green. The live eval for this scenario is added but not run: it costs real spend, and judging a prompt change is what that suite is for.