### PR TITLE
refactor: a scheduler pass cannot skip the wait that follows it

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,10 +4,12 @@ version = "0.1.0"
 description = "Guac: a local, no-auth chat surface where you and your agents talk to each other."
 authors = ["madebywelch"]
 edition = "2021"
-# What the lockfile actually needs, not an aspiration. `time`, `plist` and the
-# `icu` crates declare 1.88, and thirty-odd more are edition 2024, so an older
-# toolchain fails on the first crate it downloads rather than on this line. It
-# also steers `cargo update` toward versions that build here.
+# The floor the dependency tree already imposes, written down rather than
+# guessed at. Several crates in the lockfile pin 1.88 themselves and a large
+# number more are edition 2024, so an out-of-date toolchain gives up partway
+# through a download with an error about somebody else's crate. Declaring it
+# here moves that failure to the first line cargo reads, and keeps
+# `cargo update` inside the range that still builds.
 rust-version = "1.88"
 
 [lib]

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -338,6 +338,14 @@ const SIGNIN_SCAN_EVERY: Duration = Duration::from_secs(120);
 /// forever, because a turn that never ends is a run that never settles.
 const APPROVAL_WINDOW: Duration = Duration::from_secs(10 * 60);
 
+/// How often the schedule is swept for routines that have come due.
+///
+/// A poll rather than a timer per routine: the next due time is what is
+/// stored, so a schedule made last week survives a restart and nothing has to
+/// be rebuilt in memory at startup. The cost of the interval is lateness, and
+/// twenty seconds is under the resolution anything here can be scheduled at.
+const SCHEDULE_TICK: Duration = Duration::from_secs(20);
+
 #[derive(Debug, thiserror::Error)]
 pub enum RuntimeError {
     #[error(transparent)]
@@ -1042,54 +1050,71 @@ impl Runtime {
 
     /// Watches the clock so agents can keep their own appointments.
     ///
-    /// Polls rather than holding a timer per routine: what is stored is when a
-    /// thing is next due, so a schedule made last week still fires after a
-    /// restart, and nothing has to be rebuilt in memory at startup.
+    /// The loop is two statements, and that is the whole point: one pass, then
+    /// the wait. Nothing inside a pass can reach the next pass without going
+    /// through [`SCHEDULE_TICK`], because a pass is a separate function and the
+    /// only way out of it is to return.
     pub fn start_scheduler(&self) {
         let runtime = self.clone();
         self.inner.handle.spawn(async move {
             loop {
-                let now = now_ms();
-                // A read that fails waits for the next tick like one that
-                // succeeds. Skipping straight to the next attempt turned a
-                // database that stayed broken into a hot loop of synchronous
-                // SQLite calls, with a warning written as fast as the disk
-                // could refuse.
-                let due = runtime.inner.store.due_routines(now).unwrap_or_else(|err| {
-                    tracing::warn!(%err, "could not read the schedule; trying again next tick");
-                    Vec::new()
-                });
-
-                for routine in due {
-                    // Recorded as run before it is run. A routine that fails on
-                    // delivery must not come due again on the next tick and
-                    // again on the one after that.
-                    if let Err(err) = runtime.inner.store.routine_ran(&routine, now) {
-                        tracing::error!(%err, "could not advance a routine; skipping it");
-                        continue;
-                    }
-                    // The row moved: to its next slot, or off the list
-                    // altogether if it was a one-shot. Either way the panel is
-                    // showing a firing that has already happened.
-                    runtime.emit(UiEvent::RoutinesChanged { agent_id: routine.agent_id });
-
-                    tracing::info!(
-                        agent = %routine.agent_id.short(),
-                        trigger = %routine.trigger.as_str(),
-                        repeats = routine.repeats(),
-                        "a routine came due"
-                    );
-                    match runtime.send_from_routine(&routine) {
-                        Ok(run) => runtime.log_routine_run(&routine, run, RunKind::Scheduled, now),
-                        Err(err) => tracing::warn!(%err, "a routine could not be delivered"),
-                    }
-                }
-
-                // Swept at the end rather than the start, so anything already
-                // overdue at launch runs now instead of waiting out a tick.
-                tokio::time::sleep(std::time::Duration::from_secs(20)).await;
+                runtime.sweep_schedule().await;
+                // Swept before the first wait rather than after it, so anything
+                // already overdue at launch runs now instead of sitting out a
+                // tick that starts the moment the app opens.
+                tokio::time::sleep(SCHEDULE_TICK).await;
             }
         });
+    }
+
+    /// One pass over the schedule: everything due now, fired now.
+    ///
+    /// Split out of the loop so that giving up on a pass cannot also skip the
+    /// wait. That is not a hypothetical tidiness: a `continue` on a failed read
+    /// used to jump straight back to the top, so a database that stayed broken
+    /// spun this into a hot loop, pinning a worker on synchronous SQLite calls
+    /// and repeating one warning as fast as the disk could refuse it. The
+    /// scheduler shares its runtime with every agent, so that is not a slow
+    /// scheduler, it is a runtime nobody else gets a turn on. Returning early
+    /// is now the safe thing to write, which is why the fix is a boundary
+    /// rather than a rule about which keyword to avoid.
+    async fn sweep_schedule(&self) {
+        let now = now_ms();
+        let due = match self.inner.store.due_routines(now) {
+            Ok(due) => due,
+            Err(err) => {
+                // Named as a wait, not a stop: this line is read by whoever is
+                // wondering why a routine did not fire, and the answer is that
+                // it will be tried again in twenty seconds.
+                tracing::warn!(%err, "could not read the schedule; waiting for the next tick");
+                return;
+            }
+        };
+
+        for routine in due {
+            // Recorded as run before it is run. A routine that fails on
+            // delivery must not come due again on the next tick and again on
+            // the one after that.
+            if let Err(err) = self.inner.store.routine_ran(&routine, now) {
+                tracing::error!(%err, "could not advance a routine; skipping it");
+                continue;
+            }
+            // The row moved: to its next slot, or off the list altogether if it
+            // was a one-shot. Either way the panel is showing a firing that has
+            // already happened.
+            self.emit(UiEvent::RoutinesChanged { agent_id: routine.agent_id });
+
+            tracing::info!(
+                agent = %routine.agent_id.short(),
+                trigger = %routine.trigger.as_str(),
+                repeats = routine.repeats(),
+                "a routine came due"
+            );
+            match self.send_from_routine(&routine) {
+                Ok(run) => self.log_routine_run(&routine, run, RunKind::Scheduled, now),
+                Err(err) => tracing::warn!(%err, "a routine could not be delivered"),
+            }
+        }
     }
 
     /// Operator sends a message to one agent. Returns the run it starts.

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -1864,35 +1864,41 @@ async fn a_routine_that_is_switched_off_stays_quiet_and_starts_again_when_asked(
 }
 
 #[test]
-fn a_schedule_that_cannot_be_read_does_not_starve_the_runtime() {
-    // A store error on the schedule used to skip the sleep at the bottom of the
-    // scheduler's loop, so a database that stayed broken turned the tick into
-    // a hot loop: one worker pinned on synchronous SQLite calls and a warning
-    // written as fast as it could be. On a single-threaded runtime that task
-    // never yields, so this runs the runtime on its own thread and gives it a
-    // deadline; a hang here is the bug, and a hang is not a test failure
-    // unless something is watching the clock.
-    let (done_tx, done_rx) = std::sync::mpsc::channel();
+fn a_schedule_that_cannot_be_read_parks_until_the_next_tick() {
+    // The scheduler shares its runtime with every agent, so a pass that returns
+    // without waiting is not a slow scheduler: it is a worker nobody else gets
+    // back. Paused time is what makes that observable rather than merely slow.
+    // Tokio only advances a paused clock once every task is parked on a timer,
+    // so a scheduler spinning on a store it cannot read holds the clock still
+    // and the minute below never elapses. One thread, because on a multi-thread
+    // runtime the spin has somewhere else to go and the bug hides.
+    let (finished, watch) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
-        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .start_paused(true)
+            .build()
+            .unwrap();
         rt.block_on(async {
-            let stub = serve(|_| Script::Say("unused".into())).await;
+            let stub = serve(|_| Script::Say("never called".into())).await;
             let h = harness(&stub, &["Watcher"], GuardLimits::default());
+            // The one failure the scheduler cannot read its way out of, and the
+            // one that stays broken for as long as the process runs.
             h.runtime.store().conn().unwrap().execute_batch("DROP TABLE routines").unwrap();
 
             h.runtime.start_scheduler();
 
-            // The scheduler is the only other task on this runtime. If it
-            // does not sleep between failed reads, this never returns.
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            // Several ticks' worth, and it costs no real time: the clock jumps
+            // the moment this task and the scheduler are both on a timer.
+            tokio::time::sleep(Duration::from_secs(60)).await;
         });
-        let _ = done_tx.send(());
+        let _ = finished.send(());
     });
 
     assert!(
-        done_rx.recv_timeout(Duration::from_secs(10)).is_ok(),
-        "the scheduler kept the runtime to itself: a schedule it cannot read has to wait for \
-         the next tick like a schedule it can"
+        watch.recv_timeout(Duration::from_secs(10)).is_ok(),
+        "the clock never moved, so the scheduler never parked: a schedule it cannot read has to \
+         wait out the tick like one it can"
     );
 }
 


### PR DESCRIPTION
The scheduler's tick body and its wait were one loop, so any early exit inside the body was one keyword away from becoming a hot loop, which is how a failed schedule read once pinned a worker on synchronous SQLite calls. A pass is now its own function and `start_scheduler` is one pass then the wait, so returning early is the safe thing to write rather than the dangerous one, and the interval is a named constant beside the other two the runtime waits on.

The regression test drives it under a paused clock: tokio advances one only once every task is parked on a timer, so a scheduler that spins holds the clock still and the wait never elapses. That is a sharper assertion than a wall-clock deadline and runs two orders of magnitude faster. Verified by reintroducing the old shape and confirming the test fails against it; `./scripts/ci.sh rust` passes clean. The `rust-version` comment in `Cargo.toml` is reworded, with no change to the pinned version.