### PR TITLE
feat: a group chooses who pays for its turns, and how far they may run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,12 @@ src/                  React + TypeScript. A view over the runtime, nothing more.
   lib/notify.ts       When an interruption is warranted. Mostly when it is not.
   lib/announce.ts     What that interruption would say. One event in, one line out.
   lib/keybinds.ts     Every key the app answers to, in one list.
+  lib/limits.ts       The five bounds a conversation runs inside, in words.
   components/         One file per surface.
 src-tauri/src/
   domain/             AgentCard, Envelope, Routine, Connector, Signin, Approval,
                       Search, ids. No I/O.
+    group.rs          A crew's wall, and the settings its agents run on.
   runtime/
     guard.rs          The loop guard. Read this one first.
     mod.rs            Agent actors and the message bus.
@@ -67,6 +69,7 @@ repo: the frontend renders state and forwards intent.
 | What a turn is told it was asked for: `expects_reply`, `intent`, `ReplyMode` | *Cascades terminate because of one asymmetry*, and `runtime/prompt.rs`, which has to agree with it |
 | Streaming, retries, the budget, when a run settles | *A failed model call is retried*, *A thought is shown and never kept*, *The budget counts model calls* |
 | How a turn is paid for: providers, the ChatGPT sign-in, the Responses API | *A subscription is a second provider, not a second endpoint*, then `llm/codex.rs` and `subscription.rs` |
+| What a group decides for itself: provider, models, timeout, limits | *A group chooses its own provider*, *Nothing about who pays is inferred* and *A run is measured against the limits of the group it happens in*, then `domain/group.rs` |
 | Stopping a conversation: what a stop marks, wakes, and must never release | *A stop marks the run and releases nothing*, then `Runtime::stop_run` |
 | Permission prompts, parked turns, acting in the operator's name | *A protected action parks the turn that asked for it* |
 | What an agent may do with a page it has just read | *A page that was read this turn cannot quietly press a button* |
@@ -86,6 +89,7 @@ repo: the frontend renders state and forwards intent.
 | The rail's order, dragging a row, groups as places you go inside | *The rail is arranged by hand*, *A drop is one call* and *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/rail.ts` |
 | Preset agents, hiring a crew | *The cafeteria is a copy machine* in `docs/WORKSPACE.md`, then `src/lib/cafeteria.ts` |
 | Settings, the surface, the scale, what may interrupt the operator | *Settings is eight places*, *The reading column has two surfaces* and *An interruption has to earn it* in `docs/WORKSPACE.md` |
+| The group editor: what a crew overrides and what it inherits | *A group's settings are the app's, with the crew's answer on top* in `docs/WORKSPACE.md`, then `src/components/GroupEditor.tsx` |
 | A prompt, or anything that changes how much a crew talks | *Three test suites, asking different questions*, then run the live evals |
 
 Unqualified section names are headings in `docs/ARCHITECTURE.md`.
@@ -134,6 +138,17 @@ the model takes a screenshot to see what `browse` did.
 
 ## What looks like a simplification and is not
 
+- **A group's settings are two blocks, and each is all-or-nothing.** A draft
+  that mentions `inference` or `limits` replaces every override in that block,
+  and one that leaves it out changes none of them. Per-field "absent means leave
+  alone" would let a caller half-write a crew's settings, and would make a UI
+  that renders what it read back clear a field by forgetting to mention it. The
+  API key is the one exception and has the opposite rule — absent keeps the
+  stored key — because it is the one setting that cannot be read back.
+- **Every setting a group can hold is `None` when it is inherited, all the way
+  down.** In the draft, in the column, and in the resolved overrides. An empty
+  string is a field an operator blanked, which also means inherit, and it is
+  normalised to `None` on the way in so the two can never disagree.
 - **A thread between two agents is `pair_messages`.** A send is filed under the
   recipient and the answer under the sender, so a thread assembled from one
   channel's rows is missing messages nobody can account for.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,7 +138,10 @@ answered and were finishing their own notes.
 
 The guard is the backstop, not the mechanism. Each limit catches a different
 shape of runaway, so weakening one is not a local change. All are adjustable in
-Settings.
+Settings, and any group can override any of them: a pair drafting a document
+needs a handful of model calls, and a crew working a browser through a long form
+needs an order of magnitude more, so one number for both is either an open wallet
+or a crew that stops halfway and reports nothing.
 
 | Limit | Default | Stops |
 |---|---|---|
@@ -150,6 +153,14 @@ Settings.
 
 When a limit is hit the agent is told why, in words it can act on, and the
 reason appears on the transcript chip. Nothing is dropped silently.
+
+**A run is measured against the limits of the group it happens in, read once.**
+A run cannot cross a group, because a send addressed outside one is refused as an
+unknown recipient, so every part of the runtime that asks the guard about a run
+resolves the same numbers for it. `GuardRegistry::run_within` reads them when it
+creates the run's state and never again: a limit edited mid-cascade must not move
+the ceiling a conversation is already being measured against, or a run reports
+having spent more than it was allowed. The next run gets the new number.
 
 **A pipeline spends two hops per phase, so the depth limit is four phases, not
 eight.** A coordinator working through specialists in sequence is one hop out
@@ -308,15 +319,23 @@ set rotates on refresh, which is Guaca writing in the background, while
 writers on one file lose a refreshed token to a stale in-memory copy, and the
 symptom is a sign-in that works until an unrelated setting changes.
 
-**A group that names its own endpoint or key leaves the subscription.**
-`GroupInference::apply` flips the provider back to the endpoint, because an
-endpoint is not where a subscription is spent. Without it such a group inherits
-the app's subscription and has both of its overrides silently ignored: the
-operator is looking at a URL and a key that nothing used, with no error to
-explain it. Overriding only the model does not flip it, since that is a group
-asking for a different model on whatever the app is already paying with. The flip
-happens before the model is collapsed, so each case lands on a model its own
-provider can run.
+**A group chooses its own provider, and the sign-in is still one credential.**
+Which of the two is paying is a setting, not an account, so a group can be moved
+onto the ChatGPT subscription while the app settings still say a pasted key, and
+another group can stay on a local endpoint. The sign-in itself belongs to the
+app: there is one on this machine, performed in Settings, and a group only
+decides whether to spend it. `GroupInference::apply` resolves the provider
+first, then lays both model overrides on top, then collapses to the resolved
+provider's model, so every case lands on a model its own provider can run.
+
+**Nothing about who pays is inferred.** A group that named an endpoint used to be
+taken to have chosen one, because until the provider column there was no way for
+it to say so. That guess could not be argued with: an endpoint left in the box
+outvoted an operator choosing to follow the app settings, with nothing on screen
+to explain it. Migration 23 wrote the reading down for every group it was true
+of, and `apply` now reads a column instead of guessing. What replaces the guess
+is the UI: choosing an endpoint preset also chooses to pay with a key, exactly
+as it does in Settings.
 
 **Only OpenAI offers this.** Anthropic prohibits it. Consumer Claude OAuth tokens
 are restricted to Claude Code and Claude.ai, enforced server-side, so a Claude

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -261,6 +261,35 @@ The pinned section is a flag drawn as a place. It spans groups, so a row dropped
 among the pins keeps its own crew: the alternative is a gesture that says "keep
 this where I can see it" and quietly moves the agent to a different set of peers.
 
+## A group's settings are the app's, with the crew's answer on top
+
+Everything in the group editor except the name is an override, and blank means
+inherit. That is why the boxes carry placeholders rather than values: an operator
+has to be able to tell "this crew uses the app's model" apart from "this crew
+pins that exact model", and an empty box that means two different things is a
+setting nobody can read.
+
+It is sectioned on the Settings shell for the same reason Settings is: a group
+now decides who pays for its turns, which model answers them, how long a call may
+take and how far a conversation may run, and one scroll put the name and the
+delete button a page apart. The state lives in the shell, so changing section
+cannot discard a half-typed endpoint. Accounts is disabled until the group
+exists, because a credential has to belong to something.
+
+Three rows say who pays, and the first is "follow the app settings", which is
+where every group starts. The second is the ChatGPT subscription, and the group
+editor cannot sign in: there is one sign-in on this machine, it is performed in
+Settings, and what a group chooses is whether to spend it. The rest is the same
+preset list Settings draws, from the same file, because an endpoint that is off
+by a path segment fails the same way whoever typed it.
+
+Two model fields, not one, and only the one belonging to the resolved provider
+is on screen at a time. A model belongs to a provider — the two have disjoint
+names and neither accepts the other's — so a crew that tries the subscription for
+an hour and moves back has to find its endpoint model where it left it. Test
+connection is here for the same reason it is in Settings, and it sends what is on
+screen resolved over the app settings, which is what the next turn would do.
+
 ## Pinning is where a row is drawn and nothing else
 
 It does not bump the card version, because the version is how a peer notices a
@@ -355,6 +384,12 @@ draws and what is allowed to interrupt you are five different questions, and one
 scroll made the operator read all five to change one. So it is a nav and a pane,
 on the Cafeteria's shape: a panel that owns its own height, a head and a foot
 pinned to it, one scrolling half.
+
+Two of those eight are defaults rather than orders. Whatever Provider and Limits
+say is what a group falls back to, and a group that answers for itself is not
+affected by either. What stays app-wide is what is genuinely one of: the
+operator's name, the machine and browser accounts, and everything about how the
+app looks and when it may interrupt.
 
 Every value lives in the shell rather than in the pane that draws it, and that is
 not tidiness. The shell is unmounted when the dialog closes, so a pane holding

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -362,6 +362,7 @@ pub fn run() {
             commands::list_groups,
             commands::create_group,
             commands::update_group,
+            commands::test_group_connection,
             commands::delete_group,
             commands::approval_states,
             commands::decide_approval,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -18,7 +18,7 @@ use crate::domain::approval::{Approval, ApprovalState, Decision, ProtectedAction
 use crate::domain::attachment::Attachment;
 use crate::domain::connector::{Connector, ConnectorDraft};
 use crate::domain::envelope::Envelope;
-use crate::domain::group::{Group, GroupDraft};
+use crate::domain::group::{Group, GroupDraft, GroupInference};
 use crate::domain::ids::{AgentId, ApprovalId, ConnectorId, GroupId, MessageId, RoutineId, RunId};
 use crate::domain::now_ms;
 use crate::domain::routine::{self, Routine, RoutineRun, Trigger};
@@ -417,6 +417,41 @@ pub fn update_group(state: State<'_, AppState>, id: GroupId, draft: GroupDraft) 
     let group = state.runtime.store().update_group(id, &clean)?;
     state.runtime.emit(UiEvent::AgentsChanged);
     Ok(group)
+}
+
+/// Verifies a group's endpoint and key without involving one of its agents.
+///
+/// The group's own answer to `test_connection`, and it has to be a separate
+/// command rather than that one with an id: a group's settings are layered over
+/// the app's, so what is worth testing is the resolution rather than either
+/// half. Takes what is on screen, exactly as the app's does, and starts from the
+/// stored key so a test run without retyping it tests the key that is actually
+/// there. `id` is absent for a group that has not been created yet.
+#[tauri::command]
+pub async fn test_group_connection(
+    state: State<'_, AppState>,
+    id: Option<GroupId>,
+    draft: GroupDraft,
+) -> Reply<String> {
+    let clean = draft.validate()?;
+    let mut resolved = match id {
+        Some(id) => state.runtime.store().group_inference(id)?,
+        None => GroupInference::default(),
+    };
+    if let Some(overrides) = clean.inference {
+        resolved.overrides = overrides;
+    }
+    if let Some(key) = clean.api_key {
+        resolved.api_key = key;
+    }
+
+    let mut config = state.runtime.config();
+    config.inference = resolved.apply(&config.inference);
+    state
+        .runtime
+        .probe(&config)
+        .await
+        .map_err(|err| CommandError::new("inference", err.to_string()))
 }
 
 /// Deletes an empty group. Refused while it still holds agents; see

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -38,6 +38,32 @@ pub enum Provider {
     Chatgpt,
 }
 
+impl Provider {
+    /// How a provider is spelled in SQLite, which is the same as on the wire.
+    ///
+    /// Not `Display`: the point is that the stored spelling and the IPC one
+    /// cannot drift, and a formatting impl is where a friendlier name would
+    /// eventually be written.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Provider::Compatible => "compatible",
+            Provider::Chatgpt => "chatgpt",
+        }
+    }
+
+    /// Reads one back. Anything unrecognised is `None`, which every caller
+    /// already has a meaning for: inherit. A column written by a newer build
+    /// must leave a crew running on the app settings rather than refusing to
+    /// load the group.
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim() {
+            "compatible" => Some(Provider::Compatible),
+            "chatgpt" => Some(Provider::Chatgpt),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InferenceConfig {
@@ -455,6 +481,20 @@ fn restrict_permissions(_path: &Path) -> Result<(), ConfigError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_provider_is_spelled_the_same_way_in_sqlite_and_on_the_wire() {
+        // Two spellings of one value, and the second is a `serde` attribute
+        // nothing else would notice changing. If they ever disagree, a group's
+        // stored provider reads as inherit and a whole crew quietly moves onto
+        // the app's settings.
+        for provider in [Provider::Compatible, Provider::Chatgpt] {
+            let wire = serde_json::to_value(provider).unwrap();
+            assert_eq!(wire, serde_json::Value::String(provider.as_str().to_string()));
+            assert_eq!(Provider::parse(provider.as_str()), Some(provider));
+        }
+        assert_eq!(Provider::parse("anthropic-native"), None, "a future value is inherit");
+    }
 
     #[test]
     fn chat_url_is_built_without_a_double_slash() {

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -607,6 +607,52 @@ ALTER TABLE signins_next RENAME TO signins;
 CREATE INDEX signins_agent ON signins (agent_id);
 "#,
     ),
+    (
+        23,
+        r#"
+-- A group is where a crew's settings live. It already carried an endpoint, a
+-- key and a model; what was missing was the setting that decides which of those
+-- are even read. A group can now name the provider that pays for its turns, so
+-- one crew can run on a local server while another spends the ChatGPT plan, and
+-- the app settings are what a group falls back to rather than what it obeys.
+ALTER TABLE groups ADD COLUMN provider             TEXT;
+ALTER TABLE groups ADD COLUMN subscription_model   TEXT;
+ALTER TABLE groups ADD COLUMN request_timeout_secs INTEGER;
+
+-- And the loop guard, which is a statement about one crew's work rather than
+-- about the app: a pair drafting a document needs a handful of model calls, and
+-- a crew working a browser through a long form needs an order of magnitude
+-- more. NULL is inherit, per limit, so a group that has never been touched runs
+-- on exactly the numbers it ran on yesterday.
+ALTER TABLE groups ADD COLUMN max_hops           INTEGER;
+ALTER TABLE groups ADD COLUMN max_steps_per_run  INTEGER;
+ALTER TABLE groups ADD COLUMN max_fanout_per_call INTEGER;
+ALTER TABLE groups ADD COLUMN max_sends_per_pair INTEGER;
+ALTER TABLE groups ADD COLUMN max_tool_rounds    INTEGER;
+
+-- One model column became two, and the split changes what the old one means.
+-- It used to be "this group's model, whoever is paying"; it is now the model
+-- for a key-paid turn, with the new column beside it for a subscription-paid
+-- one. A group whose model is one of the subscription's own could only have
+-- been running on the subscription, so it is copied across and keeps running on
+-- what it was running on. The list is spelled out rather than read from the
+-- code because this is a statement about the models that existed on the day
+-- this migration ran, and it must not change when that list does.
+UPDATE groups
+   SET subscription_model = default_model
+ WHERE default_model IN
+       ('gpt-5.6-sol','gpt-5.6-terra','gpt-5.6-luna','gpt-5.5','gpt-5.4','gpt-5.4-mini');
+
+-- A group that named an endpoint or a key was taken to have chosen one, because
+-- until this column there was no way for it to say so. That reading is written
+-- down here rather than left as a guess in the code that resolves a turn: a
+-- guess there cannot be argued with, and it outvotes an operator who later
+-- chooses to follow the app settings with an endpoint still in the box.
+UPDATE groups
+   SET provider = 'compatible'
+ WHERE trim(coalesce(base_url, '')) <> '' OR trim(coalesce(api_key, '')) <> '';
+"#,
+    ),
 ];
 
 /// The group every agent starts in, and the one the UI keeps out of the way
@@ -757,6 +803,104 @@ mod tests {
             })
             .unwrap();
         assert_eq!(model, None, "a fresh group must inherit rather than pin a model");
+    }
+
+    #[test]
+    fn a_group_pinned_to_a_subscription_model_keeps_running_on_it() {
+        // The one column became two, and the split changed what the old one
+        // means. A group whose model is one of the subscription's own was being
+        // spent on the subscription; leaving it behind would move that crew to
+        // whatever the app happens to run, silently and on the next turn.
+        let mut conn = memory();
+        let tx = conn.transaction().unwrap();
+        for (version, sql) in MIGRATIONS.iter().take_while(|(v, _)| *v < 23) {
+            tx.execute_batch(sql).unwrap();
+            tx.pragma_update(None, "user_version", *version).unwrap();
+        }
+        tx.execute(
+            "INSERT INTO groups (id,name,created_at,default_model) VALUES ('g1','Plan',1,'gpt-5.4')",
+            [],
+        )
+        .unwrap();
+        tx.execute(
+            "INSERT INTO groups (id,name,created_at,default_model)
+             VALUES ('g2','Local',2,'local/qwen')",
+            [],
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        run(&mut conn).unwrap();
+
+        let carried: Option<String> = conn
+            .query_row("SELECT subscription_model FROM groups WHERE id='g1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(carried.as_deref(), Some("gpt-5.4"));
+
+        // And a model that belongs to an endpoint is left where it was: copying
+        // it would pin a crew to a model the subscription cannot run the moment
+        // anyone moved it across.
+        let untouched: Option<String> = conn
+            .query_row("SELECT subscription_model FROM groups WHERE id='g2'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(untouched, None);
+    }
+
+    #[test]
+    fn a_group_that_already_had_an_endpoint_is_written_down_as_choosing_one() {
+        // What it was doing yesterday, said out loud, so that nothing has to
+        // guess it tomorrow.
+        let mut conn = memory();
+        let tx = conn.transaction().unwrap();
+        for (version, sql) in MIGRATIONS.iter().take_while(|(v, _)| *v < 23) {
+            tx.execute_batch(sql).unwrap();
+            tx.pragma_update(None, "user_version", *version).unwrap();
+        }
+        tx.execute(
+            "INSERT INTO groups (id,name,created_at,base_url) VALUES ('g1','Local',1,'http://x/v1')",
+            [],
+        )
+        .unwrap();
+        tx.execute(
+            "INSERT INTO groups (id,name,created_at,api_key) VALUES ('g2','Keyed',2,'sk-x')",
+            [],
+        )
+        .unwrap();
+        tx.execute(
+            "INSERT INTO groups (id,name,created_at,default_model)
+             VALUES ('g3','Model only',3,'some/model')",
+            [],
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        run(&mut conn).unwrap();
+
+        let provider = |id: &str| -> Option<String> {
+            conn.query_row("SELECT provider FROM groups WHERE id=?1", [id], |r| r.get(0)).unwrap()
+        };
+        assert_eq!(provider("g1").as_deref(), Some("compatible"));
+        assert_eq!(provider("g2").as_deref(), Some("compatible"));
+        // A group that only pinned a model never said anything about who pays,
+        // and must keep saying nothing.
+        assert_eq!(provider("g3"), None);
+    }
+
+    #[test]
+    fn group_limits_start_unset_and_mean_inherit() {
+        // A number here would be a limit nobody chose, and it would override the
+        // app's the first time either was retuned.
+        let mut conn = memory();
+        run(&mut conn).unwrap();
+        let (steps, provider): (Option<i64>, Option<String>) = conn
+            .query_row(
+                "SELECT max_steps_per_run, provider FROM groups WHERE id=?1",
+                [DEFAULT_GROUP_ID],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(steps, None);
+        assert_eq!(provider, None, "a fresh group is paid for however the app is");
     }
 
     #[test]

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -16,7 +16,7 @@ use crate::domain::agent::{AgentCard, CleanDraft, Lifecycle};
 use crate::domain::approval::{Approval, ApprovalState, DetailField, ProtectedAction};
 use crate::domain::connector::{CleanConnector, Connector};
 use crate::domain::envelope::{Envelope, Intent, Part, Participant, Trust};
-use crate::domain::group::{CleanGroup, Group, GroupInference};
+use crate::domain::group::{CleanGroup, Group, GroupInference, GroupLimits, InferenceOverrides};
 use crate::domain::ids::{AgentId, ApprovalId, ConnectorId, GroupId, MessageId, RoutineId, RunId};
 use crate::domain::now_ms;
 use crate::domain::routine::{NextSlot, Routine, RoutineRun, RunKind, Trigger};
@@ -1175,7 +1175,10 @@ impl Store {
             "SELECT g.id, g.name, g.created_at,
                     (SELECT count(*) FROM agents a
                       WHERE a.group_id = g.id AND a.lifecycle <> 'terminated'),
-                    g.base_url, g.api_key, g.default_model
+                    g.base_url, g.api_key, g.default_model,
+                    g.provider, g.subscription_model, g.request_timeout_secs,
+                    g.max_hops, g.max_steps_per_run, g.max_fanout_per_call,
+                    g.max_sends_per_pair, g.max_tool_rounds
                FROM groups g
               ORDER BY g.created_at, g.rowid",
         )?;
@@ -1190,16 +1193,29 @@ impl Store {
     pub fn create_group(&self, draft: &CleanGroup) -> Result<Group, StoreError> {
         let conn = self.conn()?;
         let id = GroupId::new();
+        let over = draft.inference.clone().unwrap_or_default();
+        let limits = draft.limits.unwrap_or_default();
         conn.execute(
-            "INSERT INTO groups (id,name,created_at,base_url,api_key,default_model)
-             VALUES (?1,?2,?3,?4,?5,?6)",
+            "INSERT INTO groups (id,name,created_at,base_url,api_key,default_model,
+                                 provider,subscription_model,request_timeout_secs,
+                                 max_hops,max_steps_per_run,max_fanout_per_call,
+                                 max_sends_per_pair,max_tool_rounds)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14)",
             params![
                 id.to_string(),
                 draft.name,
                 now_ms(),
-                draft.base_url.clone().flatten(),
+                over.base_url,
                 draft.api_key.clone().flatten(),
-                draft.default_model.clone().flatten(),
+                over.default_model,
+                over.provider.map(|p| p.as_str()),
+                over.subscription_model,
+                over.request_timeout_secs,
+                limits.max_hops,
+                limits.max_steps_per_run,
+                limits.max_fanout_per_call.map(|n| n as i64),
+                limits.max_sends_per_pair,
+                limits.max_tool_rounds,
             ],
         )
         .map_err(|e| classify(e, &draft.name))?;
@@ -1211,23 +1227,45 @@ impl Store {
     /// erasing it on the next save.
     pub fn update_group(&self, id: GroupId, draft: &CleanGroup) -> Result<Group, StoreError> {
         let conn = self.conn()?;
+        // Each block is written or left alone as a whole, which is what the
+        // draft's two rules say. Per-column CASEs inside a block would let a
+        // caller half-write a group's settings, and the second half of a save
+        // that failed halfway is not a state anything here can report.
+        let over = draft.inference.clone().unwrap_or_default();
+        let limits = draft.limits.unwrap_or_default();
         let changed = conn
             .execute(
                 "UPDATE groups
                     SET name=?2,
-                        base_url      = CASE WHEN ?3 THEN ?4 ELSE base_url END,
-                        api_key       = CASE WHEN ?5 THEN ?6 ELSE api_key END,
-                        default_model = CASE WHEN ?7 THEN ?8 ELSE default_model END
+                        base_url             = CASE WHEN ?3 THEN ?4  ELSE base_url END,
+                        default_model        = CASE WHEN ?3 THEN ?5  ELSE default_model END,
+                        provider             = CASE WHEN ?3 THEN ?6  ELSE provider END,
+                        subscription_model   = CASE WHEN ?3 THEN ?7  ELSE subscription_model END,
+                        request_timeout_secs = CASE WHEN ?3 THEN ?8  ELSE request_timeout_secs END,
+                        api_key              = CASE WHEN ?9 THEN ?10 ELSE api_key END,
+                        max_hops             = CASE WHEN ?11 THEN ?12 ELSE max_hops END,
+                        max_steps_per_run    = CASE WHEN ?11 THEN ?13 ELSE max_steps_per_run END,
+                        max_fanout_per_call  = CASE WHEN ?11 THEN ?14 ELSE max_fanout_per_call END,
+                        max_sends_per_pair   = CASE WHEN ?11 THEN ?15 ELSE max_sends_per_pair END,
+                        max_tool_rounds      = CASE WHEN ?11 THEN ?16 ELSE max_tool_rounds END
                   WHERE id=?1",
                 params![
                     id.to_string(),
                     draft.name,
-                    draft.base_url.is_some(),
-                    draft.base_url.clone().flatten(),
+                    draft.inference.is_some(),
+                    over.base_url,
+                    over.default_model,
+                    over.provider.map(|p| p.as_str()),
+                    over.subscription_model,
+                    over.request_timeout_secs,
                     draft.api_key.is_some(),
                     draft.api_key.clone().flatten(),
-                    draft.default_model.is_some(),
-                    draft.default_model.clone().flatten(),
+                    draft.limits.is_some(),
+                    limits.max_hops,
+                    limits.max_steps_per_run,
+                    limits.max_fanout_per_call.map(|n| n as i64),
+                    limits.max_sends_per_pair,
+                    limits.max_tool_rounds,
                 ],
             )
             .map_err(|e| classify(e, &draft.name))?;
@@ -1245,13 +1283,50 @@ impl Store {
         let conn = self.conn()?;
         let found = conn
             .query_row(
-                "SELECT base_url, api_key, default_model FROM groups WHERE id=?1",
+                "SELECT base_url, api_key, default_model, provider, subscription_model,
+                        request_timeout_secs
+                   FROM groups WHERE id=?1",
                 params![id.to_string()],
                 |row| {
+                    let provider: Option<String> = row.get(3)?;
                     Ok(GroupInference {
-                        base_url: row.get(0)?,
+                        overrides: InferenceOverrides {
+                            base_url: row.get(0)?,
+                            default_model: row.get(2)?,
+                            provider: provider.as_deref().and_then(crate::config::Provider::parse),
+                            subscription_model: row.get(4)?,
+                            request_timeout_secs: row.get(5)?,
+                        },
                         api_key: row.get(1)?,
-                        default_model: row.get(2)?,
+                    })
+                },
+            )
+            .optional()?;
+        Ok(found.unwrap_or_default())
+    }
+
+    /// A group's loop limits, unresolved. A field it does not set is `None`,
+    /// and the runtime layers what is left over the app's.
+    ///
+    /// Its own query rather than a field on the one above: this is read on
+    /// every send and every model call, and the inference settings are read
+    /// once a turn. Reading either does not want to carry the other's cost, and
+    /// the key must not be read into memory on a path that does not need it.
+    pub fn group_limits(&self, id: GroupId) -> Result<GroupLimits, StoreError> {
+        let conn = self.conn()?;
+        let found = conn
+            .query_row(
+                "SELECT max_hops, max_steps_per_run, max_fanout_per_call, max_sends_per_pair,
+                        max_tool_rounds
+                   FROM groups WHERE id=?1",
+                params![id.to_string()],
+                |row| {
+                    Ok(GroupLimits {
+                        max_hops: row.get(0)?,
+                        max_steps_per_run: row.get(1)?,
+                        max_fanout_per_call: row.get::<_, Option<i64>>(2)?.map(|n| n as usize),
+                        max_sends_per_pair: row.get(3)?,
+                        max_tool_rounds: row.get(4)?,
                     })
                 },
             )
@@ -2054,6 +2129,7 @@ fn row_to_signin(row: &Row<'_>) -> RowResult<Signin> {
 fn row_to_group(row: &Row<'_>) -> RowResult<Group> {
     let id_raw: String = row.get(0)?;
     let api_key: Option<String> = row.get(5)?;
+    let provider: Option<String> = row.get(7)?;
 
     Ok((|| {
         Ok(Group {
@@ -2063,10 +2139,22 @@ fn row_to_group(row: &Row<'_>) -> RowResult<Group> {
             name: row.get(1)?,
             created_at: row.get(2)?,
             agent_count: row.get::<_, i64>(3)?.max(0) as u32,
-            base_url: row.get(4)?,
-            default_model: row.get(6)?,
+            inference: InferenceOverrides {
+                base_url: row.get(4)?,
+                default_model: row.get(6)?,
+                provider: provider.as_deref().and_then(crate::config::Provider::parse),
+                subscription_model: row.get(8)?,
+                request_timeout_secs: row.get(9)?,
+            },
             api_key_set: api_key.as_deref().is_some_and(|k| !k.trim().is_empty()),
             api_key_hint: crate::config::hint_for(api_key.as_deref().unwrap_or_default()),
+            limits: GroupLimits {
+                max_hops: row.get(10)?,
+                max_steps_per_run: row.get(11)?,
+                max_fanout_per_call: row.get::<_, Option<i64>>(12)?.map(|n| n as usize),
+                max_sends_per_pair: row.get(13)?,
+                max_tool_rounds: row.get(14)?,
+            },
         })
     })())
 }
@@ -2175,7 +2263,7 @@ mod tests {
     }
 
     fn group_named(name: &str) -> CleanGroup {
-        CleanGroup { name: name.into(), base_url: None, default_model: None, api_key: None }
+        CleanGroup { name: name.into(), ..Default::default() }
     }
 
     fn key_for(group: GroupId, env_var: &str, secret: &str) -> CleanConnector {
@@ -2385,12 +2473,7 @@ mod tests {
         let store = Store::open(&dir.path().join("guac.db")).unwrap();
 
         let group = store
-            .create_group(&CleanGroup {
-                name: "Research".into(),
-                base_url: None,
-                default_model: None,
-                api_key: None,
-            })
+            .create_group(&CleanGroup { name: "Research".into(), ..Default::default() })
             .unwrap();
 
         for name in ["One", "Two", "Three"] {
@@ -2892,12 +2975,7 @@ mod tests {
         let f = fixture();
         let other = f
             .store
-            .create_group(&CleanGroup {
-                name: "Research".into(),
-                base_url: None,
-                default_model: None,
-                api_key: None,
-            })
+            .create_group(&CleanGroup { name: "Research".into(), ..Default::default() })
             .unwrap();
 
         let mut d = draft("Scholar");
@@ -2960,19 +3038,139 @@ mod tests {
     fn a_group_with_live_agents_still_refuses_to_go() {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open(&dir.path().join("guac.db")).unwrap();
-        let group = store
-            .create_group(&CleanGroup {
-                name: "Busy".into(),
-                base_url: None,
-                default_model: None,
-                api_key: None,
-            })
-            .unwrap();
+        let group =
+            store.create_group(&CleanGroup { name: "Busy".into(), ..Default::default() }).unwrap();
         let mut d = draft("Busy One");
         d.group_id = Some(group.id);
         store.create_agent(&d).unwrap();
 
         assert!(matches!(store.delete_group(group.id), Err(StoreError::GroupNotEmpty { .. })));
+    }
+
+    #[test]
+    fn a_groups_settings_round_trip_and_the_key_only_travels_one_way() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&dir.path().join("guac.db")).unwrap();
+
+        let group = store
+            .create_group(&CleanGroup {
+                name: "Local".into(),
+                inference: Some(InferenceOverrides {
+                    provider: Some(crate::config::Provider::Compatible),
+                    base_url: Some("http://localhost:1234/v1".into()),
+                    default_model: Some("local/qwen".into()),
+                    subscription_model: Some("gpt-5.4".into()),
+                    request_timeout_secs: Some(600),
+                }),
+                api_key: Some(Some("sk-group-9999".into())),
+                limits: Some(GroupLimits { max_steps_per_run: Some(9), ..Default::default() }),
+            })
+            .unwrap();
+
+        assert_eq!(group.inference.provider, Some(crate::config::Provider::Compatible));
+        assert_eq!(group.inference.base_url.as_deref(), Some("http://localhost:1234/v1"));
+        assert_eq!(group.inference.subscription_model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(group.inference.request_timeout_secs, Some(600));
+        assert_eq!(group.limits.max_steps_per_run, Some(9));
+        assert_eq!(group.limits.max_hops, None, "an unset limit inherits");
+
+        // The card the UI sees says a key is set and nothing more, and the
+        // runtime's read is the only place the value exists.
+        assert!(group.api_key_set);
+        assert_eq!(group.api_key_hint, "...9999");
+        let json = serde_json::to_string(&group).unwrap();
+        assert!(!json.contains("sk-group"), "a group card leaked its key: {json}");
+        assert_eq!(
+            store.group_inference(group.id).unwrap().api_key.as_deref(),
+            Some("sk-group-9999")
+        );
+        assert_eq!(store.group_limits(group.id).unwrap().max_steps_per_run, Some(9));
+    }
+
+    #[test]
+    fn an_absent_block_leaves_that_half_of_a_groups_settings_alone() {
+        // What lets the editor save a name without holding the key, and what
+        // stops a caller that knows nothing about limits from clearing them.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&dir.path().join("guac.db")).unwrap();
+
+        let group = store
+            .create_group(&CleanGroup {
+                name: "Research".into(),
+                inference: Some(InferenceOverrides {
+                    default_model: Some("local/qwen".into()),
+                    ..Default::default()
+                }),
+                api_key: Some(Some("sk-group-9999".into())),
+                limits: Some(GroupLimits { max_hops: Some(3), ..Default::default() }),
+            })
+            .unwrap();
+
+        let renamed = store
+            .update_group(group.id, &CleanGroup { name: "Reading".into(), ..Default::default() })
+            .unwrap();
+
+        assert_eq!(renamed.name, "Reading");
+        assert_eq!(renamed.inference.default_model.as_deref(), Some("local/qwen"));
+        assert_eq!(renamed.limits.max_hops, Some(3));
+        assert!(renamed.api_key_set);
+    }
+
+    #[test]
+    fn a_present_block_of_nulls_puts_a_group_back_on_the_app_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&dir.path().join("guac.db")).unwrap();
+
+        let group = store
+            .create_group(&CleanGroup {
+                name: "Research".into(),
+                inference: Some(InferenceOverrides {
+                    provider: Some(crate::config::Provider::Chatgpt),
+                    subscription_model: Some("gpt-5.4".into()),
+                    ..Default::default()
+                }),
+                limits: Some(GroupLimits { max_hops: Some(3), ..Default::default() }),
+                ..Default::default()
+            })
+            .unwrap();
+
+        let cleared = store
+            .update_group(
+                group.id,
+                &CleanGroup {
+                    name: "Research".into(),
+                    inference: Some(InferenceOverrides::default()),
+                    limits: Some(GroupLimits::default()),
+                    api_key: None,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(cleared.inference, InferenceOverrides::default());
+        assert_eq!(cleared.limits, GroupLimits::default());
+        assert_eq!(store.group_inference(group.id).unwrap(), GroupInference::default());
+        assert_eq!(store.group_limits(group.id).unwrap(), GroupLimits::default());
+    }
+
+    #[test]
+    fn a_provider_written_by_a_newer_build_reads_as_inherit() {
+        // A group whose provider nothing here recognises has to keep working on
+        // the app settings. Refusing to read the row would take a whole crew
+        // offline over a column this build has never heard of.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&dir.path().join("guac.db")).unwrap();
+        let group = store.create_group(&group_named("Future")).unwrap();
+        store
+            .conn()
+            .unwrap()
+            .execute(
+                "UPDATE groups SET provider='anthropic-native' WHERE id=?1",
+                params![group.id.to_string()],
+            )
+            .unwrap();
+
+        assert_eq!(store.get_group(group.id).unwrap().unwrap().inference.provider, None);
+        assert_eq!(store.group_inference(group.id).unwrap().overrides.provider, None);
     }
 
     #[test]

--- a/src-tauri/src/domain/group.rs
+++ b/src-tauri/src/domain/group.rs
@@ -1,4 +1,4 @@
-//! Groups: the isolation boundary between agents.
+//! Groups: the isolation boundary between agents, and the settings they run on.
 //!
 //! Every agent belongs to exactly one group, and agents in different groups
 //! cannot reach each other. That is not a UI filter. `directory` only lists
@@ -16,10 +16,20 @@
 //!
 //! There is always at least one group, created by the migration that introduced
 //! them, so "no group" is not a state the rest of the app has to handle.
+//!
+//! A group is also where a crew's settings live. App settings are defaults: how
+//! a turn is paid for, which model answers it, and how far a conversation may
+//! run are all decided per group, and only fall back to the app when the group
+//! says nothing. `None` is that silence throughout, at every layer: in the
+//! draft the operator sends, in the columns, and in the resolved overrides. An
+//! empty string is a field an operator blanked, which means inherit too, and is
+//! normalised to `None` on the way in so the two can never disagree.
 
 use serde::{Deserialize, Serialize};
 
 use super::ids::GroupId;
+use crate::config::{InferenceConfig, Provider};
+use crate::runtime::guard::GuardLimits;
 
 /// What the UI sees. The API key is never on it: only whether one is set and a
 /// hint, the same shape the app-wide settings use, so a group's key cannot be
@@ -29,12 +39,13 @@ use super::ids::GroupId;
 pub struct Group {
     pub id: GroupId,
     pub name: String,
-    /// `None` means inherit the app default. An empty string is a value an
-    /// operator deliberately blanked, so the two are kept distinct.
-    pub base_url: Option<String>,
-    pub default_model: Option<String>,
+    /// Everything about how this group's turns are paid for and answered.
+    /// Every field `None` is a group that runs on the app's settings.
+    pub inference: InferenceOverrides,
     pub api_key_set: bool,
     pub api_key_hint: String,
+    /// How far a conversation started in this group may run.
+    pub limits: GroupLimits,
     /// How many live agents are in it. Carried on the card because every screen
     /// that lists groups wants it, and counting per group in the UI would mean
     /// walking the whole roster once per group.
@@ -42,21 +53,102 @@ pub struct Group {
     pub created_at: i64,
 }
 
+/// The inference settings an operator can put on a group. `None` inherits.
+///
+/// The API key is deliberately not here. It is the one setting the UI cannot
+/// read back, so it has its own rule on the way in — absent keeps the stored
+/// one — and this struct is the shape where absent means inherit. Keeping the
+/// two rules in two types is what stops a redacted key ever being written back
+/// as a value.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct InferenceOverrides {
+    /// Which of the two ways a turn is paid for. A group can pay with the
+    /// operator's ChatGPT sign-in while another pays with a key, because the
+    /// sign-in is one credential on this machine and choosing it is a setting
+    /// rather than a second account.
+    pub provider: Option<Provider>,
+    pub base_url: Option<String>,
+    /// The model used when a key is paying.
+    pub default_model: Option<String>,
+    /// The model used when the subscription is paying.
+    ///
+    /// Two fields for the same reason the app keeps two: the providers have
+    /// disjoint model names, and a group that tries the subscription for an
+    /// hour must find its endpoint model where it left it.
+    pub subscription_model: Option<String>,
+    pub request_timeout_secs: Option<u64>,
+}
+
+/// Per-field overrides of the app's loop guard. `None` inherits.
+///
+/// Group-scoped because a limit is a statement about one crew's work. A pair of
+/// agents drafting a document need a handful of model calls; a crew working a
+/// browser through a long form needs an order of magnitude more, and one number
+/// for both means either the first is an open wallet or the second stops
+/// halfway and reports nothing.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct GroupLimits {
+    pub max_hops: Option<u16>,
+    pub max_steps_per_run: Option<u32>,
+    pub max_fanout_per_call: Option<usize>,
+    pub max_sends_per_pair: Option<u32>,
+    pub max_tool_rounds: Option<u16>,
+}
+
+impl GroupLimits {
+    /// Layers this group's limits over the app's.
+    pub fn apply(&self, base: GuardLimits) -> GuardLimits {
+        GuardLimits {
+            max_hops: self.max_hops.unwrap_or(base.max_hops),
+            max_steps_per_run: self.max_steps_per_run.unwrap_or(base.max_steps_per_run),
+            max_fanout_per_call: self.max_fanout_per_call.unwrap_or(base.max_fanout_per_call),
+            max_sends_per_pair: self.max_sends_per_pair.unwrap_or(base.max_sends_per_pair),
+            max_tool_rounds: self.max_tool_rounds.unwrap_or(base.max_tool_rounds),
+        }
+    }
+
+    /// Clamps each override into the range the runtime survives.
+    ///
+    /// Done at the edit rather than only at the use, so the number the operator
+    /// reads back after saving is the number their agents will run on. The
+    /// ranges are `GuardLimits::sanitized`'s and are not restated here: a group
+    /// limit that could be clamped differently from the app's would be a second
+    /// definition of the same rule, drifting from the first.
+    pub fn sanitized(self) -> Self {
+        let full = self.apply(GuardLimits::default()).sanitized();
+        Self {
+            max_hops: self.max_hops.map(|_| full.max_hops),
+            max_steps_per_run: self.max_steps_per_run.map(|_| full.max_steps_per_run),
+            max_fanout_per_call: self.max_fanout_per_call.map(|_| full.max_fanout_per_call),
+            max_sends_per_pair: self.max_sends_per_pair.map(|_| full.max_sends_per_pair),
+            max_tool_rounds: self.max_tool_rounds.map(|_| full.max_tool_rounds),
+        }
+    }
+}
+
 /// Fields an operator can set. Separate from `Group` so `id` and timestamps
 /// cannot be forged across the IPC boundary.
+///
+/// Each block is all-or-nothing: absent leaves every override in it exactly as
+/// it was, and present replaces the lot, with a null field meaning inherit.
+/// One rule per block rather than per field, so a caller cannot half-write a
+/// group's settings and a UI that renders what it read back cannot clear a
+/// field by forgetting to mention it.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupDraft {
     pub name: String,
     #[serde(default)]
-    pub base_url: Option<String>,
-    #[serde(default)]
-    pub default_model: Option<String>,
+    pub inference: Option<InferenceOverrides>,
     /// Absent leaves the stored key alone; `Some("")` clears it. Without that
     /// distinction the UI could not render a redacted key without erasing it on
     /// the next save.
     #[serde(default)]
     pub api_key: Option<String>,
+    #[serde(default)]
+    pub limits: Option<GroupLimits>,
 }
 
 #[derive(Debug, thiserror::Error, PartialEq)]
@@ -76,25 +168,26 @@ pub enum GroupError {
 pub const MAX_GROUP_NAME_LEN: usize = 48;
 
 /// The validated form of a draft, ready to store.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct CleanGroup {
     pub name: String,
-    /// `Some(None)` clears the override, `None` leaves it as it was.
-    pub base_url: Option<Option<String>>,
-    pub default_model: Option<Option<String>>,
+    /// `None` leaves the stored overrides alone.
+    pub inference: Option<InferenceOverrides>,
+    /// `Some(None)` clears the key, `None` leaves it as it was.
     pub api_key: Option<Option<String>>,
+    pub limits: Option<GroupLimits>,
 }
 
 /// Blank input means "inherit", so it is stored as NULL rather than "".
-fn override_of(value: &Option<String>) -> Option<Option<String>> {
-    value.as_ref().map(|raw| {
-        let trimmed = raw.trim();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_string())
-        }
-    })
+fn override_of(value: &Option<String>) -> Option<String> {
+    value.as_ref().map(|raw| raw.trim().to_string()).filter(|trimmed| !trimmed.is_empty())
+}
+
+/// The same range the app's own timeout is clamped to, and for the same reason:
+/// five seconds cannot complete a call, and a quarter of an hour is already
+/// longer than any model this app talks to takes to refuse.
+fn clamp_timeout(secs: u64) -> u64 {
+    secs.clamp(5, 900)
 }
 
 impl GroupDraft {
@@ -107,21 +200,40 @@ impl GroupDraft {
             return Err(GroupError::NameTooLong { max: MAX_GROUP_NAME_LEN });
         }
 
-        // A base URL that cannot be parsed would fail on every turn of every
-        // agent in the group, so it is rejected at the edit instead.
-        let base_url = match override_of(&self.base_url) {
-            Some(Some(raw)) => Some(Some(
-                crate::config::normalize_base_url(&raw)
-                    .map_err(|e| GroupError::BadEndpoint(e.to_string()))?,
-            )),
-            other => other,
+        let inference = match &self.inference {
+            None => None,
+            Some(raw) => Some(InferenceOverrides {
+                provider: raw.provider,
+                // A base URL that cannot be parsed would fail on every turn of
+                // every agent in the group, so it is rejected at the edit
+                // instead.
+                base_url: match override_of(&raw.base_url) {
+                    Some(url) => Some(
+                        crate::config::normalize_base_url(&url)
+                            .map_err(|e| GroupError::BadEndpoint(e.to_string()))?,
+                    ),
+                    None => None,
+                },
+                default_model: override_of(&raw.default_model),
+                subscription_model: override_of(&raw.subscription_model),
+                request_timeout_secs: raw.request_timeout_secs.map(clamp_timeout),
+            }),
         };
 
         Ok(CleanGroup {
             name: name.to_string(),
-            base_url,
-            default_model: override_of(&self.default_model),
-            api_key: override_of(&self.api_key),
+            inference,
+            // The one field where absent and blank differ, so it cannot go
+            // through `override_of`: absent keeps the stored key.
+            api_key: self.api_key.as_ref().map(|raw| {
+                let trimmed = raw.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            }),
+            limits: self.limits.map(GroupLimits::sanitized),
         })
     }
 }
@@ -132,48 +244,52 @@ impl GroupDraft {
 /// it to make a request.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct GroupInference {
-    pub base_url: Option<String>,
+    pub overrides: InferenceOverrides,
     pub api_key: Option<String>,
-    pub default_model: Option<String>,
 }
 
 impl GroupInference {
     /// Layers this group over the app-wide settings. Anything the group does
     /// not set is inherited, so a group with no overrides behaves exactly as
-    /// before groups existed.
-    pub fn apply(&self, base: &crate::config::InferenceConfig) -> crate::config::InferenceConfig {
+    /// before groups had settings of their own.
+    pub fn apply(&self, base: &InferenceConfig) -> InferenceConfig {
         let mut out = base.clone();
+        let over = &self.overrides;
 
-        // A group that names its own endpoint or its own key has chosen an
-        // endpoint, and an endpoint is not where a subscription is spent. Left
-        // alone, such a group would inherit the app's subscription and have both
-        // of its overrides quietly ignored: the operator would be looking at a
-        // key and a URL that nothing used, with no error to explain it.
-        //
-        // Only these two flip it. Overriding the model alone is a group asking
-        // for a different model on whatever the app is already paying with,
-        // which is the common case and the one that has to keep working.
-        //
         // First, because the model that gets collapsed below depends on it.
-        if self.base_url.is_some() || self.api_key.is_some() {
-            out.provider = crate::config::Provider::Compatible;
+        //
+        // Nothing is inferred here. A group that names an endpoint used to be
+        // taken to mean it wanted one, because there was no way to say so; the
+        // migration that added this column wrote that meaning down for every
+        // group it was true of, so the guess has no work left to do. What it
+        // cost was the sentence an operator could not act on: with a guess in
+        // this path, "follow the app settings" and an endpoint in the box
+        // disagree, and the endpoint silently wins.
+        if let Some(provider) = over.provider {
+            out.provider = provider;
         }
 
-        // The app keeps a model per provider, and everything downstream of here
-        // reads one field. Collapsing to the resolved provider's model, after
-        // the flip above and before the group's own override, means each of the
-        // three cases lands on the model that provider can actually run.
-        out.default_model = out.active_model().to_string();
-
-        if let Some(url) = &self.base_url {
+        if let Some(url) = &over.base_url {
             out.base_url = url.clone();
         }
         if let Some(key) = &self.api_key {
             out.api_key = key.clone();
         }
-        if let Some(model) = &self.default_model {
+        if let Some(model) = &over.default_model {
             out.default_model = model.clone();
         }
+        if let Some(model) = &over.subscription_model {
+            out.subscription_model = model.clone();
+        }
+        if let Some(secs) = over.request_timeout_secs {
+            out.request_timeout_secs = secs;
+        }
+
+        // Everything downstream of here reads one model field. Collapsing to
+        // the resolved provider's model, after both overrides have landed,
+        // means a group gets the model that the provider paying for its turns
+        // can actually run.
+        out.default_model = out.active_model().to_string();
 
         out
     }
@@ -184,7 +300,70 @@ mod tests {
     use super::*;
 
     fn draft(name: &str) -> GroupDraft {
-        GroupDraft { name: name.into(), base_url: None, default_model: None, api_key: None }
+        GroupDraft { name: name.into(), inference: None, api_key: None, limits: None }
+    }
+
+    /// A draft that sets inference overrides, starting from all-inherit.
+    fn with_inference(name: &str, over: InferenceOverrides) -> GroupDraft {
+        GroupDraft { inference: Some(over), ..draft(name) }
+    }
+
+    #[test]
+    fn a_draft_is_read_from_the_shape_the_webview_sends() {
+        // Everything crossing IPC is camelCase, and `rename_all` on the outer
+        // struct does not reach a nested one: each block carries its own. A
+        // rename that only lands on one side is a field silently read as
+        // "inherit", which looks exactly like an operator clearing it.
+        let draft: GroupDraft = serde_json::from_str(
+            r#"{
+                 "name": "Research",
+                 "inference": {
+                   "provider": "chatgpt",
+                   "baseUrl": "http://localhost:1234/v1",
+                   "defaultModel": "local/qwen",
+                   "subscriptionModel": "gpt-5.4",
+                   "requestTimeoutSecs": 600
+                 },
+                 "apiKey": "sk-x",
+                 "limits": { "maxStepsPerRun": 9, "maxToolRounds": 40 }
+               }"#,
+        )
+        .unwrap();
+
+        let clean = draft.validate().unwrap();
+        let over = clean.inference.unwrap();
+        assert_eq!(over.provider, Some(Provider::Chatgpt));
+        assert_eq!(over.base_url.as_deref(), Some("http://localhost:1234/v1"));
+        assert_eq!(over.subscription_model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(over.request_timeout_secs, Some(600));
+        assert_eq!(clean.api_key, Some(Some("sk-x".into())));
+        assert_eq!(clean.limits.unwrap().max_steps_per_run, Some(9));
+    }
+
+    #[test]
+    fn a_group_is_written_in_the_shape_the_webview_reads() {
+        let group = Group {
+            id: GroupId::new(),
+            name: "Research".into(),
+            inference: InferenceOverrides {
+                provider: Some(Provider::Compatible),
+                subscription_model: Some("gpt-5.4".into()),
+                request_timeout_secs: Some(600),
+                ..Default::default()
+            },
+            api_key_set: false,
+            api_key_hint: String::new(),
+            limits: GroupLimits { max_steps_per_run: Some(9), ..Default::default() },
+            agent_count: 0,
+            created_at: 0,
+        };
+
+        let json = serde_json::to_value(&group).unwrap();
+        assert_eq!(json["inference"]["provider"], "compatible");
+        assert_eq!(json["inference"]["subscriptionModel"], "gpt-5.4");
+        assert_eq!(json["inference"]["requestTimeoutSecs"], 600);
+        assert_eq!(json["limits"]["maxStepsPerRun"], 9);
+        assert!(json["limits"]["maxHops"].is_null(), "inherit crosses as null, not as a number");
     }
 
     #[test]
@@ -212,41 +391,127 @@ mod tests {
     fn a_blanked_override_is_stored_as_inherit_not_as_empty() {
         // Otherwise clearing the field in the UI would pin every agent in the
         // group to an empty model rather than falling back to the app default.
-        let mut d = draft("Research");
-        d.default_model = Some("   ".into());
-        assert_eq!(d.validate().unwrap().default_model, Some(None));
+        let d = with_inference(
+            "Research",
+            InferenceOverrides { default_model: Some("   ".into()), ..Default::default() },
+        );
+        assert_eq!(d.validate().unwrap().inference.unwrap().default_model, None);
     }
 
     #[test]
-    fn an_absent_override_leaves_the_stored_value_alone() {
-        assert_eq!(draft("Research").validate().unwrap().default_model, None);
+    fn an_absent_block_leaves_the_stored_overrides_alone() {
+        let clean = draft("Research").validate().unwrap();
+        assert_eq!(clean.inference, None);
+        assert_eq!(clean.limits, None);
+        assert_eq!(clean.api_key, None);
+    }
+
+    #[test]
+    fn a_present_block_of_nulls_clears_every_override_in_it() {
+        // The whole point of the block being all-or-nothing: a group put back
+        // on the app settings is one save, not five.
+        let clean = with_inference("Research", InferenceOverrides::default()).validate().unwrap();
+        assert_eq!(clean.inference, Some(InferenceOverrides::default()));
+    }
+
+    #[test]
+    fn a_blank_key_clears_it_and_an_absent_one_keeps_it() {
+        assert_eq!(draft("Research").validate().unwrap().api_key, None);
+        assert_eq!(
+            GroupDraft { api_key: Some("  ".into()), ..draft("Research") }
+                .validate()
+                .unwrap()
+                .api_key,
+            Some(None)
+        );
+        assert_eq!(
+            GroupDraft { api_key: Some(" sk-x ".into()), ..draft("Research") }
+                .validate()
+                .unwrap()
+                .api_key,
+            Some(Some("sk-x".into()))
+        );
     }
 
     #[test]
     fn a_bad_endpoint_is_rejected_at_the_edit_not_on_every_turn() {
-        let mut d = draft("Research");
-        d.base_url = Some("not-a-url".into());
+        let d = with_inference(
+            "Research",
+            InferenceOverrides { base_url: Some("not-a-url".into()), ..Default::default() },
+        );
         assert!(matches!(d.validate(), Err(GroupError::BadEndpoint(_))));
     }
 
     #[test]
+    fn a_timeout_is_clamped_at_the_edit_so_it_reads_back_as_what_will_be_used() {
+        let d = with_inference(
+            "Research",
+            InferenceOverrides { request_timeout_secs: Some(99_999), ..Default::default() },
+        );
+        assert_eq!(d.validate().unwrap().inference.unwrap().request_timeout_secs, Some(900));
+    }
+
+    #[test]
+    fn a_limit_is_clamped_at_the_edit_and_an_unset_one_stays_unset() {
+        let d = GroupDraft {
+            limits: Some(GroupLimits {
+                max_steps_per_run: Some(9_000),
+                max_hops: Some(0),
+                ..Default::default()
+            }),
+            ..draft("Research")
+        };
+        let stored = d.validate().unwrap().limits.unwrap();
+        assert_eq!(stored.max_steps_per_run, Some(500));
+        assert_eq!(stored.max_hops, Some(1));
+        // Clamping must not turn "inherit" into a number: a group that says
+        // nothing about fan-out has to keep saying nothing after a save.
+        assert_eq!(stored.max_fanout_per_call, None);
+    }
+
+    #[test]
+    fn limits_layer_over_the_app_and_an_unset_one_inherits() {
+        let app = GuardLimits { max_steps_per_run: 60, max_hops: 8, ..GuardLimits::default() };
+        let tighter = GroupLimits { max_steps_per_run: Some(10), ..Default::default() };
+        let resolved = tighter.apply(app);
+        assert_eq!(resolved.max_steps_per_run, 10);
+        assert_eq!(resolved.max_hops, 8);
+        assert_eq!(GroupLimits::default().apply(app), app, "a silent group changes nothing");
+    }
+
+    #[test]
     fn overrides_layer_over_the_app_defaults() {
-        let base = crate::config::InferenceConfig::default();
+        let base = InferenceConfig::default();
         let empty = GroupInference::default();
         assert_eq!(empty.apply(&base), base, "a group with no overrides changes nothing");
 
-        let pinned =
-            GroupInference { default_model: Some("local/qwen".into()), ..Default::default() };
+        let pinned = GroupInference {
+            overrides: InferenceOverrides {
+                default_model: Some("local/qwen".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
         let resolved = pinned.apply(&base);
         assert_eq!(resolved.default_model, "local/qwen");
         assert_eq!(resolved.base_url, base.base_url, "an unset field still inherits");
     }
 
+    #[test]
+    fn a_group_can_run_on_its_own_timeout() {
+        let base = InferenceConfig::default();
+        let slow = GroupInference {
+            overrides: InferenceOverrides { request_timeout_secs: Some(600), ..Default::default() },
+            ..Default::default()
+        };
+        assert_eq!(slow.apply(&base).request_timeout_secs, 600);
+    }
+
     /// App-wide settings with a subscription chosen, and a model set for each
     /// provider so it is visible which one a resolution picked.
-    fn on_subscription() -> crate::config::InferenceConfig {
-        crate::config::InferenceConfig {
-            provider: crate::config::Provider::Chatgpt,
+    fn on_subscription() -> InferenceConfig {
+        InferenceConfig {
+            provider: Provider::Chatgpt,
             default_model: "anthropic/claude-sonnet-4.5".into(),
             subscription_model: "gpt-5.6-luna".into(),
             api_key: "app-key".into(),
@@ -254,10 +519,15 @@ mod tests {
         }
     }
 
+    /// A group that overrides one inference field and nothing else.
+    fn only(over: InferenceOverrides) -> GroupInference {
+        GroupInference { overrides: over, api_key: None }
+    }
+
     #[test]
     fn a_group_with_no_overrides_uses_the_subscription_and_its_own_model() {
         let resolved = GroupInference::default().apply(&on_subscription());
-        assert_eq!(resolved.provider, crate::config::Provider::Chatgpt);
+        assert_eq!(resolved.provider, Provider::Chatgpt);
         // The one field everything downstream reads has to be the subscription's
         // model, not the endpoint's, or every agent fails on a model the backend
         // has never heard of.
@@ -265,58 +535,125 @@ mod tests {
     }
 
     #[test]
-    fn a_group_that_only_overrides_the_model_stays_on_the_subscription() {
+    fn a_group_that_only_overrides_the_subscription_model_stays_on_the_subscription() {
         // The common case: a crew that wants a cheaper model on whatever the app
         // is already paying with.
-        let resolved =
-            GroupInference { default_model: Some("gpt-5.4-mini".into()), ..Default::default() }
-                .apply(&on_subscription());
-        assert_eq!(resolved.provider, crate::config::Provider::Chatgpt);
+        let resolved = only(InferenceOverrides {
+            subscription_model: Some("gpt-5.4-mini".into()),
+            ..Default::default()
+        })
+        .apply(&on_subscription());
+        assert_eq!(resolved.provider, Provider::Chatgpt);
         assert_eq!(resolved.default_model, "gpt-5.4-mini");
     }
 
     #[test]
-    fn a_group_that_names_its_own_endpoint_leaves_the_subscription() {
-        let resolved = GroupInference {
-            base_url: Some("http://localhost:1234/v1".into()),
+    fn a_model_set_for_the_other_provider_is_kept_and_not_used() {
+        // Each model belongs to one provider. A group holding an endpoint model
+        // while the subscription is paying is a group that has been switched
+        // over, not a group whose model was ignored by mistake — and switching
+        // back has to find it intact.
+        let resolved = only(InferenceOverrides {
+            default_model: Some("local/qwen".into()),
             ..Default::default()
+        })
+        .apply(&on_subscription());
+        assert_eq!(resolved.default_model, "gpt-5.6-luna", "the subscription is paying");
+
+        let back = only(InferenceOverrides {
+            provider: Some(Provider::Compatible),
+            default_model: Some("local/qwen".into()),
+            ..Default::default()
+        })
+        .apply(&on_subscription());
+        assert_eq!(back.default_model, "local/qwen");
+    }
+
+    #[test]
+    fn a_group_on_its_own_endpoint_leaves_the_subscription() {
+        let resolved = GroupInference {
+            overrides: InferenceOverrides {
+                provider: Some(Provider::Compatible),
+                base_url: Some("http://localhost:1234/v1".into()),
+                ..Default::default()
+            },
+            api_key: Some("group-key".into()),
         }
         .apply(&on_subscription());
 
-        // Otherwise the group's endpoint is set, visible in the UI, and used by
-        // nothing, with no error anywhere to explain it.
-        assert_eq!(resolved.provider, crate::config::Provider::Compatible);
+        assert_eq!(resolved.provider, Provider::Compatible);
         assert_eq!(resolved.base_url, "http://localhost:1234/v1");
+        assert_eq!(resolved.api_key, "group-key");
         // And it gets the endpoint's model, not the subscription's, because the
-        // provider flip happens before the model is collapsed.
+        // provider is resolved before the model is collapsed.
         assert_eq!(resolved.default_model, "anthropic/claude-sonnet-4.5");
     }
 
     #[test]
-    fn a_group_that_names_its_own_key_also_leaves_the_subscription() {
-        let resolved = GroupInference { api_key: Some("group-key".into()), ..Default::default() }
-            .apply(&on_subscription());
-        assert_eq!(resolved.provider, crate::config::Provider::Compatible);
-        assert_eq!(resolved.api_key, "group-key");
-        assert_eq!(resolved.default_model, "anthropic/claude-sonnet-4.5");
+    fn an_endpoint_alone_does_not_decide_who_pays() {
+        // The guess this replaced could not be argued with: an endpoint left in
+        // the box outvoted the operator choosing to follow the app settings, and
+        // there was nothing on screen to say why. The groups that meant it were
+        // written down by the migration instead.
+        let resolved = only(InferenceOverrides {
+            base_url: Some("http://localhost:1234/v1".into()),
+            ..Default::default()
+        })
+        .apply(&on_subscription());
+
+        assert_eq!(resolved.provider, Provider::Chatgpt);
+        assert_eq!(resolved.default_model, "gpt-5.6-luna");
+    }
+
+    #[test]
+    fn a_group_on_the_subscription_keeps_the_endpoint_it_came_from() {
+        // Kept rather than blanked, exactly as the app keeps its own, so a group
+        // that tries the subscription for an hour finds its endpoint where it
+        // left it.
+        let resolved = GroupInference {
+            overrides: InferenceOverrides {
+                provider: Some(Provider::Chatgpt),
+                base_url: Some("http://localhost:1234/v1".into()),
+                subscription_model: Some("gpt-5.4".into()),
+                ..Default::default()
+            },
+            api_key: Some("group-key".into()),
+        }
+        .apply(&InferenceConfig::default());
+
+        assert_eq!(resolved.provider, Provider::Chatgpt);
+        assert_eq!(resolved.default_model, "gpt-5.4");
+        assert_eq!(resolved.base_url, "http://localhost:1234/v1", "kept for the way back");
+    }
+
+    #[test]
+    fn a_group_can_pay_with_the_subscription_while_the_app_pays_with_a_key() {
+        // One sign-in on the machine, and choosing it is a setting rather than
+        // a second account, so a group can be moved onto it on its own.
+        let resolved =
+            only(InferenceOverrides { provider: Some(Provider::Chatgpt), ..Default::default() })
+                .apply(&InferenceConfig::default());
+        assert_eq!(resolved.provider, Provider::Chatgpt);
+        assert_eq!(resolved.default_model, crate::llm::codex::DEFAULT_MODEL);
     }
 
     #[test]
     fn a_group_on_its_own_endpoint_can_still_name_its_own_model() {
-        let resolved = GroupInference {
+        let resolved = only(InferenceOverrides {
+            provider: Some(Provider::Compatible),
             base_url: Some("http://localhost:1234/v1".into()),
             default_model: Some("local/qwen".into()),
             ..Default::default()
-        }
+        })
         .apply(&on_subscription());
-        assert_eq!(resolved.provider, crate::config::Provider::Compatible);
+        assert_eq!(resolved.provider, Provider::Compatible);
         assert_eq!(resolved.default_model, "local/qwen");
     }
 
     #[test]
     fn a_group_changes_nothing_when_the_app_is_on_an_endpoint() {
-        // The behaviour that existed before subscriptions, unchanged.
-        let base = crate::config::InferenceConfig::default();
+        // The behaviour that existed before groups had settings, unchanged.
+        let base = InferenceConfig::default();
         assert_eq!(GroupInference::default().apply(&base), base);
     }
 }

--- a/src-tauri/src/runtime/guard.rs
+++ b/src-tauri/src/runtime/guard.rs
@@ -373,36 +373,30 @@ impl RunState {
 /// because "complete" is not observable: an agent may still be mid-inference
 /// when its last peer goes quiet. Holding state a little too long is cheap;
 /// dropping it early re-arms every limit mid-cascade.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct GuardRegistry {
     runs: HashMap<RunId, RunState>,
-    default_limits: GuardLimits,
     max_retained: usize,
     retain_for_ms: i64,
 }
 
 impl GuardRegistry {
-    pub fn new(default_limits: GuardLimits) -> Self {
-        Self {
-            runs: HashMap::new(),
-            default_limits: default_limits.sanitized(),
-            max_retained: 256,
-            retain_for_ms: 60 * 60 * 1000,
-        }
+    pub fn new() -> Self {
+        Self { runs: HashMap::new(), max_retained: 256, retain_for_ms: 60 * 60 * 1000 }
     }
 
-    pub fn set_limits(&mut self, limits: GuardLimits) {
-        self.default_limits = limits.sanitized();
-    }
-
-    pub fn default_limits(&self) -> GuardLimits {
-        self.default_limits
-    }
-
-    /// Gets or creates the state for a run, reaping stale entries first.
-    pub fn run(&mut self, id: RunId) -> &mut RunState {
+    /// Gets or creates the state for a run, on the limits of the group it is
+    /// happening in, reaping stale entries first.
+    ///
+    /// The registry holds no limits of its own, because there is no such thing
+    /// as a run outside a group. A run cannot cross one either — a send
+    /// addressed outside a group is refused as an unknown recipient — so every
+    /// caller for a given run passes the same numbers, and it does not matter
+    /// which of them creates the state. They are read on creation and then
+    /// fixed for the life of the run: a limit edited mid-cascade must not move
+    /// the ceiling a conversation is already being measured against.
+    pub fn run_within(&mut self, id: RunId, limits: GuardLimits) -> &mut RunState {
         self.reap();
-        let limits = self.default_limits;
         self.runs.entry(id).or_insert_with(|| RunState::new(limits))
     }
 
@@ -708,33 +702,51 @@ mod tests {
     }
 
     #[test]
+    fn a_run_keeps_the_limits_it_started_on() {
+        // Two groups, two ceilings, one registry. And the second call for a run
+        // does not re-read them: a run measured against a moving number cannot
+        // report what it was allowed to spend.
+        let mut reg = GuardRegistry::new();
+        let (tight, loose) = (RunId::new(), RunId::new());
+
+        let strict = GuardLimits { max_steps_per_run: 2, ..GuardLimits::default() };
+        assert!(reg.run_within(tight, strict).reserve_step());
+        assert!(reg.run_within(loose, GuardLimits::default()).reserve_step());
+
+        assert!(reg.run_within(tight, strict).reserve_step());
+        assert!(!reg.run_within(tight, GuardLimits::default()).reserve_step(), "spent is spent");
+        assert!(reg.run_within(loose, strict).reserve_step(), "the other run is untouched");
+    }
+
+    #[test]
     fn registry_isolates_runs_from_each_other() {
-        let mut reg = GuardRegistry::new(GuardLimits { max_steps_per_run: 1, ..permissive() });
+        let mut reg = GuardRegistry::new();
+        let one_call = GuardLimits { max_steps_per_run: 1, ..permissive() };
         let (r1, r2) = (RunId::new(), RunId::new());
 
-        assert!(reg.run(r1).reserve_step());
-        assert!(!reg.run(r1).reserve_step());
-        assert!(reg.run(r2).reserve_step(), "a fresh run gets its own budget");
+        assert!(reg.run_within(r1, one_call).reserve_step());
+        assert!(!reg.run_within(r1, one_call).reserve_step());
+        assert!(reg.run_within(r2, one_call).reserve_step(), "a fresh run gets its own budget");
     }
 
     #[test]
     fn registry_bounds_retained_runs() {
-        let mut reg = GuardRegistry::new(GuardLimits::default());
+        let mut reg = GuardRegistry::new();
         reg.max_retained = 4;
         for _ in 0..40 {
-            reg.run(RunId::new()).reserve_step();
+            reg.run_within(RunId::new(), GuardLimits::default()).reserve_step();
         }
         assert!(reg.live_runs() <= 5, "expected reaping, got {} runs", reg.live_runs());
     }
 
     #[test]
     fn registry_reaps_by_age() {
-        let mut reg = GuardRegistry::new(GuardLimits::default());
+        let mut reg = GuardRegistry::new();
         let old = RunId::new();
-        reg.run(old).reserve_step();
+        reg.run_within(old, GuardLimits::default()).reserve_step();
         // Backdate past the retention window.
         reg.runs.get_mut(&old).unwrap().last_touched = now_ms() - (2 * 60 * 60 * 1000);
-        reg.run(RunId::new());
+        reg.run_within(RunId::new(), GuardLimits::default());
         assert!(reg.peek(old).is_none(), "stale run should have been reaped");
     }
 

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -447,14 +447,13 @@ impl Runtime {
         files: FileStore,
         events: Arc<dyn EventSink>,
     ) -> Self {
-        let limits = config.limits;
         Self {
             inner: Arc::new(Inner {
                 handle,
                 store,
                 llm,
                 config: RwLock::new(config),
-                guard: Mutex::new(GuardRegistry::new(limits)),
+                guard: Mutex::new(GuardRegistry::new()),
                 inboxes: Mutex::new(HashMap::new()),
                 activity: Mutex::new(HashMap::new()),
                 runs: Mutex::new(Runs::default()),
@@ -494,12 +493,7 @@ impl Runtime {
     }
 
     pub fn set_config(&self, config: AppConfig) {
-        self.inner.guard.lock().set_limits(config.limits);
         *self.inner.config.write() = config;
-    }
-
-    pub fn limits(&self) -> GuardLimits {
-        self.inner.guard.lock().default_limits()
     }
 
     // ---- lifecycle -------------------------------------------------------
@@ -1163,8 +1157,12 @@ impl Runtime {
     }
 
     /// Replies this agent is still owed in this run.
+    ///
+    /// A peek, so asking cannot be what creates a run's state. The limits that
+    /// state is created on belong to the asking agent's group, and this is the
+    /// one question about a run that is asked without one to hand.
     fn awaiting_replies(&self, run: RunId, me: AgentId) -> usize {
-        self.inner.guard.lock().run(run).awaiting(me)
+        self.inner.guard.lock().peek(run).map(|state| state.awaiting(me)).unwrap_or(0)
     }
 
     fn track_inflight(&self, run: RunId, delta: i64) {
@@ -1567,9 +1565,9 @@ impl Runtime {
         // Peek rather than claim: the budget is spent per model call inside the
         // loop below, but there is no point building a prompt or telling the UI
         // a message is coming if the run is already finished.
-        let has_budget = { self.inner.guard.lock().run(run_id).has_budget() };
+        let limits = self.limits_for(&card);
+        let has_budget = { self.inner.guard.lock().run_within(run_id, limits).has_budget() };
         if !has_budget {
-            let limits = self.limits();
             self.notice(
                 agent_id,
                 run_id,
@@ -1577,7 +1575,7 @@ impl Runtime {
                 NoticeKind::GuardStop,
                 format!(
                     "{} did not run: this conversation already used its budget of {} model calls. \
-                     Raise it in Settings if the work is genuinely this large.",
+                     Raise it in this group's settings if the work is genuinely this large.",
                     card.name, limits.max_steps_per_run
                 ),
             );
@@ -1693,7 +1691,7 @@ impl Runtime {
         let mut budget_exhausted = false;
         let mut called_off = false;
 
-        let max_rounds = config.limits.sanitized().max_tool_rounds as usize;
+        let max_rounds = limits.max_tool_rounds as usize;
         for round in 0..max_rounds {
             // Before the step is claimed, and that ordering is the whole reason
             // this check is here rather than a line lower. A run's steps have to
@@ -1709,7 +1707,7 @@ impl Runtime {
             // One claim per model call. Claiming per turn instead would let a
             // tool-looping turn bill max_rounds times against one unit of
             // budget, which is how a bounded run still runs up a bill.
-            let reserved = { self.inner.guard.lock().run(run_id).reserve_step() };
+            let reserved = { self.inner.guard.lock().run_within(run_id, limits).reserve_step() };
             if !reserved {
                 budget_exhausted = true;
                 break;
@@ -1835,7 +1833,6 @@ impl Runtime {
             });
         }
         if budget_exhausted {
-            let limits = self.limits();
             tool_parts.push(Part::Notice {
                 kind: NoticeKind::GuardStop,
                 text: format!(
@@ -2013,8 +2010,9 @@ impl Runtime {
                     .map(|c| c.name)
                     .unwrap_or_else(|| "that agent".to_string());
 
+                let limits = self.limits_for(card);
                 let verdict = {
-                    self.inner.guard.lock().run(run_id).evaluate(&SendRequest {
+                    self.inner.guard.lock().run_within(run_id, limits).evaluate(&SendRequest {
                         from: card.id,
                         to: peer,
                         to_name: peer_name.clone(),
@@ -3116,9 +3114,14 @@ impl Runtime {
         intent: Intent,
         files: &[Attachment],
     ) -> Vec<Delivery> {
+        // Resolved once for the whole call: every recipient is inside the
+        // sender's group, so they are all measured against the same numbers.
+        let limits = self.limits_for(card);
+
         // Fan-out width is checked before any recipient, so a blast at the
         // whole roster is refused as one thing rather than partly delivered.
-        let too_wide = { self.inner.guard.lock().run(run_id).check_fanout(recipients.len()) };
+        let too_wide =
+            { self.inner.guard.lock().run_within(run_id, limits).check_fanout(recipients.len()) };
         if let Some(refusal) = too_wide {
             return recipients
                 .iter()
@@ -3166,7 +3169,7 @@ impl Runtime {
             };
 
             let verdict = {
-                self.inner.guard.lock().run(run_id).evaluate(&SendRequest {
+                self.inner.guard.lock().run_within(run_id, limits).evaluate(&SendRequest {
                     from: card.id,
                     to: target.id,
                     to_name: target.name.clone(),
@@ -3202,8 +3205,13 @@ impl Runtime {
                     // inbox, so three peers answering at once can be split
                     // across turns. Two of them then looked like agents this
                     // one had never met, and got messages demanding answers.
-                    let heard_from =
-                        { self.inner.guard.lock().run(run_id).has_written(target.id, card.id) };
+                    let heard_from = {
+                        self.inner
+                            .guard
+                            .lock()
+                            .run_within(run_id, limits)
+                            .has_written(target.id, card.id)
+                    };
 
                     // Nothing asked this agent anything and this peer has
                     // already had its say, so nothing here is owed an answer.
@@ -3685,6 +3693,24 @@ impl Runtime {
                 // the app defaults are a working fallback.
                 tracing::warn!(agent = %card.name, %err, "group settings unreadable, using app defaults");
                 config.inference.clone()
+            }
+        }
+    }
+
+    /// How far a conversation this agent is part of may run.
+    ///
+    /// Layered the same way its inference is, and read rather than cached: a
+    /// limit raised in the group editor has to reach the next run, and the
+    /// guard pins the numbers for the life of a run the moment it uses them.
+    /// Reads the app's limits from the config directly rather than through the
+    /// guard, so nothing here takes the guard lock before the store.
+    fn limits_for(&self, card: &AgentCard) -> GuardLimits {
+        let base = self.inner.config.read().limits;
+        match self.inner.store.group_limits(card.group_id) {
+            Ok(overrides) => overrides.apply(base).sanitized(),
+            Err(err) => {
+                tracing::warn!(agent = %card.name, %err, "group limits unreadable, using app defaults");
+                base.sanitized()
             }
         }
     }

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -22,7 +22,7 @@ use guac_lib::domain::agent::Lifecycle;
 use guac_lib::domain::approval::{Decision, ProtectedAction};
 use guac_lib::domain::connector::CleanConnector;
 use guac_lib::domain::envelope::{Part, Participant};
-use guac_lib::domain::group::CleanGroup;
+use guac_lib::domain::group::{CleanGroup, GroupLimits, InferenceOverrides};
 use guac_lib::domain::now_ms;
 use guac_lib::domain::routine::{Cadence, RunKind, Trigger};
 use guac_lib::domain::signin::{Signin, Surface};
@@ -1245,9 +1245,11 @@ async fn a_group_can_pin_a_model_without_touching_the_other_group() {
     let pinned = store
         .create_group(&CleanGroup {
             name: "Local".into(),
-            base_url: None,
-            default_model: Some(Some("local/qwen".into())),
-            api_key: None,
+            inference: Some(InferenceOverrides {
+                default_model: Some("local/qwen".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
         })
         .unwrap();
 
@@ -1314,6 +1316,107 @@ async fn a_group_can_pin_a_model_without_touching_the_other_group() {
         models.contains(&"app/default".to_string()),
         "a group with no model must still inherit the app default, got {models:?}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_group_runs_on_its_own_budget_and_leaves_the_next_group_alone() {
+    // A limit is a statement about one crew's work, not about the app. The stub
+    // answers every call with another tool call, so each agent runs until
+    // something stops it, and the model name on the request is what says which
+    // group's ceiling did.
+    let stub = serve(|_| Script::Notes("still working".into())).await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open(&dir.path().join("guac.db")).unwrap();
+
+    let careful = store
+        .create_group(&CleanGroup {
+            name: "Careful".into(),
+            inference: Some(InferenceOverrides {
+                default_model: Some("careful/model".into()),
+                ..Default::default()
+            }),
+            limits: Some(GroupLimits { max_steps_per_run: Some(2), ..Default::default() }),
+            ..Default::default()
+        })
+        .unwrap();
+    let roomy = store
+        .create_group(&CleanGroup {
+            name: "Roomy".into(),
+            inference: Some(InferenceOverrides {
+                default_model: Some("roomy/model".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let mut thrifty = draft("Thrifty", &["testing"]);
+    thrifty.group_id = Some(careful.id);
+    thrifty.model = String::new();
+    let thrifty = store.create_agent(&thrifty).unwrap();
+
+    let mut busy = draft("Busy", &["testing"]);
+    busy.group_id = Some(roomy.id);
+    busy.model = String::new();
+    let busy = store.create_agent(&busy).unwrap();
+
+    let config = AppConfig {
+        version: guac_lib::config::CURRENT_VERSION,
+        operator_name: String::new(),
+        inference: InferenceConfig {
+            base_url: stub.base_url.clone(),
+            api_key: "sk-test".into(),
+            default_model: "app/default".into(),
+            request_timeout_secs: 10,
+            ..Default::default()
+        },
+        limits: GuardLimits { max_steps_per_run: 6, ..GuardLimits::default() },
+        e2b: Default::default(),
+        kernel: Default::default(),
+    };
+    let sink = RecordingSink::new();
+    let runtime = Runtime::new(
+        store,
+        LlmClient::new().unwrap(),
+        config,
+        Workspace::new(dir.path().join("workspace")),
+        guac_lib::files::FileStore::new(dir.path().join("files")),
+        sink.clone(),
+    );
+    runtime.start_all().unwrap();
+    let h = Harness { runtime, sink, ids: HashMap::new(), _dir: dir };
+
+    for id in [thrifty.id, busy.id] {
+        let run = h.runtime.send_from_human(id, "get to work").unwrap();
+        h.settle(run).await;
+    }
+
+    let models: Vec<String> = stub
+        .transcript
+        .lock()
+        .iter()
+        .filter_map(|body| body["model"].as_str().map(|s| s.to_string()))
+        .collect();
+    let calls = |model: &str| models.iter().filter(|m| m.as_str() == model).count();
+
+    assert_eq!(
+        calls("careful/model"),
+        2,
+        "the group's budget is the one that binds, got {models:?}"
+    );
+    assert_eq!(calls("roomy/model"), 6, "a group that sets no budget runs on the app's");
+
+    // And the crew that stopped is told why, in the group's own numbers.
+    let said: String = h
+        .runtime
+        .store()
+        .channel_messages(thrifty.id, 200)
+        .unwrap()
+        .iter()
+        .map(|e| serde_json::to_string(&e.parts).unwrap())
+        .collect();
+    assert!(said.contains("budget of 2 model calls"), "the operator must be told: {said}");
 }
 
 // ---- routines ------------------------------------------------------------

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -431,12 +431,7 @@ fn build(stub: &Stub, crew: &[Member], limits: GuardLimits, e2b: E2bConfig) -> H
         let group_id = member.group.map(|label| {
             *groups.entry(label).or_insert_with(|| {
                 store
-                    .create_group(&CleanGroup {
-                        name: label.to_string(),
-                        base_url: None,
-                        default_model: None,
-                        api_key: None,
-                    })
+                    .create_group(&CleanGroup { name: label.to_string(), ..Default::default() })
                     .expect("group name is unique in a fresh store")
                     .id
             })

--- a/src-tauri/tests/subscription.rs
+++ b/src-tauri/tests/subscription.rs
@@ -31,6 +31,7 @@ use parking_lot::Mutex;
 
 use guac_lib::config::{AppConfig, InferenceConfig, Provider};
 use guac_lib::db::Store;
+use guac_lib::domain::group::{CleanGroup, InferenceOverrides};
 use guac_lib::domain::ids::AgentId;
 use guac_lib::files::FileStore;
 use guac_lib::llm::openrouter::LlmClient;
@@ -324,8 +325,33 @@ impl Signed {
 /// because the flow that produces that file has its own tests and repeating it
 /// here would make every one of these depend on a second stub.
 fn signed_in(stub: &Stub, names: &[&str], plan: &str) -> Signed {
+    signed_in_where(stub, names, plan, false)
+}
+
+/// The same, with the choice of who pays made by the group rather than the app.
+///
+/// `by_the_group` puts the crew in a group that names the subscription while the
+/// app settings still say a pasted key, which is the arrangement that has to
+/// work: one sign-in on the machine, and each crew deciding whether to spend it.
+/// The app's endpoint is left pointing at a closed port either way, so a
+/// resolution that read the wrong layer fails rather than passing quietly.
+fn signed_in_where(stub: &Stub, names: &[&str], plan: &str, by_the_group: bool) -> Signed {
     let dir = tempfile::tempdir().unwrap();
     let store = Store::open(&dir.path().join("guac.db")).unwrap();
+
+    let group = by_the_group.then(|| {
+        store
+            .create_group(&CleanGroup {
+                name: "Subscribers".into(),
+                inference: Some(InferenceOverrides {
+                    provider: Some(Provider::Chatgpt),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+            .unwrap()
+            .id
+    });
 
     let mut ids = std::collections::HashMap::new();
     for name in names {
@@ -334,6 +360,7 @@ fn signed_in(stub: &Stub, names: &[&str], plan: &str) -> Signed {
         // model and not the endpoint's.
         let mut d = draft(name, &["testing"]);
         d.model = String::new();
+        d.group_id = group;
         ids.insert((*name).to_string(), store.create_agent(&d).unwrap().id);
     }
 
@@ -363,7 +390,7 @@ fn signed_in(stub: &Stub, names: &[&str], plan: &str) -> Signed {
         version: guac_lib::config::CURRENT_VERSION,
         operator_name: String::new(),
         inference: InferenceConfig {
-            provider: Provider::Chatgpt,
+            provider: if by_the_group { Provider::Compatible } else { Provider::Chatgpt },
             // Deliberately left pointing at a URL and a model that would fail if
             // either were used. Nothing in a subscription turn may read them.
             base_url: "http://127.0.0.1:1/v1".into(),
@@ -444,6 +471,26 @@ async fn the_call_carries_the_subscription_model_not_the_endpoint_one() {
     // one field. Resolving the wrong one is a turn the backend refuses by name.
     assert_eq!(body["model"], "gpt-5.6-luna");
     assert_eq!(body["store"], false, "a conversation lives in Guaca, not upstream");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_group_can_spend_the_subscription_while_the_app_pays_with_a_key() {
+    // The sign-in is one credential on this machine, so choosing it is a
+    // setting rather than a second account, and a crew can be moved onto it on
+    // its own. The app is left on an endpoint that is not listening: a turn
+    // that resolved the app's provider instead of the group's cannot reach
+    // anything, and this test would fail rather than pass by accident.
+    let stub = serve(|_| Say::Text("On the plan.".into())).await;
+    let app = signed_in_where(&stub, &["Manager"], "pro", true);
+
+    let run = app.ask("Manager", "Say hello.");
+    app.settle(run).await;
+
+    let texts = app.texts("Manager");
+    assert!(texts.iter().any(|t| t.contains("On the plan")), "got {}", app.everything("Manager"));
+
+    let body = stub.bodies().first().cloned().expect("the subscription was called");
+    assert_eq!(body["model"], "gpt-5.6-luna", "the group inherits the app's subscription model");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/src/components/AgentMenu.test.tsx
+++ b/src/components/AgentMenu.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AgentCard, Group } from "../lib/types";
+import { aGroup } from "../test-fixtures";
 import { AgentMenu } from "./AgentMenu";
 
 function card(over: Partial<AgentCard> = {}): AgentCard {
@@ -27,16 +28,7 @@ function card(over: Partial<AgentCard> = {}): AgentCard {
 }
 
 function group(id: string, name: string): Group {
-  return {
-    id,
-    name,
-    agentCount: 1,
-    createdAt: 0,
-    baseUrl: null,
-    defaultModel: null,
-    apiKeySet: false,
-    apiKeyHint: "",
-  };
+  return aGroup({ id, name, agentCount: 1 });
 }
 
 function open(agent: AgentCard, at = { x: 40, y: 40 }, groups: Group[] = []) {

--- a/src/components/Cafeteria.test.tsx
+++ b/src/components/Cafeteria.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AgentCard, AgentDraft, Group } from "../lib/types";
+import { aGroup } from "../test-fixtures";
 
 /**
  * The cafeteria, over a mocked store.
@@ -34,16 +35,7 @@ const { useStore } = await import("../lib/store");
 const { HIREABLE, STARTER_CREW } = await import("../lib/cafeteria");
 
 function group(id: string, name: string): Group {
-  return {
-    id,
-    name,
-    baseUrl: null,
-    defaultModel: null,
-    apiKeySet: false,
-    apiKeyHint: "",
-    agentCount: 0,
-    createdAt: 1,
-  };
+  return aGroup({ id, name, agentCount: 0, createdAt: 1 });
 }
 
 function agent(name: string, groupId = KITCHEN): AgentCard {

--- a/src/components/GroupEditor.test.tsx
+++ b/src/components/GroupEditor.test.tsx
@@ -1,0 +1,283 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Group, GroupDraft, GroupReset, Settings, SubscriptionStatus } from "../lib/types";
+import { aGroup } from "../test-fixtures";
+
+/**
+ * A group's settings, over a mocked runtime.
+ *
+ * Everything on this surface is an override, and the whole risk is in the draft
+ * it sends rather than in the markup. A blank box means "inherit" and has to
+ * arrive as null; a key nobody retyped has to be absent, because an empty one
+ * clears the stored key; and a group following the app must not send a provider
+ * at all. None of that is visible on screen, which is exactly why it is here.
+ */
+
+const KITCHEN = "00000000-0000-4000-8000-000000000001";
+
+function settings(over: Partial<Settings> = {}): Settings {
+  return {
+    operatorName: "Robert",
+    e2bKeySet: false,
+    e2bKeyHint: "",
+    computerIdleMinutes: 15,
+    kernelKeySet: false,
+    kernelKeyHint: "",
+    browserIdleMinutes: 60,
+    browserStealth: false,
+    baseUrl: "https://openrouter.ai/api/v1",
+    defaultModel: "anthropic/claude-sonnet-4.5",
+    provider: "compatible",
+    subscriptionModel: "gpt-5.6-luna",
+    subscriptionModels: ["gpt-5.6-luna", "gpt-5.4-mini"],
+    apiKeySet: true,
+    apiKeyHint: "…9f2c",
+    requestTimeoutSecs: 120,
+    limits: {
+      maxHops: 8,
+      maxStepsPerRun: 60,
+      maxFanoutPerCall: 8,
+      maxSendsPerPair: 6,
+      maxToolRounds: 24,
+    },
+    ...over,
+  };
+}
+
+function signedIn(): SubscriptionStatus {
+  return { signedIn: true, email: "robert@example.com", plan: "pro", includesCodex: true };
+}
+
+const updateGroup = vi.fn<(id: string, draft: GroupDraft) => Promise<Group>>(async () => aGroup());
+const createGroup = vi.fn<(draft: GroupDraft) => Promise<Group>>(async () => aGroup());
+const deleteGroup = vi.fn<(id: string) => Promise<void>>(async () => {});
+const clearGroup = vi.fn<(id: string) => Promise<GroupReset>>(async () => ({
+  messages: 0,
+  routines: 0,
+  notes: 0,
+  calls: 0,
+}));
+const testGroupConnection = vi.fn<(id: string | null, draft: GroupDraft) => Promise<string>>(
+  async () => "Reached it.",
+);
+const subscriptionStatus = vi.fn<() => Promise<SubscriptionStatus>>(async () => ({
+  signedIn: false,
+  email: "",
+  plan: "",
+  includesCodex: false,
+}));
+const groupConnectors = vi.fn(async () => []);
+
+vi.mock("../lib/ipc", () => ({
+  api: {
+    updateGroup: (id: string, draft: GroupDraft) => updateGroup(id, draft),
+    createGroup: (draft: GroupDraft) => createGroup(draft),
+    deleteGroup: (id: string) => deleteGroup(id),
+    clearGroup: (id: string) => clearGroup(id),
+    testGroupConnection: (id: string | null, draft: GroupDraft) => testGroupConnection(id, draft),
+    subscriptionStatus: () => subscriptionStatus(),
+    groupConnectors: () => groupConnectors(),
+  },
+}));
+
+const { GroupEditor } = await import("./GroupEditor");
+const { useStore } = await import("../lib/store");
+
+const onClose = vi.fn();
+
+/** `null` opens the editor on a group that does not exist yet. */
+function open(group: Group | null = aGroup({ id: KITCHEN, name: "Kitchen" }), over = {}) {
+  useStore.setState({ settings: settings(over), refreshAgents: async () => {} });
+  return render(<GroupEditor group={group ?? undefined} onClose={onClose} />);
+}
+
+function pane(label: string): void {
+  fireEvent.click(screen.getByRole("tab", { name: label }));
+}
+
+function field(label: RegExp): HTMLInputElement {
+  return screen.getByLabelText(label) as HTMLInputElement;
+}
+
+function type(label: RegExp, value: string): void {
+  fireEvent.change(field(label), { target: { value } });
+}
+
+async function save(): Promise<GroupDraft> {
+  // Counted rather than asserted as called at all, so a second save in one test
+  // reads the draft it just sent rather than the first one.
+  const before = updateGroup.mock.calls.length;
+  fireEvent.click(screen.getByRole("button", { name: "Save" }));
+  await waitFor(() => expect(updateGroup.mock.calls.length).toBe(before + 1));
+  return updateGroup.mock.calls.at(-1)![1];
+}
+
+function button(name: string | RegExp): HTMLButtonElement {
+  return screen.getByRole("button", { name }) as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useStore.setState({ settings: settings() });
+});
+
+describe("what a group sends", () => {
+  it("says inherit as null rather than as an empty string", async () => {
+    open();
+    const draft = await save();
+
+    expect(draft.inference).toEqual({
+      provider: null,
+      baseUrl: null,
+      defaultModel: null,
+      subscriptionModel: null,
+      requestTimeoutSecs: null,
+    });
+    expect(draft.limits).toEqual({
+      maxHops: null,
+      maxStepsPerRun: null,
+      maxFanoutPerCall: null,
+      maxSendsPerPair: null,
+      maxToolRounds: null,
+    });
+  });
+
+  it("leaves a stored key alone until somebody types one", async () => {
+    // A key sent as "" clears the stored one, so saving a group whose key was
+    // never touched must not mention it at all: the field shows a hint, and a
+    // hint written back is not a key.
+    open(aGroup({ id: KITCHEN, name: "Kitchen", apiKeySet: true, apiKeyHint: "...9999" }));
+    expect("apiKey" in (await save())).toBe(false);
+  });
+
+  it("sends a key that was typed", async () => {
+    open(aGroup({ id: KITCHEN, name: "Kitchen", apiKeySet: true, apiKeyHint: "...9999" }));
+    pane("Provider");
+    type(/API key/, "sk-typed");
+    expect((await save()).apiKey).toBe("sk-typed");
+  });
+
+  it("clears a key that was deliberately emptied", async () => {
+    open(aGroup({ id: KITCHEN, name: "Kitchen", apiKeySet: true, apiKeyHint: "...9999" }));
+    pane("Provider");
+    type(/API key/, "sk-typed");
+    type(/API key/, "");
+    // Typed and then emptied is an instruction, and the only one that can
+    // put a group back on the app's key.
+    expect((await save()).apiKey).toBe("");
+  });
+
+  it("sends a limit as a number and the rest as inherit", async () => {
+    open();
+    pane("Limits");
+    type(/Model calls per conversation/, "12");
+
+    const draft = await save();
+    expect(draft.limits?.maxStepsPerRun).toBe(12);
+    expect(draft.limits?.maxHops).toBeNull();
+  });
+
+  it("keeps what was typed in one section while another is open", async () => {
+    // The panes are unmounted on a section change, so anything a pane held
+    // would be discarded by a glance at Limits and back.
+    open();
+    pane("Provider");
+    type(/Inference endpoint/, "http://localhost:1234/v1");
+    pane("Limits");
+    pane("Provider");
+    expect(field(/Inference endpoint/).value).toBe("http://localhost:1234/v1");
+
+    expect((await save()).inference?.baseUrl).toBe("http://localhost:1234/v1");
+  });
+});
+
+describe("who pays for a group's turns", () => {
+  it("follows the app until the operator says otherwise", async () => {
+    open(null);
+    pane("Provider");
+    expect(button(/Follow the app settings/).getAttribute("aria-current")).toBe("true");
+  });
+
+  it("names the endpoint chosen from a preset, and chooses to pay with a key", async () => {
+    // Choosing an endpoint while following an app that is on a subscription
+    // would otherwise fill in a URL that nothing read.
+    open(null, { provider: "chatgpt" });
+    type(/Name/, "Groqers");
+    pane("Provider");
+    fireEvent.click(button(/Groq/));
+
+    fireEvent.click(button("Create"));
+    await waitFor(() => expect(createGroup).toHaveBeenCalled());
+    const draft = createGroup.mock.calls.at(-1)![0];
+    expect(draft.inference?.provider).toBe("compatible");
+    expect(draft.inference?.baseUrl).toBe("https://api.groq.com/openai/v1");
+  });
+
+  it("can spend the subscription while the app pays with a key", async () => {
+    subscriptionStatus.mockResolvedValueOnce(signedIn());
+    open();
+    pane("Provider");
+    await screen.findByText(/robert@example.com/);
+
+    fireEvent.click(button("Use it"));
+    expect((await save()).inference?.provider).toBe("chatgpt");
+  });
+
+  it("offers the subscription's own models once it is the one paying", async () => {
+    subscriptionStatus.mockResolvedValueOnce(signedIn());
+    open(
+      aGroup({
+        id: KITCHEN,
+        name: "Kitchen",
+        inference: { ...aGroup().inference, provider: "chatgpt" },
+      }),
+    );
+    pane("Provider");
+    await screen.findByText(/robert@example.com/);
+
+    // A model is picked from what the plan runs rather than typed, and the
+    // first row is the app's, because leaving it alone is a real answer.
+    fireEvent.change(screen.getByLabelText(/^Model/), { target: { value: "gpt-5.4-mini" } });
+    const draft = await save();
+    expect(draft.inference?.subscriptionModel).toBe("gpt-5.4-mini");
+    // The endpoint model is a different field and is not touched by this.
+    expect(draft.inference?.defaultModel).toBeNull();
+  });
+
+  it("sends what is on screen to the test, not what is stored", async () => {
+    open();
+    pane("Provider");
+    type(/Inference endpoint/, "http://localhost:1234/v1");
+    fireEvent.click(button("Test connection"));
+
+    await waitFor(() => expect(testGroupConnection).toHaveBeenCalled());
+    const [id, draft] = testGroupConnection.mock.calls.at(-1)!;
+    expect(id).toBe(KITCHEN);
+    expect(draft.inference?.baseUrl).toBe("http://localhost:1234/v1");
+    await screen.findByText("Reached it.");
+  });
+});
+
+describe("what the operator is shown", () => {
+  it("shows what would be inherited rather than an empty box", async () => {
+    open();
+    pane("Provider");
+    expect(field(/Inference endpoint/).placeholder).toBe("https://openrouter.ai/api/v1");
+    expect(field(/Default model/).placeholder).toBe("anthropic/claude-sonnet-4.5");
+    pane("Limits");
+    expect(field(/Model calls per conversation/).placeholder).toBe("60");
+  });
+
+  it("does not offer accounts for a group that does not exist yet", () => {
+    open(null);
+    expect((screen.getByRole("tab", { name: "Accounts" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it("refuses to save a group with no name", () => {
+    open(null);
+    expect(button("Create").disabled).toBe(true);
+  });
+});

--- a/src/components/GroupEditor.tsx
+++ b/src/components/GroupEditor.tsx
@@ -1,9 +1,34 @@
+/**
+ * A group's name, its wall, and the settings its agents run on.
+ *
+ * Sectioned like Settings, and for the same reason: a group now decides who
+ * pays for its turns, which model answers them and how far a conversation may
+ * run, which is more than one scroll can hold without the name and the delete
+ * button ending up a page apart. Every piece of state lives in the shell, so
+ * changing section cannot discard a half-typed endpoint.
+ *
+ * Everything except the name is an override, and blank means inherit. That is
+ * why the placeholders show what the app would use instead of a value: an
+ * operator has to be able to tell "this group uses the app model" apart from
+ * "this group pins that exact model".
+ */
+
 import { useEffect, useRef, useState } from "react";
 
 import { api } from "../lib/ipc";
+import { LIMITS } from "../lib/limits";
+import { type Provider as Preset, planLabel, providerFor } from "../lib/providers";
 import { useStore } from "../lib/store";
-import { errorMessage, type Group, type GroupDraft, type GroupReset } from "../lib/types";
+import {
+  errorMessage,
+  type Group,
+  type GroupDraft,
+  type GroupReset,
+  type Provider,
+  type SubscriptionStatus,
+} from "../lib/types";
 import { CredentialList } from "./CredentialList";
+import { ProviderPresets, SubscriptionModel } from "./ProviderFields";
 
 interface Props {
   /** Absent means create. */
@@ -11,28 +36,54 @@ interface Props {
   onClose: () => void;
 }
 
-/**
- * A group's name, its wall, and the inference settings its agents inherit.
- *
- * Every field except the name is an override. Left blank, it inherits the app
- * default, which is why the placeholders show what would be used instead of a
- * value: an operator has to be able to tell "this group uses the app model"
- * apart from "this group pins that exact model".
- */
+const SECTIONS = ["general", "provider", "limits", "accounts"] as const;
+
+type Section = (typeof SECTIONS)[number];
+
+const SECTION_LABELS: Record<Section, string> = {
+  general: "General",
+  provider: "Provider",
+  limits: "Limits",
+  accounts: "Accounts",
+};
+
+/** What a group says when it has no opinion about who pays. */
+const INHERIT = "inherit";
+
+/** A number an operator may leave blank, as it is typed and as it is stored. */
+const asText = (value: number | null | undefined) => (value === null ? "" : String(value ?? ""));
+const asNumber = (text: string) => (text.trim() ? Number(text) : null);
+
 export function GroupEditor({ group, onClose }: Props) {
   const refreshAgents = useStore((s) => s.refreshAgents);
   const settings = useStore((s) => s.settings);
 
-  const [draft, setDraft] = useState<GroupDraft>({
-    name: group?.name ?? "",
-    baseUrl: group?.baseUrl ?? "",
-    defaultModel: group?.defaultModel ?? "",
-  });
-  const [error, setError] = useState<string | null>(null);
+  const [section, setSection] = useState<Section>("general");
+  const [name, setName] = useState(group?.name ?? "");
+  const [provider, setProvider] = useState<Provider | typeof INHERIT>(
+    group?.inference.provider ?? INHERIT,
+  );
+  const [baseUrl, setBaseUrl] = useState(group?.inference.baseUrl ?? "");
+  const [model, setModel] = useState(group?.inference.defaultModel ?? "");
+  const [subscriptionModel, setSubscriptionModel] = useState(
+    group?.inference.subscriptionModel ?? "",
+  );
+  const [timeout, setTimeoutSecs] = useState(asText(group?.inference.requestTimeoutSecs));
+  // Null until the operator types, because absent and blank are different
+  // instructions: one keeps the stored key, the other clears it.
+  const [apiKey, setApiKey] = useState<string | null>(null);
+  const [limits, setLimits] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      LIMITS.map((field) => [field.key, asText(group?.limits[field.key] ?? null)]),
+    ),
+  );
+
+  const [status, setStatus] = useState<{ tone: "ok" | "error"; text: string } | null>(null);
   const [busy, setBusy] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [confirmClear, setConfirmClear] = useState(false);
   const [cleared, setCleared] = useState<GroupReset | null>(null);
+  const [subscription, setSubscription] = useState<SubscriptionStatus | null>(null);
   const nameRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -40,20 +91,87 @@ export function GroupEditor({ group, onClose }: Props) {
     nameRef.current?.select();
   }, []);
 
-  const patch = (next: Partial<GroupDraft>) => setDraft((d) => ({ ...d, ...next }));
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  // Read when the pane that shows it is opened, not on mount: a group's name is
+  // what most edits here are, and a status nobody is looking at is a round trip
+  // spent for nothing.
+  useEffect(() => {
+    if (section !== "provider" || subscription) return;
+    let live = true;
+    void api
+      .subscriptionStatus()
+      .then((value) => {
+        if (live) setSubscription(value);
+      })
+      .catch(() => {
+        if (live) setSubscription({ signedIn: false, email: "", plan: "", includesCodex: false });
+      });
+    return () => {
+      live = false;
+    };
+  }, [section, subscription]);
+
+  const draft = (): GroupDraft => ({
+    name,
+    inference: {
+      provider: provider === INHERIT ? null : provider,
+      baseUrl: baseUrl.trim() || null,
+      defaultModel: model.trim() || null,
+      subscriptionModel: subscriptionModel.trim() || null,
+      requestTimeoutSecs: asNumber(timeout),
+    },
+    // Only sent once the operator has touched it. Sending the redacted hint
+    // back would overwrite the real key with its own placeholder.
+    ...(apiKey !== null ? { apiKey } : {}),
+    limits: {
+      maxHops: asNumber(limits.maxHops ?? ""),
+      maxStepsPerRun: asNumber(limits.maxStepsPerRun ?? ""),
+      maxFanoutPerCall: asNumber(limits.maxFanoutPerCall ?? ""),
+      maxSendsPerPair: asNumber(limits.maxSendsPerPair ?? ""),
+      maxToolRounds: asNumber(limits.maxToolRounds ?? ""),
+    },
+  });
 
   const save = async () => {
     setBusy(true);
-    setError(null);
+    setStatus(null);
     try {
-      // `apiKey` is only sent when the operator typed one. Sending the redacted
-      // hint back would overwrite the real key with its own placeholder.
-      if (group) await api.updateGroup(group.id, draft);
-      else await api.createGroup(draft);
+      const saved = group
+        ? await api.updateGroup(group.id, draft())
+        : await api.createGroup(draft());
       await refreshAgents();
+      // Read the limits back rather than leaving what was typed. The runtime
+      // clamps what it stores, so a relay depth of 40 is kept as 16, and
+      // closing over a box still reading 40 would say something untrue about
+      // what this crew runs on.
+      setLimits(
+        Object.fromEntries(LIMITS.map((field) => [field.key, asText(saved.limits[field.key])])),
+      );
+      setApiKey(null);
       onClose();
     } catch (caught) {
-      setError(errorMessage(caught));
+      setStatus({ tone: "error", text: errorMessage(caught) });
+      setBusy(false);
+    }
+  };
+
+  const test = async () => {
+    setBusy(true);
+    setStatus(null);
+    try {
+      // Sends what is on screen and resolves it over the app settings, so this
+      // reports on what this crew's next turn would actually do.
+      setStatus({ tone: "ok", text: await api.testGroupConnection(group?.id ?? null, draft()) });
+    } catch (caught) {
+      setStatus({ tone: "error", text: errorMessage(caught) });
+    } finally {
       setBusy(false);
     }
   };
@@ -68,14 +186,14 @@ export function GroupEditor({ group, onClose }: Props) {
   const clear = async () => {
     if (!group) return;
     setBusy(true);
-    setError(null);
+    setStatus(null);
     try {
       const gone = await api.clearGroup(group.id);
       setCleared(gone);
       setConfirmClear(false);
       await refreshAgents();
     } catch (caught) {
-      setError(errorMessage(caught));
+      setStatus({ tone: "error", text: errorMessage(caught) });
     } finally {
       setBusy(false);
     }
@@ -84,7 +202,7 @@ export function GroupEditor({ group, onClose }: Props) {
   const remove = async () => {
     if (!group) return;
     setBusy(true);
-    setError(null);
+    setStatus(null);
     try {
       await api.deleteGroup(group.id);
       await refreshAgents();
@@ -92,105 +210,344 @@ export function GroupEditor({ group, onClose }: Props) {
     } catch (caught) {
       // The usual failure is a group that still holds agents. The message from
       // Rust already says how many and what to do, so it is shown as written.
-      setError(errorMessage(caught));
+      setStatus({ tone: "error", text: errorMessage(caught) });
       setBusy(false);
     }
   };
+
+  /** Choosing an endpoint is also choosing to pay with a key, exactly as it is
+   *  in Settings: a group left following the app would have the operator fill
+   *  in a URL that nothing read, with no error to explain it. */
+  const choose = (preset: Preset) => {
+    setProvider("compatible");
+    setBaseUrl(preset.baseUrl);
+    if (preset.model) setModel(preset.model);
+  };
+
+  /** What this group would run on if it said nothing, written for a person. */
+  const inherited =
+    settings?.provider === "chatgpt"
+      ? `ChatGPT subscription · ${settings.subscriptionModel}`
+      : `${providerFor(settings?.baseUrl ?? "")?.name ?? settings?.baseUrl ?? "the app endpoint"} · ${settings?.defaultModel ?? ""}`;
+
+  const onSubscription = provider === "chatgpt";
+  const onEndpoint = provider === "compatible";
+
+  /**
+   * The same sentence for whatever this crew is actually set to.
+   *
+   * Read from what is on screen rather than from what is stored, so the
+   * General pane is a summary of the edit in progress and not of the edit
+   * before it.
+   */
+  const paying = onSubscription
+    ? `ChatGPT subscription · ${subscriptionModel || settings?.subscriptionModel || ""}`
+    : onEndpoint
+      ? `${providerFor(baseUrl || (settings?.baseUrl ?? ""))?.name ?? baseUrl} · ${model || settings?.defaultModel || ""}`
+      : `The app settings · ${inherited}`;
+
+  const setLimitCount = LIMITS.filter((field) => (limits[field.key] ?? "").trim()).length;
 
   return (
     <div className="scrim">
       <button type="button" className="scrim__close" aria-label="Close dialog" onClick={onClose} />
       <div
-        className="dialog"
+        className="dialog dialog--settings"
         role="dialog"
         aria-modal="true"
         aria-label={group ? "Group settings" : "New group"}
       >
-        <h2 className="dialog__title">{group ? draft.name || group.name : "New group"}</h2>
-        <p className="dialog__lede" style={{ marginTop: 0 }}>
-          Agents in different groups cannot see or message each other. Everything below is inherited
-          from the app settings unless this group sets it.
-        </p>
+        <div className="settings__head">
+          <h2 className="dialog__title">{group ? name || group.name : "New group"}</h2>
+          <p className="dialog__lede" style={{ margin: 0 }}>
+            Agents in different groups cannot see or message each other. Everything below is
+            inherited from the app settings unless this group sets it.
+          </p>
+        </div>
 
-        <label className="field">
-          <span className="field__label">Name</span>
-          <input
-            className="input input--mono"
-            ref={nameRef}
-            value={draft.name}
-            maxLength={48}
-            placeholder="Research"
-            onChange={(event) => patch({ name: event.target.value })}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" && draft.name.trim()) void save();
-            }}
-          />
-        </label>
+        <div className="settings__body">
+          <div
+            className="settings__nav"
+            role="tablist"
+            aria-orientation="vertical"
+            aria-label="Group sections"
+          >
+            {SECTIONS.map((key) => (
+              <button
+                key={key}
+                type="button"
+                role="tab"
+                className="settings__tab"
+                aria-selected={section === key}
+                // A group that does not exist yet has nothing to hold accounts.
+                disabled={key === "accounts" && !group}
+                onClick={() => setSection(key)}
+              >
+                {SECTION_LABELS[key]}
+              </button>
+            ))}
+          </div>
 
-        <label className="field">
-          <span className="field__label">Model</span>
-          <input
-            className="input input--mono"
-            value={draft.defaultModel ?? ""}
-            placeholder={settings?.defaultModel || "inherit"}
-            onChange={(event) => patch({ defaultModel: event.target.value })}
-          />
-          <span className="field__hint">
-            Used by every agent in this group that does not name its own model.
-          </span>
-        </label>
+          <div className="settings__pane">
+            {section === "general" && (
+              <>
+                <h3 className="settings__title">General</h3>
+                <p className="settings__lede">What this crew is called, and what it runs on.</p>
 
-        <label className="field">
-          <span className="field__label">Inference endpoint</span>
-          <input
-            className="input input--mono"
-            value={draft.baseUrl ?? ""}
-            placeholder={settings?.baseUrl || "inherit"}
-            onChange={(event) => patch({ baseUrl: event.target.value })}
-          />
-          <span className="field__hint">
-            Any OpenAI-compatible base URL. One group can run against a local server while another
-            uses a hosted one.
-          </span>
-        </label>
+                <label className="field">
+                  <span className="field__label">Name</span>
+                  <input
+                    className="input input--mono"
+                    ref={nameRef}
+                    value={name}
+                    maxLength={48}
+                    placeholder="Research"
+                    onChange={(event) => setName(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" && name.trim()) void save();
+                    }}
+                  />
+                </label>
 
-        <label className="field">
-          <span className="field__label">API key</span>
-          <input
-            className="input input--mono"
-            type="password"
-            value={draft.apiKey ?? ""}
-            placeholder={group?.apiKeySet ? `set · ${group.apiKeyHint}` : "inherit"}
-            onChange={(event) => patch({ apiKey: event.target.value })}
-          />
-          <span className="field__hint">
-            Only needed when this group's endpoint uses a different key. Leave blank to keep the
-            stored one.
-          </span>
-        </label>
+                {/* A summary rather than more controls. Whatever is set lives
+                    one tab away, and the question this pane is opened with is
+                    what this crew is doing now. */}
+                <div className="field">
+                  <span className="field__label">Turns paid for by</span>
+                  <span className="field__hint">{paying}</span>
+                </div>
 
-        {/* Credentials belong to the crew, not to any one agent: every machine
-            in this group is handed them. */}
-        {group && <CredentialList groupId={group.id} />}
+                <div className="field">
+                  <span className="field__label">Limits</span>
+                  <span className="field__hint">
+                    {setLimitCount === 0
+                      ? "The app's, all five."
+                      : `${setLimitCount} of five set here; the rest are the app's.`}
+                  </span>
+                </div>
 
-        {cleared && (
-          <div className="banner" style={{ margin: "0.2rem 0 0.9rem" }}>
-            <span>
-              Reset: {cleared.messages} message{cleared.messages === 1 ? "" : "s"},{" "}
-              {cleared.routines} routine{cleared.routines === 1 ? "" : "s"}, {cleared.notes} memor
-              {cleared.notes === 1 ? "y" : "ies"}, and {cleared.calls} recorded call
-              {cleared.calls === 1 ? "" : "s"}.
-            </span>
+                {group && (
+                  <div className="field">
+                    <span className="field__label">Agents</span>
+                    <span className="field__hint">
+                      {group.agentCount === 0
+                        ? "Nobody yet. Agents are hired into a group, and cannot see out of it."
+                        : `${group.agentCount} agent${group.agentCount === 1 ? "" : "s"}, none of whom can see or message anybody outside this group.`}
+                    </span>
+                  </div>
+                )}
+              </>
+            )}
+
+            {section === "provider" && (
+              <>
+                <h3 className="settings__title">Provider</h3>
+                <p className="settings__lede">
+                  Who pays for this crew's turns, and which model answers them. One crew can run on
+                  a local server while another spends the subscription.
+                </p>
+
+                <button
+                  type="button"
+                  className="preset"
+                  aria-current={provider === INHERIT}
+                  onClick={() => setProvider(INHERIT)}
+                >
+                  <span className="preset__text">
+                    <span className="preset__name">Follow the app settings</span>
+                    <span className="preset__url">{inherited}</span>
+                  </span>
+                </button>
+
+                {/* Its own block, above the endpoint list, because it is not an
+                    endpoint. The sign-in itself belongs to the app: it is one
+                    credential on this machine, and a group only decides whether
+                    to spend it. */}
+                <div className="preset preset--plain" aria-current={onSubscription}>
+                  <span className="preset__text">
+                    <span className="preset__name">ChatGPT subscription</span>
+                    <span className="preset__url">
+                      {subscription?.signedIn
+                        ? `${subscription.email || "signed in"}${
+                            subscription.plan ? ` · ${planLabel(subscription.plan)}` : ""
+                          }`
+                        : "Not signed in. Settings → Provider is where that happens."}
+                    </span>
+                  </span>
+                  {subscription?.signedIn &&
+                    (onSubscription ? (
+                      <span className="preset__state" data-ready="true">
+                        In use
+                      </span>
+                    ) : (
+                      <button
+                        type="button"
+                        className="btn btn--small"
+                        disabled={busy}
+                        onClick={() => setProvider("chatgpt")}
+                      >
+                        Use it
+                      </button>
+                    ))}
+                </div>
+
+                {onSubscription && (
+                  <SubscriptionModel
+                    value={subscriptionModel}
+                    models={settings?.subscriptionModels ?? []}
+                    onChange={setSubscriptionModel}
+                    inherit={`Inherit · ${settings?.subscriptionModel ?? ""}`}
+                    hint="Used by every agent in this group that does not name its own model. A subscription has an hourly quota rather than a per-token bill, and every crew spending it shares that quota."
+                  />
+                )}
+
+                <p className="settings__lede" style={{ marginTop: "1.4rem" }}>
+                  Or any OpenAI-compatible endpoint. The ones below are spelled correctly; choosing
+                  one fills in the fields under it, and anything else can be typed in.
+                </p>
+
+                <ProviderPresets
+                  baseUrl={baseUrl || (settings?.baseUrl ?? "")}
+                  active={onEndpoint}
+                  keySet={Boolean(group?.apiKeySet || settings?.apiKeySet)}
+                  onChoose={choose}
+                />
+
+                <label className="field" style={{ marginTop: "1.1rem" }}>
+                  <span className="field__label">Inference endpoint</span>
+                  <input
+                    className="input input--mono"
+                    value={baseUrl}
+                    placeholder={settings?.baseUrl || "inherit"}
+                    onChange={(event) => setBaseUrl(event.target.value)}
+                  />
+                  <span className="field__hint">
+                    Used when a key is paying. Blank follows the app.
+                  </span>
+                </label>
+
+                <label className="field">
+                  <span className="field__label">API key</span>
+                  <input
+                    className="input input--mono"
+                    type="password"
+                    value={apiKey ?? ""}
+                    placeholder={group?.apiKeySet ? `set · ${group.apiKeyHint}` : "inherit"}
+                    autoComplete="off"
+                    onChange={(event) => setApiKey(event.target.value)}
+                  />
+                  <span className="field__hint">
+                    Only needed when this group's endpoint uses a different key. Leave blank to keep
+                    the stored one; clear it to go back to the app's.
+                  </span>
+                </label>
+
+                <label className="field">
+                  <span className="field__label">Default model</span>
+                  <input
+                    className="input input--mono"
+                    value={model}
+                    placeholder={settings?.defaultModel || "inherit"}
+                    onChange={(event) => setModel(event.target.value)}
+                  />
+                  <span className="field__hint">
+                    Used by every agent in this group that does not name its own, when a key is
+                    paying.
+                  </span>
+                </label>
+
+                <label className="field">
+                  <span className="field__label">Give up on a call after</span>
+                  <input
+                    className="input input--mono"
+                    inputMode="numeric"
+                    value={timeout}
+                    placeholder={`${settings?.requestTimeoutSecs ?? 120} seconds`}
+                    onChange={(event) => setTimeoutSecs(event.target.value.replace(/[^0-9]/g, ""))}
+                  />
+                  <span className="field__hint">
+                    Seconds to wait for a model call. A crew on a slow local model wants more than
+                    one on a hosted endpoint.
+                  </span>
+                </label>
+
+                <div className="settings__probe">
+                  <button type="button" className="btn" disabled={busy} onClick={() => void test()}>
+                    Test connection
+                  </button>
+                  <span className="hint">Tests what is on screen. Save to keep it.</span>
+                </div>
+              </>
+            )}
+
+            {section === "limits" && (
+              <>
+                <h3 className="settings__title">Limits</h3>
+                <p className="settings__lede">
+                  Agents that message each other do not stop on their own. These bounds decide when
+                  a conversation started in this group ends, and every agent is told why when it
+                  hits one. Blank follows the app.
+                </p>
+
+                {LIMITS.map((field) => (
+                  <label className="field" key={field.key}>
+                    <span className="field__label">{field.label}</span>
+                    <input
+                      className="input input--mono input--number"
+                      type="number"
+                      min={field.min}
+                      max={field.max}
+                      value={limits[field.key] ?? ""}
+                      placeholder={String(settings?.limits[field.key] ?? "")}
+                      onChange={(event) =>
+                        setLimits((current) => ({
+                          ...current,
+                          [field.key]: event.target.value.replace(/[^0-9]/g, ""),
+                        }))
+                      }
+                    />
+                    <span className="field__hint">{field.hint}</span>
+                  </label>
+                ))}
+              </>
+            )}
+
+            {/* Credentials belong to the crew, not to any one agent: every
+                machine in this group is handed them. */}
+            {section === "accounts" && group && (
+              <>
+                <h3 className="settings__title">Accounts</h3>
+                <p className="settings__lede">
+                  Credentials every machine in this group is given. An agent uses one without ever
+                  reading it.
+                </p>
+                <CredentialList groupId={group.id} />
+              </>
+            )}
+
+            {cleared && (
+              <div className="banner" style={{ margin: "0.9rem 0 0" }}>
+                <span>
+                  Reset: {cleared.messages} message{cleared.messages === 1 ? "" : "s"},{" "}
+                  {cleared.routines} routine{cleared.routines === 1 ? "" : "s"}, {cleared.notes}{" "}
+                  memor{cleared.notes === 1 ? "y" : "ies"}, and {cleared.calls} recorded call
+                  {cleared.calls === 1 ? "" : "s"}.
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {status && (
+          <div
+            className={status.tone === "error" ? "banner banner--error" : "banner banner--ok"}
+            style={{ margin: "0.75rem 1.35rem 0" }}
+          >
+            <span>{status.text}</span>
           </div>
         )}
 
-        {error && (
-          <div className="banner banner--error" style={{ margin: "0.2rem 0 0.9rem" }}>
-            <span>{error}</span>
-          </div>
-        )}
-
-        <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+        <div className="settings__foot">
           {group &&
             (confirmDelete ? (
               <>
@@ -257,7 +614,7 @@ export function GroupEditor({ group, onClose }: Props) {
           <button
             type="button"
             className="btn btn--primary"
-            disabled={busy || !draft.name.trim()}
+            disabled={busy || !name.trim()}
             onClick={() => void save()}
           >
             {group ? "Save" : "Create"}

--- a/src/components/ProviderFields.tsx
+++ b/src/components/ProviderFields.tsx
@@ -1,0 +1,122 @@
+/**
+ * The two parts of choosing a provider that are drawn twice.
+ *
+ * Once in Settings, for the app, and once in a group, for one crew. The rest of
+ * each pane differs enough that sharing it would be a component with a prop per
+ * sentence; these two are here because getting either subtly wrong is expensive
+ * and invisible. A misspelled endpoint fails on every turn of every agent with
+ * an error from a server rather than from Guaca, and a model list that has
+ * drifted from the backend's offers a model the plan refuses by name.
+ */
+
+import type { ReactNode } from "react";
+
+import { PROVIDERS, type Provider as Preset, providerFor, providerReady } from "../lib/providers";
+
+interface PresetProps {
+  /** The endpoint in the box, whatever it is. Decides which row reads as
+   *  chosen, so it is the live value rather than the stored one. */
+  baseUrl: string;
+  /** Whether an endpoint is what pays at all. A group following the app, or
+   *  anything on a subscription, has no chosen row even with a URL in the box. */
+  active: boolean;
+  /** Whether the key that belongs to the chosen endpoint is set. */
+  keySet: boolean;
+  onChoose: (preset: Preset) => void;
+}
+
+/**
+ * Endpoints that are known to speak the protocol this app speaks, as rows.
+ *
+ * A starting point, never a restriction: anything else is typed into the field
+ * below, and choosing a row only fills it in.
+ */
+export function ProviderPresets({ baseUrl, active, keySet, onChoose }: PresetProps) {
+  const current = providerFor(baseUrl);
+  return (
+    <>
+      {PROVIDERS.map((preset) => {
+        const chosen = active && current?.id === preset.id;
+        return (
+          <button
+            key={preset.id}
+            type="button"
+            className="preset"
+            aria-current={chosen}
+            onClick={() => onChoose(preset)}
+          >
+            <span className="preset__text">
+              <span className="preset__name">{preset.name}</span>
+              <span className="preset__url">{preset.baseUrl}</span>
+            </span>
+            {/* Only the row that is actually chosen can say anything about the
+                key, because there is one key and it belongs to the endpoint in
+                the field below. Saying "key stored" against six providers the
+                operator has never used, on the strength of a seventh provider's
+                key, is the same sentence repeated until it means nothing. Local
+                endpoints are the exception: wanting no key is a property of the
+                server, not of this setup. */}
+            {preset.local ? (
+              <span className="preset__state" data-ready="true">
+                On this machine
+              </span>
+            ) : (
+              chosen && (
+                <span
+                  className="preset__state"
+                  data-ready={providerReady(preset, keySet) ? "true" : undefined}
+                >
+                  {providerReady(preset, keySet) ? "Key stored" : "Needs a key"}
+                </span>
+              )
+            )}
+          </button>
+        );
+      })}
+    </>
+  );
+}
+
+interface ModelProps {
+  value: string;
+  /** What the backend says it can run. Held by the backend rather than here so
+   *  the two cannot drift. */
+  models: string[];
+  onChange: (model: string) => void;
+  /** Offered as the first row when a blank value means something: a group that
+   *  leaves this alone runs on whatever the app is set to. */
+  inherit?: string;
+  /** What this model is used for, which differs between the app and a group. */
+  hint: ReactNode;
+}
+
+/**
+ * The models a subscription can run, as a list rather than a box.
+ *
+ * There is nothing to type: the plan decides what is on offer, and a model the
+ * plan cannot run is a refusal by name on the next turn. The whole field rather
+ * than the control, so the label wraps its own input.
+ */
+export function SubscriptionModel({ value, models, onChange, inherit, hint }: ModelProps) {
+  // Whatever is stored is listed even if it is not one of the known ones, so a
+  // model chosen before this list changed is not silently swapped for another.
+  const offered = [...new Set([...models, value].filter(Boolean))];
+  return (
+    <label className="field" style={{ marginTop: "1.1rem" }}>
+      <span className="field__label">Model</span>
+      <select
+        className="input input--mono"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {inherit !== undefined && <option value="">{inherit}</option>}
+        {offered.map((slug) => (
+          <option key={slug} value={slug}>
+            {slug}
+          </option>
+        ))}
+      </select>
+      <span className="field__hint">{hint}</span>
+    </label>
+  );
+}

--- a/src/components/Search.test.tsx
+++ b/src/components/Search.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AgentCard, SearchHits } from "../lib/types";
+import { aGroup } from "../test-fixtures";
 
 /**
  * The palette, over a mocked store.
@@ -67,18 +68,7 @@ const handlers = {
 function open(agents: AgentCard[] = [agent("Manager"), agent("Chef")]) {
   useStore.setState({
     agents,
-    groups: [
-      {
-        id: GROUP,
-        name: "Kitchen",
-        agentCount: agents.length,
-        createdAt: 0,
-        baseUrl: null,
-        defaultModel: null,
-        apiKeySet: false,
-        apiKeyHint: "",
-      },
-    ],
+    groups: [aGroup({ id: GROUP, name: "Kitchen", agentCount: agents.length })],
     lastActive: {},
     selected: null,
     messages: {},

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -18,8 +18,9 @@ import { useEffect, useRef, useState } from "react";
 import { applyAppearance, resolveSurface } from "../lib/appearance";
 import { api, openExternal } from "../lib/ipc";
 import { BINDINGS, comboLabel, SURFACES } from "../lib/keybinds";
+import { LIMITS } from "../lib/limits";
 import { NOTIFY_KINDS, type NotifyKind, type SurfaceMode, UI_SCALES } from "../lib/prefs";
-import { PROVIDERS, planLabel, providerFor, providerReady } from "../lib/providers";
+import { type Provider as Preset, planLabel } from "../lib/providers";
 import { useStore } from "../lib/store";
 import {
   type DeviceCode,
@@ -29,6 +30,7 @@ import {
   type SettingsPatch,
   type SubscriptionStatus,
 } from "../lib/types";
+import { ProviderPresets, SubscriptionModel } from "./ProviderFields";
 
 interface Props {
   onClose: () => void;
@@ -60,52 +62,6 @@ const SECTION_LABELS: Record<Section, string> = {
   shortcuts: "Shortcuts",
   about: "About",
 };
-
-interface LimitField {
-  key: keyof GuardLimits;
-  label: string;
-  hint: string;
-  min: number;
-  max: number;
-}
-
-const LIMITS: LimitField[] = [
-  {
-    key: "maxStepsPerRun",
-    label: "Model calls per conversation",
-    hint: "The hard ceiling on spend. One conversation is your message plus everything it sets off.",
-    min: 1,
-    max: 500,
-  },
-  {
-    key: "maxToolRounds",
-    label: "Tool calls per turn",
-    hint: "How many times an agent can act and look again within one turn. Working a browser is a loop of read, click, read again, so this needs room.",
-    min: 1,
-    max: 100,
-  },
-  {
-    key: "maxHops",
-    label: "Relay depth",
-    hint: "How far a message can travel from you. A relays to B relays to C is two hops.",
-    min: 1,
-    max: 16,
-  },
-  {
-    key: "maxSendsPerPair",
-    label: "Messages between any two agents",
-    hint: "Stops two agents from talking to each other indefinitely.",
-    min: 1,
-    max: 50,
-  },
-  {
-    key: "maxFanoutPerCall",
-    label: "Recipients per send",
-    hint: "How many agents one message can go to at once.",
-    min: 1,
-    max: 64,
-  },
-];
 
 const SURFACE_LABELS: Record<SurfaceMode, string> = {
   light: "Paper",
@@ -262,7 +218,7 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
     }
   };
 
-  const choose = (preset: (typeof PROVIDERS)[number]) => {
+  const choose = (preset: Preset) => {
     // Choosing an endpoint is also choosing to pay with a key. Leaving the
     // provider on the subscription would have the operator fill in a URL and a
     // key that nothing used, with no error to explain why.
@@ -270,8 +226,6 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
     setBaseUrl(preset.baseUrl);
     if (preset.model) setModel(preset.model);
   };
-
-  const current = providerFor(baseUrl);
 
   // Read when the pane that shows it is opened, not at startup: nothing else in
   // the app needs to know, and a status nobody is looking at is a round trip
@@ -429,8 +383,8 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
                 <h3 className="settings__title">Provider</h3>
                 <p className="settings__lede">
                   Two ways to pay for a turn: a subscription you sign in to, or an endpoint and a
-                  key you paste. Whichever is chosen applies to every agent, and a group can still
-                  point itself somewhere else.
+                  key you paste. What is chosen here is the default. Any group can pay its own way,
+                  and one that does is not affected by anything on this page.
                 </p>
 
                 {/* Its own block, above the endpoint list, because it is not an
@@ -505,34 +459,12 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
                 )}
 
                 {subscription?.signedIn && provider === "chatgpt" && (
-                  <label className="field" style={{ marginTop: "1.1rem" }}>
-                    <span className="field__label">Model</span>
-                    <select
-                      className="input input--mono"
-                      value={subscriptionModel}
-                      onChange={(event) => setSubscriptionModel(event.target.value)}
-                    >
-                      {/* Whatever is stored is listed even if it is not one of
-                          the known ones, so a model chosen before this list
-                          changed is not silently swapped for another. */}
-                      {[
-                        ...new Set(
-                          [...(settings?.subscriptionModels ?? []), subscriptionModel].filter(
-                            Boolean,
-                          ),
-                        ),
-                      ].map((slug) => (
-                        <option key={slug} value={slug}>
-                          {slug}
-                        </option>
-                      ))}
-                    </select>
-                    <span className="field__hint">
-                      Used for new agents. Each agent, and each group, can override it. A
-                      subscription has an hourly quota rather than a per-token bill, so a crew that
-                      talks a lot reaches the ceiling faster than one person would.
-                    </span>
-                  </label>
+                  <SubscriptionModel
+                    value={subscriptionModel}
+                    models={settings?.subscriptionModels ?? []}
+                    onChange={setSubscriptionModel}
+                    hint="The default model for any group that does not name one, and any agent that does not name one. A subscription has an hourly quota rather than a per-token bill, so a crew that talks a lot reaches the ceiling faster than one person would."
+                  />
                 )}
 
                 <p className="settings__lede" style={{ marginTop: "1.4rem" }}>
@@ -540,43 +472,12 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
                   one fills in the two fields under it, and anything else can be typed in.
                 </p>
 
-                {PROVIDERS.map((preset) => {
-                  const chosen = provider === "compatible" && current?.id === preset.id;
-                  const ready = providerReady(preset, Boolean(settings?.apiKeySet));
-                  return (
-                    <button
-                      key={preset.id}
-                      type="button"
-                      className="preset"
-                      aria-current={chosen}
-                      onClick={() => choose(preset)}
-                    >
-                      <span className="preset__text">
-                        <span className="preset__name">{preset.name}</span>
-                        <span className="preset__url">{preset.baseUrl}</span>
-                      </span>
-                      {/* Only the row that is actually chosen can say
-                          anything about the key, because there is one key and
-                          it belongs to the endpoint in the field below. Saying
-                          "key stored" against six providers the operator has
-                          never used, on the strength of a seventh provider's
-                          key, is the same sentence repeated until it means
-                          nothing. Local endpoints are the exception: wanting no
-                          key is a property of the server, not of this setup. */}
-                      {preset.local ? (
-                        <span className="preset__state" data-ready="true">
-                          On this machine
-                        </span>
-                      ) : (
-                        chosen && (
-                          <span className="preset__state" data-ready={ready ? "true" : undefined}>
-                            {ready ? "Key stored" : "Needs a key"}
-                          </span>
-                        )
-                      )}
-                    </button>
-                  );
-                })}
+                <ProviderPresets
+                  baseUrl={baseUrl}
+                  active={provider === "compatible"}
+                  keySet={Boolean(settings?.apiKeySet)}
+                  onChoose={choose}
+                />
 
                 <label className="field" style={{ marginTop: "1.1rem" }}>
                   <span className="field__label">Inference endpoint</span>
@@ -620,7 +521,8 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
                     onChange={(event) => setModel(event.target.value)}
                   />
                   <span className="field__hint">
-                    Used for new agents. Each agent, and each group, can override it.
+                    The default model for any group that does not name one, and any agent that does
+                    not name one.
                   </span>
                 </label>
 
@@ -653,7 +555,8 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
                 <h3 className="settings__title">Limits</h3>
                 <p className="settings__lede">
                   Agents that message each other do not stop on their own. These bounds decide when
-                  a conversation ends, and every agent is told why when it hits one.
+                  a conversation ends, and every agent is told why when it hits one. A group can set
+                  its own; these are what it falls back to.
                 </p>
 
                 {LIMITS.map((field) => (

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useStore } from "../lib/store";
 import type { Activity, AgentCard, Group } from "../lib/types";
+import { aGroup, DEFAULT_GROUP } from "../test-fixtures";
 import { Sidebar } from "./Sidebar";
 
 const moveAgent =
@@ -24,19 +25,8 @@ vi.mock("../lib/ipc", () => ({
 }));
 
 const MODEL = "anthropic/claude-opus-4-1-20250805";
-const DEFAULT_GROUP = "00000000-0000-4000-8000-000000000001";
-
 function group(name: string, defaultModel: string | null = null, id = DEFAULT_GROUP): Group {
-  return {
-    id,
-    name,
-    agentCount: 0,
-    createdAt: 0,
-    baseUrl: null,
-    defaultModel,
-    apiKeySet: false,
-    apiKeyHint: "",
-  };
+  return aGroup({ id, name, inference: { ...aGroup().inference, defaultModel } });
 }
 
 function agent(name: string, over: Partial<AgentCard> = {}): AgentCard {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -134,6 +134,16 @@ export const api = {
 
   updateGroup: (id: GroupId, draft: GroupDraft) => invoke<Group>("update_group", { id, draft }),
 
+  /**
+   * Tests a group's endpoint and key, resolved over the app settings.
+   *
+   * Sends what is on screen and starts from the stored key, so testing without
+   * retyping it reports on the key that is actually there. `id` is null for a
+   * group that has not been created yet.
+   */
+  testGroupConnection: (id: GroupId | null, draft: GroupDraft) =>
+    invoke<string>("test_group_connection", { id, draft }),
+
   /** Refused while the group still holds agents; the error carries which. */
   deleteGroup: (id: GroupId) => invoke<void>("delete_group", { id }),
 

--- a/src/lib/limits.ts
+++ b/src/lib/limits.ts
@@ -1,0 +1,61 @@
+/**
+ * The five bounds a conversation runs inside, as they are written for a person.
+ *
+ * Here rather than in the dialog that first drew them, because they are now set
+ * in two places: app-wide in Settings, and per crew in a group. Two copies of
+ * this list would drift, and what drifts is the sentence explaining a number
+ * whose consequence is money.
+ *
+ * The ranges are the ones `GuardLimits::sanitized` clamps to. They are advisory
+ * here — a typed or pasted number sails past a `max` on an input — and the
+ * runtime clamps whatever arrives, which is why both dialogs read their limits
+ * back after saving rather than leaving what was typed on screen.
+ */
+
+import type { GuardLimits } from "./types";
+
+export interface LimitField {
+  key: keyof GuardLimits;
+  label: string;
+  hint: string;
+  min: number;
+  max: number;
+}
+
+export const LIMITS: LimitField[] = [
+  {
+    key: "maxStepsPerRun",
+    label: "Model calls per conversation",
+    hint: "The hard ceiling on spend. One conversation is your message plus everything it sets off.",
+    min: 1,
+    max: 500,
+  },
+  {
+    key: "maxToolRounds",
+    label: "Tool calls per turn",
+    hint: "How many times an agent can act and look again within one turn. Working a browser is a loop of read, click, read again, so this needs room.",
+    min: 1,
+    max: 100,
+  },
+  {
+    key: "maxHops",
+    label: "Relay depth",
+    hint: "How far a message can travel from you. A relays to B relays to C is two hops.",
+    min: 1,
+    max: 16,
+  },
+  {
+    key: "maxSendsPerPair",
+    label: "Messages between any two agents",
+    hint: "Stops two agents from talking to each other indefinitely.",
+    min: 1,
+    max: 50,
+  },
+  {
+    key: "maxFanoutPerCall",
+    label: "Recipients per send",
+    hint: "How many agents one message can go to at once.",
+    min: 1,
+    max: 64,
+  },
+];

--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-
+import { aGroup } from "../test-fixtures";
 import { describeTrigger } from "./routine";
 import { inScope, type SearchInput, score, searchResults, shortUrl } from "./search";
 import type { AgentCard, Group, SearchHits } from "./types";
@@ -30,16 +30,7 @@ function agent(name: string, extra: Partial<AgentCard> = {}): AgentCard {
 }
 
 function group(name: string): Group {
-  return {
-    id: `group-${name}`,
-    name,
-    agentCount: 2,
-    createdAt: 1,
-    baseUrl: null,
-    defaultModel: null,
-    apiKeySet: false,
-    apiKeyHint: "",
-  };
+  return aGroup({ id: `group-${name}`, name, agentCount: 2, createdAt: 1 });
 }
 
 const NOTHING: SearchHits = { messages: [], files: [], links: [], routines: [] };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -141,19 +141,49 @@ export interface Group {
   /** Live agents in it. Terminated ones are excluded. */
   agentCount: number;
   createdAt: number;
-  /** `null` means inherit the app default. Settings resolve agent → group → app. */
-  baseUrl: string | null;
-  defaultModel: string | null;
+  /** How this group's turns are paid for and answered. Settings resolve agent →
+   *  group → app, so `null` anywhere in here means the app decides. */
+  inference: InferenceOverrides;
   apiKeySet: boolean;
   apiKeyHint: string;
+  /** How far a conversation started in this group may run. */
+  limits: GroupLimits;
 }
 
-/** Absent fields are left as they were; empty strings clear the override. */
+/** Every field `null` is a group that runs on the app settings. */
+export interface InferenceOverrides {
+  provider: Provider | null;
+  baseUrl: string | null;
+  /** The model used when a key is paying. */
+  defaultModel: string | null;
+  /** The model used when the subscription is paying. Two fields for the reason
+   *  the app keeps two: the providers have disjoint model names. */
+  subscriptionModel: string | null;
+  requestTimeoutSecs: number | null;
+}
+
+/** Per-field overrides of the app's loop guard. `null` inherits. */
+export interface GroupLimits {
+  maxHops: number | null;
+  maxStepsPerRun: number | null;
+  maxFanoutPerCall: number | null;
+  maxSendsPerPair: number | null;
+  maxToolRounds: number | null;
+}
+
+/**
+ * What an operator can set on a group.
+ *
+ * Each block is all-or-nothing: absent leaves every override in it as it was,
+ * and present replaces the lot, with a null field inside meaning inherit. The
+ * key is the exception, because it is the one setting that cannot be read back:
+ * absent keeps the stored one and `""` clears it.
+ */
 export interface GroupDraft {
   name: string;
-  baseUrl?: string;
-  defaultModel?: string;
+  inference?: InferenceOverrides;
   apiKey?: string;
+  limits?: GroupLimits;
 }
 
 export type ConnectorId = string;

--- a/src/test-fixtures.ts
+++ b/src/test-fixtures.ts
@@ -1,0 +1,40 @@
+/**
+ * Shapes that tests need whole but only care about a field or two of.
+ *
+ * A group is the first of them. Five test files each built one by hand, so
+ * adding a setting to a group meant editing five fixtures that had nothing to
+ * do with the change and nothing to say about it. Imported only by tests, so
+ * nothing here reaches the bundle.
+ */
+
+import type { Group, GroupId } from "./lib/types";
+
+/** The group the migration creates, which the UI hides while it is the only one. */
+export const DEFAULT_GROUP: GroupId = "00000000-0000-4000-8000-000000000001";
+
+/** A group that inherits everything, with whatever the test cares about on top. */
+export function aGroup(over: Partial<Group> = {}): Group {
+  return {
+    id: DEFAULT_GROUP,
+    name: "Everyone",
+    agentCount: 0,
+    createdAt: 0,
+    inference: {
+      provider: null,
+      baseUrl: null,
+      defaultModel: null,
+      subscriptionModel: null,
+      requestTimeoutSecs: null,
+    },
+    apiKeySet: false,
+    apiKeyHint: "",
+    limits: {
+      maxHops: null,
+      maxStepsPerRun: null,
+      maxFanoutPerCall: null,
+      maxSendsPerPair: null,
+      maxToolRounds: null,
+    },
+    ...over,
+  };
+}


### PR DESCRIPTION
App settings become defaults: a group now names its own provider, endpoint, key, a model per provider, request timeout and all five guard limits, and falls back to the app for anything it does not set, so one crew can run on a local server while another spends the ChatGPT subscription. Nothing about who pays is inferred any more, because the guess that read an endpoint as a choice of provider outvoted an operator choosing to follow the app settings; migration 23 writes that reading down for every group it was true of, and carries a model that could only have been a subscription's across to the new column. A run is measured against the limits of the group it happens in, read once when the guard creates its state and fixed for the run's life, and the registry holds no default of its own. The group editor is sectioned on the Settings shell, and the endpoint list, the subscription model list and the limit copy each live in one place now rather than two.

Covered by a cascade test where one group runs out of budget at two model calls while the next runs to the app's six, a subscription test where a group spends the plan while the app settings say a key (the app endpoint points at a closed port, so a wrong resolution fails rather than passes), migration tests for both back-fills, and IPC-shape tests for the nested camelCase blocks. Migration 23 was also applied to a copy of a real database, which it migrates clean.