### PR TITLE
fix: one yes covers the site, and the next turn asks again

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,12 @@ the model takes a screenshot to see what `browse` did.
   login. Do not loosen them without a fresh capture from a live machine.
 - **All three conditions in `needs_consent` are load-bearing.** Each one alone
   refuses honest work. Read the doc comment before narrowing or widening any.
+  The fourth clause is not one of them: a yes is remembered against that site
+  for the rest of the turn, because asking per press produced four dialogs in a
+  row for one account and a question in that shape is one an operator clicks
+  through. It is not a standing yes. It lives on the turn's `Reading`, reaches
+  no table, and `Reading::took_in` drops it the moment the turn takes in a page
+  from anywhere else.
 - **An envelope booked against a run is released by whatever consumes it.** A
   path that takes one without turning it into a turn leaves the run outstanding
   for the life of the process.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -549,6 +549,30 @@ the answer is read back from the `approvals` row. There is no "always allow",
 for the reason `ActOnBehalf` never had one. A standing yes here would be granted
 once, on one page, and would cover every page after it.
 
+**A yes covers the site, for the turn.** The first version asked per press, and
+what that produced in practice was four identical dialogs in a row for one
+Facebook account inside one piece of work. That is not a stricter gate, it is a
+gate the operator has learned to click through, which costs the one thing the
+whole mechanism is buying: a person actually reading the question. So the answer
+is remembered against the *session it was given for*, on the `Reading` that
+already tracks what the turn has taken in.
+
+Two things keep that narrow, and they are the reason it is not a standing yes in
+disguise. `Reading` is built fresh for every turn, so the grant cannot outlive
+the work the operator was watching and nothing about it reaches the `grants`
+table. And `Reading::took_in` drops it the moment the turn takes in a page from
+anywhere else, because what the operator allowed was an agent working inside one
+site: content from off that site is the injection they were never shown, so the
+next press asks again. A screenshot carries no URL, cannot show that the turn
+stayed put, and counts as somewhere else. The same-site walk that this is for,
+`www.facebook.com` to `business.facebook.com`, is one question rather than none,
+and it is decided by `signin::on_domain`, which is `session_for` asked about a
+single domain so that the two cannot disagree about a lookalike.
+
+What the operator is told has to match: the request carries a *What allowing
+covers* field naming the service and the two ways the grant ends, because a
+scope nobody was shown is not a scope anybody consented to.
+
 The rule is a pure function and the asking is not, so the rule can be read and
 tested on its own. Two of its tests exist only to fail a careless version:
 `notgmail.com` must not match a `gmail.com` session, and

--- a/docs/BROWSERS.md
+++ b/docs/BROWSERS.md
@@ -148,6 +148,12 @@ is not the thing that action could spend: gating on it would stop and ask about
 an account the action cannot touch, which teaches an operator to click through
 the prompt without reading it.
 
+A yes is remembered against that site until the turn ends or the browser reads
+something off another one, so an agent working through an inbox is asked once
+rather than once per press. It is held on the turn's `Reading` and never
+written down: the next turn asks again, and so does the first press after the
+agent has been anywhere else.
+
 `ARCHITECTURE.md`, *A page that was read this turn cannot quietly press a
 button*, is the rest of it.
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -198,7 +198,10 @@ attack either, and gating navigation would mean approving a click in order to
 reach the click being approved. What is left is the case this paper and
 BrowseSafe agree is worth paying for: the payload does not need to obtain
 access, it already has the operator's, and the next press is the operator's to
-allow.
+allow. Once, per site, per turn: a question asked again for every press on the
+same account is one an operator stops reading, and a defence nobody reads is
+wording again. The grant lives on the turn and dies with it, and any page from
+off that site takes it back.
 
 The rule is a pure function, separate from the asking, because a security rule
 nobody can read in one sitting is a rule nobody can check. Its tests carry the

--- a/src-tauri/src/domain/signin.rs
+++ b/src-tauri/src/domain/signin.rs
@@ -232,6 +232,16 @@ pub fn session_for<'a>(signins: &'a [Signin], url: &str) -> Option<&'a Signin> {
     signins.iter().find(|signin| under(&host, &signin.domain))
 }
 
+/// Whether a URL is on `domain`, decided exactly as a session is.
+///
+/// The same question as `session_for` asked about one domain instead of a list,
+/// and here rather than at the call site because the parsing above is the part
+/// that has to see through `evil.com` wearing another site's name. A second
+/// copy of it somewhere else is a second copy that can rot.
+pub fn on_domain(url: &str, domain: &str) -> bool {
+    host_in(url).is_some_and(|host| under(&host, domain))
+}
+
 /// Reads a browser's cookie jar and says what it is signed in to.
 ///
 /// `now` is passed rather than read so the result is a pure function of its
@@ -566,5 +576,17 @@ mod tests {
             "a suffix match without the dot would cover every lookalike domain"
         );
         assert!(session_for(&held, "https://example.org/").is_none());
+    }
+
+    #[test]
+    fn asking_about_one_domain_sees_through_the_same_two_tricks() {
+        // `on_domain` is what a turn's consent grant is checked against, so a
+        // version that answered these differently from `session_for` would let
+        // a page the operator never saw inherit the yes they gave for another.
+        assert!(on_domain("https://business.facebook.com/latest/inbox", "facebook.com"));
+        assert!(on_domain("https://facebook.com/", "facebook.com"));
+        assert!(!on_domain("https://notfacebook.com/", "facebook.com"));
+        assert!(!on_domain("https://facebook.com@evil.com/x", "facebook.com"));
+        assert!(!on_domain("not a url", "facebook.com"));
     }
 }

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -53,6 +53,34 @@ struct Reading {
     /// marks the turn without moving this: the browser is still wherever
     /// `browse` last left it.
     url: Option<String>,
+    /// The site the operator has already said this agent may act on, and only
+    /// for the rest of this turn. `None` until they say so, `None` again the
+    /// moment the turn takes in content from anywhere else, and `None` on the
+    /// next turn because this whole struct is built fresh for each one.
+    allowed: Option<String>,
+}
+
+impl Reading {
+    /// Records that the turn has taken content in, and moves the browser if
+    /// that content said where it came from.
+    ///
+    /// The one place a grant is taken back. What the operator allowed was an
+    /// agent working inside one site, and a page from anywhere else is the
+    /// thing they did not see: it re-arms the gate rather than inheriting the
+    /// yes. A screenshot carries no URL and so cannot show that the turn
+    /// stayed put, which counts as anywhere else.
+    fn took_in(&mut self, url: Option<String>) {
+        self.ingested = true;
+        let stayed = url.as_deref().is_some_and(|url| {
+            self.allowed.as_deref().is_some_and(|domain| signin::on_domain(url, domain))
+        });
+        if !stayed {
+            self.allowed = None;
+        }
+        if let Some(url) = url {
+            self.url = Some(url);
+        }
+    }
 }
 
 /// The session an action would spend, if it needs the operator's say-so first.
@@ -72,11 +100,20 @@ struct Reading {
 ///   That is what turns an action into the operator's rather than the agent's,
 ///   and it is exactly the condition that makes the payload worth writing:
 ///   the injection does not have to obtain access, it already has it.
+///
+/// Then one thing that is not a condition of the risk: a yes covers the site it
+/// was given for until the turn ends or the turn reads something off another
+/// site, so a crew working through an inbox is asked once rather than once per
+/// press. It is scoped to a `Reading` that is built fresh for every turn, so
+/// nothing here outlives the work the operator was watching.
 fn needs_consent<'a>(action: &str, reading: &Reading, held: &'a [Signin]) -> Option<&'a Signin> {
     if !matches!(action, "click" | "type") || !reading.ingested {
         return None;
     }
-    crate::domain::signin::session_for(held, reading.url.as_deref()?)
+    let session = signin::session_for(held, reading.url.as_deref()?)?;
+    // Already answered, for this site, in this turn. `Reading::took_in` is what
+    // keeps that narrow.
+    (reading.allowed.as_deref() != Some(session.domain.as_str())).then_some(session)
 }
 
 /// What a screenshot is introduced as, and what replaces one that has aged out.
@@ -280,7 +317,7 @@ use crate::domain::ids::{AgentId, ApprovalId, GroupId, MessageId, RunId};
 use crate::domain::now_ms;
 use crate::domain::plugin::PluginKind;
 use crate::domain::routine::{Routine, RunKind};
-use crate::domain::signin::{BrowserState, Signin, Surface};
+use crate::domain::signin::{self, BrowserState, Signin, Surface};
 use crate::files::FileStore;
 use crate::llm::openrouter::{ChatMessage, ChatRequest, LlmClient, LlmError, Token, ToolCall};
 use crate::llm::tools::{self, Delivery, ToolInvocation};
@@ -2293,7 +2330,7 @@ impl Runtime {
             // read through a different tool. It carries no URL, so the turn is
             // marked without moving where the browser is standing.
             if result.2.is_some() {
-                reading.ingested = true;
+                reading.took_in(None);
             }
             return result;
         }
@@ -2445,14 +2482,13 @@ impl Runtime {
                         // has read something. Both are set from what came back
                         // rather than from what was asked for, because a click
                         // that navigates lands somewhere the caller did not
-                        // name.
-                        reading.ingested = true;
-                        if let Some(url) = serde_json::from_str::<serde_json::Value>(&page)
-                            .ok()
-                            .and_then(|page| page["url"].as_str().map(str::to_string))
-                        {
-                            reading.url = Some(url);
-                        }
+                        // name, and a grant the operator gave for one site must
+                        // not follow the agent off it.
+                        reading.took_in(
+                            serde_json::from_str::<serde_json::Value>(&page)
+                                .ok()
+                                .and_then(|page| page["url"].as_str().map(str::to_string)),
+                        );
                         let summary = format!("{action} in the browser");
                         (render_page(&page), ToolOutcome::Ok { summary })
                     }
@@ -2694,14 +2730,23 @@ impl Runtime {
     ///   is what makes the action the operator's rather than the agent's, and
     ///   it is exactly the condition that makes the payload worth writing.
     ///
-    /// Deliberately not "always allow": `ActOnBehalf` has no standing yes, and
-    /// a page that could earn one once would earn it for every page after.
+    /// A yes is remembered against that site for the rest of the turn, because
+    /// the alternative is a dialog per press: four in a row for one Facebook
+    /// account was the live report, and by the fourth the operator is not
+    /// reading them. What the yes cannot do is widen. It is held on `Reading`,
+    /// which is built fresh for each turn and drops the grant the moment the
+    /// turn takes in a page from anywhere else, so the next turn asks again and
+    /// so does the first press after the agent has been somewhere new.
+    ///
+    /// Deliberately still not "always allow": `ActOnBehalf` has no standing yes,
+    /// nothing here reaches the `grants` table, and a page that could earn one
+    /// once would earn it for every page after.
     async fn may_act_on(
         &self,
         card: &AgentCard,
         run_id: RunId,
         action: &str,
-        reading: &Reading,
+        reading: &mut Reading,
     ) -> Option<String> {
         // The browser's own sessions, not the agent's whole list. The URL this
         // is decided from came from the browser, so a session the *computer*
@@ -2716,9 +2761,9 @@ impl Runtime {
             .into_iter()
             .filter(|signin| signin.surface == Surface::Browser)
             .collect();
-        let (url, service) = {
+        let (url, domain, service) = {
             let session = needs_consent(action, reading, &held)?;
-            (reading.url.clone().unwrap_or_default(), session.label())
+            (reading.url.clone().unwrap_or_default(), session.domain.clone(), session.label())
         };
 
         let permission = self
@@ -2749,12 +2794,25 @@ impl Runtime {
                             card.name
                         ),
                     },
+                    // What a yes buys, in full, because it is more than the
+                    // press being asked about and an operator cannot consent to
+                    // a scope nobody told them.
+                    DetailField {
+                        label: "What allowing covers".to_string(),
+                        value: format!(
+                            "Every press and typed line on {service} for the rest of this turn.                              It is not remembered afterwards, and it ends early if {} reads a                              page somewhere else.",
+                            card.name
+                        ),
+                    },
                 ],
             )
             .await;
 
         match permission {
-            Permission::Granted => None,
+            Permission::Granted => {
+                reading.allowed = Some(domain);
+                None
+            }
             Permission::Refused => Some(format!(
                 "Refused: the operator declined to let you act on {service} in their name. Do not \
                  try another way round it. Say what you would have done and carry on with \
@@ -4378,7 +4436,7 @@ mod tests {
     }
 
     fn having_read(url: &str) -> Reading {
-        Reading { ingested: true, url: Some(url.into()) }
+        Reading { ingested: true, url: Some(url.into()), allowed: None }
     }
 
     #[test]
@@ -4415,7 +4473,8 @@ mod tests {
         // from the operator's instruction rather than from a page. Asking here
         // would put a dialog in front of ordinary work.
         let held = [session("gmail.com")];
-        let untainted = Reading { ingested: false, url: Some("https://gmail.com/".into()) };
+        let untainted =
+            Reading { ingested: false, url: Some("https://gmail.com/".into()), allowed: None };
         assert!(needs_consent("click", &untainted, &held).is_none());
     }
 
@@ -4441,6 +4500,91 @@ mod tests {
         assert!(
             needs_consent("click", &having_read("https://gmail.com@evil.com/x"), &held).is_none()
         );
+    }
+
+    #[test]
+    fn one_yes_covers_the_site_it_was_given_for_until_the_turn_ends() {
+        // The live report: four dialogs in a row, one Facebook account, one
+        // piece of work. A question asked per press is a question an operator
+        // learns to click through, which is the failure mode this gate exists
+        // to avoid rather than one it may cause.
+        let held = [session("facebook.com")];
+        let mut reading = having_read("https://www.facebook.com/");
+        assert!(needs_consent("click", &reading, &held).is_some(), "the first press asks");
+
+        reading.allowed = Some("facebook.com".into());
+        assert!(needs_consent("click", &reading, &held).is_none());
+        assert!(needs_consent("type", &reading, &held).is_none());
+
+        // Including the rest of the site. A crew answering a page's messages
+        // walks from `www` to `business` without leaving the account the
+        // operator was asked about.
+        reading.took_in(Some("https://business.facebook.com/latest/inbox/all".into()));
+        assert!(needs_consent("click", &reading, &held).is_none());
+    }
+
+    #[test]
+    fn a_grant_covers_one_site_and_does_not_travel() {
+        // The yes named an account. Another account the same agent holds is a
+        // second thing to spend and a second question.
+        let held = [session("facebook.com"), session("gmail.com")];
+        let mut reading = having_read("https://www.facebook.com/");
+        reading.allowed = Some("facebook.com".into());
+        reading.took_in(Some("https://mail.gmail.com/u/0/#inbox".into()));
+        assert!(
+            needs_consent("click", &reading, &held).is_some(),
+            "a grant for one account cannot be spent on another"
+        );
+    }
+
+    #[test]
+    fn content_from_anywhere_else_takes_the_grant_back() {
+        // The whole reason the grant is safe to give. What the operator allowed
+        // was an agent working inside one site; a page from somewhere else is
+        // the injection they were never shown, so the next press asks again.
+        let held = [session("facebook.com")];
+        let mut reading = having_read("https://www.facebook.com/");
+        reading.allowed = Some("facebook.com".into());
+
+        reading.took_in(Some("https://attacker.example/post".into()));
+        assert_eq!(reading.allowed, None, "a page off the site re-arms the gate");
+
+        // And back on the site, the browser has moved but the yes has not
+        // followed it. Nothing restores a grant except the operator.
+        reading.took_in(Some("https://www.facebook.com/".into()));
+        assert!(needs_consent("click", &reading, &held).is_some());
+
+        // A screenshot cannot show that the turn stayed put, so it counts as
+        // somewhere else. It is untrusted content read through another tool.
+        reading.allowed = Some("facebook.com".into());
+        reading.took_in(None);
+        assert_eq!(reading.allowed, None);
+        assert_eq!(
+            reading.url.as_deref(),
+            Some("https://www.facebook.com/"),
+            "and a picture still does not move the browser"
+        );
+    }
+
+    #[test]
+    fn a_grant_is_not_a_lookalike_domains_way_in() {
+        // `on_domain` decides this the way a session is matched, and both
+        // tricks have to come back as somewhere else. A grant that inherited
+        // either would be worse than asking every time.
+        let held = [session("facebook.com")];
+        let mut reading = having_read("https://www.facebook.com/");
+
+        for elsewhere in ["https://notfacebook.com/x", "https://facebook.com@evil.com/x"] {
+            reading.allowed = Some("facebook.com".into());
+            reading.took_in(Some(elsewhere.into()));
+            assert_eq!(reading.allowed, None, "{elsewhere} is not the site that was allowed");
+        }
+
+        // And the check at the press is the same one: a grant recorded for the
+        // account cannot answer for a press on a page merely named after it.
+        reading.url = Some("https://notfacebook.com/x".into());
+        reading.allowed = Some("facebook.com".into());
+        assert!(needs_consent("click", &reading, &held).is_none(), "nobody is signed in there");
     }
 
     #[test]
@@ -4499,13 +4643,14 @@ mod tests {
         // that read the page, so the browser's last known position is what the
         // click is judged against.
         let held = [session("gmail.com")];
-        let looked = Reading { ingested: true, url: Some("https://mail.gmail.com/".into()) };
+        let looked =
+            Reading { ingested: true, url: Some("https://mail.gmail.com/".into()), allowed: None };
         assert!(needs_consent("click", &looked, &held).is_some());
 
         // With nowhere known to be, there is nothing to judge and nothing is
         // claimed. The turn is still marked, so the first `browse` that lands
         // somewhere signed in re-arms it.
-        let blind = Reading { ingested: true, url: None };
+        let blind = Reading { ingested: true, url: None, allowed: None };
         assert!(needs_consent("click", &blind, &held).is_none());
     }
 

--- a/src/components/ApprovalRequest.test.tsx
+++ b/src/components/ApprovalRequest.test.tsx
@@ -153,7 +153,7 @@ describe("a request for permission", () => {
     expect(screen.getByRole("button", { name: "Allow" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Deny" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Always allow" })).toBeNull();
-    expect(screen.getByText("This answer covers this one action only.")).toBeTruthy();
+    expect(screen.getByText("Nothing here is remembered after this turn.")).toBeTruthy();
     // And the waiting line says what has not happened, which is not a creation.
     expect(screen.getByText(/Nothing has been sent yet/)).toBeTruthy();
   });

--- a/src/components/ApprovalRequest.tsx
+++ b/src/components/ApprovalRequest.tsx
@@ -133,11 +133,17 @@ export function ApprovalRequest({ part, agent }: Props) {
           </button>
           {/* The scope of the middle button, said in full. "Always" reads as a
               setting for the workspace, and it is not: it is one agent being
-              let off one question. */}
+              let off one question.
+
+              Nothing to say about scope for the other action, because the
+              runtime says it: a yes to acting in the operator's name can cover
+              the rest of a turn on one site, and only the request knows which
+              site that is. What is true of every one of them is that it is
+              gone by the next turn. */}
           {part.action === "createAgent" ? (
             <span className="ask__scope">Always allow is for {asker} only.</span>
           ) : (
-            <span className="ask__scope">This answer covers this one action only.</span>
+            <span className="ask__scope">Nothing here is remembered after this turn.</span>
           )}
         </div>
       )}


### PR DESCRIPTION
The browser consent gate asked per press, which produced four identical dialogs in a row for one Facebook account inside one piece of work, and a gate in that shape is one the operator learns to click through. Condition two was never load-bearing: `browse` marks the turn as having taken content in on every successful action, `open` and `read` included, and no click can be aimed without reading the page first, so the rule was really "every click or type on a signed-in site, every time". A yes is now remembered against the session it was given for, on the per-turn `Reading`, and it is still not a standing yes: nothing reaches the `grants` table, the next turn asks again, and `Reading::took_in` drops the grant the moment the turn takes in a page from anywhere else, a screenshot included. Domain matching goes through a new `signin::on_domain` so the grant and the gate cannot disagree about a lookalike, and the request now carries a field naming what allowing covers. Five new tests, and `./scripts/ci.sh` passes.
