### PR TITLE
fix: an agent that answered its peer does not then write to the operator

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,6 +126,24 @@ rather than a door quietly opened. The rule lives in two places and they have to
 agree: `runtime/prompt.rs` tells the model the same thing, in the mode where it
 matters.
 
+**A turn that has already answered has nothing left to deliver, and the operator
+is not the fallback.** Models answer their correspondent by calling
+`send_message` at them rather than by replying in plain text, and then keep
+typing. The trailing text is not a second answer: sending it on as well put two
+near-identical messages in the peer's channel. It went to the operator instead,
+on the reasoning that it was still readable there, and that was worse. A crew
+being introduced produced it seven times over: the operator had messaged one
+agent, and four wrote back, three of them agents they had never spoken to,
+each reporting that it had replied to somebody else. Being the one participant
+an envelope can always be addressed to is not the same as being the audience.
+Trailing text is now filed on that turn's own record, in the sending agent's
+channel, delivered to nobody.
+
+A file is the exception, and the reason is that it is not a restatement of
+anything. `send_message` carries its own files, so one attached after the answer
+went is the only part of the turn that has reached nobody at all, and the agent
+that asked for the work is who it belongs to. It goes to them, guard and all.
+
 Messages that do not expect a reply are batched: an agent waking to four replies
 reads all four in one turn. Because real replies arrive seconds apart rather
 than together, an agent will also wait briefly for replies it is still owed,

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -1991,15 +1991,29 @@ impl Runtime {
 
         // An agent that already answered this peer with `send_message` has said
         // its piece. The text it trails afterwards is commentary on its own
-        // turn, and delivering that as a second message is how one turn put two
-        // near-identical messages in the peer's channel. It goes to the
-        // operator instead, where it is still readable.
+        // turn, and sending it on as well is how one turn put two near-identical
+        // messages in the peer's channel.
+        //
+        // It does not go to the operator either, which is what it used to do.
+        // Nobody in this turn is the operator: they messaged one agent, that
+        // agent asked seven others for something, and each of the seven then
+        // wrote to the operator to say it had answered. An agent the operator
+        // has never spoken to reporting on a conversation they were not in is
+        // not readable-in-passing, it is the flow board filling with mail
+        // addressed to somebody else. So the commentary is filed on this turn's
+        // record, in this agent's own channel, delivered to no one.
+        //
+        // A file is the exception, and the reason is that it is not a
+        // restatement of anything. `send_message` carries its own files, so one
+        // attached afterwards is the only part of the turn that has reached
+        // nobody, and the peer that asked is who it is for.
         let already_answered = matches!(
             reply_target,
             Some(Participant::Agent { id }) if addressed.contains(&id)
         );
+        let commentary = mode == ReplyMode::ToPeer && already_answered && files.is_empty();
 
-        if mode == ReplyMode::ToPeer && !already_answered {
+        if mode == ReplyMode::ToPeer && !commentary {
             if let Some(Participant::Agent { id: peer }) = reply_target {
                 // An automatic reply still travels a hop and still counts
                 // against the pair budget, otherwise two agents could bounce
@@ -2061,6 +2075,14 @@ impl Runtime {
             });
         }
 
+        // Commentary rides the record rather than an envelope of its own. Last,
+        // so it reads in the order the turn happened: the calls, then whatever
+        // the guard or the budget had to say about them, then the agent's own
+        // closing words.
+        if commentary && !text.is_empty() {
+            tool_parts.push(Part::Text { text: text.clone() });
+        }
+
         // The record of what this agent did belongs in this agent's own
         // channel, always. Attaching it to the reply meant that a reply to a
         // peer carried the sender's private working notes into the recipient's
@@ -2084,6 +2106,11 @@ impl Runtime {
             if let Err(err) = self.deliver(record) {
                 tracing::error!(%err, "failed to record agent activity");
             }
+        }
+
+        // Already written down, and there is nobody left to send it to.
+        if commentary {
+            return;
         }
 
         // A file with nothing typed is still an answer, and the one this app

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -952,6 +952,131 @@ async fn a_reply_sent_through_the_tool_does_not_demand_another() {
 }
 
 #[tokio::test]
+async fn a_peer_that_answered_through_the_tool_does_not_then_write_to_the_operator() {
+    // Found in a real workspace. The operator asked one agent to introduce
+    // itself to the crew, it messaged seven, and three of the seven then wrote
+    // to the operator: "I replied to the Chief of Staff confirming how I work".
+    // The operator had spoken to one agent and got mail from four.
+    //
+    // The turn shape that produces it is ordinary: answer the peer with
+    // `send_message`, then keep typing. The trailing text is not a second
+    // answer, so it was sent to the operator instead, who is the one
+    // participant an envelope can always be addressed to. Being addressable is
+    // not the same as being the audience.
+    let stub = serve(|body| {
+        if speaker(body) == "Chef" {
+            if has_tool_result(body) {
+                Script::Say("Replied to Manager confirming how I work.".into())
+            } else {
+                Script::SendTo {
+                    recipients: vec!["Manager".into()],
+                    text: "Glad to be aboard.".into(),
+                }
+            }
+        } else if has_tool_result(body) || reading_peer_replies(body) {
+            Script::Say("Chef is introduced.".into())
+        } else {
+            Script::SendTo { recipients: vec!["Chef".into()], text: "hello from manager".into() }
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager", "Chef"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "Introduce yourself to Chef.").unwrap();
+    h.settle(run).await;
+
+    let chef = h.runtime.store().channel_messages(h.id("Chef"), 200).unwrap();
+    let to_operator: Vec<String> = chef
+        .iter()
+        .filter(|e| e.from.is_agent() && e.to == Participant::Human)
+        .map(guac_lib::domain::envelope::Envelope::plain_text)
+        .collect();
+    assert!(
+        to_operator.is_empty(),
+        "Chef was answering Manager and wrote to the operator, who was never in it: \
+         {to_operator:?}"
+    );
+
+    // Not delivered is not the same as thrown away. It is on the record of the
+    // turn that wrote it, in Chef's own channel, where the operator can read
+    // what their agent did without being handed a message about it.
+    let recorded: Vec<String> = chef
+        .iter()
+        .filter(|e| e.to == Participant::System)
+        .map(guac_lib::domain::envelope::Envelope::plain_text)
+        .collect();
+    assert!(
+        recorded.iter().any(|t| t.contains("Replied to Manager")),
+        "the trailing text has to be written down somewhere: {recorded:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_document_attached_after_the_answer_still_reaches_the_peer_that_asked() {
+    // The carve-out in the rule above, and the reason it is not "drop whatever
+    // a turn trails". Text written after the answer went is a restatement of
+    // it; a file is not. `send_message` carries its own files, so one attached
+    // afterwards has reached nobody at all, and the agent that asked for the
+    // work is who it belongs to. Silently filing it as commentary would lose
+    // the only thing the turn produced.
+    let stub = serve(|body| {
+        let calls = body["messages"]
+            .as_array()
+            .map(|m| m.iter().filter(|msg| msg["role"] == "tool").count())
+            .unwrap_or(0);
+
+        if speaker(body) == "Chef" {
+            match calls {
+                // Answer the way the real models do, then hand the document
+                // over afterwards, then say so.
+                0 => Script::SendTo { recipients: vec!["Manager".into()], text: "On it.".into() },
+                1 => Script::Attach { tool: "attach_file".into(), files: vec!["menu.md".into()] },
+                _ => Script::Say("Tidied and attached.".into()),
+            }
+        } else if calls > 0 || reading_peer_replies(body) {
+            Script::Say("Chef has it.".into())
+        } else {
+            Script::SendFiles {
+                recipients: vec!["Chef".into()],
+                text: "tidy this up".into(),
+                files: vec!["menu.md".into()],
+            }
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager", "Chef"], GuardLimits::default());
+    let menu = h.runtime.files().put("menu.md", b"soup, then fish").unwrap();
+    let run = h
+        .runtime
+        .send_from_human_with(h.id("Manager"), "Have Chef tidy the menu.", vec![menu])
+        .unwrap();
+    h.settle(run).await;
+
+    // In Manager's channel and from Chef: that is a document delivered to the
+    // agent that asked, rather than one filed in the sender's own record.
+    let handed_back: Vec<String> = h
+        .runtime
+        .store()
+        .channel_messages(h.id("Manager"), 200)
+        .unwrap()
+        .iter()
+        .filter(|e| e.from == Participant::Agent { id: h.id("Chef") })
+        .flat_map(|e| e.parts.clone())
+        .filter_map(|part| match part {
+            Part::File(file) => Some(file.name),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        handed_back,
+        vec!["menu.md".to_string()],
+        "the document never reached the agent that asked for it:\n{}",
+        h.transcript()
+    );
+}
+
+#[tokio::test]
 async fn a_refused_courtesy_tells_the_agent_what_to_do_instead() {
     // The refusal is read mid-turn by the model that caused it, and it is the
     // only thing standing between "stop being polite at each other" and a

--- a/src/components/MessageItem.test.tsx
+++ b/src/components/MessageItem.test.tsx
@@ -236,6 +236,19 @@ describe("an agent's own record of what it did", () => {
     show(record({ type: "notice", kind: "guardStop", text: "hop limit (8) reached" }));
     expect(screen.getByText("hop limit (8) reached")).toBeTruthy();
   });
+
+  it("draws text the turn trailed as an aside, not as a message to the operator", () => {
+    // A turn that answered its peer through `send_message` and then kept
+    // typing produces text with no recipient. The runtime files it here. Drawn
+    // as a bubble it reads as the agent addressing the operator, which is what
+    // seven agents each saying "I replied to the Chief of Staff" looked like.
+    const { container } = show(
+      record({ type: "text", text: "Replied to Manager confirming how I work." }),
+    );
+    expect(screen.getByText("Replied to Manager confirming how I work.")).toBeTruthy();
+    expect(container.querySelector(".aside")).toBeTruthy();
+    expect(container.querySelector(".msg")).toBeNull();
+  });
 });
 
 describe("a failed turn", () => {

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -21,7 +21,7 @@ import { ApprovalRequest } from "./ApprovalRequest";
 import { FileCard } from "./FileCard";
 import { Markdown } from "./Markdown";
 import { TrailRow } from "./Trail";
-import { NoticeRow, RoutineRow } from "./WireRow";
+import { AsideRow, NoticeRow, RoutineRow } from "./WireRow";
 
 interface Props {
   message: Envelope;
@@ -175,6 +175,10 @@ export const MessageItem = memo(function MessageItem({
  * and folding across it would put the explanation somewhere other than the
  * thing it explains.
  *
+ * Text reaches here in one case: a turn that answered its peer through
+ * `send_message` and then carried on typing. That text has no recipient, so it
+ * is drawn as an aside rather than as anything addressed to the operator.
+ *
  * A `json` part is the one kind that reaches here and draws nothing. Nothing in
  * the runtime emits one yet; it is the seam a model-authored artifact would
  * arrive through, and a renderer for it before there is a producer is surface
@@ -199,6 +203,9 @@ function ActivityRecord({ message }: { message: Envelope }) {
     close();
     if (part.type === "notice") {
       rows.push(<NoticeRow key={key} kind={part.kind} text={part.text} />);
+    }
+    if (part.type === "text") {
+      rows.push(<AsideRow key={key} text={part.text} />);
     }
   }
   close();

--- a/src/components/WireRow.tsx
+++ b/src/components/WireRow.tsx
@@ -323,6 +323,29 @@ export function RoutineRow({
 }
 
 /**
+ * What an agent wrote after it had already answered.
+ *
+ * A turn that replies to its peer through `send_message` and then keeps typing
+ * has produced text with no recipient: the peer has been answered, and the
+ * operator was never in that conversation. The runtime files it here rather
+ * than delivering it, so this is deliberately not a bubble. A bubble in this
+ * channel means the operator was addressed, and seven agents each posting one
+ * to say they had replied to somebody else is exactly what that used to look
+ * like.
+ *
+ * In the trail's column rather than the transcript's, because it is the same
+ * kind of thing as the tool calls above it: what the turn did, not what it said
+ * to anyone.
+ */
+export function AsideRow({ text }: { text: string }) {
+  return (
+    <div className="aside">
+      <Markdown>{text}</Markdown>
+    </div>
+  );
+}
+
+/**
  * A centred system line: guard stops, upstream failures, lifecycle notes.
  *
  * `onRetry` is offered only where trying again could plausibly work. The

--- a/src/lib/transcript.test.ts
+++ b/src/lib/transcript.test.ts
@@ -250,6 +250,23 @@ describe("an agent's own trail", () => {
       { type: "notice", kind: "guardStop", text: "Reply to Scribe was not delivered" },
     ]);
   });
+
+  it("keeps the text a turn trailed after answering through the tool", () => {
+    // The answer went through `send_message`, so it is peer traffic and lifts
+    // into the burst. What the turn typed afterwards reached nobody and is on
+    // the record instead. Folding it away with the send would delete the only
+    // copy of it there is.
+    const rows = transcriptRows(
+      [record(send(["Chef"], ok), { type: "text", text: "Replied to Chef." })],
+      lookups,
+    );
+
+    expect(rows.map((row) => row.kind)).toEqual(["peers", "message"]);
+    const trail = rows.find((row) => row.kind === "message");
+    expect(trail?.kind === "message" && trail.message.parts).toEqual([
+      { type: "text", text: "Replied to Chef." },
+    ]);
+  });
 });
 
 describe("merging consecutive messages under one header", () => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1836,6 +1836,23 @@ button {
   justify-content: center;
 }
 
+/* An agent's own closing words, written after it had already answered its peer.
+   Nobody was sent them, so they are neither centred like a system line nor
+   bracketed like traffic: both of those say something passed between two
+   participants. In the trail's column, on the same 2.85rem of gutter, because
+   this belongs with what the turn did rather than with what was said to
+   anybody. */
+.aside {
+  padding: 0.1rem 1.5rem 0.35rem 2.85rem;
+}
+
+.aside .md {
+  border-left: 2px solid var(--edge);
+  padding-left: 0.7rem;
+  font-size: 0.85rem;
+  color: var(--faint);
+}
+
 /* ==========================================================================
    The trail: what an agent did on its own turn
 


### PR DESCRIPTION
A turn that answers its correspondent by calling `send_message` and then keeps typing produces trailing text that is not a second answer, and that text was delivered to the operator on the reasoning that it was still readable there. It is not: introducing a crew produced it seven times over, where the operator messaged one agent and three agents they had never spoken to wrote back to report that they had replied to somebody else, one of them opening "Acknowledged, Chief of Staff".

Trailing text is now filed as a text part on that turn's own record, in the sending agent's channel, delivered to nobody, and drawn as a quiet aside in the trail's column rather than as a bubble. A file is the exception and takes the ordinary peer path, guard and all, because `send_message` carries its own files and one attached after the answer went is the only part of the turn that has reached nobody: previously that document went to the operator, silently.

Two cascade tests cover both, and both fail without the change; `ActivityRecord` dropped text parts on the floor before this, so the transcript and component suites cover the new row and the fold that must not swallow it.