### PR TITLE
feat: a crew's circle is arranged by how many are in it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ table below says which one to open before changing something.
 src/                  React + TypeScript. A view over the runtime, nothing more.
   lib/transcript.ts   What a channel shows, and what it collapses. Read first.
   lib/rail.ts         What order the rail draws agents in, and where a drop lands.
+  lib/orb.ts          How a crew stands inside its circle, and when it counts.
   lib/search.ts       One ranking over hits from SQLite and from the store.
   lib/trail.ts        A turn's own tool calls: what folds into one chip.
   lib/cafeteria.ts    Preset agents, waiting to be hired. Content, not runtime.
@@ -83,7 +84,7 @@ repo: the frontend renders state and forwards intent.
 | Anything announced to a screen reader, or a live region | *A transcript is a log, and says one thing out loud* in `docs/WORKSPACE.md` |
 | Scrolling a transcript, following the newest line, when the view may move | *A transcript follows the end for whoever is at the end, and nobody else* in `docs/WORKSPACE.md`, then `src/lib/follow.ts` |
 | The menu bar: the glyph, the count, what the menu offers, closing the window | *The menu bar is Guaca with the window shut* in `docs/WORKSPACE.md`, then `src-tauri/src/menubar.rs` |
-| The rail's order, dragging a row, groups as places you go inside | *The rail is arranged by hand*, *A drop is one call* and *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/rail.ts` |
+| The rail's order, dragging a row, groups as places you go inside | *The rail is arranged by hand*, *A drop is one call* and *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/rail.ts` and `src/lib/orb.ts` |
 | Preset agents, hiring a crew | *The cafeteria is a copy machine* in `docs/WORKSPACE.md`, then `src/lib/cafeteria.ts` |
 | Settings, the surface, the scale, what may interrupt the operator | *Settings is eight places*, *The reading column has two surfaces* and *An interruption has to earn it* in `docs/WORKSPACE.md` |
 | A prompt, or anything that changes how much a crew talks | *Three test suites, asking different questions*, then run the live evals |

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -218,11 +218,24 @@ pins folded to the head of the single list rather than kept in a section of thei
 own, because everybody drawn there is in that crew already.
 
 The circles are faces, not names. A crew is recognised by who is in it long
-before its name is read, and four of them have to fit across a rail that is
-15.5rem wide. Four faces tiled in a square rather than a row of overlaps: the
-circle is 38px across and three 1.35rem avatars in a row measure 51px even
-leaning on each other, so a row either overflowed the ring or hid the faces it
-was drawn to show.
+before its name is read, and four of these have to fit across a rail that is
+15.5rem wide.
+
+How the faces stand is the size of the crew. One is a portrait, two stand side
+by side, and three to six stand on a ring, so a strip of crews is a strip of
+different badges and the number of people in each is legible before any single
+face is. Every crew of two or more used to draw the same square of four, which
+made the circle read as the app's own mark rather than as these agents. The
+seating is `src/lib/orb.ts`, in fractions of the ring rather than in pixels, and
+it is sized against the ink instead of the box the ink is drawn in: a character
+fills 62% of its box across and 83% of it down, so the tight axis is vertical
+and `orb.test.ts` holds every ring to the catalog's own construction spec rather
+than to a number copied out of it.
+
+Six is where it stops. A seventh face is a smudge and it makes the six already
+there smaller, so the rest are a count, hung off the rim rather than laid on it:
+a ring with a seat in every quarter has nowhere inside it for an opaque chip
+that is not somebody's face.
 
 Each circle does two jobs, which is why it is a circle and not an item in a menu.
 Clicking it opens the group. Dropping an agent on it puts the agent in the group,

--- a/src/components/GroupOrb.tsx
+++ b/src/components/GroupOrb.tsx
@@ -1,4 +1,7 @@
+import type { CSSProperties } from "react";
+
 import { AgentAvatar } from "../avatars/AgentAvatar";
+import { cluster } from "../lib/orb";
 import { liftOf } from "../lib/rail";
 import type { Activity, AgentCard, AgentId, Group } from "../lib/types";
 
@@ -16,16 +19,19 @@ interface Props {
   onDragOut: () => void;
 }
 
-/** How many faces fit in the circle before it starts counting instead. */
-const FACES = 4;
+/** A seat's fraction of the ring, as a length the stylesheet can use. */
+function percent(fraction: number): string {
+  return `${(fraction * 100).toFixed(2)}%`;
+}
 
 /**
  * A group, small enough to sit in a strip and be aimed at.
  *
  * Faces rather than a name, because a crew is recognised by who is in it long
- * before its name is read, and four of these have to fit across a rail that is
- * 15.5rem wide. The name is still there for anything that reads rather than
- * looks: the label, the tooltip, and the heading you get after clicking.
+ * before its name is read. How they stand is the crew's size: `lib/orb.ts` owns
+ * the seating and says why. The name is still there for anything that reads
+ * rather than looks: the label, the tooltip, and the heading you get after
+ * clicking.
  *
  * Two jobs in one control, which is why it is a circle and not a row in a menu.
  * Clicking opens the group. Dropping an agent on it puts the agent in the group,
@@ -42,8 +48,7 @@ export function GroupOrb({
   onDragOver,
   onDragOut,
 }: Props) {
-  const faces = members.slice(0, FACES);
-  const rest = members.length - faces.length;
+  const { seats, rest } = cluster(members);
 
   // The two states worth interrupting a glance for. Asking is louder because
   // the agent is parked until the operator answers, and after focusing on one
@@ -70,19 +75,34 @@ export function GroupOrb({
       onPointerLeave={onDragOut}
     >
       <span className="orb__ring">
-        <span className="orb__faces" data-count={faces.length}>
-          {faces.map((member) => (
-            <AgentAvatar
-              key={member.id}
-              avatar={member.avatar}
-              color={member.color}
-              size="xs"
-              seed={member.id}
-              lifecycle={member.lifecycle}
-              title={member.name}
-            />
-          ))}
-          {faces.length === 0 && <span className="orb__none">·</span>}
+        <span className="orb__faces">
+          {seats.map((seat) => {
+            const member = seat.of;
+            return (
+              <span
+                key={member.id}
+                className="orb__face"
+                style={
+                  {
+                    "--seat-x": percent(seat.x),
+                    "--seat-y": percent(seat.y),
+                    "--seat-size": percent(seat.size),
+                    "--seat-tilt": `${seat.tilt}deg`,
+                  } as CSSProperties
+                }
+              >
+                <AgentAvatar
+                  avatar={member.avatar}
+                  color={member.color}
+                  size="xs"
+                  seed={member.id}
+                  lifecycle={member.lifecycle}
+                  title={member.name}
+                />
+              </span>
+            );
+          })}
+          {seats.length === 0 && <span className="orb__none">·</span>}
         </span>
         {rest > 0 && <span className="orb__more">+{rest}</span>}
       </span>

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -291,6 +291,20 @@ describe("groups as places", () => {
     expect(screen.getByTitle("Reader")).toBeTruthy();
   });
 
+  // The circle is how a crew is told apart at 38px, and every crew of two or
+  // more used to draw the same square of four. Where the faces stand is now the
+  // crew's size, so the ring holds more than four and says so when it cannot.
+  it("seats six of a crew, and counts whoever is past that", () => {
+    const cooks = Array.from({ length: 9 }, (_, i) =>
+      agent(`Cook ${i}`, { groupId: RESEARCH, railOrder: i }),
+    );
+    draw([group("everyone"), group("research", null, RESEARCH)], [agent("Manager"), ...cooks]);
+
+    const orb = screen.getByLabelText("research, 9 agents");
+    expect(orb.querySelectorAll(".orb__face")).toHaveLength(6);
+    expect(orb.textContent).toContain("+3");
+  });
+
   it("says on the circle when somebody inside it needs the operator", () => {
     // After focusing on one group the strip is the only place the other crews
     // are still visible, so it has to carry the one state that is waiting on a

--- a/src/lib/orb.test.ts
+++ b/src/lib/orb.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { FORM } from "../avatars/catalog";
+import { cluster, SEATS } from "./orb";
+
+/** The viewBox every character is drawn in. `AgentAvatar` sets it. */
+const BOX = 64;
+
+/**
+ * How far a face's ink reaches from its own centre, as a fraction of its box.
+ *
+ * Taken from the catalog's construction spec rather than assumed, because the
+ * seating is sized against the drawing and not against the box around it: a
+ * character that grew inside `FORM` would make every ring here too wide, and
+ * nothing else in the app would notice.
+ */
+const INK = {
+  x: Math.max(FORM.right - BOX / 2, BOX / 2 - FORM.left) / BOX,
+  y: Math.max(FORM.bottom - BOX / 2, BOX / 2 - FORM.top) / BOX,
+};
+
+/** The rim of the ring, which is 1px of inset shadow on a 2.4rem circle. */
+const RIM = 0.5 - 1 / 38.4;
+
+function crew(n: number): { id: string }[] {
+  return Array.from({ length: n }, (_, i) => ({ id: `agent-${i}` }));
+}
+
+describe("seating a crew", () => {
+  it("gives every member a seat until the ring is full, then counts the rest", () => {
+    expect(cluster([]).seats).toHaveLength(0);
+    expect(cluster(crew(1)).seats).toHaveLength(1);
+    expect(cluster(crew(SEATS)).seats).toHaveLength(SEATS);
+    expect(cluster(crew(SEATS)).rest).toBe(0);
+
+    const crowd = cluster(crew(SEATS + 3));
+    expect(crowd.seats).toHaveLength(SEATS);
+    expect(crowd.rest).toBe(3);
+  });
+
+  // The point of the change: a strip of crews used to be one badge repeated,
+  // because four faces in a square is what every group of two or more drew.
+  it("arranges each size differently", () => {
+    const shapes = new Set<string>();
+    for (let n = 1; n <= SEATS; n++) {
+      shapes.add(JSON.stringify(cluster(crew(n)).seats.map((s) => [s.x, s.y, s.size])));
+    }
+    expect(shapes.size).toBe(SEATS);
+  });
+
+  it.each(Array.from({ length: SEATS }, (_, i) => i + 1))("keeps %i inside the ring", (n) => {
+    for (const seat of cluster(crew(n)).seats) {
+      expect(Math.abs(seat.x - 0.5) + INK.x * seat.size).toBeLessThanOrEqual(RIM);
+      expect(Math.abs(seat.y - 0.5) + INK.y * seat.size).toBeLessThanOrEqual(RIM);
+    }
+  });
+
+  // Faces are the whole content of the circle. Packing one more in is not worth
+  // anything if it stands where the face beside it is drawn.
+  it.each(Array.from({ length: SEATS }, (_, i) => i + 1))("hides nobody at %i", (n) => {
+    const seats = cluster(crew(n)).seats;
+    for (const a of seats) {
+      for (const b of seats) {
+        if (a === b) continue;
+        const apart = Math.hypot(a.x - b.x, a.y - b.y);
+        expect(apart).toBeGreaterThanOrEqual(INK.x * 2 * a.size);
+      }
+    }
+  });
+
+  // The lean is decoration, and decoration that moves is a crew rearranging
+  // itself for no reason every time the rail re-renders.
+  it("leans a member the same way every time", () => {
+    const once = cluster(crew(4)).seats.map((s) => s.tilt);
+    const again = cluster(crew(4)).seats.map((s) => s.tilt);
+
+    expect(again).toEqual(once);
+    for (const tilt of once) expect(Math.abs(tilt)).toBeLessThanOrEqual(6);
+  });
+
+  // Ids are UUIDs, which any hash spreads. Short seeds are what catch one out:
+  // a rolling multiply-add gave `cook 1`, `cook 2` and `cook 3` leans a tenth
+  // of a degree apart, which is a crew drawn as one face repeated, and the only
+  // place it would have shown is a screenshot nobody took.
+  it("leans seeds that differ in one character differently", () => {
+    const leans = cluster([{ id: "cook 1" }, { id: "cook 2" }, { id: "cook 3" }]).seats.map(
+      (s) => s.tilt,
+    );
+
+    expect(new Set(leans).size).toBe(3);
+  });
+
+  it("stands a crew of one straight", () => {
+    expect(cluster(crew(1)).seats[0]?.tilt).toBe(0);
+  });
+});

--- a/src/lib/orb.ts
+++ b/src/lib/orb.ts
@@ -1,0 +1,111 @@
+/**
+ * Where a crew's faces sit inside its circle.
+ *
+ * A group is recognised by who is in it, and at the 38px the strip draws that
+ * recognition is mostly shape: how many faces there are and how they stand.
+ * Tiling every crew into the same square threw that away, so a strip of crews
+ * read as one badge repeated.
+ *
+ * Here the arrangement is the count. One face is centred, two stand side by
+ * side, and three to six stand on a ring, so the size of a crew is legible
+ * before any single face in it is, and two crews of different sizes cannot draw
+ * the same badge.
+ *
+ * Geometry only, in fractions of the ring's own box, so the ring can be resized
+ * in the stylesheet without a number in here having to be changed to agree.
+ */
+
+/** A face's place in the ring. `x`, `y` and `size` are fractions of the ring. */
+export interface Seat {
+  /** Centre of the face, 0 at the ring's left and top edge, 1 at its right and bottom. */
+  x: number;
+  y: number;
+  /** Width of the face's box. */
+  size: number;
+  /** Degrees of lean, so a crew looks arranged by hand rather than tiled. */
+  tilt: number;
+}
+
+/** How many faces a ring seats before it starts counting instead. */
+export const SEATS = 6;
+
+/**
+ * The ring each crew size stands on, and how big its faces are.
+ *
+ * Sized against the ink rather than the box: a character is drawn inside
+ * `FORM`, which leaves it 62% of its box wide and 83% of it tall, so the tight
+ * axis is vertical and it is `radius + 0.42 × size` that has to stay inside the
+ * rim. Every row here leaves about a pixel of daylight at 2.4rem, and
+ * `orb.test.ts` holds them to it against the catalog's own box rather than
+ * against the numbers here.
+ *
+ * `from` is where the first face stands, in degrees clockwise from the right,
+ * so -90 is the top. Everything but the pair starts there: a shape with a face
+ * above a base under it reads as standing rather than as spilled.
+ */
+const RINGS: Record<number, { radius: number; size: number; from: number }> = {
+  1: { radius: 0, size: 0.7, from: 0 },
+  2: { radius: 0.2, size: 0.55, from: 180 },
+  3: { radius: 0.235, size: 0.48, from: -90 },
+  4: { radius: 0.265, size: 0.42, from: -90 },
+  5: { radius: 0.285, size: 0.38, from: -90 },
+  6: { radius: 0.3, size: 0.35, from: -90 },
+};
+
+/** Furthest a face leans, in degrees. Enough to notice, not enough to topple. */
+const LEAN = 6;
+
+/**
+ * Deterministic 0..1 from a string, so a crew's arrangement never moves.
+ *
+ * FNV-1a with a mixing step on the end, rather than the rolling multiply-add
+ * used elsewhere for animation phase. In that one the last character of the
+ * seed reaches the result unmixed, so two seeds differing only there come out a
+ * thousandth apart and lean the same way. An agent id is a UUID and would
+ * survive either, but a seed that is anything shorter would not, and the
+ * failure is a crew drawn as one face repeated with nothing to say why.
+ */
+function hash(seed: string): number {
+  let at = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    at = Math.imul(at ^ seed.charCodeAt(i), 16777619);
+  }
+  at = Math.imul(at ^ (at >>> 15), 2246822507);
+  return ((at ^ (at >>> 13)) >>> 0) / 2 ** 32;
+}
+
+/** Keeps a seat's arithmetic from reaching the stylesheet at full precision. */
+function round(value: number): number {
+  return Math.round(value * 1e4) / 1e4;
+}
+
+/**
+ * Seats as many of these members as the ring holds, and counts the rest.
+ *
+ * Each seat carries the member it was cut for, so nothing downstream has to
+ * line two arrays up by index. Only the id is read: the lean has to survive a
+ * rename and a recolour, or a crew rearranges itself when somebody is edited.
+ */
+export function cluster<T extends { id: string }>(
+  members: T[],
+): { seats: (Seat & { of: T })[]; rest: number } {
+  const seated = members.slice(0, SEATS);
+  const ring = RINGS[seated.length];
+  if (!ring) return { seats: [], rest: 0 };
+
+  const step = 360 / seated.length;
+  const seats = seated.map((of, i) => {
+    const angle = ((ring.from + i * step) * Math.PI) / 180;
+    return {
+      of,
+      x: round(0.5 + ring.radius * Math.cos(angle)),
+      y: round(0.5 + ring.radius * Math.sin(angle)),
+      size: ring.size,
+      // A crew of one has nobody to be arranged with, and a lone face leaning
+      // reads as a mistake rather than as an arrangement.
+      tilt: seated.length === 1 ? 0 : Math.round((hash(of.id) - 0.5) * 2 * LEAN * 10) / 10,
+    };
+  });
+
+  return { seats, rest: members.length - seated.length };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -708,57 +708,78 @@ button {
   color: var(--rail-text);
 }
 
-/* Faces, tiled. Four in a square rather than a row of overlaps: a 2.4rem
-   circle is 38px across, and three 1.35rem avatars in a row measure 51px even
-   leaning on each other, so a row either overflowed the ring or hid the faces
-   it was there to show. A square of four fits, and it is what a group of people
-   looks like everywhere else.
+/* Faces, standing in a ring. Where each one goes is `lib/orb.ts`: a crew of
+   two, of four and of six have to draw three different badges, or a strip of
+   crews is one badge repeated and the faces in it are decoration. A square of
+   four was what every crew of two or more drew, and it read as the app's own
+   mark rather than as these four agents.
 
-   Sized here rather than through the avatar's own scale, because these have to
-   fit a circle rather than sit beside a name. The selector carries the extra
-   class deliberately: `.avatar--xs` is defined further down the file. */
+   Every number arrives as a custom property in fractions of this box, so the
+   ring can be resized on the rule above without a constant in the module having
+   to be changed to agree with it. Sized here rather than through the avatar's
+   own scale, because these have to fill a circle rather than sit beside a name:
+   the selector carries the extra class deliberately, `.avatar--xs` being
+   defined further down the file. */
 .orb__faces {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 0.05rem;
-  place-content: center;
-  width: 1.85rem;
+  position: absolute;
+  inset: 0;
+  /* Opens the ring a little under the pointer. The crew is a drop target as
+     well as a place, so it is worth answering before it is clicked. */
+  transition: transform 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
-.orb__faces > .avatar {
+.orb:hover .orb__faces {
+  transform: scale(1.06);
+}
+
+.orb__face {
+  position: absolute;
+  left: var(--seat-x);
+  top: var(--seat-y);
+  width: var(--seat-size);
+  /* The lean is on this wrapper and not on the avatar: the avatar's own
+     transform is where looking up or down at a peer is expressed. */
+  transform: translate(-50%, -50%) rotate(var(--seat-tilt, 0deg));
+  line-height: 0;
+}
+
+.orb__face > .avatar {
   width: 100%;
   height: auto;
   aspect-ratio: 1;
 }
 
-.orb__faces[data-count="1"] {
-  grid-template-columns: 1fr;
-  width: 1.7rem;
+@media (prefers-reduced-motion: reduce) {
+  .orb__faces {
+    transition: none;
+  }
+
+  .orb:hover .orb__faces {
+    transform: none;
+  }
 }
 
-.orb__faces[data-count="2"] {
-  width: 2.1rem;
-}
-
-/* Three in a square leaves the last one in a corner. Spanning both columns
-   centres it, so the shape reads as a group and not as a gap. */
-.orb__faces[data-count="3"] > .avatar:last-child {
-  grid-column: span 2;
-  justify-self: center;
-  width: 50%;
-}
-
+/* An empty crew. Centred by hand, because everything else in the ring is
+   placed absolutely and there is no flow left to sit in the middle of. */
 .orb__none {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
   font-family: var(--font-mono);
   color: var(--rail-muted);
 }
 
-/* The members that did not fit. A number, because four faces at this size is
-   four smudges. */
+/* The members that did not fit. A number, because a seventh face on this ring
+   is a smudge and it makes the six already there smaller.
+
+   Hung off the rim rather than laid on it. A ring with a seat in every quarter
+   has nowhere inside it for an opaque chip to sit that is not somebody's face,
+   and the crew is what the circle is for. */
 .orb__more {
   position: absolute;
-  right: -0.1rem;
-  bottom: -0.1rem;
+  right: -0.3rem;
+  bottom: -0.2rem;
   font-family: var(--font-mono);
   font-size: 0.52rem;
   line-height: 1;


### PR DESCRIPTION
The strip drew every crew of two or more as the same square of four faces, so a
row of circles read as the app's own mark repeated rather than as these agents.
A circle is 38px across and a name does not fit in one, which leaves shape as
the only thing it has to say.

So the arrangement is the count. One face is a portrait, two stand side by side,
and three to six stand on a ring: a triangle, a diamond, a pentagon, a hexagon.
The size of a crew is legible before any single face in it is, and two crews of
different sizes cannot draw one badge. Six is where it stops, because a seventh
face is a smudge and it makes the six already there smaller; the rest are a
count, hung off the rim rather than laid on it, since a ring with a seat in
every quarter has nowhere inside it for an opaque chip that is not somebody's
face. Faces are bigger than before at every count up to four, the square having
given each 38.5% of the ring where the diamond gives 42%.

`lib/orb.ts` owns the seating and hands back fractions of the ring, so the ring
can be resized in the stylesheet without a constant in the module quietly
disagreeing with it. Sizes are set against the ink rather than the box around
it: a character fills 62% of its box across and 83% of it down, so the tight
axis is vertical, and `orb.test.ts` derives that from the catalog's own `FORM`
and holds every ring to it. A character redrawn larger fails there rather than
by eye.

Each face also leans a few degrees, deterministically, so a crew reads as
arranged rather than tiled, and hovering opens the ring six percent because the
circle is a drop target as well as a place.

The hash behind that lean was the rolling multiply-add used elsewhere for
animation phase, which lets the last character of a seed reach the result
unmixed: `cook 1`, `cook 2` and `cook 3` came out a tenth of a degree apart and
leaned as one. Ids are UUIDs and would have survived it either way, but the
failure is a crew drawn as one face repeated with nothing on screen to say why,
so it is FNV-1a with a mixing step and a test on those three names.

Seventeen tests on the seating, one on the strip. Every crew size from zero to
nine was drawn in the harness and looked at, resting and hovered.

