### PR TITLE
fix: a sign-in asks the resource, and Cloudflare is the whole account

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,12 +196,24 @@ the model takes a screenshot to see what `browse` did.
   one pixel is enough and no threshold is. Its listener is bound by a ref
   callback for the same reason: the node is replaced whenever the pane shows a
   pair thread or the activity board, and an effect cannot re-bind on that.
-- **What a plugin's sign-in asks for is the server's list, not Guaca's.**
-  Cloudflare's consent screen names four permissions because its Workers
-  Bindings server hardcodes that scope set and publishes no `scopes_supported`,
-  so Guaca sends no `scope` at all. Where a server does publish a list, Guaca
-  asks for all of it except `*`. Reaching more of a vendor is another entry on
-  the list, not another parameter: `docs/PLUGINS.md`.
+- **What a plugin's sign-in asks for is the resource's list, not its
+  authorisation server's.** They are two documents and two lists: RFC 9728 names
+  the scopes for *that resource*, RFC 8414 names everything the server can issue
+  behind it. AgentMail's MCP server wants three and the Clerk instance behind it
+  lists seven, four of which it refuses a registered client, as an
+  `invalid_scope` in the operator's browser. So the resource's list wins, the
+  server's is the fallback, `*` is dropped and `offline_access` is added when the
+  server names it: without a refresh token a plugin asks to be signed in again
+  every hour. Where neither publishes a list, Guaca sends no `scope` at all and
+  the server applies its own default, which is what Cloudflare's consent screen
+  is choosing between. `oauth::requested_scope`, then `docs/PLUGINS.md`.
+- **Cloudflare is `mcp.cloudflare.com`, not one of the fifteen
+  `*.mcp.cloudflare.com`.** Each subdomain is a single product area, so one of
+  them is a crew that can make a Worker and cannot read a DNS record, and
+  several of them is a hundred tool definitions on every turn. The apex host is
+  the whole API behind `search` and `execute`: the model writes JavaScript
+  against the OpenAPI document and Cloudflare runs it, so 2,500 endpoints cost
+  about a thousand tokens instead of a million.
 - **A plugin's tool list is read once and kept.** `tools/list` on every turn is
   a network round trip in front of every model call, paid by every agent in the
   crew, to re-learn something that changes when a vendor ships rather than when

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -95,25 +95,85 @@ possible, and it is the same mechanism that decides who is on the list at all.
 The device flow is not an option here anyway. None of the five advertises it,
 and the MCP authorisation specification mandates authorisation code with PKCE.
 
-## What a plugin asks for is the server's list, not Guaca's
+## What a plugin asks for is the resource's list, not Guaca's
 
-Connecting Cloudflare shows a consent screen with four permissions on it: user
-read, account read, Workers write, D1 write. That is not Guaca choosing a
-cautious subset. Cloudflare's Workers Bindings server hardcodes that scope set
-for every client that connects to it, and its authorisation-server metadata
-publishes no `scopes_supported` at all, so Guaca sends no `scope` parameter and
-has nothing to widen.
+Guaca never invents a scope. A scope it invented is a scope the server refuses
+in a browser window that cannot explain why, and the operator is left reading
+`invalid_scope` on a vendor's error page.
 
-Where a server does publish a list, Guaca asks for all of it minus `*`, because
-a scope it invented is a scope the server refuses in a browser window that
-cannot explain why, and a wildcard is not what an operator agreed to by
-connecting a database. `oauth::requested_scope` is the whole rule.
+Two documents publish a list, and they are not the same list.
 
-The way to reach more of a vendor's surface is therefore another entry on the
-list, not another parameter on the request. Cloudflare publishes fifteen MCP
-servers, one per product area; Workers Bindings is the one that makes things
-rather than reads about them, and offering all fifteen would put a hundred tools
-in front of a model that asked for "Cloudflare".
+| Document | RFC | What its `scopes_supported` means |
+|---|---|---|
+| Protected resource, at the MCP server | 9728 | What to ask for to reach *this resource* |
+| Authorisation server, at the issuer | 8414 | Everything the issuer can grant, for every resource behind it and every client registered by any means |
+
+The resource's is the one asked for. The server's is the fallback for a resource
+that says nothing, which is most of them.
+
+AgentMail is why, and it was found the hard way. Its MCP server names three
+scopes: `openid email profile`. The Clerk instance behind it lists seven, and
+four of those are ones a vendor grants to clients it created by hand, not to one
+that registered itself. Asking the resource's question of the authorisation
+server got every sign-in refused: *The OAuth 2.0 Client is not allowed to
+request scope 'public_metadata'*. Linear has the same shape and had not broken
+yet: its resource wants `read write` and its issuer also lists `openid email`.
+
+Two rules sit on top of that, and both only ever name a scope the server itself
+published:
+
+- **`*` is dropped wherever it appears.** Neon offers one. An operator
+  connecting a database has not agreed to hand over everything their account can
+  do, and the named scopes beside it add up to the part Guaca needs.
+- **`offline_access` is added when the authorisation server names it.** It is
+  not access to anything. It is the scope that decides whether a refresh token
+  comes back, and without one a plugin works until the access token expires and
+  then asks the operator to sign in again, every hour, for as long as they keep
+  it connected.
+
+`Discovered::requested_scope` is the whole rule, and the live half of
+`tests/plugins.rs` is what keeps it honest: it asserts that every scope this
+build would send is one the vendor publishes today. Offline tests cannot see a
+vendor narrowing what a registered client may ask for, which is exactly how
+AgentMail broke while all five discovered correctly.
+
+Where neither document publishes a list, Guaca sends no `scope` parameter at
+all, and the server applies its own default. Cloudflare is that case, and its
+consent screen is a permission picker that opens on **read only**. The operator
+widens it there, on the screen that says what each scope is, or leaves it and
+has a crew that can look at the account without changing it.
+
+The way to reach more of a vendor's surface is therefore the consent screen or
+another entry on this list, never another parameter on the request.
+
+## Cloudflare is the account, not a product area
+
+Cloudflare publishes two kinds of MCP server and Guaca dials the one that is not
+a product area.
+
+The fifteen `*.mcp.cloudflare.com` hosts are one product each: Workers bindings,
+DNS, Radar, observability, and so on. Curated, typed, and a fifteenth of the
+account apiece. Picking one is deciding on the operator's behalf which fifteenth
+their crew gets, with nothing on the tile saying which, and an agent that can
+create a Worker and cannot read a DNS record spends the turn discovering that.
+Offering several instead is a hundred tool definitions in front of a model that
+asked for "Cloudflare", paid for on every turn by every agent in the crew.
+
+`mcp.cloudflare.com` is the whole Cloudflare API — over 2,500 endpoints — behind
+`search` and `execute`, plus `docs`. The model writes JavaScript against the
+OpenAPI document and Cloudflare runs it in a sandboxed Worker, so the API
+surface stays on the server: about a thousand tokens of context rather than the
+million the same endpoints would cost as tool definitions. It is the only server
+on the list that works this way, and it is the reason Cloudflare can be one
+entry rather than fifteen.
+
+Migration 26 deletes the rows from before the move. Nothing on one survives it:
+the tokens were issued by the old host's issuer and the new one refuses them,
+and the stored tool list names tools the new server does not have — which is
+what the crew is offered on every turn until something re-reads it. Left in
+place, an agent calls `cloudflare__workers_list`, takes a 401 from a host it was
+never signed in to, and reports the operator's account as broken. Deleted, the
+tile says "Connect" and one consent screen fixes it.
 
 ## What crosses which boundary
 

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -712,6 +712,28 @@ CREATE UNIQUE INDEX plugins_kind_unique ON plugins (group_id, kind);
 DELETE FROM plugins WHERE kind = 'clerk';
 "#,
     ),
+    (
+        26,
+        r#"
+-- Cloudflare moved from `bindings.mcp.cloudflare.com` to `mcp.cloudflare.com`:
+-- from one product area of fifteen to the whole API behind `search` and
+-- `execute`. `PluginKind::endpoint` is what the runtime dials, so an existing
+-- row is now a grant issued by one server being spent against another.
+--
+-- Nothing on the row survives the move. The access and refresh tokens were
+-- issued by the old issuer and the new one will refuse them; the stored tool
+-- list names tools the new server does not have, and those are what the crew
+-- is offered on every turn until something re-reads them. Left in place, an
+-- agent calls `cloudflare__workers_list`, gets a 401 from a host it was never
+-- signed in to, and reports it as the operator's account being broken.
+--
+-- Deleted rather than blanked, because an empty row still holds the group's
+-- slot in `plugins_kind_unique`, and the tile the operator needs to click says
+-- "Connect" only when there is no row at all. Reconnecting is one click and one
+-- consent screen, and it is the only way to get a grant for the new server.
+DELETE FROM plugins WHERE kind = 'cloudflare';
+"#,
+    ),
 ];
 
 /// The group every agent starts in, and the one the UI keeps out of the way
@@ -857,6 +879,36 @@ mod tests {
             .map(Result::unwrap)
             .collect();
         assert_eq!(left, vec!["neon".to_string()]);
+    }
+
+    #[test]
+    fn a_plugin_that_changed_server_loses_the_grant_it_had_for_the_old_one() {
+        // Cloudflare's endpoint moved hosts, so the stored token was issued by
+        // an issuer the new server does not share and the stored tool list
+        // names tools it does not have. Both are read on every turn, and a row
+        // that survives is an agent calling a tool that 401s against a host
+        // nobody signed in to.
+        let mut conn = memory();
+        for (version, sql) in MIGRATIONS.iter().filter(|(v, _)| *v < 26) {
+            conn.execute_batch(sql).unwrap();
+            conn.pragma_update(None, "user_version", *version).unwrap();
+        }
+        let insert =
+            "INSERT INTO plugins (id,group_id,kind,account,tools,access_token,connected_at)
+                      VALUES (?1,?2,?3,'','[\"workers_list\"]','tok',0)";
+        conn.execute(insert, rusqlite::params!["p1", DEFAULT_GROUP_ID, "cloudflare"]).unwrap();
+        conn.execute(insert, rusqlite::params!["p2", DEFAULT_GROUP_ID, "linear"]).unwrap();
+
+        run(&mut conn).unwrap();
+
+        let left: Vec<String> = conn
+            .prepare("SELECT kind FROM plugins ORDER BY kind")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert_eq!(left, vec!["linear".to_string()], "and only Cloudflare's");
     }
 
     #[test]

--- a/src-tauri/src/domain/plugin.rs
+++ b/src-tauri/src/domain/plugin.rs
@@ -106,14 +106,18 @@ impl PluginKind {
     /// `format!("{host}/mcp")` would be a resource the server does not
     /// recognise, and the refusal arrives in the operator's browser.
     ///
-    /// Cloudflare publishes fifteen of these, one per product area. Workers
-    /// bindings is the one that makes things rather than reads about them, and
-    /// offering all fifteen would put a hundred tools in front of a model that
-    /// asked for "Cloudflare".
+    /// Cloudflare publishes two kinds of server, and this is the account-wide
+    /// one. The fifteen `*.mcp.cloudflare.com` hosts are one product area each,
+    /// so picking one is picking which fifteenth of the operator's account the
+    /// crew gets, and picking several is a hundred tool definitions in front of
+    /// a model that asked for "Cloudflare". `mcp.cloudflare.com` is the whole
+    /// API behind `search` and `execute`: the model writes JavaScript against
+    /// the OpenAPI document, Cloudflare runs it, and 2,500 endpoints cost about
+    /// a thousand tokens of context instead of a million.
     pub const fn endpoint(self) -> &'static str {
         match self {
             PluginKind::Neon => "https://mcp.neon.tech/mcp",
-            PluginKind::Cloudflare => "https://bindings.mcp.cloudflare.com/mcp",
+            PluginKind::Cloudflare => "https://mcp.cloudflare.com/mcp",
             PluginKind::Linear => "https://mcp.linear.app/mcp",
             PluginKind::Stripe => "https://mcp.stripe.com",
             PluginKind::Agentmail => "https://mcp.agentmail.to/mcp",
@@ -124,7 +128,7 @@ impl PluginKind {
     pub const fn blurb(self) -> &'static str {
         match self {
             PluginKind::Neon => "Postgres databases: branch one, run SQL, migrate it.",
-            PluginKind::Cloudflare => "Workers and their bindings: KV, R2, D1, Hyperdrive.",
+            PluginKind::Cloudflare => "The whole API: Workers, DNS, R2, D1, Zero Trust.",
             PluginKind::Linear => "Issues and projects: find them, file them, move them on.",
             PluginKind::Stripe => "The live account: payments, customers, invoices, refunds.",
             PluginKind::Agentmail => "Inboxes an agent owns: read a thread, send, reply, forward.",
@@ -135,7 +139,9 @@ impl PluginKind {
     pub const fn docs(self) -> &'static str {
         match self {
             PluginKind::Neon => "https://neon.com/docs/ai/neon-mcp-server",
-            PluginKind::Cloudflare => "https://github.com/cloudflare/mcp-server-cloudflare",
+            PluginKind::Cloudflare => {
+                "https://developers.cloudflare.com/agents/model-context-protocol/cloudflare/servers-for-cloudflare/"
+            }
             PluginKind::Linear => "https://linear.app/docs/mcp",
             PluginKind::Stripe => "https://docs.stripe.com/mcp",
             PluginKind::Agentmail => "https://www.agentmail.to/docs/integrations/mcp",
@@ -261,6 +267,20 @@ mod tests {
             assert!(kind.endpoint().starts_with("https://"), "{}", kind.label());
             assert!(kind.docs().starts_with("https://"), "{}", kind.label());
         }
+    }
+
+    #[test]
+    fn cloudflare_is_the_account_wide_server_and_not_one_product_area() {
+        // A `*.mcp.cloudflare.com` host is one product area of fifteen, so an
+        // operator who connected "Cloudflare" would get a crew that can make a
+        // Worker and cannot see a DNS record, with nothing on the tile saying
+        // so. The apex host is the whole API behind `search` and `execute`.
+        let endpoint = PluginKind::Cloudflare.endpoint();
+        assert_eq!(endpoint, "https://mcp.cloudflare.com/mcp");
+        assert!(
+            !endpoint.contains(".mcp.cloudflare.com"),
+            "a subdomain here is one product area, not the account: {endpoint}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -141,7 +141,9 @@ pub async fn authorize(
     now_ms: impl Fn() -> i64,
 ) -> Result<Grant, OauthError> {
     let http = http()?;
-    let Discovered { issuer, server } = discover(resource, challenge_header).await?;
+    let discovered = discover(resource, challenge_header).await?;
+    let scope = discovered.requested_scope();
+    let Discovered { issuer, server, .. } = discovered;
 
     let Some(registration_endpoint) = server.registration_endpoint.clone() else {
         return Err(OauthError::NoRegistration { issuer });
@@ -175,7 +177,7 @@ pub async fn authorize(
     // Asked for only when the server publishes what there is to ask for. A
     // scope Guaca invented is a scope the server refuses, and the refusal
     // arrives in the operator's browser rather than here.
-    if let Some(scope) = requested_scope(&server) {
+    if let Some(scope) = scope {
         url.push_str(&format!("&scope={}", encode(&scope)));
     }
 
@@ -223,6 +225,10 @@ pub async fn refresh(grant: &Grant, now_ms: impl Fn() -> i64) -> Result<Grant, O
 pub struct Discovered {
     pub issuer: String,
     pub server: ServerMetadata,
+    /// What the *resource* said it wants asked for, which is not the same list
+    /// as the authorisation server's and takes precedence over it. See
+    /// [`Discovered::requested_scope`].
+    pub resource_scopes: Vec<String>,
 }
 
 /// Steps 1 and 2 of the dance, on their own.
@@ -237,34 +243,42 @@ pub async fn discover(
     challenge_header: Option<&str>,
 ) -> Result<Discovered, OauthError> {
     let http = http()?;
-    let issuer = issuer_for(&http, resource, challenge_header).await?;
+    let Resource { issuer, scopes } = resource_for(&http, resource, challenge_header).await?;
     let server = server_metadata(&http, &issuer).await?;
-    Ok(Discovered { issuer, server })
+    Ok(Discovered { issuer, server, resource_scopes: scopes })
 }
 
-/// Who can issue a grant for this resource.
+/// RFC 9728 protected-resource metadata, as far as this build reads it.
+struct Resource {
+    /// Who can issue a grant for it.
+    issuer: String,
+    /// What it says to ask for. Empty when it does not say.
+    scopes: Vec<String>,
+}
+
+/// What the resource publishes about itself.
 ///
 /// The challenge on a 401 is consulted first because it is the answer the
 /// server itself just gave; the well-known paths are what to try when a server
 /// refuses without saying where to go, which is most of them.
-async fn issuer_for(
+async fn resource_for(
     http: &reqwest::Client,
     resource: &str,
     challenge: Option<&str>,
-) -> Result<String, OauthError> {
+) -> Result<Resource, OauthError> {
     let mut tried = Vec::new();
 
     if let Some(url) = challenge.and_then(resource_metadata_url) {
         tried.push(url.clone());
-        if let Some(issuer) = protected_resource(http, &url).await {
-            return Ok(issuer);
+        if let Some(found) = protected_resource(http, &url).await {
+            return Ok(found);
         }
     }
 
     for url in well_known(resource, "oauth-protected-resource") {
         tried.push(url.clone());
-        if let Some(issuer) = protected_resource(http, &url).await {
-            return Ok(issuer);
+        if let Some(found) = protected_resource(http, &url).await {
+            return Ok(found);
         }
     }
 
@@ -274,11 +288,13 @@ async fn issuer_for(
     })
 }
 
-async fn protected_resource(http: &reqwest::Client, url: &str) -> Option<String> {
+async fn protected_resource(http: &reqwest::Client, url: &str) -> Option<Resource> {
     #[derive(Deserialize)]
     struct Metadata {
         #[serde(default)]
         authorization_servers: Vec<String>,
+        #[serde(default)]
+        scopes_supported: Vec<String>,
     }
 
     let response = http.get(url).timeout(HTTP_TIMEOUT).send().await.ok()?;
@@ -286,7 +302,8 @@ async fn protected_resource(http: &reqwest::Client, url: &str) -> Option<String>
         return None;
     }
     let metadata: Metadata = response.json().await.ok()?;
-    metadata.authorization_servers.into_iter().next()
+    let issuer = metadata.authorization_servers.into_iter().next()?;
+    Some(Resource { issuer, scopes: metadata.scopes_supported })
 }
 
 /// RFC 8414 authorisation-server metadata, as far as this build reads it.
@@ -373,16 +390,50 @@ fn resource_metadata_url(challenge: &str) -> Option<String> {
     (!value.is_empty()).then(|| value.to_string())
 }
 
-/// What to ask for, when the server publishes a list.
-///
-/// `*` is filtered out wherever it appears: an operator connecting a database
-/// plugin has not agreed to hand over everything their account can do, and a
-/// server that offers a wildcard also offers the named scopes that add up to
-/// the part Guaca needs.
-fn requested_scope(server: &ServerMetadata) -> Option<String> {
-    let wanted: Vec<&str> =
-        server.scopes_supported.iter().map(String::as_str).filter(|s| *s != "*").collect();
-    (!wanted.is_empty()).then(|| wanted.join(" "))
+impl Discovered {
+    /// What to ask for, when something publishes a list.
+    ///
+    /// Two documents publish one and they are not the same list. The resource's
+    /// (RFC 9728) is the scopes used to request access to *that resource*; the
+    /// authorisation server's (RFC 8414) is everything the issuer can grant,
+    /// across every resource behind it and for clients it created by hand as
+    /// well as ones that registered themselves. So the resource's is asked for
+    /// when there is one, and the server's is the fallback for the resource
+    /// that says nothing, which is most of them.
+    ///
+    /// AgentMail is why, and it was found by an operator rather than by a test.
+    /// Its MCP server names `openid email profile`; the Clerk instance behind
+    /// it also lists `public_metadata`, `private_metadata` and `user:org:read`,
+    /// and refuses a registered client that asks for them: `invalid_scope`, on
+    /// a vendor's error page, where nothing here can explain it.
+    ///
+    /// `offline_access` is the one addition, and only when the authorisation
+    /// server names it. It is not access to anything: it is the scope that
+    /// decides whether a refresh token comes back, and without one a plugin
+    /// works until the access token expires and then asks to be signed in
+    /// again, every hour, for as long as it stays connected.
+    ///
+    /// `*` is filtered out wherever it appears: an operator connecting a
+    /// database plugin has not agreed to hand over everything their account can
+    /// do, and a server that offers a wildcard also offers the named scopes
+    /// that add up to the part Guaca needs.
+    pub fn requested_scope(&self) -> Option<String> {
+        let published = if self.resource_scopes.is_empty() {
+            &self.server.scopes_supported
+        } else {
+            &self.resource_scopes
+        };
+
+        let mut wanted: Vec<&str> =
+            published.iter().map(String::as_str).filter(|s| *s != "*").collect();
+
+        let offline = "offline_access";
+        if !wanted.contains(&offline) && self.server.scopes_supported.iter().any(|s| s == offline) {
+            wanted.push(offline);
+        }
+
+        (!wanted.is_empty()).then(|| wanted.join(" "))
+    }
 }
 
 // ---- registration --------------------------------------------------------
@@ -793,32 +844,80 @@ mod tests {
         assert_eq!(resource_metadata_url("Bearer").as_deref(), None);
     }
 
-    #[test]
-    fn a_wildcard_scope_is_never_asked_for() {
-        // Neon offers `read`, `write` and `*`. Connecting a database plugin is
-        // not consent to everything the operator's account can do.
-        let server = ServerMetadata {
+    fn server_offering(scopes: &[&str]) -> ServerMetadata {
+        ServerMetadata {
             authorization_endpoint: "https://x.test/a".into(),
             token_endpoint: "https://x.test/t".into(),
             registration_endpoint: None,
-            scopes_supported: vec!["read".into(), "write".into(), "*".into()],
+            scopes_supported: scopes.iter().map(|s| (*s).to_string()).collect(),
             code_challenge_methods_supported: vec!["S256".into()],
-        };
-        assert_eq!(requested_scope(&server).as_deref(), Some("read write"));
+        }
+    }
+
+    fn scopes(resource: &[&str], server: &[&str]) -> Option<String> {
+        Discovered {
+            issuer: "https://x.test".into(),
+            server: server_offering(server),
+            resource_scopes: resource.iter().map(|s| (*s).to_string()).collect(),
+        }
+        .requested_scope()
+    }
+
+    #[test]
+    fn a_wildcard_scope_is_never_asked_for() {
+        // Neon offers `read`, `write` and `*`, and publishes no list of its
+        // own on the resource. Connecting a database plugin is not consent to
+        // everything the operator's account can do.
+        assert_eq!(scopes(&[], &["read", "write", "*"]).as_deref(), Some("read write"));
     }
 
     #[test]
     fn a_server_that_publishes_no_scopes_is_not_asked_for_one() {
         // Cloudflare's does not. An invented scope is refused in the browser,
         // where nothing can explain it.
-        let server = ServerMetadata {
-            authorization_endpoint: "https://x.test/a".into(),
-            token_endpoint: "https://x.test/t".into(),
-            registration_endpoint: None,
-            scopes_supported: Vec::new(),
-            code_challenge_methods_supported: vec!["S256".into()],
-        };
-        assert_eq!(requested_scope(&server), None);
+        assert_eq!(scopes(&[], &[]), None);
+    }
+
+    #[test]
+    fn the_resource_decides_what_is_asked_for_and_not_its_authorisation_server() {
+        // AgentMail, exactly as the two documents read today. Its MCP server
+        // wants three scopes; the Clerk instance behind it can issue seven and
+        // refuses a registered client that asks for the other four, with an
+        // `invalid_scope` the operator sees and cannot act on.
+        let asked = scopes(
+            &["openid", "email", "profile"],
+            &[
+                "openid",
+                "profile",
+                "email",
+                "public_metadata",
+                "private_metadata",
+                "offline_access",
+                "user:org:read",
+            ],
+        );
+        assert_eq!(asked.as_deref(), Some("openid email profile offline_access"));
+    }
+
+    #[test]
+    fn a_refresh_token_is_asked_for_whenever_the_server_can_issue_one() {
+        // `offline_access` is not access to anything: it is the difference
+        // between a plugin that renews itself and one that asks the operator to
+        // sign in again every hour. Added once, and never invented.
+        assert_eq!(
+            scopes(&["read"], &["read", "offline_access"]).as_deref(),
+            Some("read offline_access")
+        );
+        assert_eq!(
+            scopes(&["read", "offline_access"], &["read", "offline_access"]).as_deref(),
+            Some("read offline_access"),
+            "already asked for is not asked for twice"
+        );
+        assert_eq!(
+            scopes(&["read"], &["read", "write"]).as_deref(),
+            Some("read"),
+            "a server that cannot issue a refresh token is not asked for one"
+        );
     }
 
     #[test]

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -1033,7 +1033,7 @@ mod tests {
             &[],
             &[],
             &[],
-            &[plugin(PluginKind::Cloudflare, &["workers_list"])],
+            &[plugin(PluginKind::Cloudflare, &["execute"])],
             "",
             &[],
             ReplyMode::ToOperator,

--- a/src-tauri/tests/plugins.rs
+++ b/src-tauri/tests/plugins.rs
@@ -866,6 +866,41 @@ async fn every_server_on_the_list_still_publishes_what_this_build_expects() {
             "{} no longer supports the only PKCE method this build sends",
             kind.label()
         );
-        println!("{}: signs in at {}", kind.label(), found.issuer);
+
+        // 4. And that the scope this build would send is one the vendor
+        //    publishes. Everything above passed while AgentMail refused every
+        //    sign-in: Guaca asked its Clerk instance for all seven scopes the
+        //    *authorisation server* lists, and four of those are ones a
+        //    registered client may not have. Discovery is not the only thing
+        //    that goes stale, and `invalid_scope` arrives in the operator's
+        //    browser where no error message can reach it.
+        let asked = found.requested_scope();
+        for scope in asked.iter().flat_map(|s| s.split(' ')) {
+            let published = if found.resource_scopes.is_empty() {
+                found.server.scopes_supported.iter().any(|s| s == scope)
+            } else {
+                // `offline_access` is the one this build adds, and only ever on
+                // the authorisation server's say-so.
+                found.resource_scopes.iter().any(|s| s == scope)
+                    || (scope == "offline_access"
+                        && found.server.scopes_supported.iter().any(|s| s == scope))
+            };
+            assert!(
+                published,
+                "{} would be asked for `{scope}`, which it does not publish: \
+                 resource {:?}, server {:?}",
+                kind.label(),
+                found.resource_scopes,
+                found.server.scopes_supported
+            );
+            assert_ne!(scope, "*", "{} would be asked for everything", kind.label());
+        }
+
+        println!(
+            "{}: signs in at {}, asking for {}",
+            kind.label(),
+            found.issuer,
+            asked.as_deref().unwrap_or("nothing (the server's own default)")
+        );
     }
 }


### PR DESCRIPTION
Guaca asked the authorisation server's `scopes_supported` instead of the resource's, so AgentMail's Clerk instance refused every sign-in with `invalid_scope` on four scopes it does not grant a self-registered client; the resource's list (RFC 9728) now wins, the server's (RFC 8414) is the fallback, `*` is still dropped, and `offline_access` is added when the server names it so a plugin renews instead of asking to be signed in again every hour.

Cloudflare moves from `bindings.mcp.cloudflare.com`, one product area of fifteen, to `mcp.cloudflare.com`, the whole API behind `search` and `execute`, which costs about a thousand tokens of context rather than the million the same 2,500 endpoints would cost as tool definitions.

Migration 26 deletes the rows from before that move, because the grant was issued by an issuer the new host does not share and the stored tool list names tools it does not have.

The live vendor test is why this reached an operator: it checked discovery and never checked the scope, so all five passed while one refused every sign-in, and it now asserts that every scope this build would send is one the vendor publishes today (verified to fail on the old behaviour).

`./scripts/ci.sh`, the trajectory suite and `./scripts/plugins.sh` all pass; a completed sign-in still needs a browser and a real account, so that is unverified.