### PR TITLE
fix: a browser key that is typed in is a browser key that is saved

### DIFF
--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -143,6 +143,11 @@ function type(label: RegExp, value: string): void {
   fireEvent.change(field(label), { target: { value } });
 }
 
+/** A checkbox on the same surface, found the same way and toggled. */
+function check(label: RegExp): void {
+  fireEvent.click(field(label));
+}
+
 function save(): HTMLButtonElement {
   return screen.getByRole("button", { name: "Save" }) as HTMLButtonElement;
 }
@@ -271,6 +276,8 @@ describe("what a save sends", () => {
     expect("apiKey" in patch).toBe(false);
     expect("e2bApiKey" in patch).toBe(false);
     expect("computerIdleMinutes" in patch).toBe(false);
+    expect("kernelApiKey" in patch).toBe(false);
+    expect("browserIdleMinutes" in patch).toBe(false);
     expect("requestTimeoutSecs" in patch).toBe(false);
     expect(patch).toEqual({
       operatorName: "Robert",
@@ -281,6 +288,9 @@ describe("what a save sends", () => {
       baseUrl: "https://openrouter.ai/api/v1",
       defaultModel: "anthropic/claude-sonnet-4.5",
       subscriptionModel: "gpt-5.6-luna",
+      // The one field here that cannot be omitted: a checkbox left alone is a
+      // decision, and off has to be sendable or stealth can never be turned off.
+      browserStealth: false,
       limits: HELD,
     });
   });
@@ -291,11 +301,13 @@ describe("what a save sends", () => {
     type(/^API key/, "   ");
     pane("Machines");
     type(/^E2B API key/, " ");
+    type(/^Kernel API key/, "   ");
     fireEvent.click(save());
 
     await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
     expect("apiKey" in sentPatch()).toBe(false);
     expect("e2bApiKey" in sentPatch()).toBe(false);
+    expect("kernelApiKey" in sentPatch()).toBe(false);
   });
 
   it("refuses anything but digits in a duration, so no patch can carry NaN", async () => {
@@ -350,6 +362,9 @@ describe("what a save sends", () => {
     pane("Machines");
     type(/^E2B API key/, " e2b_typed ");
     type(/^Sleep computers after/, "45");
+    type(/^Kernel API key/, "  sk_typed  ");
+    type(/^Close browsers after/, "5");
+    check(/^Hide that browsers are automated/);
     pane("General");
     type(/^Your name/, "Robert");
 
@@ -364,9 +379,52 @@ describe("what a save sends", () => {
       apiKey: "sk-or-v1-typed",
       e2bApiKey: "e2b_typed",
       computerIdleMinutes: 45,
+      kernelApiKey: "sk_typed",
+      browserIdleMinutes: 5,
+      browserStealth: true,
       requestTimeoutSecs: 30,
       limits: HELD,
     });
+  });
+
+  it("carries the browser half of Machines on its own, with no computer touched", async () => {
+    // The half of this pane that pays for browsers went missing from the patch
+    // once: three fields typed into, cleared on save, and never sent. What the
+    // operator saw was the Kernel key refusing to stick and no browser widget
+    // in the channel, with "Saved." over the top of it.
+    open();
+    pane("Machines");
+    type(/^Kernel API key/, "sk_typed");
+    type(/^Close browsers after/, "5");
+
+    fireEvent.click(save());
+    await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
+    expect(sentPatch().kernelApiKey).toBe("sk_typed");
+    expect(sentPatch().browserIdleMinutes).toBe(5);
+    expect("e2bApiKey" in sentPatch()).toBe(false);
+    expect("computerIdleMinutes" in sentPatch()).toBe(false);
+  });
+
+  it("sends stealth turned back off, which omission would make unreachable", async () => {
+    open(stored({ browserStealth: true }));
+    pane("Machines");
+    expect(field(/^Hide that browsers are automated/).checked).toBe(true);
+    check(/^Hide that browsers are automated/);
+
+    fireEvent.click(save());
+    await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
+    expect(sentPatch().browserStealth).toBe(false);
+  });
+
+  it("refuses anything but digits in the browser timer too", async () => {
+    open();
+    pane("Machines");
+    type(/^Close browsers after/, "5 minutes");
+    expect(field(/^Close browsers after/).value).toBe("5");
+
+    fireEvent.click(save());
+    await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
+    expect(sentPatch().browserIdleMinutes).toBe(5);
   });
 
   it("clears the API key box afterwards and leaves every other box alone", async () => {
@@ -498,6 +556,7 @@ describe("testing the endpoint", () => {
       defaultModel: "anthropic/claude-sonnet-4.5",
       subscriptionModel: "gpt-5.6-luna",
       apiKey: "gsk_typed",
+      browserStealth: false,
     });
     expect(updateSettings).not.toHaveBeenCalled();
   });

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -219,6 +219,11 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
     ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
     ...(e2bKey.trim() ? { e2bApiKey: e2bKey.trim() } : {}),
     ...(idleMinutes.trim() ? { computerIdleMinutes: Number(idleMinutes) } : {}),
+    ...(kernelKey.trim() ? { kernelApiKey: kernelKey.trim() } : {}),
+    ...(browserIdleMinutes.trim() ? { browserIdleMinutes: Number(browserIdleMinutes) } : {}),
+    // A checkbox is never blank, so it goes every time. Omitting it would leave
+    // the only way to turn stealth back off unreachable.
+    browserStealth: stealth,
     ...(timeout.trim() ? { requestTimeoutSecs: Number(timeout) } : {}),
   });
 


### PR DESCRIPTION
The Machines pane assembles what Save sends field by field, and the browser half of it was never in that object: the Kernel key, the browser idle timer and the stealth switch. It failed silently in the worst way, because saving clears the key box and puts "Saved." over it while `kernelKeySet` stays false and the widget that draws an agent's browser is gated on exactly that flag. The two text fields now follow the rule the ones above them already follow and are omitted when blank; stealth is sent every time, since a checkbox is never blank and omitting `false` would leave no way to turn it back off. The Rust side has handled all three since they were added, so nothing below the webview changed.

Three exhaustive assertions on the sent patch named every field and never mentioned these, so the suite had the omission written down as correct: those are corrected, and three tests cover the browser fields travelling on their own, stealth going off, and the timer refusing a NaN.