### PR TITLE
fix: the rail draws the token count, and a free model draws no price

### DIFF
--- a/src/components/ActivityFlow.tsx
+++ b/src/components/ActivityFlow.tsx
@@ -6,7 +6,7 @@ import { useStore } from "../lib/store";
 import type { WirePeer } from "../lib/transcript";
 import type { AgentCard, AgentId, Envelope, Participant, RunId, Tokens } from "../lib/types";
 import { plainText } from "../lib/types";
-import { compact, money } from "./TokenMeter";
+import { compact, money, priced } from "./TokenMeter";
 import { MessageModal } from "./WireRow";
 
 /**
@@ -155,6 +155,7 @@ export function ActivityFlow({ messages, byId }: Props) {
           const boardWidth = Math.max(block.lanes.length * laneW, laneW);
           const laneX = (i: number) => i * laneW + laneW / 2;
           const day = dayLabel(block.startedAt);
+          const usage = spent[block.runId];
 
           return (
             <section className="run" key={block.key} data-open={isOpen ? "true" : undefined}>
@@ -187,19 +188,13 @@ export function ActivityFlow({ messages, byId }: Props) {
                 <span className="run__count">
                   {block.rows.length} {block.rows.length === 1 ? "message" : "messages"}
                 </span>
-                {spent[block.runId] && (
+                {usage && (
                   <span
                     className="run__tokens"
-                    title={`${spent[block.runId]!.prompt.toLocaleString()} in, ${spent[
-                      block.runId
-                    ]!.completion.toLocaleString()} out, over ${spent[
-                      block.runId
-                    ]!.calls.toLocaleString()} model call(s)`}
+                    title={`${usage.prompt.toLocaleString()} in, ${usage.completion.toLocaleString()} out, over ${usage.calls.toLocaleString()} model call(s)`}
                   >
-                    {compact(spent[block.runId]!.prompt + spent[block.runId]!.completion)}
-                    {spent[block.runId]!.cost != null && (
-                      <span className="run__cost">{money(spent[block.runId]!.cost!)}</span>
-                    )}
+                    {compact(usage.prompt + usage.completion)}
+                    {priced(usage.cost) && <span className="run__cost">{money(usage.cost)}</span>}
                   </span>
                 )}
               </button>

--- a/src/components/RoutineDetail.tsx
+++ b/src/components/RoutineDetail.tsx
@@ -24,7 +24,7 @@ import {
   type RoutineId,
   type RoutineRun,
 } from "../lib/types";
-import { compact, money } from "./TokenMeter";
+import { compact, money, priced } from "./TokenMeter";
 
 interface Props {
   agentId: AgentId;
@@ -499,7 +499,7 @@ function History({ runs, now }: { runs: RoutineRun[] | null; now: number }) {
                   title={`${entry.spent.prompt.toLocaleString()} in, ${entry.spent.completion.toLocaleString()} out, over ${entry.spent.calls} model call(s)`}
                 >
                   {compact(entry.spent.prompt + entry.spent.completion)}
-                  {entry.spent.cost !== null && (
+                  {priced(entry.spent.cost) && (
                     <span className="history__cost">{money(entry.spent.cost)}</span>
                   )}
                 </span>

--- a/src/components/TokenMeter.test.tsx
+++ b/src/components/TokenMeter.test.tsx
@@ -1,7 +1,9 @@
+import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { PULSE_WINDOW_MS } from "../lib/store";
-import { bars, compact, money } from "./TokenMeter";
+import { PULSE_WINDOW_MS, useStore } from "../lib/store";
+import type { Tokens } from "../lib/types";
+import { bars, compact, money, priced, TokenMeter } from "./TokenMeter";
 
 describe("compact", () => {
   it("is exact while the numbers are small", () => {
@@ -62,5 +64,76 @@ describe("bars", () => {
 
   it("keeps a fixed width whatever it is given", () => {
     expect(bars([], now)).toHaveLength(bars([{ at: now, tokens: 1 }], now).length);
+  });
+});
+
+describe("priced", () => {
+  it("says no to the two ways a provider reports no charge", () => {
+    // A local server prices nothing and reports null. A free model prices every
+    // call at a real zero. Neither has anything to say in a narrow rail.
+    expect(priced(null)).toBe(false);
+    expect(priced(undefined)).toBe(false);
+    expect(priced(0)).toBe(false);
+  });
+
+  it("says no to a price that would draw as zeros anyway", () => {
+    // money() pads to four places, so anything under a ten-thousandth of a
+    // dollar is $0.0000: the same nothing, at more precision.
+    expect(priced(0.000_02)).toBe(false);
+    expect(money(0.000_02)).toBe("$0.0000");
+  });
+
+  it("says yes as soon as there is a digit to draw", () => {
+    expect(priced(0.0001)).toBe(true);
+    expect(priced(4.2)).toBe(true);
+  });
+});
+
+describe("TokenMeter", () => {
+  const GROUP = "00000000-0000-4000-8000-000000000001";
+
+  function draw(total: Tokens | undefined, points: { at: number; tokens: number }[] = []) {
+    useStore.setState({
+      usage: total ? { [GROUP]: total } : {},
+      pulse: { [GROUP]: points },
+    });
+    return render(<TokenMeter groupId={GROUP} />);
+  }
+
+  function spent(over: Partial<Tokens> = {}): Tokens {
+    return { prompt: 1200, completion: 300, cost: null, calls: 4, ...over };
+  }
+
+  // The count is the invariant: it is the one figure every provider produces
+  // and the one that climbs while a crew works.
+  it.each<[string, number | null]>([
+    ["a paid model", 0.0234],
+    ["a free model", 0],
+    ["a local server", null],
+  ])("draws the count under %s", (_what, cost) => {
+    const { container } = draw(spent({ cost }));
+    expect(container.querySelector(".meter__count")?.textContent).toBe("1.5k");
+  });
+
+  it("drops the price a free model reports, and keeps the count", () => {
+    // The whole complaint: free inference charged a real zero, the price won
+    // the one slot, and the rail spent seven characters on $0.0000 while the
+    // only figure going anywhere was not drawn at all.
+    const { container } = draw(spent({ cost: 0 }));
+    expect(container.textContent).toContain("1.5k");
+    expect(container.textContent).not.toContain("$");
+    expect(container.querySelector(".meter")?.getAttribute("title")).not.toContain("$");
+  });
+
+  it("draws the price beside the count once there is one", () => {
+    const { container } = draw(spent({ cost: 0.0234 }));
+    expect(container.textContent).toContain("$0.023");
+    expect(container.querySelector(".meter")?.getAttribute("title")).toContain("$0.023");
+  });
+
+  it("draws nothing at all for a group that has never spent anything", () => {
+    // An idle rail is not a column of zeros.
+    const { container } = draw(undefined);
+    expect(container.textContent).toBe("");
   });
 });

--- a/src/components/TokenMeter.tsx
+++ b/src/components/TokenMeter.tsx
@@ -23,6 +23,26 @@ export function money(dollars: number): string {
   return `$${dollars.toFixed(4)}`;
 }
 
+/** The smallest price {@link money} can draw. Below it every digit is a zero. */
+const MIN_PRICE = 0.0001;
+
+/**
+ * Whether there is a price worth the space it takes to draw.
+ *
+ * Three things report no charge and only one of them is null. A local server
+ * prices nothing, so its cost is absent. A free model prices every call at a
+ * real zero, and free inference over an afternoon stays zero, which drew
+ * `$0.0000` beside the sparkline: seven characters of a narrow rail saying
+ * nothing. A paid call small enough to round away says the same nothing at more
+ * precision, which is why the floor is what {@link money} can render rather
+ * than zero itself.
+ *
+ * Narrows, so the caller that draws the price does not have to assert it.
+ */
+export function priced(cost: number | null | undefined): cost is number {
+  return cost != null && cost >= MIN_PRICE;
+}
+
 /** 1.2k, 3.4M. Exact below a thousand, because early numbers are small. */
 export function compact(tokens: number): string {
   if (tokens < 1000) return String(tokens);
@@ -90,8 +110,9 @@ export function TokenMeter({ groupId }: Props) {
           ? [
               `${total.prompt.toLocaleString()} in, ${total.completion.toLocaleString()} out`,
               `${total.calls.toLocaleString()} model call${total.calls === 1 ? "" : "s"}`,
-              // Absent on a local server, which has nothing to charge.
-              total.cost === null ? null : `$${total.cost.toFixed(total.cost < 1 ? 4 : 2)}`,
+              // Absent on a local server and on a free model, neither of which
+              // has anything to charge.
+              priced(total.cost) ? money(total.cost) : null,
             ]
               .filter(Boolean)
               .join(" · ")
@@ -110,16 +131,15 @@ export function TokenMeter({ groupId }: Props) {
           />
         ))}
       </span>
-      {/* One number, not two. A group header already carries a name, a
-          sparkline, a headcount and a gear, and tokens and dollars are the
-          same fact twice: the price is the one an operator acts on. The count
-          is what is left when a provider prices nothing, and then it is the
-          only signal there is. Both are in the tooltip either way. */}
-      {total?.cost != null ? (
-        <span className="meter__cost">{money(total.cost)}</span>
-      ) : (
-        <span className="meter__count">{compact(spent)}</span>
-      )}
+      {/* The count is the one that is always there, because it is the one that
+          always moves: every call adds to it whatever the provider charges, and
+          a number climbing next to the sparkline is the difference between
+          watching work and watching a spinner. The price joins it only when
+          there is one to name. This used to be the other way around, one number
+          with the price winning, which showed a free model as `$0.0000` and hid
+          the only figure that was going anywhere. */}
+      <span className="meter__count">{compact(spent)}</span>
+      {priced(total?.cost) && <span className="meter__cost">{money(total.cost)}</span>}
     </span>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -371,6 +371,12 @@ button {
   color: var(--rail-muted);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+  /* The group header this hangs off is uppercased, and the only letters in a
+     readout are its units: `909k` arrived as `909K`, one glyph away from the
+     `M` that means a thousand times more. Nothing else in the app that draws a
+     token count sits inside an uppercased heading, so the unit is normalised
+     here rather than in the number. */
+  text-transform: none;
 }
 
 .meter[data-busy] .meter__count,


### PR DESCRIPTION
A free model prices every call at a real zero rather than reporting no price at all, so the meter beside a crew's name drew `$0.0000` and never drew the token count, which is the one number that climbs while a crew works.

The count is now unconditional and the price joins it only when there is one to name: `priced` is the single rule for that (null is a local server, zero is free inference, and anything under a ten-thousandth of a dollar can only render as `$0.0000`), and the run headers in the activity feed and the firing history under a routine drew the same zeros from the same cause and now share it. The readout also inherited `text-transform: uppercase` from the group header it hangs off, so `909k` arrived as `909K`, one glyph from the `M` that means a thousand times more.

Nine new tests, and the free-model case fails without the fix on the count rather than on the price: expected `1.5k`, got `$0.0000`.
