### PR TITLE
feat: a group is deleted with its crew, and the machines they were renting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ repo: the frontend renders state and forwards intent.
 | Scrolling a transcript, following the newest line, when the view may move | *A transcript follows the end for whoever is at the end, and nobody else* in `docs/WORKSPACE.md`, then `src/lib/follow.ts` |
 | The menu bar: the glyph, the count, what the menu offers, closing the window | *The menu bar is Guaca with the window shut* in `docs/WORKSPACE.md`, then `src-tauri/src/menubar.rs` |
 | The rail's order, dragging a row, groups as places you go inside | *The rail is arranged by hand*, *A drop is one call* and *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/rail.ts` |
+| Deleting a group, deleting an agent, what goes with either | *Deleting a group deletes the crew, and the machines they were renting* in `docs/WORKSPACE.md`, then `retire_agent` in `src-tauri/src/commands.rs` |
 | Preset agents, hiring a crew | *The cafeteria is a copy machine* in `docs/WORKSPACE.md`, then `src/lib/cafeteria.ts` |
 | Settings, the surface, the scale, what may interrupt the operator | *Settings is eight places*, *The reading column has two surfaces* and *An interruption has to earn it* in `docs/WORKSPACE.md` |
 | A prompt, or anything that changes how much a crew talks | *Three test suites, asking different questions*, then run the live evals |

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -261,6 +261,41 @@ The pinned section is a flag drawn as a place. It spans groups, so a row dropped
 among the pins keeps its own crew: the alternative is a gesture that says "keep
 this where I can see it" and quietly moves the agent to a different set of peers.
 
+## Deleting a group deletes the crew, and the machines they were renting
+
+One button, two calls. An empty group loses a row; a group with four agents in
+it loses the four agents, their computers, their browsers and the profiles
+holding those browsers' cookies. Which call a click makes is decided by the
+roster, and the confirmation names the count before it is pressed.
+
+It was two buttons, and the one for a populated group had exactly one outcome:
+an error telling the operator to go and delete four agents by hand and come
+back. That is not a refusal protecting anything. It is the work, described. An
+operator winding a crew down wants the crew gone, and the half-finished state
+that path produces is a group with one agent left in it and no reason to keep
+that one either.
+
+What a disband is not is a bigger *Start fresh*. A reset keeps the crew and
+takes what it accumulated; this takes the crew. They sit next to each other and
+only one of them is reversible in the sense that matters: a computer is rented
+from a provider, and killing it is not a row in a table.
+
+Each agent goes exactly as `delete_agent` sends one, through `retire_agent`,
+which is why they are the same function. Transcripts stay readable, because a
+delete at the scale of a crew is not a different rule about history: a message
+survives its author here for the same reason it does there. What is gone is
+everything the agent held privately, which is its memory, its schedule, its
+sign-ins and any standing permission the operator gave it.
+
+The refusal that remains is the first group, which cannot be deleted because
+every agent has to be in one. `Store::group_for_removal` asks that question
+separately from the emptiness check, and the command asks it *first*: a disband
+that killed four computers and then found the group could not go would have
+spent the irreversible half of the work on a call that fails. Terminated agents
+are not in the crew it takes. Their machines are already destroyed, and handing
+one back would mean a second kill against a sandbox that is not there, which the
+operator would be shown as the failure of the disband.
+
 ## Pinning is where a row is drawn and nothing else
 
 It does not bump the card version, because the version is how a peer notices a

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -363,6 +363,7 @@ pub fn run() {
             commands::create_group,
             commands::update_group,
             commands::delete_group,
+            commands::disband_group,
             commands::approval_states,
             commands::decide_approval,
             commands::agent_grants,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -428,6 +428,47 @@ pub fn delete_group(state: State<'_, AppState>, id: GroupId) -> Reply<()> {
     Ok(())
 }
 
+/// Deletes a group and the crew inside it.
+///
+/// The other half of `delete_group`, which refuses while anyone is still in
+/// there. An operator winding a crew down had to delete each agent by hand and
+/// then the group, and stopping halfway left a group with three agents in it
+/// and no reason to keep any of them.
+///
+/// Every agent goes exactly as `delete_agent` sends one: its computer killed,
+/// its browser and profile destroyed, its memory, schedule, sign-ins and
+/// standing permission gone. What each of them said stays readable, because a
+/// disband is a delete at the scale of a crew and not a different rule about
+/// history.
+///
+/// Refused before anything irreversible. `group_for_removal` asks the one
+/// question that does not depend on the crew: killing four computers and then
+/// discovering the group itself cannot go would leave the operator with neither
+/// the crew nor the deletion.
+///
+/// Past that point a failure stops where it is and is reported. Retrying is
+/// safe and picks up where it left off, because the crew is read fresh and the
+/// agents already retired are no longer in it.
+#[tauri::command]
+pub async fn disband_group(state: State<'_, AppState>, id: GroupId) -> Reply<()> {
+    state.runtime.store().group_for_removal(id)?;
+
+    let outcome = async {
+        for card in state.runtime.store().group_crew(id)? {
+            retire_agent(&state, &card).await?;
+        }
+        state.runtime.store().delete_group(id)?;
+        Ok(())
+    }
+    .await;
+
+    // Emitted either way. A disband that stopped part-way has still deleted
+    // whoever it reached, and a rail left drawing them is rows the operator can
+    // click on to open channels belonging to agents that are gone.
+    state.runtime.emit(UiEvent::AgentsChanged);
+    outcome
+}
+
 // ---- agents --------------------------------------------------------------
 
 #[tauri::command]
@@ -456,21 +497,26 @@ pub fn update_agent(
     Ok(card)
 }
 
-/// Deletes an agent.
+/// Everything one agent takes with it, in the order that leaves nothing
+/// running and nothing billing.
 ///
-/// A soft delete: the agent leaves the sidebar and the directory immediately
-/// and can never be messaged again, but what it already said stays readable in
-/// the other agents' channels. Hard-deleting would punch holes in transcripts
-/// that had nothing to do with this agent.
-#[tauri::command]
-pub async fn delete_agent(state: State<'_, AppState>, id: AgentId) -> Reply<()> {
+/// Shared by deleting a single agent and disbanding a whole crew, because the
+/// two are the same act at different scales: a disband that only marked the
+/// rows would leave a group's worth of sandboxes and browser profiles alive
+/// with nothing left on screen pointing at them.
+///
+/// A provider that refuses is logged and stepped over. The rows are the record
+/// the operator sees, and stopping halfway through would leave an agent that is
+/// still in the rail and has already lost its memory.
+async fn retire_agent(state: &State<'_, AppState>, card: &AgentCard) -> Reply<()> {
+    let id = card.id;
     // The machine goes first. A deleted agent cannot be asked to tidy up after
     // itself, and a sandbox nobody holds a reference to keeps billing.
-    let card = agent_card(&state, id)?;
+    //
     // A missing key means no machine was ever made through this build, so there
     // is nothing to release.
-    if let (Some(sandbox), Ok(client)) = (card.sandbox_id, computers(&state)) {
-        if let Err(err) = client.kill(&sandbox).await {
+    if let (Some(sandbox), Ok(client)) = (card.sandbox_id.as_ref(), computers(state)) {
+        if let Err(err) = client.kill(sandbox).await {
             tracing::warn!(%err, %sandbox, "could not destroy the agent's computer");
         }
     }
@@ -478,9 +524,9 @@ pub async fn delete_agent(state: State<'_, AppState>, id: AgentId) -> Reply<()> 
     // profile behind it goes too: it holds the cookies of accounts belonging to
     // an agent that no longer exists, and a name is free to reuse the moment an
     // agent is deleted, so whoever takes it next must not inherit its sessions.
-    if let Ok(client) = browsers(&state) {
-        if let Some(browser) = card.browser_id {
-            if let Err(err) = client.delete(&browser).await {
+    if let Ok(client) = browsers(state) {
+        if let Some(browser) = card.browser_id.as_ref() {
+            if let Err(err) = client.delete(browser).await {
                 tracing::warn!(%err, %browser, "could not destroy the agent's browser");
             }
         }
@@ -508,6 +554,19 @@ pub async fn delete_agent(state: State<'_, AppState>, id: AgentId) -> Reply<()> 
     // reuse the moment an agent is deleted, and whoever takes it next must not
     // inherit a standing grant given to somebody else.
     let _ = state.runtime.store().delete_agent_approvals(id);
+    Ok(())
+}
+
+/// Deletes an agent.
+///
+/// A soft delete: the agent leaves the sidebar and the directory immediately
+/// and can never be messaged again, but what it already said stays readable in
+/// the other agents' channels. Hard-deleting would punch holes in transcripts
+/// that had nothing to do with this agent.
+#[tauri::command]
+pub async fn delete_agent(state: State<'_, AppState>, id: AgentId) -> Reply<()> {
+    let card = agent_card(&state, id)?;
+    retire_agent(&state, &card).await?;
     state.runtime.emit(UiEvent::AgentsChanged);
     Ok(())
 }

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -1263,6 +1263,22 @@ impl Store {
         Ok(self.list_groups()?.into_iter().find(|g| g.id == id))
     }
 
+    /// The refusals that do not depend on the group being empty: it has to
+    /// exist, and the default group has to stay, because every agent has to be
+    /// in one.
+    ///
+    /// Separate from `delete_group` so disbanding a crew can refuse before it
+    /// starts destroying machines. A disband that killed a group's computers
+    /// and browsers and then found the group itself could not go would have
+    /// spent the irreversible half of the work on a call that fails.
+    pub fn group_for_removal(&self, id: GroupId) -> Result<Group, StoreError> {
+        let group = self.get_group(id)?.ok_or(StoreError::GroupNotFound(id))?;
+        if id == default_group_id() {
+            return Err(StoreError::CannotDeleteDefaultGroup);
+        }
+        Ok(group)
+    }
+
     /// Deletes a group that no live agent is in.
     ///
     /// Refuses while it still holds agents that can act, rather than moving
@@ -1276,16 +1292,12 @@ impl Store {
     /// Counting them was why deleting every agent in a group still reported
     /// three agents in it.
     pub fn delete_group(&self, id: GroupId) -> Result<(), StoreError> {
-        let group = self.get_group(id)?.ok_or(StoreError::GroupNotFound(id))?;
+        let group = self.group_for_removal(id)?;
         if group.agent_count > 0 {
             return Err(StoreError::GroupNotEmpty { name: group.name, agents: group.agent_count });
         }
 
         let default = default_group_id();
-        if id == default {
-            return Err(StoreError::CannotDeleteDefaultGroup);
-        }
-
         let conn = self.conn()?;
         conn.execute(
             "UPDATE agents SET group_id=?2 WHERE group_id=?1",
@@ -1729,6 +1741,27 @@ impl Store {
     pub fn delete_group_usage(&self, group: GroupId) -> Result<usize, StoreError> {
         let conn = self.conn()?;
         Ok(conn.execute("DELETE FROM usage WHERE group_id=?1", params![group.to_string()])?)
+    }
+
+    /// Every live agent in a group, whole cards.
+    ///
+    /// Terminated ones are left out. They have already been retired: their
+    /// machines are destroyed and their memories gone, and they are only still
+    /// filed under the group so old transcripts render. Handing one back to a
+    /// disband would mean a second attempt to kill a sandbox that no longer
+    /// exists, which is the failure the operator would then be shown.
+    pub fn group_crew(&self, group: GroupId) -> Result<Vec<AgentCard>, StoreError> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id,sandbox_id,sandbox_envd_token,sandbox_traffic_token,pinned,rail_order,browser_id
+               FROM agents WHERE group_id=?1 AND lifecycle <> 'terminated' ORDER BY rowid",
+        )?;
+        let rows = stmt.query_map(params![group.to_string()], row_to_card)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row??);
+        }
+        Ok(out)
     }
 
     /// The agents a group holds, deleted ones included.
@@ -2954,6 +2987,83 @@ mod tests {
             1,
             "clearing one group must not touch another"
         );
+    }
+
+    #[test]
+    fn a_disband_is_told_the_group_cannot_go_before_it_takes_anything() {
+        // The failure path this covers: a disband kills every computer and
+        // browser in a crew and only then asks whether the group itself may be
+        // deleted. The first group may not, and the operator would be left with
+        // the machines gone, the agents gone and the group still there.
+        let f = fixture();
+        let default = default_group_id();
+        let mut d = draft("Resident");
+        d.group_id = Some(default);
+        f.store.create_agent(&d).unwrap();
+
+        assert!(matches!(
+            f.store.group_for_removal(default),
+            Err(StoreError::CannotDeleteDefaultGroup)
+        ));
+
+        // The same question answered for a group that can go, while it is still
+        // full: the check is about the group, not about whether it is empty.
+        let group = f
+            .store
+            .create_group(&CleanGroup {
+                name: "Research".into(),
+                base_url: None,
+                default_model: None,
+                api_key: None,
+            })
+            .unwrap();
+        let mut d = draft("Scholar");
+        d.group_id = Some(group.id);
+        f.store.create_agent(&d).unwrap();
+        assert!(f.store.group_for_removal(group.id).is_ok());
+        assert!(
+            matches!(f.store.delete_group(group.id), Err(StoreError::GroupNotEmpty { .. })),
+            "the emptiness check has to stay on delete_group"
+        );
+    }
+
+    #[test]
+    fn a_disband_takes_the_live_crew_and_not_the_agents_already_deleted() {
+        // A terminated agent's sandbox is already destroyed and its memory is
+        // already gone. Handing one back would make a disband try to kill a
+        // machine that is not there and show the operator that failure.
+        let f = fixture();
+        let group = f
+            .store
+            .create_group(&CleanGroup {
+                name: "Research".into(),
+                base_url: None,
+                default_model: None,
+                api_key: None,
+            })
+            .unwrap();
+
+        let mut live = draft("Scholar");
+        live.group_id = Some(group.id);
+        let live = f.store.create_agent(&live).unwrap();
+
+        let mut gone = draft("Departed");
+        gone.group_id = Some(group.id);
+        let gone = f.store.create_agent(&gone).unwrap();
+        f.store.set_lifecycle(gone.id, Lifecycle::Terminated).unwrap();
+
+        // And somebody in another crew, who a disband must never reach.
+        let bystander = f.store.create_agent(&draft("Bystander")).unwrap();
+
+        let crew = f.store.group_crew(group.id).unwrap();
+        assert_eq!(crew.iter().map(|c| c.id).collect::<Vec<_>>(), vec![live.id]);
+        assert!(!crew.iter().any(|c| c.id == bystander.id));
+
+        // What the command does after retiring them, which is the reason the
+        // count above has to be right: the group is empty and goes.
+        f.store.set_lifecycle(live.id, Lifecycle::Terminated).unwrap();
+        assert!(f.store.group_crew(group.id).unwrap().is_empty());
+        f.store.delete_group(group.id).expect("a disbanded group must be deletable");
     }
 
     #[test]

--- a/src/components/GroupEditor.test.tsx
+++ b/src/components/GroupEditor.test.tsx
@@ -1,0 +1,166 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Group } from "../lib/types";
+
+/**
+ * The group dialog, over a mocked runtime.
+ *
+ * The risk on this surface is the delete button, which is two different calls
+ * behind one word. An empty group loses a row in a table; a group with a crew
+ * in it loses four agents, their computers and their browsers, and none of that
+ * comes back. Which call a click makes, and what the operator is told before
+ * they make it, is what is asserted here.
+ */
+
+const deleteGroup = vi.fn<(id: string) => Promise<void>>();
+const disbandGroup = vi.fn<(id: string) => Promise<void>>();
+const clearGroup = vi.fn();
+const updateGroup = vi.fn();
+const createGroup = vi.fn();
+
+vi.mock("../lib/ipc", () => ({
+  api: {
+    deleteGroup: (id: string) => deleteGroup(id),
+    disbandGroup: (id: string) => disbandGroup(id),
+    clearGroup: (id: string) => clearGroup(id),
+    updateGroup: (id: string, draft: unknown) => updateGroup(id, draft),
+    createGroup: (draft: unknown) => createGroup(draft),
+    // The roster refresh the dialog fires after any of the above, and the one
+    // call CredentialList makes on mount.
+    listAgents: () => Promise.resolve([]),
+    listGroups: () => Promise.resolve([]),
+    groupConnectors: () => Promise.resolve([]),
+  },
+}));
+
+const { GroupEditor } = await import("./GroupEditor");
+
+const ID = "00000000-0000-4000-8000-000000000001";
+
+function group(over: Partial<Group> = {}): Group {
+  return {
+    id: ID,
+    name: "Research",
+    agentCount: 0,
+    createdAt: 0,
+    baseUrl: null,
+    defaultModel: null,
+    apiKeySet: false,
+    apiKeyHint: "",
+    ...over,
+  };
+}
+
+const onClose = vi.fn();
+
+/**
+ * The dialog, mounted and settled.
+ *
+ * `CredentialList` reads the group's accounts on mount, so letting that land
+ * before the first click keeps every assertion on a tree that has stopped
+ * moving.
+ */
+async function open(on?: Group) {
+  const view = render(<GroupEditor group={on} onClose={onClose} />);
+  await act(async () => {});
+  return view;
+}
+
+describe("GroupEditor", () => {
+  beforeEach(() => {
+    deleteGroup.mockReset();
+    disbandGroup.mockReset();
+    clearGroup.mockReset();
+    onClose.mockReset();
+    deleteGroup.mockResolvedValue(undefined);
+    disbandGroup.mockResolvedValue(undefined);
+  });
+
+  it("takes two clicks to delete anything", async () => {
+    await open(group());
+    fireEvent.click(screen.getByText("Delete"));
+    expect(deleteGroup).not.toHaveBeenCalled();
+    expect(disbandGroup).not.toHaveBeenCalled();
+  });
+
+  it("deletes an empty group without disbanding anybody", async () => {
+    await open(group());
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByText("Delete Research"));
+
+    await waitFor(() => expect(deleteGroup).toHaveBeenCalledWith(ID));
+    expect(disbandGroup).not.toHaveBeenCalled();
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("says how many agents go, and what goes with them", async () => {
+    // The count is on the button because that is what the operator is about to
+    // press. The machines are in the banner because a count does not say that
+    // anything was rented, and destroying a computer is the half of this that
+    // cannot be undone.
+    await open(group({ agentCount: 4 }));
+    fireEvent.click(screen.getByText("Delete"));
+
+    expect(screen.getByText("Delete Research and 4 agents")).toBeTruthy();
+    expect(screen.getByText(/computers, browsers/)).toBeTruthy();
+  });
+
+  it("counts one agent as one agent", async () => {
+    await open(group({ agentCount: 1 }));
+    fireEvent.click(screen.getByText("Delete"));
+    expect(screen.getByText("Delete Research and 1 agent")).toBeTruthy();
+  });
+
+  it("disbands a group that still holds a crew", async () => {
+    await open(group({ agentCount: 4 }));
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByText("Delete Research and 4 agents"));
+
+    await waitFor(() => expect(disbandGroup).toHaveBeenCalledWith(ID));
+    // The plain delete would be refused for a group with agents in it, and
+    // refusing is all it could do: nothing about that error is what was asked
+    // for here.
+    expect(deleteGroup).not.toHaveBeenCalled();
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("keeps the crew when the second click is Keep", async () => {
+    await open(group({ agentCount: 4 }));
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByText("Keep"));
+
+    expect(disbandGroup).not.toHaveBeenCalled();
+    expect(screen.queryByText(/computers, browsers/)).toBeNull();
+    expect(screen.getByText("Delete")).toBeTruthy();
+  });
+
+  it("leaves the dialog open on a refusal, with the reason from the runtime", async () => {
+    // The first group cannot be deleted, because every agent has to be in one.
+    // A dialog that closed on that would look like it had worked.
+    disbandGroup.mockRejectedValue({
+      kind: "groupNotEmpty",
+      message: "every agent has to be in a group, so the first one cannot be deleted",
+    });
+    await open(group({ agentCount: 2 }));
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByText("Delete Research and 2 agents"));
+
+    expect(await screen.findByText(/cannot be deleted/)).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not offer to reset a group it is already deleting", async () => {
+    // Two destructive confirmations open at once is a click on the wrong one.
+    await open(group({ agentCount: 2 }));
+    expect(screen.getByText("Start fresh")).toBeTruthy();
+    fireEvent.click(screen.getByText("Delete"));
+    expect(screen.queryByText("Start fresh")).toBeNull();
+  });
+
+  it("offers nothing to delete on a group that does not exist yet", async () => {
+    await open();
+    expect(screen.queryByText("Delete")).toBeNull();
+    expect(screen.queryByText("Start fresh")).toBeNull();
+  });
+});

--- a/src/components/GroupEditor.tsx
+++ b/src/components/GroupEditor.tsx
@@ -42,6 +42,9 @@ export function GroupEditor({ group, onClose }: Props) {
 
   const patch = (next: Partial<GroupDraft>) => setDraft((d) => ({ ...d, ...next }));
 
+  /** Live agents. Terminated ones are not in the count and are not deleted twice. */
+  const crew = group?.agentCount ?? 0;
+
   const save = async () => {
     setBusy(true);
     setError(null);
@@ -81,17 +84,33 @@ export function GroupEditor({ group, onClose }: Props) {
     }
   };
 
+  /**
+   * The group, and whoever is still standing in it.
+   *
+   * One button rather than two, because "delete this crew" is one intent an
+   * operator arrives with and an empty group is the same act with nothing in
+   * the way. Two buttons would mean the one for a populated group had a single
+   * outcome, which was an error telling the operator to go and delete four
+   * agents by hand first.
+   *
+   * What changes is the confirmation, which names the count before it is
+   * pressed. The count is the roster's, so a group emptied elsewhere since the
+   * dialog opened takes the plain delete and a stale zero is refused by the
+   * runtime rather than quietly widened.
+   */
   const remove = async () => {
     if (!group) return;
     setBusy(true);
     setError(null);
     try {
-      await api.deleteGroup(group.id);
+      if (crew > 0) await api.disbandGroup(group.id);
+      else await api.deleteGroup(group.id);
       await refreshAgents();
       onClose();
     } catch (caught) {
-      // The usual failure is a group that still holds agents. The message from
-      // Rust already says how many and what to do, so it is shown as written.
+      // The remaining failure is the first group, which cannot go because every
+      // agent has to be in one. The message from Rust says so, and is shown as
+      // written.
       setError(errorMessage(caught));
       setBusy(false);
     }
@@ -184,6 +203,19 @@ export function GroupEditor({ group, onClose }: Props) {
           </div>
         )}
 
+        {/* What the second click costs, written where the operator is already
+            looking. The button beside it carries the count; this is the part a
+            count does not say: the machines are rented, and destroying them is
+            the half of a disband that cannot be undone. */}
+        {group && confirmDelete && crew > 0 && (
+          <div className="banner banner--error" style={{ margin: "0.2rem 0 0.9rem" }}>
+            <span>
+              {crew} agent{crew === 1 ? "" : "s"} go with the group: their computers, browsers,
+              memories and schedules are destroyed. What they said stays readable.
+            </span>
+          </div>
+        )}
+
         {error && (
           <div className="banner banner--error" style={{ margin: "0.2rem 0 0.9rem" }}>
             <span>{error}</span>
@@ -200,7 +232,9 @@ export function GroupEditor({ group, onClose }: Props) {
                   disabled={busy}
                   onClick={() => void remove()}
                 >
-                  Delete {group.name}
+                  {crew > 0
+                    ? `Delete ${group.name} and ${crew} agent${crew === 1 ? "" : "s"}`
+                    : `Delete ${group.name}`}
                 </button>
                 <button
                   type="button"
@@ -215,6 +249,11 @@ export function GroupEditor({ group, onClose }: Props) {
                 type="button"
                 className="btn btn--danger"
                 onClick={() => setConfirmDelete(true)}
+                title={
+                  crew > 0
+                    ? "Deletes the group and every agent in it, along with their computers and browsers. What they said stays readable."
+                    : "Deletes the group. It holds no agents."
+                }
               >
                 Delete
               </button>

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -137,6 +137,13 @@ export const api = {
   /** Refused while the group still holds agents; the error carries which. */
   deleteGroup: (id: GroupId) => invoke<void>("delete_group", { id }),
 
+  /**
+   * The group and everybody in it: every agent deleted, every computer and
+   * browser destroyed with them. Refused for the default group, before
+   * anything is taken.
+   */
+  disbandGroup: (id: GroupId) => invoke<void>("disband_group", { id }),
+
   listAgents: () => invoke<AgentCard[]>("list_agents"),
 
   createAgent: (draft: AgentDraft) => invoke<AgentCard>("create_agent", { draft }),


### PR DESCRIPTION
Deleting a group refused while anyone was still in it, so the button's only outcome on a populated group was an error telling the operator to go and delete four agents by hand first. Delete now takes the crew with the group: every agent, its computer, its browser and the profile holding that browser's cookies, with the count on the confirmation and the machines named in a banner beside it. Each agent goes through `retire_agent`, which is `delete_agent`'s teardown extracted, so transcripts stay readable exactly as they do for a single delete, and Start fresh is untouched. The one refusal left, the first group, is asked before anything irreversible: killing four computers and then finding the group could not go would spend the irreversible half of the work on a call that fails. Nine tests on the dialog and two on the store orderings; the provider calls themselves were not exercised here, since they are the same path a single agent delete has always taken.