### PR TITLE
fix: going inside a crew closes a chat from the one you left

### DIFF
--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -193,9 +193,25 @@ are in. A choice of one is chrome that never changes and a drop target that
 cannot move anybody anywhere.
 
 The group being looked inside is in the store rather than in the sidebar, because
-opening a channel can invalidate it. A search hit or a click on the flow board
-can land on an agent in another crew, and a rail still showing the group you were
-in has the open channel nowhere on it, so `select` lets the focus go.
+it and the open channel invalidate each other, and both are in the store. A
+search hit or a click on the flow board can land on an agent in another crew, and
+a rail still showing the group you were in has the open channel nowhere on it, so
+`select` lets the focus go. Going inside a crew is the same mismatch from the
+other end, so `focusGroup` closes the channel and the pane falls back to the
+activity feed, which belongs to no crew and is never closed. Whichever of the two
+the operator just asked for is the one that survives.
+
+Closing it is not tidiness. Two crews can hold two agents with the same name and
+the same face, and a rail that is not drawing the row leaves nothing on screen
+saying which crew the pane belongs to: a channel left open from the group you
+came from reads as a member of the group you are looking at, working while nobody
+here is. The agent goes on working either way. Closing a channel is not a control
+on the conversation, only on what you are looking at.
+
+Going back out to the overview keeps whatever was open, because the overview
+draws everybody. Neither does a move close anything: dragging somebody into
+another crew is not a change of view, and the operator who just made the gesture
+is the one person who does not need telling where that row went.
 
 The pinned section is a flag drawn as a place. It spans groups, so a row dropped
 among the pins keeps its own crew: the alternative is a gesture that says "keep

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -13,6 +13,10 @@ vi.mock("../lib/ipc", () => ({
   api: {
     listAgents: async () => [],
     listGroups: async () => [],
+    // Clicking a row opens a channel, and going inside a crew can close one:
+    // both read what they are about to draw.
+    channelMessages: async () => [],
+    conversationFlow: async () => [],
     moveAgent: (id: string, groupId: string, before: string | null) =>
       moveAgent(id, groupId, before),
     setAgentPinned: (id: string, pinned: boolean) => setAgentPinned(id, pinned),
@@ -312,6 +316,26 @@ describe("groups as places", () => {
 
     fireEvent.click(screen.getByLabelText("All groups, 2 agents"));
     expect(screen.getByText("Manager")).toBeTruthy();
+  });
+
+  it("closes a channel from the crew being left, and keeps one from the crew opened", async () => {
+    // Two crews can hold two agents with the same name and the same face, and
+    // going inside one does not draw the other's row: a channel left open from
+    // the crew you came from reads as this crew's, working while nobody here is.
+    draw(
+      [group("everyone"), group("research", null, RESEARCH)],
+      [agent("Chief"), agent("Chief of research", { groupId: RESEARCH, railOrder: 1 })],
+    );
+    useStore.setState({ selected: "Chief" });
+
+    fireEvent.click(screen.getByLabelText("research, 1 agent"));
+    await vi.waitFor(() => expect(useStore.getState().selected).toBe("activity"));
+
+    fireEvent.click(screen.getByLabelText("All groups, 2 agents"));
+    fireEvent.click(row("Chief of research"));
+    fireEvent.click(screen.getByLabelText("research, 1 agent"));
+    await vi.waitFor(() => expect(useStore.getState().railGroup).toBe(RESEARCH));
+    expect(useStore.getState().selected).toBe("Chief of research");
   });
 
   it("moves an agent into the group whose circle it was dropped on", async () => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -422,7 +422,7 @@ export function Sidebar({
             className="orb orb--all"
             aria-current={focused === null}
             aria-label={`All groups, ${agents.length} agents`}
-            onClick={() => focusGroup(null)}
+            onClick={() => void focusGroup(null)}
           >
             <span className="orb__ring">
               {/* The count, because the word is already under it and a circle
@@ -442,7 +442,7 @@ export function Sidebar({
               activity={activity}
               current={focused?.id === group.id}
               over={isOver({ kind: "group", id: group.id })}
-              onOpen={() => focusGroup(focused?.id === group.id ? null : group.id)}
+              onOpen={() => void focusGroup(focused?.id === group.id ? null : group.id)}
               onDragOver={() => hover({ kind: "group", id: group.id })}
               onDragOut={() => hover(null)}
             />

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -356,14 +356,14 @@ describe("the group the rail is inside", () => {
 
   it("is left alone while the channel being opened is in it", async () => {
     reset({ chef: [] });
-    useStore.getState().focusGroup(AGENTS[0]!.groupId);
+    await useStore.getState().focusGroup(AGENTS[0]!.groupId);
     await useStore.getState().select("manager");
     expect(useStore.getState().railGroup).toBe(AGENTS[0]!.groupId);
   });
 
   it("is left alone by the activity feed, which belongs to no group", async () => {
     reset({ chef: [] });
-    useStore.getState().focusGroup(AGENTS[0]!.groupId);
+    await useStore.getState().focusGroup(AGENTS[0]!.groupId);
     await useStore.getState().select(ACTIVITY_CHANNEL);
     expect(useStore.getState().railGroup).toBe(AGENTS[0]!.groupId);
   });
@@ -376,7 +376,7 @@ describe("the group the rail is inside", () => {
     useStore.setState({
       agents: [AGENTS[0]!, { ...AGENTS[1]!, groupId: RESEARCH }],
     });
-    useStore.getState().focusGroup(RESEARCH);
+    await useStore.getState().focusGroup(RESEARCH);
 
     await useStore.getState().select("manager");
     expect(useStore.getState().railGroup).toBeNull();
@@ -387,10 +387,70 @@ describe("the group the rail is inside", () => {
     useStore.setState({
       agents: [AGENTS[0]!, { ...AGENTS[1]!, groupId: RESEARCH }],
     });
-    useStore.getState().focusGroup(RESEARCH);
+    await useStore.getState().focusGroup(RESEARCH);
 
     await useStore.getState().openMessage("manager", "m-old");
     expect(useStore.getState().railGroup).toBeNull();
+  });
+});
+
+describe("the channel open when the rail goes inside a crew", () => {
+  const RESEARCH = "00000000-0000-4000-8000-000000000002";
+
+  /** The same crew twice, with a namesake in each. */
+  function twoCrews() {
+    reset({ chef: [] });
+    useStore.setState({
+      agents: [AGENTS[1]!, { ...AGENTS[1]!, id: "chef-research", groupId: RESEARCH }],
+    });
+  }
+
+  it("closes when it belongs to the crew being left", async () => {
+    // The reported confusion, and why the name is the same on both: the rail
+    // does not draw the row, so nothing on screen says which crew the pane
+    // belongs to, and a namesake left open from the crew you came from reads as
+    // this crew's, working while nobody here is.
+    twoCrews();
+    useStore.setState({ selected: "chef-research" });
+
+    await useStore.getState().focusGroup(AGENTS[1]!.groupId);
+
+    expect(useStore.getState().selected).toBe(ACTIVITY_CHANNEL);
+    expect(useStore.getState().railGroup).toBe(AGENTS[1]!.groupId);
+    // Landed on rather than merely pointed at: the feed the pane falls back to
+    // is read here, and nowhere else.
+    expect(useStore.getState().messages[ACTIVITY_CHANNEL]).toBeDefined();
+  });
+
+  it("stays open when it belongs to the crew being opened", async () => {
+    twoCrews();
+    useStore.setState({ selected: "chef-research" });
+
+    await useStore.getState().focusGroup(RESEARCH);
+
+    expect(useStore.getState().selected).toBe("chef-research");
+    expect(useStore.getState().railGroup).toBe(RESEARCH);
+  });
+
+  it("stays open on the way back out to the overview, which draws everybody", async () => {
+    twoCrews();
+    useStore.setState({ selected: "chef-research" });
+    await useStore.getState().focusGroup(RESEARCH);
+
+    await useStore.getState().focusGroup(null);
+
+    expect(useStore.getState().selected).toBe("chef-research");
+    expect(useStore.getState().railGroup).toBeNull();
+  });
+
+  it("leaves the activity feed alone, because it belongs to no crew", async () => {
+    twoCrews();
+    useStore.setState({ selected: ACTIVITY_CHANNEL });
+
+    await useStore.getState().focusGroup(RESEARCH);
+
+    expect(useStore.getState().selected).toBe(ACTIVITY_CHANNEL);
+    expect(useStore.getState().railGroup).toBe(RESEARCH);
   });
 });
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -109,11 +109,13 @@ interface State {
   /**
    * The group the rail is looking inside, or `null` for all of them.
    *
-   * Here rather than in the sidebar because opening a channel can invalidate
-   * it: an agent reached from search or from the flow board may live in another
-   * crew, and a rail that keeps showing the group you were in has the open
-   * channel nowhere on it. `select` is what knows a channel changed, so `select`
-   * is what lets the focus go.
+   * Here rather than in the sidebar because it and the open channel invalidate
+   * each other, and both are here. An agent reached from search or from the flow
+   * board may live in another crew, and a rail that keeps showing the group you
+   * were in has the open channel nowhere on it; going inside a crew while
+   * somebody else's channel is open is the same mismatch from the other end.
+   * Whichever of the two was just asked for wins: `select` lets the focus go,
+   * and `focusGroup` closes the channel.
    */
   railGroup: GroupId | null;
   messages: Record<ChannelKey, Envelope[] | undefined>;
@@ -158,8 +160,11 @@ interface State {
   refreshUsage: () => Promise<void>;
   refreshApprovals: () => Promise<void>;
   select: (key: ChannelKey) => Promise<void>;
-  /** Looks inside one group, or back out at all of them. */
-  focusGroup: (id: GroupId | null) => void;
+  /**
+   * Looks inside one group, or back out at all of them. Closes the open channel
+   * if the crew being opened is not the one it belongs to.
+   */
+  focusGroup: (id: GroupId | null) => Promise<void>;
   /**
    * Puts an agent somewhere: which group, in front of which row, and whether it
    * is pinned. Absent `pinned` leaves the section it is in alone.
@@ -229,6 +234,21 @@ function keptFocus(state: State, key: ChannelKey): GroupId | null {
   if (state.railGroup === null || key === ACTIVITY_CHANNEL) return state.railGroup;
   const agent = state.agents.find((a) => a.id === key);
   return agent && agent.groupId !== state.railGroup ? null : state.railGroup;
+}
+
+/**
+ * Whether the open channel survives the rail going inside a group.
+ *
+ * The same invariant as `keptFocus` read from the other end: the rail has to be
+ * able to draw the channel that is open. Going back out to the overview keeps
+ * whatever was open, because the overview draws everybody. The activity feed
+ * belongs to no group and is never closed.
+ */
+function keptChannel(state: State, group: GroupId | null): boolean {
+  const key = state.selected;
+  if (group === null || key === null || key === ACTIVITY_CHANNEL) return true;
+  const agent = state.agents.find((a) => a.id === key);
+  return agent === undefined || agent.groupId === group;
 }
 
 export const useStore = create<State>((set, get) => ({
@@ -310,8 +330,24 @@ export const useStore = create<State>((set, get) => ({
     await get().loadChannel(key);
   },
 
-  focusGroup(id) {
+  /**
+   * A crew, opened.
+   *
+   * A channel from the crew you came from does not stay open behind it. The rail
+   * would not be drawing its row, so there is nothing on screen that says which
+   * crew the pane belongs to, and two crews can hold two agents with the same
+   * name and the same face: one left open from the group you just left reads as
+   * a member of the group you are looking at, working while nobody here is. The
+   * agent goes on working. It is the reading of it that was wrong.
+   *
+   * Through `select` rather than by writing `selected`, so the feed the pane
+   * falls back to is read before it is drawn instead of arriving empty. It
+   * belongs to no group, so the focus set just above survives `keptFocus`.
+   */
+  async focusGroup(id) {
+    const closing = !keptChannel(get(), id);
     set({ railGroup: id });
+    if (closing) await get().select(ACTIVITY_CHANNEL);
   },
 
   /**


### PR DESCRIPTION
Switching from a crew where a Chief of Staff was working to a crew where its namesake was idle left the working chat open in the pane, so the idle crew looked like it had somebody mid-turn: the rail was not drawing that row, and two crews can hold two agents with the same name and the same face.

`select` already let the rail's focus go when a search hit landed on another crew's agent, and `focusGroup` did nothing in the other direction, so `keptChannel` now mirrors `keptFocus` and states the invariant once: the rail has to be able to draw the channel that is open, and whichever of the two the operator just asked for is the one that survives.

The pane falls back to the activity feed, which belongs to no crew, and going back out to the overview keeps whatever was open because the overview draws everybody; a move still closes nothing, deliberately, and the agent goes on working either way.

Five tests cover it, four in the store and one clicking the real orb through the real store, and the closing one fails without the fix. `./scripts/ci.sh` is green.