### PR TITLE
fix: the pull-out holds one agent, not every agent that has been through it

### DIFF
--- a/src/components/AgentMenu.tsx
+++ b/src/components/AgentMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import type { AgentCard, Group } from "../lib/types";
 
@@ -150,7 +150,14 @@ export function AgentMenu({
             the rail is: there is nowhere else to go. */}
         {groups
           .filter((group) => group.id !== agent.groupId)
-          .map((group) => item(`Move to ${group.name}`, () => onMoveToGroup(agent, group)))}
+          .map((group) => (
+            // Keyed on the crew, not on its name: two crews may be called the
+            // same thing, and the row that moves an agent has to be the row
+            // for the crew it names.
+            <Fragment key={group.id}>
+              {item(`Move to ${group.name}`, () => onMoveToGroup(agent, group))}
+            </Fragment>
+          ))}
         <hr className="menu__rule" />
         {confirming ? (
           item("Delete this history", () => onClearHistory(agent), "danger")

--- a/src/components/Inspector.test.tsx
+++ b/src/components/Inspector.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useStore } from "../lib/store";
+import type { AgentCard, Browser, Computer } from "../lib/types";
+import { Inspector } from "./Inspector";
+
+const agentComputer = vi.fn<(id: string) => Promise<Computer | null>>();
+const agentBrowser = vi.fn<(id: string) => Promise<Browser | null>>();
+const agentRoutines = vi.fn<() => Promise<never[]>>();
+
+vi.mock("../lib/ipc", () => ({
+  api: {
+    agentComputer: (id: string) => agentComputer(id),
+    agentBrowser: (id: string) => agentBrowser(id),
+    agentRoutines: () => agentRoutines(),
+    startAgentComputer: vi.fn(),
+    stopAgentComputer: vi.fn(),
+    deleteAgentComputer: vi.fn(),
+    startAgentBrowser: vi.fn(),
+    stopAgentBrowser: vi.fn(),
+  },
+}));
+
+function card(id: string, name: string): AgentCard {
+  return {
+    id,
+    groupId: "00000000-0000-4000-8000-000000000001",
+    sandboxId: null,
+    browserId: null,
+    name,
+    avatar: "plain",
+    color: "#c7d96b",
+    model: "m",
+    systemPrompt: "",
+    skills: [],
+    lifecycle: "active",
+    pinned: false,
+    railOrder: 0,
+    version: 1,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function configure() {
+  useStore.setState({
+    openingRoutine: null,
+    routineVersion: {},
+    settings: {
+      operatorName: "",
+      e2bKeySet: true,
+      e2bKeyHint: "",
+      computerIdleMinutes: 15,
+      kernelKeySet: true,
+      kernelKeyHint: "",
+      browserIdleMinutes: 60,
+      browserStealth: false,
+      baseUrl: "",
+      defaultModel: "",
+      provider: "compatible",
+      subscriptionModel: "gpt-5.6-luna",
+      subscriptionModels: ["gpt-5.6-luna", "gpt-5.4-mini"],
+      apiKeySet: true,
+      apiKeyHint: "",
+      requestTimeoutSecs: 120,
+      limits: {
+        maxHops: 8,
+        maxStepsPerRun: 60,
+        maxFanoutPerCall: 8,
+        maxSendsPerPair: 6,
+        maxToolRounds: 24,
+      },
+    },
+  });
+}
+
+describe("Inspector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    agentComputer.mockResolvedValue(null);
+    agentBrowser.mockResolvedValue(null);
+    agentRoutines.mockResolvedValue([]);
+    localStorage.clear();
+    configure();
+  });
+
+  it("holds one panel's worth of an agent, however many agents have been through it", async () => {
+    // Two siblings under the same key left the first agent's screen in the DOM
+    // when the second arrived: React's reconciler indexes the old children by
+    // key, so the duplicate overwrote the entry it would have deleted through.
+    // Every switch added another dead card, and only closing the panel, which
+    // unmounts their container, cleared them.
+    const view = render(<Inspector agent={card("a1", "Cook")} onEditProfile={vi.fn()} />);
+    await screen.findByText("Cook's screen");
+
+    for (const [id, name] of [
+      ["a2", "Scribe"],
+      ["a3", "Runner"],
+    ] as const) {
+      view.rerender(<Inspector agent={card(id, name)} onEditProfile={vi.fn()} />);
+      await screen.findByText(`${name}'s screen`);
+    }
+
+    await waitFor(() => expect(screen.getAllByText(/'s screen$/)).toHaveLength(1));
+    expect(screen.getAllByText(/'s browser$/)).toHaveLength(1);
+    expect(screen.getAllByRole("heading", { name: "Routines" })).toHaveLength(1);
+    expect(screen.queryByText("Cook's screen")).toBeNull();
+    expect(screen.queryByText("Scribe's screen")).toBeNull();
+  });
+});

--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -148,11 +148,23 @@ export function Inspector({ agent, onEditProfile }: Props) {
         {/* Hidden rather than unmounted while a routine is open. The screen
             holds a live connection to the agent's desktop, and rebuilding it
             every time somebody looked at a schedule would drop and reconnect
-            it. */}
-        <div className="inspector__level" hidden={routine !== null}>
-          <ComputerScreen agent={agent} key={agent.id} />
-          <BrowserScreen agent={agent} key={`browser:${agent.id}`} />
-          <RoutineList agentId={agent.id} onOpen={setRoutine} key={agent.id} />
+            it.
+
+            The key is here rather than on each section, and it is the whole
+            mechanism for switching agent: every section below holds one
+            agent's thing, a desktop connection, a browser, a list read over
+            IPC, and none of them may be left under the next agent's name. One
+            key on what they share says that once. Saying it three times, once
+            per section, collided: React indexes the outgoing children by key
+            to decide what to delete, so the duplicate overwrote the entry the
+            screen would have been deleted through. The previous agent's
+            screen stayed in the document with no fiber left to update it and
+            its polling still running, every switch added another, and only
+            closing the panel cleared them. */}
+        <div className="inspector__level" hidden={routine !== null} key={agent.id}>
+          <ComputerScreen agent={agent} />
+          <BrowserScreen agent={agent} />
+          <RoutineList agentId={agent.id} onOpen={setRoutine} />
         </div>
 
         {routine !== null && (

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -89,3 +89,22 @@ if (typeof (globalThis as { localStorage?: Storage }).localStorage?.getItem !== 
     },
   });
 }
+
+// A duplicate or missing key is a defect, not a warning. React's reconciler
+// indexes the outgoing children by key to decide what to delete, so two
+// siblings under one key silently leak whichever of them the map lost: the
+// element stays in the document with no fiber left to update it, which reads
+// as a panel that will not change until it is closed and opened again. React
+// says so on `console.error` and nothing was listening, so the tests are made
+// to listen. Only these two messages: everything else a component logs is the
+// component's business.
+{
+  const complain = console.error;
+  console.error = (...args: unknown[]) => {
+    const said = args.map((arg) => (typeof arg === "string" ? arg : "")).join(" ");
+    if (said.includes("the same key") || said.includes('unique "key"')) {
+      throw new Error(`React key defect: ${said}`);
+    }
+    complain(...args);
+  };
+}


### PR DESCRIPTION
`ComputerScreen` and `RoutineList` were siblings under the same `key={agent.id}`, and React indexes the outgoing children by key to decide what to delete, so the duplicate overwrote the entry the screen would have been deleted through: switching agent left the previous one's screen in the document with no fiber left to update it and its 15s poll still running, and only closing the panel, which unmounts their container, cleared them. `BrowserScreen` escaped because its key was prefixed. One key on `.inspector__level` instead, which is what three copies of it were trying to say, and none on the sections.

React had been reporting the collision on `console.error` all along, so the tests now listen: a duplicate or missing key throws. That caught the second one immediately, in `AgentMenu`, where the crew rows were mapped with no key at all. `Inspector.test.tsx` puts three agents through the panel and fails on the old code.