### PR TITLE
feat: a crew signs in to a plugin, and chooses which of its agents may spend it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,8 @@ src-tauri/src/
   domain/             AgentCard, Envelope, Routine, Connector, Signin, Approval,
                       Search, ids. No I/O.
     group.rs          A crew's wall, and the settings its agents run on.
-    plugin.rs         The servers a crew can sign in to, and what it got.
+    plugin.rs         The servers a crew can sign in to, what it got, and
+                      which of its agents may spend it.
   runtime/
     guard.rs          The loop guard. Read this one first.
     mod.rs            Agent actors and the message bus.
@@ -88,6 +89,7 @@ repo: the frontend renders state and forwards intent.
 | Hosted browsers, CDP, `browse`, live view, browser profiles | `docs/BROWSERS.md` |
 | Which of the two a piece of work belongs on, and credentials | *Connectors* in `docs/PROTOCOL.md`, then both files above |
 | Plugins: what is on the list, signing one in, calling its tools | `docs/PLUGINS.md`, then `oauth.rs` and `mcp.rs` |
+| Which agents in a crew get a plugin | *Signing in is one decision, and handing it out is another* in `docs/PLUGINS.md`, then `domain/plugin.rs` and `Store::plugin_tools`, which has to agree with `Store::plugin_reach` |
 | Channels, the rail, search: what the operator sees | `docs/WORKSPACE.md`, then `src/lib/transcript.ts` |
 | A turn's tool calls in a channel: what folds, what a chip says, what opens | *A turn's own work is chips* in `docs/WORKSPACE.md`, then `src/lib/trail.ts` |
 | Anything announced to a screen reader, or a live region | *A transcript is a log, and says one thing out loud* in `docs/WORKSPACE.md` |
@@ -214,6 +216,16 @@ the model takes a screenshot to see what `browse` did.
   the whole API behind `search` and `execute`: the model writes JavaScript
   against the OpenAPI document and Cloudflare runs it, so 2,500 endpoints cost
   about a thousand tokens instead of a million.
+- **A plugin's sign-in belongs to the group, and who may spend it does not.**
+  `PluginAccess` is `Everyone` or a named list, and the empty list is why it is
+  not one list with a sentinel: everyone covers agents nobody has hired yet, and
+  a list that meant everyone when it was empty would hand a plugin back to the
+  crew at the moment the operator unticked the last name. Filtering the tool
+  definitions is not the enforcement either. A model names tools it was never
+  offered, so `Store::plugin_reach` asks the same question again on the call
+  path, from the same SQL fragment, and its two refusals are different
+  sentences: "nobody connected this" is the operator's to fix, "connected, but
+  not for you" is a peer's to do.
 - **A plugin's tool list is read once and kept.** `tools/list` on every turn is
   a network round trip in front of every model call, paid by every agent in the
   crew, to re-learn something that changes when a vendor ships rather than when

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,7 +1,7 @@
 # Plugins
 
-A plugin is a server a crew signs in to once. After that, every agent in the
-group is offered that server's tools on every turn, and none of them ever holds
+A plugin is a server a crew signs in to once. After that, the agents that crew
+chose are offered that server's tools on every turn, and none of them ever holds
 the sign-in.
 
 There are five: Neon, Cloudflare, Linear, Stripe and AgentMail. That is the
@@ -191,6 +191,77 @@ can echo it; a plugin's grant never leaves the host process except onto the wire
 back to the server that issued it. There is no field on `Plugin` for a token to
 arrive in, and no command that returns one.
 
+## Signing in is one decision, and handing it out is another
+
+A group holds the sign-in. Who may spend it is a second question, asked per
+plugin, and until it was asked the answer was always "everybody in the crew".
+
+That answer only holds while a crew is uniform, and a crew is not. Agents run on
+different models at different competencies and cost, and they have different
+jobs. The one that files issues has no business holding the account that issues
+refunds, and an agent on a cheap model with Stripe in its tool list is a bad
+trade whichever way the turn goes: it is either being asked to be careful with
+something it cannot be careful with, or it is being paid for on every turn for a
+capability it will never use.
+
+So each connected plugin carries one of two answers:
+
+- **Every agent.** The default, what every plugin connected before this existed
+  keeps, and the right answer for most of them. It covers agents that do not
+  exist yet: an agent hired next week gets it without anybody going back to the
+  panel.
+- **Only these agents.** A list, and it may be empty. An empty one means nobody,
+  which is where an operator stands for the second between narrowing a plugin
+  and ticking the first name.
+
+Two states rather than a list with a sentinel, and the empty list is the reason.
+"Everyone" is a decision about people who have not been hired, which no list of
+today's ids can express, and a list that meant everyone when it was empty would
+hand a plugin back to the whole crew at the moment the operator unticked the
+last agent. `PluginAccess` is the type; `plugins.access` and `plugin_agents` are
+the two columns it reads back out of.
+
+### The rule is written once and read twice
+
+`Store::plugin_tools` decides what an agent is *told* it has, and
+`Store::plugin_reach` decides what it *gets*. Both paste the same SQL fragment,
+`PLUGIN_REACHED_BY_AGENT`, because the two disagreeing is either a model calling
+something it was never offered, or a model refused something the prompt told it
+to use, which it will then try again with different arguments.
+
+Filtering the tool definitions is not the enforcement. A model emits a tool name
+it read somewhere often enough that a tool list has to be treated as a
+description of what an agent has, never a fence: the call path asks the same
+question again and refuses on its own. The refusal is a different sentence from
+the one for a plugin nobody connected, and that matters more than it looks.
+"Neon is not connected" sends the operator to a panel that says Disconnect, and
+it never occurs to the agent to ask the peer who can. "Connected, but not for
+you" names the way forward, which is the peer.
+
+The peer is named for it too. An agent's roster already lists what each peer's
+browser is signed in to, so that an agent asked for something it has no account
+for can name the one who does rather than reporting that the crew cannot do it.
+A plugin this agent does not have and a peer does is exactly that case, and it
+is listed under exactly the same rule: only when this agent does not have it
+itself, or the roster reads as a reason to delegate work it could do.
+
+### What a change does not do
+
+Reconnecting does not widen. `save_plugin` leaves `access` alone and keeps the
+row's id, so an operator fixing a grant that was revoked at the vendor does not
+silently hand Stripe back to the crew while they are fixing something else.
+
+Retiring an agent takes its place with it, beside its approvals and its
+sign-ins, and disconnecting a plugin takes every place on it. A row naming an
+agent that no longer exists, or a plugin that is gone, is a standing permission
+attached to nothing.
+
+An access value this build does not recognise reads as a restriction, not as an
+opening. Only the literal `everyone` widens a plugin past its named agents, in
+the SQL and in `PluginAccess::from_row`. A permission that cannot be read has to
+fail closed: a crew losing a plugin is visible and one click to fix, and a crew
+silently gaining one is neither.
+
 ## A tool name is `plugin__tool`
 
 Two underscores, because MCP servers use one inside tool names constantly and
@@ -241,6 +312,12 @@ gated, because a prompt on every call would make plugins unusable, and the
 existing gate is aimed at the case where a page an agent has just read chose the
 button. The prompt carries the warning instead. This is the open question worth
 revisiting first.
+
+**No per-agent sign-in.** An agent is chosen from the crew's one grant; it does
+not get its own. Two sign-ins to the same vendor for one group would be two sets
+of tools under names a model cannot tell apart, and `plugins_kind_unique` says
+so at the schema. An operator who wants two accounts at one vendor wants two
+groups.
 
 **No operator-typed endpoint.** "Any MCP server" would mean an operator pasting
 a URL that Guaca then sends a crew's tokens to. The set is closed for the same

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -323,6 +323,15 @@ delete button a page apart. The state lives in the shell, so changing section
 cannot discard a half-typed endpoint. Plugins is disabled until the group
 exists, because a sign-in and a credential both have to belong to something.
 
+That section holds two decisions, not one. Connecting is the crew's sign-in;
+under each connected row is who in the crew may use it, which is every agent
+until an operator says otherwise. It is written the moment it is clicked, like
+the Connect and Disconnect buttons above it: a draft nobody submitted would be a
+permission the operator believes they granted. The reasoning is in
+`docs/PLUGINS.md`; what the panel owes the operator is the sentence saying who
+a plugin is currently offered to, including the honest one for a plugin narrowed
+to nobody, which is otherwise indistinguishable from a working row.
+
 Three rows say who pays, and the first is "follow the app settings", which is
 where every group starts. The second is the ChatGPT subscription, and the group
 editor cannot sign in: there is one sign-in on this machine, it is performed in

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -359,6 +359,7 @@ pub fn run() {
             commands::delete_connector,
             commands::plugin_catalogue,
             commands::group_plugins,
+            commands::set_plugin_access,
             commands::connect_plugin,
             commands::disconnect_plugin,
             commands::scan_agent_signins,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -23,7 +23,7 @@ use crate::domain::ids::{
     AgentId, ApprovalId, ConnectorId, GroupId, MessageId, PluginId, RoutineId, RunId,
 };
 use crate::domain::now_ms;
-use crate::domain::plugin::{self, Plugin, PluginKind, PluginOffer};
+use crate::domain::plugin::{self, Plugin, PluginAccess, PluginKind, PluginOffer};
 use crate::domain::routine::{self, Routine, RoutineRun, Trigger};
 use crate::domain::search::SearchHits;
 use crate::domain::signin::Signin;
@@ -398,6 +398,24 @@ pub async fn connect_plugin(
     Ok(plugin)
 }
 
+/// Chooses which of a crew's agents may call one plugin.
+///
+/// The whole answer, every time: `everyone`, or the complete list of agents.
+/// A merge would let a panel narrow a plugin by forgetting somebody, and this
+/// one renders what it last read.
+#[tauri::command]
+pub fn set_plugin_access(
+    state: State<'_, AppState>,
+    id: PluginId,
+    access: PluginAccess,
+) -> Reply<Plugin> {
+    let plugin = state.runtime.store().set_plugin_access(id, &access)?;
+    // Changes what every agent in the crew is offered on its next turn, and
+    // what the roster says its peers can reach.
+    state.runtime.emit(UiEvent::AgentsChanged);
+    Ok(plugin)
+}
+
 /// Forgets a plugin, and the grant with it.
 ///
 /// The grant is dropped locally rather than revoked at the vendor: not every
@@ -666,6 +684,10 @@ async fn retire_agent(state: &State<'_, AppState>, card: &AgentCard) -> Reply<()
     // reuse the moment an agent is deleted, and whoever takes it next must not
     // inherit a standing grant given to somebody else.
     let _ = state.runtime.store().delete_agent_approvals(id);
+    // And its place on any plugin the operator narrowed to named agents, for
+    // the same reason: a row naming an agent that no longer exists grants
+    // nothing and draws as nobody in the panel that lists them.
+    let _ = state.runtime.store().delete_agent_plugin_access(id);
     Ok(())
 }
 

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -734,6 +734,40 @@ DELETE FROM plugins WHERE kind = 'clerk';
 DELETE FROM plugins WHERE kind = 'cloudflare';
 "#,
     ),
+    (
+        27,
+        r#"
+-- Who in a crew may call a plugin, which until now was "all of them". A group
+-- signs in once and that was the whole decision, which only holds while a crew
+-- is uniform. A crew is not: agents run on different models at different
+-- competencies, and the one that files issues has no business holding the
+-- account that issues refunds.
+--
+-- 'everyone' is the default here and the default in `PluginAccess::from_row`,
+-- so every row that already exists keeps exactly the reach it had. Nothing an
+-- operator connected yesterday narrows because this migration ran.
+ALTER TABLE plugins ADD COLUMN access TEXT NOT NULL DEFAULT 'everyone';
+
+-- The named agents. Only ever populated while `access` is 'chosen': a write
+-- replaces the whole set, so flipping a plugin back to the whole crew leaves
+-- nothing behind claiming otherwise. Nothing here is a memory of a choice the
+-- operator has since changed.
+--
+-- No ON DELETE CASCADE. Foreign keys are off while migrations run, which is
+-- what SQLite's table-rebuild procedure wants, so a later migration deleting a
+-- plugin row would silently leave these behind; the deletes are written out at
+-- every call site instead, beside the ones that already remove a group's
+-- plugins and a retired agent's approvals.
+CREATE TABLE plugin_agents (
+    plugin_id TEXT NOT NULL REFERENCES plugins(id),
+    agent_id  TEXT NOT NULL REFERENCES agents(id),
+    PRIMARY KEY (plugin_id, agent_id)
+);
+
+-- Retiring an agent takes its permissions with it, and that read is by agent.
+CREATE INDEX plugin_agents_agent ON plugin_agents (agent_id);
+"#,
+    ),
 ];
 
 /// The group every agent starts in, and the one the UI keeps out of the way
@@ -909,6 +943,34 @@ mod tests {
             .map(Result::unwrap)
             .collect();
         assert_eq!(left, vec!["linear".to_string()], "and only Cloudflare's");
+    }
+
+    #[test]
+    fn a_plugin_connected_before_agents_could_be_chosen_stays_the_whole_crew_s() {
+        // The one thing this migration must not do. A crew whose Neon sign-in
+        // worked yesterday has to work today, without the operator opening a
+        // panel they have never seen to re-grant what they already had.
+        let mut conn = memory();
+        for (version, sql) in MIGRATIONS.iter().filter(|(v, _)| *v < 27) {
+            conn.execute_batch(sql).unwrap();
+            conn.pragma_update(None, "user_version", *version).unwrap();
+        }
+        conn.execute(
+            "INSERT INTO plugins (id,group_id,kind,account,tools,connected_at)
+             VALUES ('p1',?1,'neon','','[]',0)",
+            rusqlite::params![DEFAULT_GROUP_ID],
+        )
+        .unwrap();
+
+        run(&mut conn).unwrap();
+
+        let access: String = conn
+            .query_row("SELECT access FROM plugins WHERE id='p1'", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(access, "everyone");
+        let named: i64 =
+            conn.query_row("SELECT count(*) FROM plugin_agents", [], |row| row.get(0)).unwrap();
+        assert_eq!(named, 0, "nobody was named, and nobody needs to be");
     }
 
     #[test]

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use r2d2::{Pool, PooledConnection};
 use r2d2_sqlite::SqliteConnectionManager;
-use rusqlite::{params, OptionalExtension, Row};
+use rusqlite::{named_params, params, OptionalExtension, Row};
 
 use crate::db::migrations;
 use crate::domain::agent::{AgentCard, CleanDraft, Lifecycle};
@@ -21,7 +21,7 @@ use crate::domain::ids::{
     AgentId, ApprovalId, ConnectorId, GroupId, MessageId, PluginId, RoutineId, RunId,
 };
 use crate::domain::now_ms;
-use crate::domain::plugin::{Plugin, PluginKind, PluginTool};
+use crate::domain::plugin::{Plugin, PluginAccess, PluginKind, PluginTool};
 use crate::domain::routine::{NextSlot, Routine, RoutineRun, RunKind, Trigger};
 use crate::domain::search::{
     contains_fold, excerpt, like_pattern, links_in, FileHit, LinkHit, MessageHit, SearchHits,
@@ -57,6 +57,8 @@ pub enum StoreError {
     ConnectorNotFound(ConnectorId),
     #[error("no plugin with id {0}")]
     PluginNotFound(PluginId),
+    #[error("agent {0} is not in this group, so it cannot be given one of the group's plugins")]
+    AgentNotInGroup(AgentId),
     #[error("no permission request with id {0}")]
     ApprovalNotFound(ApprovalId),
     #[error("that request was already answered ({})", state.as_str())]
@@ -1065,9 +1067,10 @@ impl Store {
     /// is no command that returns one.
     pub fn group_plugins(&self, group: GroupId) -> Result<Vec<Plugin>, StoreError> {
         let conn = self.conn()?;
+        let chosen = self.chosen_agents(&conn, group)?;
         let mut stmt =
             conn.prepare(&format!("{PLUGIN_COLUMNS} WHERE group_id=?1 ORDER BY kind, rowid"))?;
-        let rows = stmt.query_map(params![group.to_string()], row_to_plugin)?;
+        let rows = stmt.query_map(params![group.to_string()], |row| row_to_plugin(row, &chosen))?;
         let mut out = Vec::new();
         for row in rows {
             // A row whose kind is not one this build knows is skipped rather
@@ -1081,21 +1084,67 @@ impl Store {
         Ok(out)
     }
 
-    /// What the crew can call, with the schemas the model is shown.
+    /// Every named agent in one group's plugins, by the plugin that named them.
+    ///
+    /// One query for the whole group rather than one per row: this is read to
+    /// draw a settings panel and to build a roster, and a query per plugin
+    /// would be five for a screen that shows five tiles.
+    fn chosen_agents(
+        &self,
+        conn: &Conn,
+        group: GroupId,
+    ) -> Result<HashMap<PluginId, Vec<AgentId>>, StoreError> {
+        let mut stmt = conn.prepare(
+            "SELECT plugin_agents.plugin_id, plugin_agents.agent_id
+               FROM plugin_agents
+               JOIN plugins ON plugins.id = plugin_agents.plugin_id
+              WHERE plugins.group_id = ?1
+              ORDER BY plugin_agents.rowid",
+        )?;
+        let rows = stmt.query_map(params![group.to_string()], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+
+        let mut out: HashMap<PluginId, Vec<AgentId>> = HashMap::new();
+        for row in rows {
+            let (plugin, agent) = row?;
+            let (Ok(plugin), Ok(agent)) = (plugin.parse::<PluginId>(), agent.parse::<AgentId>())
+            else {
+                // An id that will not parse names nothing, so it grants
+                // nothing. Dropping it is the fail-closed reading, and the
+                // alternative is a settings panel nobody can open.
+                continue;
+            };
+            out.entry(plugin).or_default().push(agent);
+        }
+        Ok(out)
+    }
+
+    /// What one agent can call, with the schemas the model is shown.
     ///
     /// Separate from `group_plugins` for the reason `connector_env` is separate
     /// from `group_connectors`: this is the bulk nothing but the turn needs,
     /// and it is read on the hot path rather than to draw a list.
+    ///
+    /// Filtered by agent rather than by group, because what is offered to a
+    /// model has to be what that model may actually call. The prompt is built
+    /// from the same list on the same turn, so an agent is never told about a
+    /// plugin it would be refused.
     pub fn plugin_tools(
         &self,
         group: GroupId,
+        agent: AgentId,
     ) -> Result<Vec<(PluginKind, Vec<PluginTool>)>, StoreError> {
         let conn = self.conn()?;
-        let mut stmt =
-            conn.prepare("SELECT kind, tools FROM plugins WHERE group_id=?1 ORDER BY kind, rowid")?;
-        let rows = stmt.query_map(params![group.to_string()], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        })?;
+        let mut stmt = conn.prepare(&format!(
+            "SELECT kind, tools FROM plugins
+              WHERE group_id=:group AND {PLUGIN_REACHED_BY_AGENT}
+              ORDER BY kind, rowid"
+        ))?;
+        let rows = stmt.query_map(
+            named_params! { ":group": group.to_string(), ":agent": agent.to_string() },
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )?;
 
         let mut out = Vec::new();
         for row in rows {
@@ -1108,39 +1157,68 @@ impl Store {
         Ok(out)
     }
 
-    /// The grant one plugin holds, and the row it belongs to.
+    /// What one agent gets when it names one of its crew's plugins.
     ///
     /// The only path a stored token takes out of this table, and it leads
     /// straight back to the server that issued it. Nothing here reaches a
     /// prompt, a transcript, an event or the webview.
-    pub fn plugin_grant(
+    ///
+    /// Three answers rather than an `Option`, because two of them are refusals
+    /// an agent reads mid-turn and they call for opposite things. "Nobody has
+    /// connected this" is something to tell the operator about; "you are not
+    /// one of the agents it was connected for" is something to hand to a peer.
+    /// Collapsing them would have an agent asking an operator to connect a
+    /// plugin they are looking at in the settings panel, already connected.
+    pub fn plugin_reach(
         &self,
         group: GroupId,
+        agent: AgentId,
         kind: PluginKind,
-    ) -> Result<Option<(PluginId, Option<crate::oauth::Grant>)>, StoreError> {
+    ) -> Result<PluginReach, StoreError> {
         let conn = self.conn()?;
-        let mut stmt = conn.prepare(
-            "SELECT id,access_token,refresh_token,expires_at,client_id,client_secret,token_endpoint
-               FROM plugins WHERE group_id=?1 AND kind=?2",
-        )?;
+        let mut stmt = conn.prepare(&format!(
+            "SELECT id,access_token,refresh_token,expires_at,client_id,client_secret,
+                    token_endpoint,{PLUGIN_REACHED_BY_AGENT}
+               FROM plugins WHERE group_id=:group AND kind=:kind",
+        ))?;
         let row = stmt
-            .query_row(params![group.to_string(), kind.slug()], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, String>(2)?,
-                    row.get::<_, Option<i64>>(3)?,
-                    row.get::<_, String>(4)?,
-                    row.get::<_, String>(5)?,
-                    row.get::<_, String>(6)?,
-                ))
-            })
+            .query_row(
+                named_params! {
+                    ":group": group.to_string(),
+                    ":kind": kind.slug(),
+                    ":agent": agent.to_string(),
+                },
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, Option<i64>>(3)?,
+                        row.get::<_, String>(4)?,
+                        row.get::<_, String>(5)?,
+                        row.get::<_, String>(6)?,
+                        row.get::<_, i64>(7)? != 0,
+                    ))
+                },
+            )
             .optional()?;
 
-        let Some((id, access, refresh, expires_at, client_id, client_secret, token_endpoint)) = row
+        let Some((
+            id,
+            access,
+            refresh,
+            expires_at,
+            client_id,
+            client_secret,
+            token_endpoint,
+            reached,
+        )) = row
         else {
-            return Ok(None);
+            return Ok(PluginReach::NotConnected);
         };
+        if !reached {
+            return Ok(PluginReach::NotChosen);
+        }
         let id = id
             .parse::<PluginId>()
             .map_err(|e| StoreError::Corrupt(format!("bad plugin id {id:?}: {e}")))?;
@@ -1157,7 +1235,86 @@ impl Store {
             client_secret: (!client_secret.is_empty()).then_some(client_secret),
             token_endpoint,
         });
-        Ok(Some((id, grant)))
+        Ok(PluginReach::Granted { id, grant })
+    }
+
+    /// Narrows a plugin to some of the crew, or opens it to all of it.
+    ///
+    /// The whole set is replaced, never merged. A caller that sent the agents
+    /// it knew about would narrow a plugin by forgetting one, and the panel
+    /// that sends this renders what it last read.
+    pub fn set_plugin_access(
+        &self,
+        id: PluginId,
+        access: &PluginAccess,
+    ) -> Result<Plugin, StoreError> {
+        let mut conn = self.conn()?;
+        let tx = conn.transaction()?;
+
+        let group: String = tx
+            .query_row("SELECT group_id FROM plugins WHERE id=?1", params![id.to_string()], |row| {
+                row.get(0)
+            })
+            .optional()?
+            .ok_or(StoreError::PluginNotFound(id))?;
+
+        if let PluginAccess::Chosen { agents } = access {
+            for agent in agents {
+                // Refused rather than filtered out. An agent from another crew
+                // could never reach this plugin anyway, because the turn asks
+                // by group as well as by agent, so storing one would be a row
+                // that means nothing and a settings panel drawing a name that
+                // grants nothing.
+                let known: Option<i64> = tx
+                    .query_row(
+                        "SELECT 1 FROM agents
+                          WHERE id=?1 AND group_id=?2 AND lifecycle<>'terminated'",
+                        params![agent.to_string(), group],
+                        |row| row.get(0),
+                    )
+                    .optional()?;
+                if known.is_none() {
+                    return Err(StoreError::AgentNotInGroup(*agent));
+                }
+            }
+        }
+
+        tx.execute(
+            "UPDATE plugins SET access=?2 WHERE id=?1",
+            params![id.to_string(), access.as_str()],
+        )?;
+        tx.execute("DELETE FROM plugin_agents WHERE plugin_id=?1", params![id.to_string()])?;
+        if let PluginAccess::Chosen { agents } = access {
+            for agent in agents {
+                // A set, so a name sent twice is one row rather than a
+                // conflict. Nothing about who may call this depends on how
+                // many times the caller listed them.
+                tx.execute(
+                    "INSERT OR IGNORE INTO plugin_agents (plugin_id, agent_id) VALUES (?1, ?2)",
+                    params![id.to_string(), agent.to_string()],
+                )?;
+            }
+        }
+        tx.commit()?;
+
+        let group = group
+            .parse::<GroupId>()
+            .map_err(|e| StoreError::Corrupt(format!("bad group id {group:?}: {e}")))?;
+        self.group_plugins(group)?
+            .into_iter()
+            .find(|plugin| plugin.id == id)
+            .ok_or(StoreError::PluginNotFound(id))
+    }
+
+    /// Drops one agent's place on every plugin that named it.
+    ///
+    /// Called when an agent is retired, for the reason its approvals are: a
+    /// permission the operator gave to an agent that no longer exists is a row
+    /// nothing can act on and a name in a settings panel that points at nobody.
+    pub fn delete_agent_plugin_access(&self, agent: AgentId) -> Result<usize, StoreError> {
+        let conn = self.conn()?;
+        Ok(conn
+            .execute("DELETE FROM plugin_agents WHERE agent_id=?1", params![agent.to_string()])?)
     }
 
     /// Records a connection, replacing whatever was there for that server.
@@ -1165,6 +1322,12 @@ impl Store {
     /// Replace rather than reject: connecting again is how an operator fixes a
     /// grant that was revoked at the vendor, and the unique index makes an
     /// insert the wrong shape for that.
+    ///
+    /// `access` is not in the update, and the row keeps its id, so who may call
+    /// the plugin survives the sign-in being redone. Renewing a grant is not a
+    /// decision about the crew, and a reconnection that quietly handed Stripe
+    /// back to everybody would undo one silently, at the moment the operator
+    /// was fixing something else.
     pub fn save_plugin(
         &self,
         group: GroupId,
@@ -1234,9 +1397,19 @@ impl Store {
         Ok(())
     }
 
+    /// Forgets a plugin, its grant, and who was allowed to spend it.
+    ///
+    /// The named agents go first, and not only because the foreign key would
+    /// refuse otherwise: a row naming a plugin that is gone would be a standing
+    /// permission attached to nothing, waiting to attach itself to whatever
+    /// took the id next.
     pub fn delete_plugin(&self, id: PluginId) -> Result<bool, StoreError> {
-        let conn = self.conn()?;
-        Ok(conn.execute("DELETE FROM plugins WHERE id=?1", params![id.to_string()])? > 0)
+        let mut conn = self.conn()?;
+        let tx = conn.transaction()?;
+        tx.execute("DELETE FROM plugin_agents WHERE plugin_id=?1", params![id.to_string()])?;
+        let removed = tx.execute("DELETE FROM plugins WHERE id=?1", params![id.to_string()])?;
+        tx.commit()?;
+        Ok(removed > 0)
     }
 
     // ---- sign-ins --------------------------------------------------------
@@ -1569,7 +1742,13 @@ impl Store {
         conn.execute("DELETE FROM connectors WHERE group_id=?1", params![id.to_string()])?;
         // And its plugins, for both of those reasons and one more: the row
         // holds a grant against the operator's own Neon or Cloudflare account,
-        // and a disbanded crew is not a reason to keep one.
+        // and a disbanded crew is not a reason to keep one. Whoever was named
+        // on one goes first, or the foreign key refuses the line below.
+        conn.execute(
+            "DELETE FROM plugin_agents WHERE plugin_id IN
+                 (SELECT id FROM plugins WHERE group_id=?1)",
+            params![id.to_string()],
+        )?;
         conn.execute("DELETE FROM plugins WHERE group_id=?1", params![id.to_string()])?;
         conn.execute("DELETE FROM groups WHERE id=?1", params![id.to_string()])?;
         Ok(())
@@ -2330,34 +2509,76 @@ fn row_to_connector(row: &Row<'_>) -> RowResult<Connector> {
     })())
 }
 
+/// What one agent gets when it names one of its crew's plugins.
+///
+/// The two refusals are separate because they are read by a model mid-turn and
+/// they have different answers: one is the operator's to fix, the other is a
+/// peer's to do.
+#[derive(Debug)]
+pub enum PluginReach {
+    /// No row: this crew has not connected it, and no agent can.
+    NotConnected,
+    /// Connected, and this agent is not one of the ones it was connected for.
+    NotChosen,
+    /// The row, and the grant to spend against it. `None` for a server that
+    /// authorised nobody because it asked for nothing.
+    Granted { id: PluginId, grant: Option<crate::oauth::Grant> },
+}
+
 const PLUGIN_COLUMNS: &str =
-    "SELECT id,group_id,kind,account,tools,access_token,connected_at FROM plugins";
+    "SELECT id,group_id,kind,account,tools,access_token,connected_at,access FROM plugins";
+
+/// The one rule that decides whether an agent is offered a plugin's tools and
+/// whether a call it makes may spend the grant.
+///
+/// Written once and pasted into both queries, because a turn where the two
+/// disagree is either a model calling something it was never told it had, or a
+/// model refused something it was told it had and told to try again. Named
+/// parameters rather than numbered so the fragment does not care where it lands
+/// in the statement around it.
+///
+/// The comparison is what makes it fail closed: only the literal `everyone`
+/// widens a plugin past its named agents, so a value written by a build this
+/// one has never met restricts rather than opens.
+const PLUGIN_REACHED_BY_AGENT: &str = "(plugins.access = 'everyone'
+     OR EXISTS (SELECT 1 FROM plugin_agents
+                 WHERE plugin_agents.plugin_id = plugins.id
+                   AND plugin_agents.agent_id = :agent))";
 
 /// `None` for a row naming a plugin this build does not have, which is what a
 /// downgrade leaves behind. Corrupt rows still raise: a tool list that will not
 /// parse is a bug here, not a version skew.
-fn row_to_plugin(row: &Row<'_>) -> RowResult<Option<Plugin>> {
+///
+/// `chosen` is the row's named agents, read separately because they are a
+/// second table. A plugin missing from that map is one with nobody named.
+fn row_to_plugin(
+    row: &Row<'_>,
+    chosen: &HashMap<PluginId, Vec<AgentId>>,
+) -> RowResult<Option<Plugin>> {
     let id_raw: String = row.get(0)?;
     let group_raw: String = row.get(1)?;
     let kind_raw: String = row.get(2)?;
     let tools_raw: String = row.get(4)?;
     let access: String = row.get(5)?;
+    let reach: String = row.get(7)?;
 
     Ok((|| {
         let Some(kind) = PluginKind::from_slug(&kind_raw) else { return Ok(None) };
         let tools: Vec<PluginTool> = serde_json::from_str(&tools_raw)
             .map_err(|e| StoreError::Corrupt(format!("bad tool list for {kind_raw:?}: {e}")))?;
+        let id = id_raw
+            .parse::<PluginId>()
+            .map_err(|e| StoreError::Corrupt(format!("bad plugin id {id_raw:?}: {e}")))?;
 
         Ok(Some(Plugin {
-            id: id_raw
-                .parse::<PluginId>()
-                .map_err(|e| StoreError::Corrupt(format!("bad plugin id {id_raw:?}: {e}")))?,
+            id,
             group_id: group_raw
                 .parse::<GroupId>()
                 .map_err(|e| StoreError::Corrupt(format!("bad group id {group_raw:?}: {e}")))?,
             kind,
             account: row.get(3)?,
             tools: tools.into_iter().map(|tool| tool.name).collect(),
+            access: PluginAccess::from_row(&reach, chosen.get(&id).cloned().unwrap_or_default()),
             signed_in: !access.is_empty(),
             connected_at: row.get(6)?,
         }))
@@ -2487,6 +2708,16 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open(&dir.path().join("guac.db")).unwrap();
         Fixture { store, _dir: dir }
+    }
+
+    /// One tool on a connected plugin. What it does is never read here; what
+    /// matters is whether it is offered at all.
+    fn tool(name: &str) -> PluginTool {
+        PluginTool {
+            name: name.into(),
+            description: String::new(),
+            input_schema: serde_json::json!({ "type": "object" }),
+        }
     }
 
     fn draft(name: &str) -> CleanDraft {
@@ -4505,8 +4736,9 @@ mod tests {
             )
             .unwrap();
 
+        let agent = f.store.create_agent(&draft("Manager")).unwrap();
         assert!(f.store.group_plugins(group).unwrap().is_empty());
-        assert!(f.store.plugin_tools(group).unwrap().is_empty());
+        assert!(f.store.plugin_tools(group, agent.id).unwrap().is_empty());
     }
 
     #[test]
@@ -4523,7 +4755,10 @@ mod tests {
 
         f.store.delete_group(group.id).unwrap();
         assert!(f.store.group_plugins(group.id).unwrap().is_empty());
-        assert!(f.store.plugin_grant(group.id, PluginKind::Neon).unwrap().is_none());
+        assert!(matches!(
+            f.store.plugin_reach(group.id, AgentId::new(), PluginKind::Neon).unwrap(),
+            PluginReach::NotConnected
+        ));
     }
 
     #[test]
@@ -4536,8 +4771,223 @@ mod tests {
         let group = default_group_id();
         f.store.save_plugin(group, PluginKind::Neon, "", &[], None).unwrap();
 
-        let (_, grant) = f.store.plugin_grant(group, PluginKind::Neon).unwrap().unwrap();
+        let agent = f.store.create_agent(&draft("Manager")).unwrap();
+        let PluginReach::Granted { grant, .. } =
+            f.store.plugin_reach(group, agent.id, PluginKind::Neon).unwrap()
+        else {
+            panic!("a connected plugin is reachable by the crew it was connected for")
+        };
         assert!(grant.is_none());
         assert!(!f.store.group_plugins(group).unwrap()[0].signed_in);
+    }
+
+    #[test]
+    fn a_plugin_is_the_whole_crew_s_until_somebody_says_otherwise() {
+        // The default, and the reading every plugin connected before this
+        // existed keeps. An operator who has never opened this control has a
+        // crew that works exactly as it did.
+        let f = fixture();
+        let group = default_group_id();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        f.store.save_plugin(group, PluginKind::Neon, "", &[tool("run_sql")], None).unwrap();
+
+        assert_eq!(f.store.group_plugins(group).unwrap()[0].access, PluginAccess::Everyone);
+        assert_eq!(f.store.plugin_tools(group, manager.id).unwrap().len(), 1);
+
+        // Including an agent hired after the plugin was connected, which is the
+        // half a list of ids could not express.
+        let hired = f.store.create_agent(&draft("Researcher")).unwrap();
+        assert_eq!(f.store.plugin_tools(group, hired.id).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn a_narrowed_plugin_is_offered_to_the_chosen_and_to_nobody_else() {
+        let f = fixture();
+        let group = default_group_id();
+        let revenue = f.store.create_agent(&draft("Revenue")).unwrap();
+        let scribe = f.store.create_agent(&draft("Scribe")).unwrap();
+        let plugin =
+            f.store.save_plugin(group, PluginKind::Stripe, "", &[tool("refund")], None).unwrap();
+
+        let saved = f
+            .store
+            .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![revenue.id] })
+            .unwrap();
+        assert_eq!(saved.access, PluginAccess::Chosen { agents: vec![revenue.id] });
+
+        assert_eq!(f.store.plugin_tools(group, revenue.id).unwrap().len(), 1);
+        assert!(f.store.plugin_tools(group, scribe.id).unwrap().is_empty());
+
+        // And the tool list and the grant agree, because a model can name a
+        // tool it was never offered.
+        assert!(matches!(
+            f.store.plugin_reach(group, revenue.id, PluginKind::Stripe).unwrap(),
+            PluginReach::Granted { .. }
+        ));
+        assert!(matches!(
+            f.store.plugin_reach(group, scribe.id, PluginKind::Stripe).unwrap(),
+            PluginReach::NotChosen
+        ));
+    }
+
+    #[test]
+    fn a_plugin_narrowed_to_nobody_is_a_plugin_nobody_gets() {
+        // Reachable in the UI on the way to naming the first agent, so it has
+        // to mean what it says. An empty list read as "everyone" would hand the
+        // plugin back to the crew at the moment the last name was removed.
+        let f = fixture();
+        let group = default_group_id();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let plugin =
+            f.store.save_plugin(group, PluginKind::Stripe, "", &[tool("refund")], None).unwrap();
+
+        f.store.set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![] }).unwrap();
+
+        assert!(f.store.plugin_tools(group, manager.id).unwrap().is_empty());
+        assert!(matches!(
+            f.store.plugin_reach(group, manager.id, PluginKind::Stripe).unwrap(),
+            PluginReach::NotChosen
+        ));
+    }
+
+    #[test]
+    fn opening_a_plugin_back_up_leaves_nothing_behind_that_still_names_anybody() {
+        // The stored state has to be what is true. A remembered list would be a
+        // decision the operator has already changed, waiting to come back.
+        let f = fixture();
+        let group = default_group_id();
+        let revenue = f.store.create_agent(&draft("Revenue")).unwrap();
+        let plugin = f.store.save_plugin(group, PluginKind::Stripe, "", &[], None).unwrap();
+
+        f.store
+            .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![revenue.id] })
+            .unwrap();
+        let opened = f.store.set_plugin_access(plugin.id, &PluginAccess::Everyone).unwrap();
+
+        assert_eq!(opened.access, PluginAccess::Everyone);
+        let left: i64 = f
+            .store
+            .conn()
+            .unwrap()
+            .query_row("SELECT count(*) FROM plugin_agents", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(left, 0);
+    }
+
+    #[test]
+    fn an_agent_from_another_crew_cannot_be_named_on_a_plugin() {
+        // It could never reach it — the turn asks by group as well as by agent
+        // — so the row would grant nothing and draw as a name in a panel that
+        // means nothing.
+        let f = fixture();
+        let other = f
+            .store
+            .create_group(&CleanGroup { name: "Elsewhere".into(), ..Default::default() })
+            .unwrap();
+        let outsider = f
+            .store
+            .create_agent(&CleanDraft { group_id: Some(other.id), ..draft("Outsider") })
+            .unwrap();
+        let plugin =
+            f.store.save_plugin(default_group_id(), PluginKind::Stripe, "", &[], None).unwrap();
+
+        let refused = f
+            .store
+            .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![outsider.id] })
+            .unwrap_err();
+        assert!(matches!(refused, StoreError::AgentNotInGroup(id) if id == outsider.id));
+    }
+
+    #[test]
+    fn connecting_again_does_not_hand_a_narrowed_plugin_back_to_the_crew() {
+        // Reconnecting is how an operator fixes a grant revoked at the vendor.
+        // It is not a decision about who may use it, and one that quietly
+        // widened the plugin would undo the narrowing at the moment the
+        // operator was fixing something else.
+        let f = fixture();
+        let group = default_group_id();
+        let revenue = f.store.create_agent(&draft("Revenue")).unwrap();
+        let scribe = f.store.create_agent(&draft("Scribe")).unwrap();
+        let plugin =
+            f.store.save_plugin(group, PluginKind::Stripe, "", &[tool("refund")], None).unwrap();
+        f.store
+            .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![revenue.id] })
+            .unwrap();
+
+        let again =
+            f.store.save_plugin(group, PluginKind::Stripe, "", &[tool("refund")], None).unwrap();
+
+        assert_eq!(again.access, PluginAccess::Chosen { agents: vec![revenue.id] });
+        assert!(f.store.plugin_tools(group, scribe.id).unwrap().is_empty());
+    }
+
+    #[test]
+    fn retiring_an_agent_takes_its_place_on_a_plugin_with_it() {
+        let f = fixture();
+        let group = default_group_id();
+        let revenue = f.store.create_agent(&draft("Revenue")).unwrap();
+        let plugin = f.store.save_plugin(group, PluginKind::Stripe, "", &[], None).unwrap();
+        f.store
+            .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![revenue.id] })
+            .unwrap();
+
+        assert_eq!(f.store.delete_agent_plugin_access(revenue.id).unwrap(), 1);
+        assert_eq!(
+            f.store.group_plugins(group).unwrap()[0].access,
+            PluginAccess::Chosen { agents: vec![] },
+            "the plugin stays narrowed; it just names nobody"
+        );
+    }
+
+    #[test]
+    fn disconnecting_a_narrowed_plugin_leaves_no_permission_behind() {
+        // The foreign key would refuse the delete, and a row naming a plugin
+        // that is gone is a standing permission attached to nothing.
+        let f = fixture();
+        let group = default_group_id();
+        let revenue = f.store.create_agent(&draft("Revenue")).unwrap();
+        let plugin = f.store.save_plugin(group, PluginKind::Stripe, "", &[], None).unwrap();
+        f.store
+            .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![revenue.id] })
+            .unwrap();
+
+        assert!(f.store.delete_plugin(plugin.id).unwrap());
+        let left: i64 = f
+            .store
+            .conn()
+            .unwrap()
+            .query_row("SELECT count(*) FROM plugin_agents", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(left, 0);
+    }
+
+    #[test]
+    fn an_access_value_this_build_does_not_know_shuts_the_plugin_rather_than_opening_it() {
+        // What a downgrade leaves behind. A permission that cannot be read has
+        // to fail closed: the crew losing a plugin is visible and fixable, and
+        // a crew silently gaining one is neither.
+        let f = fixture();
+        let group = default_group_id();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let plugin =
+            f.store.save_plugin(group, PluginKind::Neon, "", &[tool("run_sql")], None).unwrap();
+        f.store
+            .conn()
+            .unwrap()
+            .execute(
+                "UPDATE plugins SET access='whoever' WHERE id=?1",
+                params![plugin.id.to_string()],
+            )
+            .unwrap();
+
+        assert!(f.store.plugin_tools(group, manager.id).unwrap().is_empty());
+        assert!(matches!(
+            f.store.plugin_reach(group, manager.id, PluginKind::Neon).unwrap(),
+            PluginReach::NotChosen
+        ));
+        assert_eq!(
+            f.store.group_plugins(group).unwrap()[0].access,
+            PluginAccess::Chosen { agents: vec![] }
+        );
     }
 }

--- a/src-tauri/src/domain/agent.rs
+++ b/src-tauri/src/domain/agent.rs
@@ -143,12 +143,15 @@ pub struct DirectoryEntry {
     pub id: AgentId,
     pub name: String,
     pub skills: Vec<String>,
-    /// Accounts signed in on this agent's machine, as `Gmail as robert@…`.
+    /// What this peer can reach and the reader cannot: accounts signed in on its
+    /// machine, as `Gmail as robert@…`, and any of the crew's plugins the
+    /// reader was not chosen for, as `the Stripe plugin`.
     ///
     /// A skill is a claim its agent wrote about itself; this is a fact the
     /// operator established. It is here so an agent asked for something it has
     /// no account for can name the peer that does, instead of reporting that
-    /// the crew cannot do it.
+    /// the crew cannot do it. Only what the reader lacks: listing something it
+    /// holds itself reads as a reason to delegate work it can already do.
     #[serde(default)]
     pub reaches: Vec<String>,
     pub lifecycle: Lifecycle,

--- a/src-tauri/src/domain/plugin.rs
+++ b/src-tauri/src/domain/plugin.rs
@@ -1,10 +1,14 @@
 //! Plugins: the services a crew can reach through their own MCP server.
 //!
 //! A plugin is not a credential. It is a remote server the operator signs in
-//! to once, on behalf of a group, after which that server's tools are offered
-//! to every agent in the crew on every turn. Nothing is pasted, nothing is put
+//! to once, on behalf of a group, after which the agents that group chose are
+//! offered that server's tools on every turn. Nothing is pasted, nothing is put
 //! into a machine's environment, and the agent never holds a token: the call
 //! goes out of Guaca over HTTP with the group's own grant on it.
+//!
+//! Signing in and being allowed to spend the sign-in are two decisions, and
+//! [`PluginAccess`] is the second. Everyone in the crew is the default and the
+//! usual answer; Stripe is the one that is not.
 //!
 //! That is the whole reason this exists beside [`super::connector`], which is
 //! the other half and stays. A credential is for a service an agent reaches by
@@ -42,7 +46,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::ids::{GroupId, PluginId};
+use super::ids::{AgentId, GroupId, PluginId};
 
 /// One of the servers Guaca knows how to sign in to.
 ///
@@ -191,6 +195,74 @@ pub struct PluginTool {
     pub input_schema: serde_json::Value,
 }
 
+/// Who in a crew may call one plugin's tools.
+///
+/// A plugin is signed in once, for the group, and until this existed that
+/// sign-in was the whole decision: every agent in the crew was offered every
+/// tool it published. That reading only holds while a crew is uniform. A crew
+/// is not: agents run on different models at different competencies, and the
+/// one that files issues has no business holding the account that issues
+/// refunds. So the sign-in stays the group's and who may spend it becomes a
+/// second question, asked per plugin because that is the shape the answer has:
+/// most plugins are for everybody and one or two are for one agent.
+///
+/// Two states rather than a list with a sentinel, and the empty list is why.
+/// `Everyone` is a decision about agents that do not exist yet — an agent hired
+/// tomorrow gets it — which no list of today's ids can express. And a list that
+/// meant "everyone" when it was empty would hand a plugin back to the whole
+/// crew at the moment the operator unticked the last agent, which is the exact
+/// opposite of what unticking means.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum PluginAccess {
+    /// Everyone in the group, including whoever joins it later.
+    Everyone,
+    /// These agents and nobody else. Legally empty: a plugin nobody may call is
+    /// what an operator has on the way to naming the first one, and it is a
+    /// state the UI says out loud rather than one this type forbids.
+    Chosen { agents: Vec<AgentId> },
+}
+
+/// The stored form of [`PluginAccess::Everyone`], and the only value that
+/// widens a plugin past its named agents.
+///
+/// Compared rather than parsed, in SQL and here, so that a value neither side
+/// recognises reads as a restriction rather than as an opening. A permission
+/// that cannot be read must fail closed: the crew loses a plugin, which the
+/// operator can see and fix, rather than gaining one nobody chose.
+pub const ACCESS_EVERYONE: &str = "everyone";
+
+/// The stored form of [`PluginAccess::Chosen`].
+pub const ACCESS_CHOSEN: &str = "chosen";
+
+impl PluginAccess {
+    /// Whether this agent may be offered the plugin's tools, and may spend its
+    /// grant. The same question in both places, asked of the same value.
+    pub fn allows(&self, agent: AgentId) -> bool {
+        match self {
+            PluginAccess::Everyone => true,
+            PluginAccess::Chosen { agents } => agents.contains(&agent),
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PluginAccess::Everyone => ACCESS_EVERYONE,
+            PluginAccess::Chosen { .. } => ACCESS_CHOSEN,
+        }
+    }
+
+    /// Reads a row back. See [`ACCESS_EVERYONE`] for why anything else is a
+    /// restriction rather than an error.
+    pub fn from_row(access: &str, agents: Vec<AgentId>) -> Self {
+        if access == ACCESS_EVERYONE {
+            PluginAccess::Everyone
+        } else {
+            PluginAccess::Chosen { agents }
+        }
+    }
+}
+
 /// A plugin a group has connected.
 ///
 /// Serialisable in full: there is no grant on it. The tokens live in the store
@@ -210,6 +282,10 @@ pub struct Plugin {
     /// they are bulk the webview has no use for, and the runtime reads them
     /// from the store on the turn that needs them.
     pub tools: Vec<String>,
+    /// Which of the crew may call them. The sign-in behind this row is the
+    /// group's either way: this decides who is allowed to spend it, not who
+    /// holds it.
+    pub access: PluginAccess,
     /// False for a server that authorised nothing because it asked for nothing.
     /// Every server on the list today asks, so this is true in practice; it is
     /// read off whether a grant was actually issued rather than off the fact

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -26,8 +26,8 @@
 //! environment. This is the same boundary a pasted credential has, and it is
 //! stronger, because with a plugin there is no variable for the agent to echo.
 
-use crate::db::store::{Store, StoreError};
-use crate::domain::ids::{GroupId, PluginId};
+use crate::db::store::{PluginReach, Store, StoreError};
+use crate::domain::ids::{AgentId, GroupId, PluginId};
 use crate::domain::now_ms;
 use crate::domain::plugin::{Plugin, PluginKind, PluginTool};
 use crate::mcp::{self, McpError};
@@ -46,6 +46,12 @@ pub enum PluginError {
          Plugins settings; nothing you can do from here will connect it."
     )]
     NotConnected { label: &'static str },
+    #[error(
+        "{label} is connected for this group, but not for you: the operator chose which agents \
+         may use it. Ask a peer who has it to do that part, or ask the operator to add you in \
+         the group's Plugins settings. Nothing you can do from here will add you."
+    )]
+    NotChosen { label: &'static str },
     #[error(
         "{label}'s sign-in is no longer accepted, and renewing it did not work. Ask the operator \
          to connect it again in the group's Plugins settings."
@@ -113,6 +119,11 @@ pub async fn connect(
 
 /// Runs one of a plugin's tools on behalf of an agent.
 ///
+/// Asked of the agent rather than of its group, and that is the check rather
+/// than a second one: a model can name a tool it was never offered, so
+/// filtering the definitions decides what an agent is *told* it has and this
+/// decides what it *gets*. The two read the same rule, in `plugin_reach`.
+///
 /// Renews the grant first when it is close to expiring, and once more if the
 /// server rejects it anyway: a token can be revoked at the vendor between one
 /// turn and the next, and a clock that is a little wrong makes "close to
@@ -120,14 +131,17 @@ pub async fn connect(
 pub async fn call(
     store: &Store,
     group: GroupId,
+    agent: AgentId,
     kind: PluginKind,
     // See `connect`: production passes `kind.endpoint()`.
     endpoint: &str,
     tool: &str,
     arguments: &serde_json::Value,
 ) -> Result<String, PluginError> {
-    let Some((id, grant)) = store.plugin_grant(group, kind)? else {
-        return Err(PluginError::NotConnected { label: kind.label() });
+    let (id, grant) = match store.plugin_reach(group, agent, kind)? {
+        PluginReach::Granted { id, grant } => (id, grant),
+        PluginReach::NotConnected => return Err(PluginError::NotConnected { label: kind.label() }),
+        PluginReach::NotChosen => return Err(PluginError::NotChosen { label: kind.label() }),
     };
 
     let grant = match grant {
@@ -188,6 +202,19 @@ mod tests {
         assert!(refusal.contains("Neon"));
         assert!(refusal.contains("operator"));
         assert!(refusal.contains("nothing you can do"));
+    }
+
+    #[test]
+    fn a_plugin_this_agent_was_not_chosen_for_does_not_read_as_a_missing_sign_in() {
+        // Two refusals, two different answers. An agent told "not connected"
+        // about a plugin the crew is using would send the operator to a panel
+        // that already says Disconnect, and would never think to ask the peer
+        // who can actually do it.
+        let refusal = PluginError::NotChosen { label: "Stripe" }.to_string();
+        assert!(refusal.contains("Stripe"));
+        assert!(refusal.contains("not for you"), "{refusal}");
+        assert!(refusal.contains("peer"), "the way forward is delegation: {refusal}");
+        assert!(!refusal.contains("is not connected"), "{refusal}");
     }
 
     #[test]

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -1678,12 +1678,14 @@ impl Runtime {
         }
 
         let (credentials, signins) = self.reach_of(&card);
-        // What the crew has signed in to, read once for the same two uses as
-        // everything above: it is named in the prompt and offered as tools, and
-        // a turn where those two disagree is a model calling something it was
-        // never told it had, or being told about something it cannot call.
-        let plugins = self.inner.store.plugin_tools(card.group_id).unwrap_or_else(|err| {
-            tracing::warn!(%err, "could not read this group's plugins for its turn");
+        // What the crew has signed in to *and this agent may spend*, read once
+        // for the same two uses as everything above: it is named in the prompt
+        // and offered as tools, and a turn where those two disagree is a model
+        // calling something it was never told it had, or being told about
+        // something it cannot call. A plugin the crew has and this agent was
+        // not chosen for is neither, which is the whole point of the filter.
+        let plugins = self.inner.store.plugin_tools(card.group_id, card.id).unwrap_or_else(|err| {
+            tracing::warn!(%err, "could not read this agent's plugins for its turn");
             Vec::new()
         });
         // What this agent actually has, decided once and used twice: the prompt
@@ -2634,6 +2636,7 @@ impl Runtime {
                 let called = plugins::call(
                     self.store(),
                     card.group_id,
+                    card.id,
                     kind,
                     self.plugin_endpoint(kind),
                     &tool,
@@ -3859,6 +3862,26 @@ impl Runtime {
         let mut reaches: HashMap<AgentId, Vec<String>> = HashMap::new();
         for signin in self.inner.store.group_signins(group).unwrap_or_default() {
             reaches.entry(signin.agent_id).or_default().push(signin.label());
+        }
+
+        // And the crew's plugins, under exactly the rule the credentials above
+        // are left out by: a plugin this agent may call itself is not a reason
+        // to ask anybody. What is left is the one case narrowing a plugin
+        // creates — the crew can refund a payment and this agent cannot — and
+        // without it the honest answer to "refund this" becomes "we can't",
+        // from an agent sitting next to the one who can.
+        for plugin in self.inner.store.group_plugins(group).unwrap_or_default() {
+            if plugin.access.allows(me) {
+                continue;
+            }
+            for card in &agents {
+                if card.id != me && card.group_id == group && plugin.access.allows(card.id) {
+                    reaches
+                        .entry(card.id)
+                        .or_default()
+                        .push(format!("the {} plugin", plugin.kind.label()));
+                }
+            }
         }
 
         agents

--- a/src-tauri/tests/plugins.rs
+++ b/src-tauri/tests/plugins.rs
@@ -30,10 +30,12 @@ use axum::routing::{get, post};
 use axum::Router;
 use parking_lot::Mutex;
 
+use guac_lib::db::store::PluginReach;
 use guac_lib::db::Store;
+use guac_lib::domain::agent::CleanDraft;
 use guac_lib::domain::group::CleanGroup;
-use guac_lib::domain::ids::GroupId;
-use guac_lib::domain::plugin::PluginKind;
+use guac_lib::domain::ids::{AgentId, GroupId};
+use guac_lib::domain::plugin::{PluginAccess, PluginKind};
 use guac_lib::llm::tools::{self, ToolInvocation};
 use guac_lib::plugins;
 
@@ -378,14 +380,33 @@ fn unescape(raw: &str) -> String {
 }
 
 /// A store with one group in it, in a directory that dies with the test.
-fn workspace() -> (tempfile::TempDir, Store, GroupId) {
+/// A crew of one, which is what every call below is made on behalf of. A
+/// plugin call is an agent's, not a group's: the group holds the sign-in and
+/// the agent has to be one the operator allowed to spend it.
+fn workspace() -> (tempfile::TempDir, Store, GroupId, AgentId) {
     let dir = tempfile::tempdir().unwrap();
     let store = Store::open(&dir.path().join("guac.db")).unwrap();
     let group = store
         .create_group(&CleanGroup { name: "Crew".to_string(), ..Default::default() })
         .unwrap()
         .id;
-    (dir, store, group)
+    let agent = crew(&store, group, "Manager");
+    (dir, store, group, agent)
+}
+
+fn crew(store: &Store, group: GroupId, name: &str) -> AgentId {
+    store
+        .create_agent(&CleanDraft {
+            group_id: Some(group),
+            name: name.to_string(),
+            avatar: "avocado".to_string(),
+            color: "#7fb069".to_string(),
+            model: "anthropic/claude-sonnet-4.5".to_string(),
+            system_prompt: "be useful".to_string(),
+            skills: Vec::new(),
+        })
+        .unwrap()
+        .id
 }
 
 #[tokio::test]
@@ -395,7 +416,7 @@ async fn a_server_that_asks_for_nothing_connects_without_sending_anybody_to_a_br
     // happened. No vendor on the list is public today; this is the behaviour if
     // one becomes it, and the live test is what would say so.
     let server = serve(Rules { needs_token: false, ..Default::default() }).await;
-    let (_dir, store, group) = workspace();
+    let (_dir, store, group, _agent) = workspace();
 
     let plugin = plugins::connect(
         &store,
@@ -415,7 +436,7 @@ async fn a_server_that_asks_for_nothing_connects_without_sending_anybody_to_a_br
 #[tokio::test]
 async fn a_protected_server_signs_in_and_the_grant_stays_in_the_store() {
     let server = serve(Rules::default()).await;
-    let (_dir, store, group) = workspace();
+    let (_dir, store, group, _agent) = workspace();
 
     let plugin = plugins::connect(
         &store,
@@ -445,7 +466,7 @@ async fn a_redirect_that_does_not_match_is_refused() {
     // Nothing else can arrive on that port with the wrong state, so this is an
     // attack rather than a mistake, and it must not produce a usable plugin.
     let server = serve(Rules::default()).await;
-    let (_dir, store, group) = workspace();
+    let (_dir, store, group, _agent) = workspace();
 
     let failed = plugins::connect(
         &store,
@@ -464,7 +485,7 @@ async fn a_redirect_that_does_not_match_is_refused() {
 #[tokio::test]
 async fn a_refusal_in_the_browser_is_reported_as_one() {
     let server = serve(Rules::default()).await;
-    let (_dir, store, group) = workspace();
+    let (_dir, store, group, _agent) = workspace();
 
     let failed = plugins::connect(
         &store,
@@ -489,7 +510,7 @@ async fn a_server_with_no_registration_says_so_rather_than_failing_obscurely() {
     // stops, and it has to say what is actually wrong rather than fail at the
     // next leg with a client id nobody issued.
     let server = serve(Rules { registers: false, ..Default::default() }).await;
-    let (_dir, store, group) = workspace();
+    let (_dir, store, group, _agent) = workspace();
 
     let failed = plugins::connect(
         &store,
@@ -508,7 +529,7 @@ async fn a_server_with_no_registration_says_so_rather_than_failing_obscurely() {
 async fn a_tool_call_carries_the_grant_and_the_answer_comes_back() {
     let server = serve(Rules::default()).await;
     let endpoint = format!("{}/mcp", server.base());
-    let (_dir, store, group) = workspace();
+    let (_dir, store, group, agent) = workspace();
 
     plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
         .await
@@ -517,6 +538,7 @@ async fn a_tool_call_carries_the_grant_and_the_answer_comes_back() {
     let answer = plugins::call(
         &store,
         group,
+        agent,
         PluginKind::Neon,
         &endpoint,
         "run_sql",
@@ -539,11 +561,12 @@ async fn a_tool_call_carries_the_grant_and_the_answer_comes_back() {
 
 #[tokio::test]
 async fn a_call_on_an_unconnected_plugin_says_who_can_connect_it() {
-    let (_dir, store, group) = workspace();
+    let (_dir, store, group, agent) = workspace();
 
     let failed = plugins::call(
         &store,
         group,
+        agent,
         PluginKind::Neon,
         "http://127.0.0.1:1/mcp",
         "run_sql",
@@ -565,7 +588,7 @@ async fn a_stale_grant_is_renewed_before_it_is_spent() {
     // discovers the token expired has already spent the operator's wait.
     let server = serve(Rules { issue_expired: true, ..Default::default() }).await;
     let endpoint = format!("{}/mcp", server.base());
-    let (_dir, store, group) = workspace();
+    let (_dir, store, group, agent) = workspace();
 
     plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
         .await
@@ -576,9 +599,17 @@ async fn a_stale_grant_is_renewed_before_it_is_spent() {
     // the next turn.
     let after_connecting = server.seen.lock().len();
 
-    plugins::call(&store, group, PluginKind::Neon, &endpoint, "run_sql", &serde_json::json!({}))
-        .await
-        .expect("a stale grant is renewed rather than refused");
+    plugins::call(
+        &store,
+        group,
+        agent,
+        PluginKind::Neon,
+        &endpoint,
+        "run_sql",
+        &serde_json::json!({}),
+    )
+    .await
+    .expect("a stale grant is renewed rather than refused");
 
     assert_eq!(server.refreshes.load(Ordering::SeqCst), 1);
     assert!(
@@ -594,7 +625,7 @@ async fn a_grant_revoked_at_the_vendor_is_renewed_once_and_the_call_retried() {
     // allowance: a refresh that does not fix it is a sign-in to redo.
     let server = serve(Rules::default()).await;
     let endpoint = format!("{}/mcp", server.base());
-    let (_dir, store, group) = workspace();
+    let (_dir, store, group, agent) = workspace();
 
     plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
         .await
@@ -605,6 +636,7 @@ async fn a_grant_revoked_at_the_vendor_is_renewed_once_and_the_call_retried() {
     let answer = plugins::call(
         &store,
         group,
+        agent,
         PluginKind::Neon,
         &endpoint,
         "run_sql",
@@ -618,7 +650,11 @@ async fn a_grant_revoked_at_the_vendor_is_renewed_once_and_the_call_retried() {
 
     // And the renewed grant is written back, or every later turn pays for the
     // same discovery.
-    let (_, grant) = store.plugin_grant(group, PluginKind::Neon).unwrap().unwrap();
+    let PluginReach::Granted { grant, .. } =
+        store.plugin_reach(group, agent, PluginKind::Neon).unwrap()
+    else {
+        panic!("the plugin is connected and this agent was not excluded from it")
+    };
     assert_eq!(grant.unwrap().access_token, "access-1");
 }
 
@@ -626,7 +662,7 @@ async fn a_grant_revoked_at_the_vendor_is_renewed_once_and_the_call_retried() {
 async fn disconnecting_forgets_the_plugin_and_its_grant() {
     let server = serve(Rules::default()).await;
     let endpoint = format!("{}/mcp", server.base());
-    let (_dir, store, group) = workspace();
+    let (_dir, store, group, agent) = workspace();
 
     let plugin =
         plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
@@ -635,7 +671,10 @@ async fn disconnecting_forgets_the_plugin_and_its_grant() {
 
     assert!(store.delete_plugin(plugin.id).unwrap());
     assert!(store.group_plugins(group).unwrap().is_empty());
-    assert!(store.plugin_grant(group, PluginKind::Neon).unwrap().is_none());
+    assert!(matches!(
+        store.plugin_reach(group, agent, PluginKind::Neon).unwrap(),
+        PluginReach::NotConnected
+    ));
 }
 
 #[tokio::test]
@@ -645,7 +684,7 @@ async fn connecting_twice_replaces_the_grant_rather_than_refusing() {
     // with no way back except disconnecting first.
     let server = serve(Rules::default()).await;
     let endpoint = format!("{}/mcp", server.base());
-    let (_dir, store, group) = workspace();
+    let (_dir, store, group, agent) = workspace();
 
     plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
         .await
@@ -655,7 +694,11 @@ async fn connecting_twice_replaces_the_grant_rather_than_refusing() {
         .unwrap();
 
     assert_eq!(store.group_plugins(group).unwrap().len(), 1);
-    let (_, grant) = store.plugin_grant(group, PluginKind::Neon).unwrap().unwrap();
+    let PluginReach::Granted { grant, .. } =
+        store.plugin_reach(group, agent, PluginKind::Neon).unwrap()
+    else {
+        panic!("connecting again leaves a plugin the crew can use")
+    };
     assert_eq!(grant.unwrap().access_token, "access-1", "the newer sign-in is the one held");
 }
 
@@ -666,13 +709,13 @@ async fn what_the_crew_connected_is_what_the_model_is_offered() {
     // cannot be called.
     let server = serve(Rules::default()).await;
     let endpoint = format!("{}/mcp", server.base());
-    let (_dir, store, group) = workspace();
+    let (_dir, store, group, agent) = workspace();
 
     plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
         .await
         .unwrap();
 
-    let connected = store.plugin_tools(group).unwrap();
+    let connected = store.plugin_tools(group, agent).unwrap();
     let specs = tools::plugin_specs(&connected);
     let names: Vec<&str> = specs.iter().map(|spec| spec.name.as_str()).collect();
     assert_eq!(names, vec!["neon__run_sql", "neon__list_projects"]);
@@ -800,6 +843,172 @@ async fn an_agent_calling_a_plugin_its_crew_has_not_connected_is_told_who_can() 
     // deliberately not asserted here: the trajectory suite counts that failure,
     // which is exactly what it is for.
     assert_eq!(h.channel_texts("Manager").len(), 2, "the operator is answered either way");
+}
+
+#[tokio::test]
+async fn an_agent_the_plugin_was_narrowed_away_from_is_neither_told_nor_allowed() {
+    // The whole feature, on the two seams it has to hold at once. A crew signs
+    // in once and the operator decides who may spend it: the agent that was not
+    // chosen is not offered the tools, is not told the crew has the plugin, and
+    // is refused if it names one anyway. The third is not redundant. A model
+    // emits a tool name it read somewhere often enough that the tool list is a
+    // description of what an agent has, never a fence.
+    let server = serve(Rules::default()).await;
+    let endpoint = format!("{}/mcp", server.base());
+
+    let model = harness::serve(|body| {
+        if harness::has_tool_result(body) {
+            harness::Script::Say("I could not do that part.".into())
+        } else {
+            harness::Script::Plugin {
+                name: "neon__run_sql".into(),
+                arguments: serde_json::json!({ "sql": "select 1" }),
+            }
+        }
+    })
+    .await;
+
+    let h = harness::harness(
+        &model,
+        &["Revenue", "Scribe"],
+        guac_lib::runtime::guard::GuardLimits::default(),
+    );
+    h.runtime.plugins_at(HashMap::from([(PluginKind::Neon, endpoint.clone())]));
+
+    let group = h.runtime.store().get_agent(h.id("Revenue")).unwrap().unwrap().group_id;
+    let plugin = plugins::connect(
+        h.runtime.store(),
+        group,
+        PluginKind::Neon,
+        &endpoint,
+        browser(Outcome::Allowed),
+    )
+    .await
+    .unwrap();
+    h.runtime
+        .store()
+        .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![h.id("Revenue")] })
+        .unwrap();
+
+    let run = h.runtime.send_from_human(h.id("Scribe"), "Check the database.").unwrap();
+    h.settle(run).await;
+
+    // Nothing was offered.
+    let offered: Vec<String> = model.transcript.lock()[0]["tools"]
+        .as_array()
+        .expect("a turn carries tool definitions")
+        .iter()
+        .map(|tool| tool["function"]["name"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(!offered.iter().any(|name| name.starts_with("neon__")), "offered {offered:?}");
+    assert!(offered.contains(&"send_message".to_string()), "the app's own tools stay");
+
+    // And nothing was claimed. The prompt and the tool list are built from one
+    // read for exactly this reason: an agent told its crew has Neon and offered
+    // no Neon tools spends the turn looking for them.
+    let prompt = harness::prompts_by_agent(&model).remove("Scribe").expect("Scribe had a turn");
+    assert!(!prompt.contains("plugins connected"), "{prompt}");
+
+    // The call it made anyway was refused here rather than at Neon, and the
+    // refusal points at the peer who can, not at the operator.
+    let results = harness::tool_results(&model);
+    assert!(
+        results.iter().any(|r| r.contains("not for you") && r.contains("peer")),
+        "got {results:?}"
+    );
+    assert!(server.called.lock().is_empty(), "an unauthorised call must not reach the vendor");
+    assert_eq!(h.channel_texts("Scribe").len(), 2, "the operator is answered either way");
+}
+
+#[tokio::test]
+async fn a_narrowed_plugin_shows_up_as_a_peer_who_can_do_it() {
+    // What narrowing costs if nothing replaces it: an agent that can only say
+    // no, sitting beside the one that can say yes. The roster is where the crew
+    // already answers this for browser sign-ins, so it answers it here too, and
+    // only for a plugin this agent does not have itself.
+    let server = serve(Rules::default()).await;
+    let endpoint = format!("{}/mcp", server.base());
+    let model = harness::serve(|_| harness::Script::Say("Noted.".into())).await;
+
+    let h = harness::harness(
+        &model,
+        &["Revenue", "Scribe"],
+        guac_lib::runtime::guard::GuardLimits::default(),
+    );
+    h.runtime.plugins_at(HashMap::from([(PluginKind::Neon, endpoint.clone())]));
+
+    let group = h.runtime.store().get_agent(h.id("Revenue")).unwrap().unwrap().group_id;
+    let plugin = plugins::connect(
+        h.runtime.store(),
+        group,
+        PluginKind::Neon,
+        &endpoint,
+        browser(Outcome::Allowed),
+    )
+    .await
+    .unwrap();
+    h.runtime
+        .store()
+        .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![h.id("Revenue")] })
+        .unwrap();
+
+    let run = h.runtime.send_from_human(h.id("Scribe"), "Anything to report?").unwrap();
+    h.settle(run).await;
+    let scribe = harness::prompts_by_agent(&model).remove("Scribe").expect("Scribe had a turn");
+    assert!(scribe.contains("Revenue"), "{scribe}");
+    assert!(scribe.contains("the Neon plugin"), "{scribe}");
+
+    // And the agent that holds it is not told to go and ask itself.
+    let run = h.runtime.send_from_human(h.id("Revenue"), "Anything to report?").unwrap();
+    h.settle(run).await;
+    let revenue = harness::prompts_by_agent(&model).remove("Revenue").expect("Revenue had a turn");
+    assert!(!revenue.contains("the Neon plugin"), "{revenue}");
+}
+
+#[tokio::test]
+async fn a_plugin_call_from_an_agent_outside_the_crew_is_refused() {
+    // The store's own boundary, under the call path rather than under a query.
+    // An agent id from another group names nobody on this plugin and is in no
+    // crew that connected it, so the grant is not there to be spent.
+    let server = serve(Rules::default()).await;
+    let endpoint = format!("{}/mcp", server.base());
+    let (_dir, store, group, agent) = workspace();
+
+    plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
+        .await
+        .unwrap();
+
+    let other = store
+        .create_group(&CleanGroup { name: "Elsewhere".to_string(), ..Default::default() })
+        .unwrap()
+        .id;
+    let outsider = crew(&store, other, "Outsider");
+
+    let failed = plugins::call(
+        &store,
+        other,
+        outsider,
+        PluginKind::Neon,
+        &endpoint,
+        "run_sql",
+        &serde_json::json!({}),
+    )
+    .await
+    .expect_err("another crew's sign-in is not this agent's to spend");
+    assert!(failed.to_string().contains("not connected"), "{failed}");
+
+    // And the crew that did connect it is unaffected.
+    plugins::call(
+        &store,
+        group,
+        agent,
+        PluginKind::Neon,
+        &endpoint,
+        "run_sql",
+        &serde_json::json!({}),
+    )
+    .await
+    .expect("the crew that signed in still has it");
 }
 
 // ---- live --------------------------------------------------------------

--- a/src/components/GroupEditor.tsx
+++ b/src/components/GroupEditor.tsx
@@ -58,6 +58,7 @@ const asNumber = (text: string) => (text.trim() ? Number(text) : null);
 export function GroupEditor({ group, onClose }: Props) {
   const refreshAgents = useStore((s) => s.refreshAgents);
   const settings = useStore((s) => s.settings);
+  const agents = useStore((s) => s.agents);
 
   const [section, setSection] = useState<Section>("general");
   const [name, setName] = useState(group?.name ?? "");
@@ -142,6 +143,18 @@ export function GroupEditor({ group, onClose }: Props) {
 
   /** Live agents. Terminated ones are not in the count and are not deleted twice. */
   const crew = group?.agentCount ?? 0;
+
+  /**
+   * The crew itself, for the plugins panel: who a plugin can be narrowed to.
+   *
+   * Read from the rail's own list rather than fetched, so a rename or a hiring
+   * is on this screen at the moment it is anywhere else. A terminated agent is
+   * left out because it cannot be given anything; the runtime drops its place
+   * on every plugin when it goes.
+   */
+  const members = agents.filter(
+    (agent) => agent.groupId === group?.id && agent.lifecycle !== "terminated",
+  );
 
   const save = async () => {
     setBusy(true);
@@ -533,17 +546,20 @@ export function GroupEditor({ group, onClose }: Props) {
               </>
             )}
 
-            {/* What a crew can reach belongs to the crew, not to any one agent
-                in it: a plugin's sign-in and a machine's credentials are both
-                handed to everybody here. */}
+            {/* What a crew can reach is signed in to once, here, and handing it
+                out is a second decision: a plugin can be narrowed to named
+                agents, because the one that files issues has no business
+                holding the account that issues refunds. Credentials are still
+                the whole group's. */}
             {section === "plugins" && group && (
               <>
                 <h3 className="settings__title">Plugins</h3>
                 <p className="settings__lede">
-                  Sign in once, on behalf of this group. Every agent in it can then call that
-                  service's tools, and none of them ever holds the sign-in.
+                  Sign in once, on behalf of this group, then choose which agents get it. Every
+                  agent is the default; narrow the ones that reach money or production. None of them
+                  ever holds the sign-in.
                 </p>
-                <PluginList groupId={group.id} />
+                <PluginList groupId={group.id} crew={members} />
                 <CredentialList groupId={group.id} />
               </>
             )}

--- a/src/components/PluginList.test.tsx
+++ b/src/components/PluginList.test.tsx
@@ -1,13 +1,14 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Plugin, PluginOffer } from "../lib/types";
+import type { AgentCard, Plugin, PluginAccess, PluginOffer } from "../lib/types";
 import { PluginList } from "./PluginList";
 
 const pluginCatalogue = vi.fn<() => Promise<PluginOffer[]>>();
 const groupPlugins = vi.fn<() => Promise<Plugin[]>>();
 const connectPlugin = vi.fn<(groupId: string, kind: string) => Promise<Plugin>>();
 const disconnectPlugin = vi.fn();
+const setPluginAccess = vi.fn<(id: string, access: PluginAccess) => Promise<Plugin>>();
 const openExternal = vi.fn();
 
 vi.mock("../lib/ipc", () => ({
@@ -16,6 +17,7 @@ vi.mock("../lib/ipc", () => ({
     groupPlugins: () => groupPlugins(),
     connectPlugin: (groupId: string, kind: string) => connectPlugin(groupId, kind),
     disconnectPlugin: (id: string) => disconnectPlugin(id),
+    setPluginAccess: (id: string, access: PluginAccess) => setPluginAccess(id, access),
   },
   openExternal: (url: string) => openExternal(url),
 }));
@@ -47,11 +49,36 @@ function plugin(over: Partial<Plugin> = {}): Plugin {
     kind: "neon",
     account: "",
     tools: ["run_sql", "create_branch"],
+    access: { mode: "everyone" },
     signedIn: true,
     connectedAt: 0,
     ...over,
   };
 }
+
+/** Two agents, which is the smallest crew a plugin can be narrowed inside. */
+function member(id: string, name: string): AgentCard {
+  return {
+    id,
+    groupId: GROUP,
+    name,
+    avatar: "avocado",
+    color: "#7fb069",
+    model: "",
+    systemPrompt: "",
+    skills: [],
+    sandboxId: null,
+    browserId: null,
+    lifecycle: "active",
+    pinned: false,
+    railOrder: 0,
+    version: 1,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+const CREW = [member("a1", "Revenue"), member("a2", "Scribe")];
 
 describe("PluginList", () => {
   beforeEach(() => {
@@ -59,6 +86,7 @@ describe("PluginList", () => {
     groupPlugins.mockReset();
     connectPlugin.mockReset();
     disconnectPlugin.mockReset();
+    setPluginAccess.mockReset();
     openExternal.mockReset();
     pluginCatalogue.mockResolvedValue(OFFERS);
     groupPlugins.mockResolvedValue([]);
@@ -67,7 +95,7 @@ describe("PluginList", () => {
   it("names the host each sign-in would go to, before anything is clicked", async () => {
     // What an operator is agreeing to is which company gets their account. The
     // host is that; the path is noise beside it.
-    render(<PluginList groupId={GROUP} />);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
 
     expect(await screen.findByText("mcp.neon.tech")).toBeTruthy();
     expect(screen.getByText("mcp.stripe.com")).toBeTruthy();
@@ -83,7 +111,7 @@ describe("PluginList", () => {
       }),
     );
 
-    render(<PluginList groupId={GROUP} />);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
     fireEvent.click((await screen.findAllByText("Connect"))[0]!);
 
     await waitFor(() => expect(connectPlugin).toHaveBeenCalledWith(GROUP, "neon"));
@@ -98,7 +126,7 @@ describe("PluginList", () => {
     // Two loopback listeners and two browser windows, for one operator with
     // one pair of hands.
     connectPlugin.mockReturnValue(new Promise<Plugin>(() => {}));
-    render(<PluginList groupId={GROUP} />);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
 
     fireEvent.click((await screen.findAllByText("Connect"))[0]!);
     await waitFor(() => expect(connectPlugin).toHaveBeenCalled());
@@ -113,7 +141,7 @@ describe("PluginList", () => {
     // if one stops, because reporting it as signed in would be a claim about
     // the operator's account that is not true.
     groupPlugins.mockResolvedValue([plugin({ kind: "stripe", signedIn: false, tools: ["docs"] })]);
-    render(<PluginList groupId={GROUP} />);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
 
     expect(await screen.findByText(/asked for no sign-in/)).toBeTruthy();
   });
@@ -121,7 +149,7 @@ describe("PluginList", () => {
   it("disconnects one", async () => {
     groupPlugins.mockResolvedValue([plugin()]);
     disconnectPlugin.mockResolvedValue(undefined);
-    render(<PluginList groupId={GROUP} />);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
 
     fireEvent.click(await screen.findByText("Disconnect"));
     await waitFor(() => expect(disconnectPlugin).toHaveBeenCalledWith("p1"));
@@ -129,15 +157,93 @@ describe("PluginList", () => {
 
   it("opens the documentation in the shell, not in the webview", async () => {
     // A webview that navigates away from the app has no way back.
-    render(<PluginList groupId={GROUP} />);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
 
     fireEvent.click((await screen.findAllByText("What this can do"))[0]!);
     expect(openExternal).toHaveBeenCalledWith("https://neon.com/docs/ai/neon-mcp-server");
   });
 
+  it("says a connected plugin is the whole crew's, until it is not", async () => {
+    groupPlugins.mockResolvedValue([plugin()]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    expect(await screen.findByText(/offered to every agent in this group/)).toBeTruthy();
+    // Nobody is named while it is everyone's, because a tick list would be
+    // claiming that the answer is those two agents rather than the crew.
+    expect(screen.queryByRole("button", { name: "Revenue" })).toBe(null);
+  });
+
+  it("narrows one to chosen agents, and says plainly that nobody has it yet", async () => {
+    // The state an operator is standing in for one click. It has to say what it
+    // means: a plugin connected and callable by nobody looks identical to a
+    // working one from the row above.
+    const narrowed = plugin({ access: { mode: "chosen", agents: [] } });
+    // What the panel reads back is what the store now says, which is the whole
+    // reason nothing here keeps a draft.
+    groupPlugins.mockResolvedValueOnce([plugin()]);
+    groupPlugins.mockResolvedValue([narrowed]);
+    setPluginAccess.mockResolvedValue(narrowed);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    fireEvent.click(await screen.findByText("Only chosen agents"));
+
+    await waitFor(() =>
+      expect(setPluginAccess).toHaveBeenCalledWith("p1", { mode: "chosen", agents: [] }),
+    );
+    expect(await screen.findByText(/offered to nobody/)).toBeTruthy();
+  });
+
+  it("adds an agent to a narrowed plugin, and takes one back out", async () => {
+    const both = plugin({ access: { mode: "chosen", agents: ["a1", "a2"] } });
+    groupPlugins.mockResolvedValueOnce([plugin({ access: { mode: "chosen", agents: [] } })]);
+    groupPlugins.mockResolvedValue([both]);
+    setPluginAccess.mockResolvedValue(both);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Revenue" }));
+    await waitFor(() =>
+      expect(setPluginAccess).toHaveBeenCalledWith("p1", { mode: "chosen", agents: ["a1"] }),
+    );
+
+    // And the whole set every time, never a difference: the panel that sends
+    // this is the one that knows who else was ticked, and a merge on the far
+    // side would make unticking impossible to express.
+    setPluginAccess.mockClear();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Scribe" }).getAttribute("aria-pressed")).toBe(
+        "true",
+      ),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Revenue" }));
+    await waitFor(() =>
+      expect(setPluginAccess).toHaveBeenCalledWith("p1", { mode: "chosen", agents: ["a2"] }),
+    );
+  });
+
+  it("names who a narrowed plugin is for", async () => {
+    groupPlugins.mockResolvedValue([plugin({ access: { mode: "chosen", agents: ["a1"] } })]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    expect(await screen.findByText(/offered to Revenue/)).toBeTruthy();
+    const revenue = screen.getByRole("button", { name: "Revenue" });
+    expect(revenue.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "Scribe" }).getAttribute("aria-pressed")).toBe(
+      "false",
+    );
+  });
+
+  it("asks nothing about who can use a plugin nobody has connected", async () => {
+    // There is no sign-in to hand out, so the question is noise on four tiles.
+    groupPlugins.mockResolvedValue([]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    await screen.findAllByText("Connect");
+    expect(screen.queryByText("Only chosen agents")).toBe(null);
+  });
+
   it("reports a refused sign-in instead of leaving the row looking connected", async () => {
     connectPlugin.mockRejectedValue(new Error("the sign-in was refused: access_denied"));
-    render(<PluginList groupId={GROUP} />);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
 
     fireEvent.click((await screen.findAllByText("Connect"))[0]!);
     expect(await screen.findByText(/access_denied/)).toBeTruthy();

--- a/src/components/PluginList.tsx
+++ b/src/components/PluginList.tsx
@@ -2,20 +2,63 @@ import { useCallback, useEffect, useState } from "react";
 
 import { api, openExternal } from "../lib/ipc";
 import { BRANDS, hostOf } from "../lib/plugins";
-import { errorMessage, type GroupId, type Plugin, type PluginOffer } from "../lib/types";
+import {
+  type AgentCard,
+  type AgentId,
+  errorMessage,
+  type GroupId,
+  type Plugin,
+  type PluginAccess,
+  type PluginOffer,
+} from "../lib/types";
 
 interface Props {
   groupId: GroupId;
+  /** The group's live agents, in rail order, for the ones a plugin is for. */
+  crew: AgentCard[];
+}
+
+/**
+ * The two answers to who may use a plugin.
+ *
+ * Two buttons rather than a list of agents with an "everyone" entry at the top:
+ * everyone is a standing answer that covers whoever is hired next week, and a
+ * tick beside today's names cannot say that.
+ */
+const ACCESS_MODES = [
+  { value: "everyone", label: "Every agent" },
+  { value: "chosen", label: "Only chosen agents" },
+] as const;
+
+/** The chosen set with one agent added or taken out. */
+function toggled(access: PluginAccess, agent: AgentId): AgentId[] {
+  const current = access.mode === "chosen" ? access.agents : [];
+  return current.includes(agent) ? current.filter((id) => id !== agent) : [...current, agent];
+}
+
+/** Who a connected plugin is offered to, in the operator's words. */
+function offeredTo(access: PluginAccess, crew: AgentCard[]): string {
+  if (access.mode === "everyone") return "offered to every agent in this group";
+  const named = crew.filter((agent) => access.agents.includes(agent.id));
+  if (named.length === 0) return "offered to nobody: tick an agent, or nothing here can be called";
+  return `offered to ${named.map((agent) => agent.name).join(", ")}`;
 }
 
 /**
  * The plugins a crew has, and the ones it can have.
  *
  * A plugin is a server the operator signs in to once, on behalf of the whole
- * group, after which every agent in it can call that server's tools. Nothing is
- * pasted and nothing is put on a machine: the call is made by Guaca with the
- * group's own sign-in on it, so the agent never holds a token and has nothing
- * to leak.
+ * group, after which the agents they chose can call that server's tools.
+ * Nothing is pasted and nothing is put on a machine: the call is made by Guaca
+ * with the group's own sign-in on it, so the agent never holds a token and has
+ * nothing to leak.
+ *
+ * Signing in and handing it out are two decisions, and the second one is on
+ * this row. Every agent is the default and the usual answer; the crew's Stripe
+ * account is why it is not the only one. Each change is written the moment it
+ * is made, like connecting and disconnecting above it: there is no Save on this
+ * panel, so a draft nobody submitted would be a permission the operator thinks
+ * they granted.
  *
  * A short list, and that is the design rather than a starting point. The list
  * this replaced was twelve brands and a text box, which asked the operator for
@@ -32,7 +75,7 @@ interface Props {
  * a button that opened another window is how an operator ends up clicking it
  * twice.
  */
-export function PluginList({ groupId }: Props) {
+export function PluginList({ groupId, crew }: Props) {
   const [offers, setOffers] = useState<PluginOffer[] | null>(null);
   const [connected, setConnected] = useState<Plugin[] | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
@@ -79,6 +122,7 @@ export function PluginList({ groupId }: Props) {
         const held = connected.find((plugin) => plugin.kind === offer.kind);
         const brand = BRANDS[offer.kind];
         const working = busy === offer.kind;
+        const chosen = held?.access.mode === "chosen" ? held.access.agents : [];
 
         return (
           <div className="access__item" key={offer.kind}>
@@ -120,12 +164,84 @@ export function PluginList({ groupId }: Props) {
             </div>
 
             {held ? (
-              <p className="field__hint">
-                {held.tools.length} tool{held.tools.length === 1 ? "" : "s"}, offered to every agent
-                in this group.
-                {held.account && ` Signed in as ${held.account}.`}
-                {!held.signedIn && " This server asked for no sign-in, so nothing was authorised."}
-              </p>
+              <>
+                <p className="field__hint">
+                  {held.tools.length} tool{held.tools.length === 1 ? "" : "s"},{" "}
+                  {offeredTo(held.access, crew)}.{held.account && ` Signed in as ${held.account}.`}
+                  {!held.signedIn &&
+                    " This server asked for no sign-in, so nothing was authorised."}
+                </p>
+
+                {/* Two buttons rather than a list with an "all" entry at the
+                    top: every agent is a standing answer that covers whoever
+                    is hired next week, and a tick beside today's names cannot
+                    say that. */}
+                <span className="field__label">Who can use it</span>
+                <div className="choices">
+                  {ACCESS_MODES.map((mode) => (
+                    <button
+                      key={mode.value}
+                      type="button"
+                      className="choice"
+                      aria-pressed={held.access.mode === mode.value}
+                      disabled={busy !== null}
+                      onClick={() => {
+                        // Narrowing to nobody is a real state and the hint
+                        // above says so. Starting from the whole crew ticked
+                        // would be a click that changed nothing, on the button
+                        // whose whole purpose is to take something away.
+                        if (held.access.mode === mode.value) return;
+                        void run(`${offer.kind}-access`, () =>
+                          api.setPluginAccess(
+                            held.id,
+                            mode.value === "everyone"
+                              ? { mode: "everyone" }
+                              : { mode: "chosen", agents: [] },
+                          ),
+                        );
+                      }}
+                    >
+                      {mode.label}
+                    </button>
+                  ))}
+                </div>
+
+                {held.access.mode === "chosen" && (
+                  <div className="choices">
+                    {crew.length === 0 ? (
+                      <span className="field__hint">This group has no agents yet.</span>
+                    ) : (
+                      crew.map((agent) => {
+                        const has = chosen.includes(agent.id);
+                        return (
+                          <button
+                            key={agent.id}
+                            type="button"
+                            className="choice"
+                            // A toggle button rather than a checkbox with a
+                            // name beside it: the row is a line of names and
+                            // the state is which of them are lit, which is what
+                            // pressed means. The same control the surface and
+                            // the accent pickers use.
+                            aria-pressed={has}
+                            disabled={busy !== null}
+                            onClick={() =>
+                              void run(`${offer.kind}-${agent.id}`, () =>
+                                api.setPluginAccess(held.id, {
+                                  mode: "chosen",
+                                  agents: toggled(held.access, agent.id),
+                                }),
+                              )
+                            }
+                          >
+                            {agent.name}
+                          </button>
+                        );
+                      })
+                    )}
+                  </div>
+                )}
+              </>
             ) : (
               <p className="field__hint">
                 {offer.blurb}{" "}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -39,6 +39,7 @@ import type {
   GroupUsage,
   MessageId,
   Plugin,
+  PluginAccess,
   PluginId,
   PluginKind,
   PluginOffer,
@@ -118,6 +119,15 @@ export const api = {
    */
   connectPlugin: (groupId: GroupId, kind: PluginKind) =>
     invoke<Plugin>("connect_plugin", { groupId, kind }),
+
+  /**
+   * Narrows a plugin to named agents, or opens it back up to the crew.
+   *
+   * The whole answer every time. A merge would let this panel narrow a plugin
+   * by forgetting somebody it had not drawn yet.
+   */
+  setPluginAccess: (id: PluginId, access: PluginAccess) =>
+    invoke<Plugin>("set_plugin_access", { id, access }),
 
   disconnectPlugin: (id: PluginId) => invoke<void>("disconnect_plugin", { id }),
 

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -335,7 +335,7 @@ function actionsFor(agents: AgentCard[], groups: Group[]): Omit<SearchResult, "s
       key: `action:group-settings:${group.id}`,
       kind: "actions",
       title: `${group.name} settings`,
-      detail: "Endpoint, model, plugins for the whole group",
+      detail: "Endpoint, model, limits, and who gets which plugin",
       meta: "Action",
       action: { do: "editGroup", groupId: group.id },
     });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -242,6 +242,17 @@ export interface PluginOffer {
 }
 
 /**
+ * Who in a crew may call one plugin's tools.
+ *
+ * The sign-in belongs to the group either way; this is who is allowed to spend
+ * it. Two shapes rather than a list that means everybody when it is empty:
+ * `everyone` covers agents that do not exist yet, and an empty `chosen` is a
+ * plugin nobody may call, which is where an operator is standing the moment
+ * before they tick the first name.
+ */
+export type PluginAccess = { mode: "everyone" } | { mode: "chosen"; agents: AgentId[] };
+
+/**
  * A plugin a group has connected.
  *
  * The grant is never on this side of the boundary: there is no command that
@@ -256,6 +267,8 @@ export interface Plugin {
   account: string;
   /** What the crew can call, by the server's own name for each. */
   tools: string[];
+  /** Which of the crew is offered them. `everyone` until somebody says else. */
+  access: PluginAccess;
   signedIn: boolean;
   connectedAt: number;
 }


### PR DESCRIPTION
A group holds a plugin's sign-in; who may spend it is now a second question, asked per plugin, so Stripe can be the CRO's while Linear stays the crew's. `PluginAccess` is `Everyone` or a named list, and migration 27 defaults every existing row to everyone, so nothing an operator connected yesterday narrows because this shipped.

The rule is written once and read twice: `plugin_tools` decides what an agent is told it has, `plugin_reach` decides what it gets, and both paste the same SQL fragment, because a model names tools it was never offered and a filtered tool list describes rather than fences. The two refusals are deliberately different sentences, since "nobody connected this" is the operator's to fix and "connected, but not for you" is a peer's to do, and the roster names that peer under the rule it already uses for browser sign-ins.

Nothing widens a plugin by accident: not reconnecting to fix a revoked grant, not an access value a downgrade wrote, not an agent from another crew, and retiring an agent or disconnecting a plugin takes the rows with it. The reasoning is in `docs/PLUGINS.md`; the live evals were not run, and are worth the spend before shipping because a narrowed crew's prompt changes.