### PR TITLE
fix: a pin holds the head of its crew, and holds inside the crew too

### DIFF
--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -157,9 +157,10 @@ is lifted to the top of its section for exactly as long as it is working, and th
 place goes back the moment it stops. `awaitingApproval` outranks working, because
 it is the one state the operator is the fix for; `paused` scores nothing, because
 it is not work in progress but a row that will not move until somebody moves it,
-and lifting it would hold the top indefinitely. A pinned row never lifts at all:
-being findable in one glance is what a pin is for, and a row that moves when its
-agent gets busy is the thing a pin exists to stop.
+and lifting it would hold the top indefinitely. A pinned row is above all of
+this: it heads its crew and never lifts at all, because being findable in one
+glance is what a pin is for, and a row that moves when its agent gets busy is the
+thing a pin exists to stop.
 
 Before this, the rail was ordered by who spoke last and by nothing else. That is
 an order nobody chose and one that moves under the hand reaching for it: every
@@ -214,8 +215,10 @@ from a keyboard at all.
 Two views of one rail. In the overview every group has a heading and its members
 under it, which is what it always was. Clicking a group's circle takes the rail
 inside it: one crew, its name and controls given a line of their own, and the
-pins folded to the head of the single list rather than kept in a section of their
-own, because everybody drawn there is in that crew already.
+same list in the same order, because a crew's pins are at the head of it in
+either view. Neither view gives them a heading: everybody drawn under a crew is
+in that crew already, and a heading over one or two rows would divide nothing.
+The mark on the row is what says which rows are pinned.
 
 The circles are faces, not names. A crew is recognised by who is in it long
 before its name is read, and four of these have to fit across a rail that is
@@ -270,10 +273,6 @@ draws everybody. Neither does a move close anything: dragging somebody into
 another crew is not a change of view, and the operator who just made the gesture
 is the one person who does not need telling where that row went.
 
-The pinned section is a flag drawn as a place. It spans groups, so a row dropped
-among the pins keeps its own crew: the alternative is a gesture that says "keep
-this where I can see it" and quietly moves the agent to a different set of peers.
-
 ## Deleting a group deletes the crew, and the machines they were renting
 
 One button, two calls. An empty group loses a row; a group with four agents in
@@ -309,17 +308,38 @@ are not in the crew it takes. Their machines are already destroyed, and handing
 one back would mean a second kill against a sandbox that is not there, which the
 operator would be shown as the failure of the disband.
 
-## Pinning is where a row is drawn and nothing else
+## Pinning is the head of a crew, and nothing else
 
 It does not bump the card version, because the version is how a peer notices a
 card changed under it and nothing a peer can read has. `railOrder` is the same
 kind of fact and is kept the same way, and both live on the agent rather than in
 a preferences blob because they have to die with it: a name is free to reuse the
 moment an agent is deleted, and whoever takes it next must not inherit a pin or a
-place. A pinned agent is lifted out of its group in the rail and still counted in
-it, because it is still in it: same wall, same bill, same peers. Two rows for one
-agent would be two nodes in the sidebar's `rowRefs`, and the wire would have to
-pick one to throw a message at.
+place. A pinned agent is still in its group in every other sense: same wall, same
+bill, same peers, and counted in the crew it heads.
+
+The pins used to be a section of their own, above the groups and spanning them.
+That made a pin the one arrangement that came undone on the way into the crew it
+was arranging: inside a group the rail draws that group and nothing else, so the
+section holding the row was not on screen, and pinning something while looking at
+the list it was in moved nothing until the operator went back out to the
+overview. A pin is a band at the head of a crew now, drawn wherever that crew is
+drawn, which is both views and the same order in each.
+
+The band is why the row that a drag lands on decides both things: the crew it
+joins, and whether it is pinned. Dropping onto a pinned row pins the dragged
+agent, dropping below the band unpins it, and dropping on a group says nothing
+about the band and therefore changes nothing about it. A pin is a standing
+instruction about one agent, and moving somebody between crews is not a decision
+to drop it.
+
+The mark on the row is load-bearing. A crew whose pin is also the row the
+operator arranged at the top looks exactly like a pin that did nothing, and being
+first is not a state anything on screen can say by itself.
+
+An agent is drawn once, wherever it is drawn: two rows for one agent would be two
+nodes in the sidebar's `rowRefs`, and the wire would have to pick one to throw a
+message at.
 
 ## The cafeteria is a copy machine, not a registry
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -306,16 +306,20 @@ describe("App", () => {
 
     await waitFor(() => expect(screen.getByText("Chef")).toBeTruthy());
     expect(railNames()).toEqual(["Chef", "Manager", "Host"]);
-    expect(screen.getByText("Pinned")).toBeTruthy();
   });
 
-  it("counts a pinned agent in its group even though the row is drawn above", async () => {
-    // It is still in the group, still costs it money, and its peers can still
-    // message it. Only where the row is drawn has changed.
+  it("draws a pinned agent at the head of its crew rather than above the crews", async () => {
+    // The pins had a section of their own above the groups, which made a pin
+    // the one arrangement that came undone on the way into the crew it was
+    // arranging. They are the head of the crew now, and counted in it: a pinned
+    // agent is still in the group, still costs it money, and is still someone
+    // its peers can message.
     listAgents.mockResolvedValue([agent("Manager"), { ...agent("Chef"), pinned: true }]);
     render(<App />);
 
     await waitFor(() => expect(screen.getByText("Chef")).toBeTruthy());
+    expect(screen.queryByText("Pinned")).toBeNull();
+    expect(railRow("Chef").closest(".rail__group")?.textContent).toContain("Everyone");
     expect(screen.getByText("Everyone").closest(".rail__group-head")?.textContent).toContain("2");
   });
 

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -98,6 +98,11 @@ function row(name: string): HTMLElement {
   return found;
 }
 
+/** Every row the rail is drawing, top to bottom. */
+function names(): (string | null)[] {
+  return [...document.querySelectorAll(".agent-row__name")].map((n) => n.textContent);
+}
+
 /**
  * One drag, from a row to whatever should catch it.
  *
@@ -199,8 +204,6 @@ describe("arranging the rail", () => {
       { Scribe: { state: "thinking" } },
     );
 
-    const names = () =>
-      [...document.querySelectorAll(".agent-row__name")].map((n) => n.textContent);
     expect(names()).toEqual(["Scribe", "Manager", "Cook"]);
 
     fireEvent.pointerDown(row("Manager"), { button: 0, clientX: 100, clientY: 300 });
@@ -232,24 +235,22 @@ describe("arranging the rail", () => {
     expect(moveAgent).not.toHaveBeenCalled();
   });
 
-  it("pins a row dropped on the pinned section and moves it nowhere", async () => {
-    // The section spans groups, so there is no place in it to express. Pinning
-    // is the whole of what the gesture asked for.
+  it("pins a row dropped on a pinned peer, and lands it among the pins", async () => {
+    // The row landed on says both things at once: which crew, and whether the
+    // place aimed at is the band a pin holds or the rest of the crew below it.
     draw(
       [group("everyone")],
-      [agent("Manager", { railOrder: 0, pinned: true }), agent("Cook", { railOrder: 1 })],
+      [
+        agent("Manager", { railOrder: 0, pinned: true }),
+        agent("Chef", { railOrder: 1, pinned: true }),
+        agent("Cook", { railOrder: 2 }),
+      ],
     );
 
-    const pinned = document.querySelector(".rail__group");
-    if (!pinned) throw new Error("the pinned section was not drawn");
-
-    fireEvent.pointerDown(row("Cook"), { button: 0, clientX: 100, clientY: 300 });
-    fireEvent.pointerMove(window, { clientX: 100, clientY: 250 });
-    fireEvent.pointerEnter(pinned, { clientX: 100, clientY: 210 });
-    fireEvent.pointerUp(window, { clientX: 100, clientY: 210 });
+    await dragTo(row("Cook"), row("Chef"));
 
     await vi.waitFor(() => expect(setAgentPinned).toHaveBeenCalledWith("Cook", true));
-    expect(moveAgent).not.toHaveBeenCalled();
+    expect(moveAgent).toHaveBeenCalledWith("Cook", DEFAULT_GROUP, "Chef");
   });
 
   it("unpins a row dragged out of the pins and into a crew", async () => {
@@ -269,6 +270,59 @@ describe("arranging the rail", () => {
     // direction to read and it takes the place of what it was dropped on.
     expect(setAgentPinned).toHaveBeenCalledWith("Manager", false);
     expect(moveAgent).toHaveBeenCalledWith("Manager", DEFAULT_GROUP, "Scribe");
+  });
+});
+
+describe("pins", () => {
+  const RESEARCH = "00000000-0000-4000-8000-000000000002";
+
+  /** The crew, and one other so the strip is drawn and can be clicked. */
+  function crews() {
+    return [group("everyone"), group("research", null, RESEARCH)];
+  }
+
+  function roster() {
+    return [
+      agent("Manager", { railOrder: 0 }),
+      agent("Cook", { railOrder: 1 }),
+      agent("Chef", { railOrder: 2, pinned: true }),
+      agent("Reader", { groupId: RESEARCH, railOrder: 3 }),
+    ];
+  }
+
+  it("heads the crew with its pins, in the overview and inside the crew", () => {
+    // The one that was reported: pinning a row while looking inside a crew did
+    // nothing until the operator went back out to the overview, because the
+    // section a pin moved a row into was only drawn out there.
+    draw(crews(), roster());
+
+    expect(names()).toEqual(["Chef", "Manager", "Cook", "Reader"]);
+    expect(screen.queryByText("Pinned")).toBeNull();
+
+    fireEvent.click(screen.getByLabelText("everyone, 3 agents"));
+    expect(names()).toEqual(["Chef", "Manager", "Cook"]);
+  });
+
+  it("marks the pinned row, because being first is not a state", () => {
+    // A crew whose pin is also the row the operator arranged at the top looks
+    // exactly like a pin that did nothing, and the mark is the only thing on
+    // screen that tells those two apart.
+    draw(crews(), roster());
+
+    expect(row("Chef").querySelector(".agent-row__pin")).toBeTruthy();
+    expect(row("Manager").querySelector(".agent-row__pin")).toBeNull();
+  });
+
+  it("keeps the pin when the agent is moved to another crew", async () => {
+    // A pin is a standing instruction about one agent. Changing who it works
+    // with is not a decision to drop it, and the drop says nothing about the
+    // band either way.
+    draw(crews(), roster());
+
+    await dragTo(row("Chef"), screen.getByLabelText("research, 1 agent"));
+
+    expect(moveAgent).toHaveBeenCalledWith("Chef", RESEARCH, null);
+    expect(setAgentPinned).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -259,7 +259,7 @@ export function Sidebar({
   const isOver = (target: DropTarget): boolean => {
     const over = drag?.over;
     if (!over || over.kind !== target.kind) return false;
-    return over.kind === "pinned" || ("id" in over && "id" in target && over.id === target.id);
+    return over.id === target.id;
   };
 
   /** Which way an agent should turn to face a peer. */
@@ -343,7 +343,21 @@ export function Sidebar({
           look={facing(agent.id, role.facing ?? undefined)}
           says={role.says}
         />
-        <span className="agent-row__name">{agent.name}</span>
+        <span className="agent-row__title">
+          <span className="agent-row__name">{agent.name}</span>
+          {/* The only thing on screen that says a row is pinned rather than
+              first. Being at the head of a crew is what a pin does, and a crew
+              whose pinned member is also the one the operator arranged at the
+              top looks exactly like a pin that did nothing. */}
+          {agent.pinned && (
+            <svg className="agent-row__pin" viewBox="0 0 12 12" role="img" aria-label="pinned">
+              <path
+                d="M6 1.4a2.6 2.6 0 0 1 .9 5.04L6 10.6l-.9-4.16A2.6 2.6 0 0 1 6 1.4z"
+                fill="currentColor"
+              />
+            </svg>
+          )}
+        </span>
         <span className="agent-row__meta" data-state={label.kind}>
           {label.text}
         </span>
@@ -366,18 +380,6 @@ export function Sidebar({
         ⚙
       </button>
     </span>
-  );
-
-  // Pinned agents are lifted out of their group rather than drawn twice. Two
-  // rows for one agent would be two nodes in `rowRefs`, and the wire would
-  // have to pick one of them to throw a message at.
-  //
-  // Ordered by the arrangement, which is the one order that does not move on
-  // its own. The rest of a section lifts whoever is working to the top, and a
-  // row pinned so it could be found in one glance must not do that.
-  const pinned = railOrder(
-    agents.filter((a) => a.pinned),
-    shape,
   );
 
   const held = drag ? agents.find((a) => a.id === drag.id) : undefined;
@@ -480,9 +482,10 @@ export function Sidebar({
             // Inside one group. The heading carries the name and the controls
             // that were squeezed onto a 0.6rem label in the overview, because
             // here there is one group on screen and room to say so. The pins
-            // stay at the head of the list rather than in a section of their
-            // own: everybody drawn here is in this crew already, so a second
-            // heading over one or two rows would divide nothing.
+            // head the list rather than sitting in a section of their own:
+            // everybody drawn here is in this crew already, so a heading over
+            // one or two rows would divide nothing, and the mark on the row is
+            // what says which rows those are.
             <div
               className="rail__group rail__group--open"
               data-over={isOver({ kind: "group", id: focused.id }) ? "true" : undefined}
@@ -495,7 +498,7 @@ export function Sidebar({
               </div>
               {railOrder(
                 agents.filter((a) => a.groupId === focused.id),
-                { ...shape, pinnedFirst: true },
+                shape,
               ).map(row)}
               {agents.every((a) => a.groupId !== focused.id) && (
                 <p className="rail__empty">
@@ -505,33 +508,17 @@ export function Sidebar({
             </div>
           ) : (
             <>
-              {/* Whoever the operator wants to hand, above the groups and in
-                  the same place every time. */}
-              {pinned.length > 0 && (
-                <div
-                  className="rail__group"
-                  data-over={isOver({ kind: "pinned" }) ? "true" : undefined}
-                  onPointerEnter={() => hover({ kind: "pinned" })}
-                  onPointerLeave={() => hover(null)}
-                >
-                  <div className="rail__group-head">
-                    <span className="rail__group-name">Pinned</span>
-                  </div>
-                  {pinned.map(row)}
-                </div>
-              )}
-
               {/* Every group gets a header, including the only one, because the
-                  gear on it is where that group's model and endpoint live. */}
+                  gear on it is where that group's model and endpoint live. A
+                  crew's pins are at the head of it and nowhere else. They had a
+                  section of their own above the groups, which made a pin the one
+                  arrangement that was undone by going inside the crew it was
+                  arranging: the list on screen was the group's, and the row the
+                  operator had just pinned was in a section that was not being
+                  drawn. */}
               {groups.map((group) => {
                 const members = agents.filter((a) => a.groupId === group.id);
-                // Drawn here minus whoever is pinned above, but counted in
-                // full: a pinned agent is still in this group, still costs it
-                // money and is still someone its peers can message.
-                const here = railOrder(
-                  members.filter((a) => !a.pinned),
-                  shape,
-                );
+                const here = railOrder(members, shape);
                 return (
                   // The whole block catches a drop, not just the heading:
                   // anywhere in a group that is not a row means the group and no
@@ -557,7 +544,7 @@ export function Sidebar({
                   rail hiding an agent is worse than the rail looking untidy,
                   and an empty group list used to hide every agent at once. */}
               {railOrder(
-                agents.filter((a) => !a.pinned && !groups.some((g) => g.id === a.groupId)),
+                agents.filter((a) => !groups.some((g) => g.id === a.groupId)),
                 shape,
               ).map(row)}
             </>

--- a/src/lib/rail.test.ts
+++ b/src/lib/rail.test.ts
@@ -42,7 +42,7 @@ function drawn(
   rows: AgentCard[],
   activity: Record<AgentId, Activity> = {},
   lastActive: Record<AgentId, number> = {},
-  options: { frozen?: boolean; pinnedFirst?: boolean } = {},
+  options: { frozen?: boolean } = {},
 ): string[] {
   return names(railOrder(rows, { activity, lastActive, ...options }));
 }
@@ -111,8 +111,11 @@ describe("what activity is lent", () => {
   });
 
   it("never lifts a pinned row, which is the whole of what a pin is for", () => {
+    // Both pinned, so both are in the band a pin holds. The one that is working
+    // still does not move: being in the same place every time is what a pin is
+    // for, and a row that climbs when its agent gets busy is what it stops.
     const rows = [
-      agent("Manager", { railOrder: 0 }),
+      agent("Manager", { railOrder: 0, pinned: true }),
       agent("Cook", { railOrder: 1, pinned: true }),
       agent("Scribe", { railOrder: 2 }),
     ];
@@ -128,17 +131,17 @@ describe("what activity is lent", () => {
     expect(drawn(rows, working, {}, { frozen: true })).toEqual(["Manager", "Cook", "Scribe"]);
   });
 
-  it("keeps the pins at the head of a section that is a whole group", () => {
+  it("keeps a pin at the head of its crew, over the arrangement and over a turn", () => {
+    // Every section is a crew or part of one, so there is no section a pin does
+    // not head. It used to hold only where the rail drew a pinned section of its
+    // own, which was the overview: going inside the crew drew the list without
+    // it, and pinning a row while looking at that list moved nothing.
     const rows = [
       agent("Manager", { railOrder: 0 }),
       agent("Cook", { railOrder: 1 }),
       agent("Scribe", { railOrder: 2, pinned: true }),
     ];
-    expect(drawn(rows, { Cook: { state: "thinking" } }, {}, { pinnedFirst: true })).toEqual([
-      "Scribe",
-      "Cook",
-      "Manager",
-    ]);
+    expect(drawn(rows, { Cook: { state: "thinking" } })).toEqual(["Scribe", "Cook", "Manager"]);
   });
 });
 

--- a/src/lib/rail.ts
+++ b/src/lib/rail.ts
@@ -11,6 +11,9 @@
  * that had just moved and no arrangement could survive a conversation. Keeping
  * both halves is what makes a drag worth doing: the shape you arranged is the
  * shape the rail returns to.
+ *
+ * A pin is a third thing and the shortest: it holds a row at the head of its
+ * crew, in every view that draws that crew, and it never lends the place back.
  */
 
 import type { Activity, AgentCard, AgentId, GroupId } from "./types";
@@ -18,15 +21,11 @@ import type { Activity, AgentCard, AgentId, GroupId } from "./types";
 /**
  * What a dragged row was let go over.
  *
- * Three targets rather than one, because the rail says three different things.
- * A row is a place in an arrangement. A group is a crew, and dropping on one
- * asks for membership without saying where. Pinned is neither: it is a flag on
- * an agent, drawn as a section so it can be aimed at.
+ * Two targets, because the rail says two things. A row is a place in an
+ * arrangement, and it carries whether that place is pinned. A group is a crew,
+ * and dropping on one asks for membership without saying where in it.
  */
-export type DropTarget =
-  | { kind: "row"; id: AgentId }
-  | { kind: "group"; id: GroupId }
-  | { kind: "pinned" };
+export type DropTarget = { kind: "row"; id: AgentId } | { kind: "group"; id: GroupId };
 
 /**
  * How loudly a state asks for the top of its section.
@@ -64,23 +63,23 @@ export interface RailOptions {
    * moment that turn ended.
    */
   frozen?: boolean;
-  /**
-   * Keep pinned members at the head of this section.
-   *
-   * For a section that is a whole group, which is what focusing on one draws. In
-   * the rail's overview the pinned rows are lifted out into their own section
-   * above the groups, so there is nothing to keep at the head of anything.
-   */
-  pinnedFirst?: boolean;
 }
 
-/** Which band of its section a row sits in. Lower is nearer the top. */
-function bandOf(agent: AgentCard, lift: number, pinnedFirst: boolean): number {
-  if (pinnedFirst && agent.pinned) return 0;
-  // A pinned row never floats, wherever it is drawn. It is where it is so it can
-  // be found in one glance, and a row that moves when the agent gets busy is the
-  // one thing a pin is for stopping.
-  if (lift > 0 && !agent.pinned) return 1;
+/**
+ * Which band of its section a row sits in. Lower is nearer the top.
+ *
+ * A pin is the head of the crew, and it is the same head in both views: the
+ * overview draws every group with its pins on top, and going inside one draws
+ * that group and nothing else. A pin that only held in the overview was a
+ * gesture that did nothing to the list the operator was looking at.
+ *
+ * A pinned row never floats either. It is at the head so it can be found in one
+ * glance, and a row that moves when the agent gets busy is the one thing a pin
+ * is for stopping.
+ */
+function bandOf(agent: AgentCard, lift: number): number {
+  if (agent.pinned) return 0;
+  if (lift > 0) return 1;
   return 2;
 }
 
@@ -92,12 +91,12 @@ function bandOf(agent: AgentCard, lift: number, pinnedFirst: boolean): number {
  * accidentally decide where rows go.
  */
 export function railOrder(agents: AgentCard[], options: RailOptions): AgentCard[] {
-  const { activity, lastActive, frozen = false, pinnedFirst = false } = options;
+  const { activity, lastActive, frozen = false } = options;
 
   return agents
     .map((agent, index) => {
       const lift = frozen ? 0 : liftOf(activity[agent.id]);
-      return { agent, index, lift, band: bandOf(agent, lift, pinnedFirst) };
+      return { agent, index, lift, band: bandOf(agent, lift) };
     })
     .sort((a, b) => {
       if (a.band !== b.band) return a.band - b.band;

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -393,47 +393,31 @@ export const useStore = create<State>((set, get) => ({
    * the row lands and a component recomputing them would be a second place for
    * them to drift.
    *
-   * The pinned section is a flag and not a place. It spans groups, so a row
-   * dropped among pins keeps its own crew: the alternative is a gesture that
-   * says "keep this where I can see it" and quietly moves the agent to a
-   * different set of peers.
+   * A pin is the head of a crew, so the row landed on says both things at once:
+   * which crew, and whether the place aimed at is the pinned band above it or
+   * the rest below. Dropping onto a pinned row pins the dragged agent, dropping
+   * below the band unpins it, and either can also change the crew.
+   *
+   * Dropping on a group is the one gesture that says nothing about the band, so
+   * it says nothing: the pin is the operator's standing instruction about that
+   * agent, and moving somebody between crews is not a decision to drop it.
    */
   async dropAgent(id, target) {
     const state = get();
     const dragged = state.agents.find((a) => a.id === id);
     if (!dragged) return;
 
-    if (target.kind === "pinned") {
-      if (dragged.pinned) return;
-      await api.setAgentPinned(id, true);
-      await get().refreshAgents();
-      return;
-    }
-
     const live = state.agents.filter((a) => a.lifecycle !== "terminated");
 
     if (target.kind === "group") {
-      await get().moveAgent(id, { groupId: target.id, before: null, pinned: false });
+      await get().moveAgent(id, { groupId: target.id, before: null });
       return;
     }
 
     const onto = live.find((a) => a.id === target.id);
     if (!onto || onto.id === id) return;
 
-    // Dropped among the pins from another crew: pin it, and leave the crew and
-    // the place it already had. There is no position in that section to express,
-    // because the section is drawn from rows the arrangement holds apart.
-    if (onto.pinned && onto.groupId !== dragged.groupId) {
-      if (!dragged.pinned) {
-        await api.setAgentPinned(id, true);
-        await get().refreshAgents();
-      }
-      return;
-    }
-
-    const section = onto.pinned
-      ? live.filter((a) => a.pinned && a.groupId === onto.groupId)
-      : live.filter((a) => a.groupId === onto.groupId && !a.pinned);
+    const section = live.filter((a) => a.groupId === onto.groupId && a.pinned === onto.pinned);
     const order = railOrder(section, {
       activity: state.activity,
       lastActive: state.lastActive,
@@ -457,11 +441,10 @@ export const useStore = create<State>((set, get) => ({
     if (!agent) return;
 
     const live = state.agents.filter((a) => a.lifecycle !== "terminated");
-    // A pinned row moves among the pinned rows: that section spans groups and is
-    // drawn above them, so its neighbours are the other pins and not the crew.
-    const section = agent.pinned
-      ? live.filter((a) => a.pinned)
-      : live.filter((a) => a.groupId === agent.groupId && !a.pinned);
+    // Within its own band, because that is the list the row is drawn in. A
+    // nudge across the boundary would ask for a place the bands then take back,
+    // and the row would sit exactly where it was with a write behind it.
+    const section = live.filter((a) => a.groupId === agent.groupId && a.pinned === agent.pinned);
 
     const order = railOrder(section, {
       activity: state.activity,

--- a/src/styles.css
+++ b/src/styles.css
@@ -528,6 +528,16 @@ button {
   background: var(--accent, var(--flesh));
 }
 
+/* The name and its pin as one cell, rather than a fourth column. A column that
+   is empty on every unpinned row still takes its gap, so the names in a crew
+   would line up with each other and with nothing else in the rail. */
+.agent-row__title {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
 .agent-row__name {
   font-family: var(--font-display);
   font-size: 0.88rem;
@@ -537,6 +547,16 @@ button {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Quiet, and after the name so the name is what truncates. A pin is read once,
+   when the operator wonders why this row is at the top; the row it is on is
+   already carrying a face, a name and a state. */
+.agent-row__pin {
+  flex: none;
+  width: 0.68rem;
+  height: 0.68rem;
+  color: var(--rail-muted);
 }
 
 .agent-row[data-lifecycle="paused"] .agent-row__name {


### PR DESCRIPTION
The pins had a section of their own above the groups, which is only drawn in the overview, so pinning a row while looking inside a crew moved it into a section that was not on screen and read as doing nothing until the operator went back out to All. A pin is a band at the head of a crew now, drawn wherever that crew is drawn and in the same order in both views, and the row carries a mark because a crew whose pin is also the row arranged at the top looks exactly like a pin that did nothing. The row a drag lands on says both things: dropping onto a pinned row pins the dragged agent and places it among the pins, dropping below unpins it, and either can change the crew at the same time. Dropping on a group says nothing about the band and no longer clears the pin, since moving somebody between crews is not a decision to unpin them. `rail.ts` loses the `pinnedFirst` option and the `pinned` drop target, `docs/WORKSPACE.md` records the failure and the new rule, and the rail, sidebar and app suites cover both views, the mark, and the pin surviving a move between crews.