### PR TITLE
feat: an account is optional, and the app signs in to it with PKCE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ src-tauri/src/
   llm/                OpenAI-compatible client, SSE decoding, tool definitions.
     codex.rs          The other protocol: where a ChatGPT subscription is spent.
   subscription.rs     Signing in to that subscription. A credential, not a wire.
+  account.rs          The optional Guaca account. Nothing else depends on it.
   mcp.rs              The client end of MCP. Three methods, one POST each.
   oauth.rs            Signing a crew in to a plugin's server. PKCE, no client id.
   plugins.rs          Where those two meet the store, and a turn spends a grant.
@@ -91,6 +92,7 @@ repo: the frontend renders state and forwards intent.
 | Which of the two a piece of work belongs on, and credentials | *Connectors* in `docs/PROTOCOL.md`, then both files above |
 | Plugins: what is on the list, signing one in, calling its tools | `docs/PLUGINS.md`, then `oauth.rs` and `mcp.rs` |
 | Which agents in a crew get a plugin | *Signing in is one decision, and handing it out is another* in `docs/PLUGINS.md`, then `domain/plugin.rs` and `Store::plugin_tools`, which has to agree with `Store::plugin_reach` |
+| The guaca.bot account: signing in, what it is for, why it is optional | `docs/ACCOUNT.md`, then `account.rs` |
 | Channels, the rail, search: what the operator sees | `docs/WORKSPACE.md`, then `src/lib/transcript.ts` |
 | A turn's tool calls in a channel: what folds, what a chip says, what opens | *A turn's own work is chips* in `docs/WORKSPACE.md`, then `src/lib/trail.ts` |
 | Anything announced to a screen reader, or a live region | *A transcript is a log, and says one thing out loud* in `docs/WORKSPACE.md` |
@@ -99,7 +101,7 @@ repo: the frontend renders state and forwards intent.
 | The rail's order, dragging a row, groups as places you go inside | *The rail is arranged by hand*, *A drop is one call* and *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/rail.ts` and `src/lib/orb.ts` |
 | Deleting a group, deleting an agent, what goes with either | *Deleting a group deletes the crew, and the machines they were renting* in `docs/WORKSPACE.md`, then `retire_agent` in `src-tauri/src/commands.rs` |
 | Preset agents, hiring a crew | *The cafeteria is a copy machine* in `docs/WORKSPACE.md`, then `src/lib/cafeteria.ts` |
-| Settings, the surface, the scale, what may interrupt the operator | *Settings is eight places*, *The reading column has two surfaces* and *An interruption has to earn it* in `docs/WORKSPACE.md` |
+| Settings, the surface, the scale, what may interrupt the operator | *Settings is nine places*, *The reading column has two surfaces* and *An interruption has to earn it* in `docs/WORKSPACE.md` |
 | The group editor: what a crew overrides and what it inherits | *A group's settings are the app's, with the crew's answer on top* in `docs/WORKSPACE.md`, then `src/components/GroupEditor.tsx` |
 | A prompt, or anything that changes how much a crew talks | *Three test suites, asking different questions*, then run the live evals |
 
@@ -127,6 +129,18 @@ choose, and no price on the answer. The two meet in exactly one function,
 `LlmClient::stream_chat`, and `llm/codex.rs` translates. Anything above that line
 sees one shape of request. Keep it that way: a provider branch in the runtime, the
 prompt or the guard is the wrong half of the repo.
+
+**An account is optional and nothing depends on it.** `guaca.bot` holds one
+thing Guaca cannot: an OAuth client, for the services that will only issue
+programmatic access to a registered application. `Account` is a field on
+`AppState` that no turn, prompt, tool or guard reads, and both of its reads
+happen when the Settings pane is opened rather than at startup, so an install
+that never opens that pane never contacts the service. Signing in is
+authorization code with PKCE on a loopback port bound before the redirect is
+named, which is `oauth.rs`'s argument pointed at one known server; the device
+grant that was there first is gone rather than kept beside it, because two doors
+to one account means the weaker one decides what the account is worth.
+`docs/ACCOUNT.md`.
 
 **A Claude subscription cannot pay for a turn, and this is not an oversight.**
 Anthropic restricts consumer OAuth tokens to Claude Code and Claude.ai, enforced
@@ -429,6 +443,19 @@ failure worth catching is that belief going stale.
 
 ```sh
 ./scripts/subscription.sh    # a real call against your own ChatGPT plan
+```
+
+`tests/account.rs` is the same shape again for the guaca.bot sign-in: a scripted
+authorization server, and the real `Account` driven through discovery, the
+loopback listener, the PKCE exchange and the first call the token is spent on.
+Its stub checks that the verifier presented at the token endpoint actually
+hashes to the challenge that was sent, because a sign-in that stops proving that
+still works. Its `#[ignore]`d half asks whether the live service still publishes
+what this build reads, and `GUACA_ACCOUNT_ORIGIN` points it at a Worker on this
+machine instead. It authorizes nothing and stores nothing.
+
+```sh
+cargo test --manifest-path src-tauri/Cargo.toml --test account -- --ignored
 ```
 
 A fifth, `tests/plugins.rs`, does the same job for MCP: a scripted server that

--- a/docs/ACCOUNT.md
+++ b/docs/ACCOUNT.md
@@ -1,0 +1,173 @@
+# The account
+
+Guaca runs on your machine, with your keys, and an account changes none of that.
+This file is about the one thing it does change, why that thing cannot be done
+locally, and what had to be true before it was worth building at all.
+
+## Nobody has to sign in
+
+The app is fully usable with no account, and the code is arranged so that stays
+true rather than so it reads well in a README:
+
+- `Account` is a field on `AppState` that nothing else in the app depends on.
+  No turn, no prompt, no tool, no guard reads it. Deleting the module would
+  remove one Settings pane and break nothing else.
+- Both reads happen when the Account pane is opened, not at startup. An install
+  that never opens that pane never sends `guaca.bot` a request, ever.
+- The pane's first sentence says it is optional. That is not marketing copy; it
+  is the answer to the question an operator is actually asking when they find a
+  sign-in inside a local app.
+
+If a change makes any of those three false, it is a change to what Guaca is, and
+it needs arguing on those terms rather than landing as a refactor.
+
+## What an account is for
+
+One thing: a hosted OAuth client.
+
+Guaca's answer to reaching an operator's accounts is normally to sign a browser
+in on the agent's own computer. Where that works it is the better answer — the
+app never handles a password, there is no token to keep, and logging out ends it
+(`docs/MACHINES.md`). It stops working at exactly one place, which is a service
+that will only issue programmatic access to a registered OAuth application.
+Gmail is the example everybody hits.
+
+Guaca cannot be that application. Its client secret would ship inside a download
+anybody can read, which is not a secret, and no amount of local cleverness
+changes that. A hosted origin can be, and `guaca.bot` is: it holds the client,
+holds the refresh token, and hands a paired machine a short-lived access token.
+The refresh token never reaches this machine, which is the whole reason storing
+it there beats storing it here.
+
+Everything else that has ever been proposed for an account — agents that run in
+the cloud, managed provider keys — is a separate argument that has not been had.
+Nothing in this file or in `account.rs` assumes them.
+
+## Signing in is authorization code with PKCE, on a loopback port
+
+This is the third OAuth flow in the app and the second of its kind:
+
+| | Flow | Why |
+|---|---|---|
+| `subscription.rs` | Device code | OpenAI operates the client; the device flow is what they publish |
+| `oauth.rs` | Code + PKCE, loopback | MCP mandates it, and vendors issue a client on the spot |
+| `account.rs` | Code + PKCE, loopback | RFC 8252, and the asset is somebody's mail |
+
+`subscription.rs` argues against a loopback redirect: a fixed port may already
+belong to something else, and a URL scheme is claimed by whichever build
+registered last. Both objections are about a port or a scheme **chosen in
+advance**. `oauth.rs` answers them by binding `127.0.0.1:0` *before* naming the
+redirect, so the port is one the operating system has already handed out and
+nothing can take it in between. This module is that answer pointed at one known
+server.
+
+### Why not the device grant, given one was already built
+
+`guaca.bot` shipped an RFC 8628 device grant before the app half existed, and it
+was removed rather than kept beside this one.
+
+A device code is a bearer secret carried by a human. RFC 8628 §5.4 names what
+follows: nothing binds the code to the machine that asked for it, so anyone who
+can talk an operator into approving a code walks away with a token that mints
+Gmail access tokens on that operator's account. "Your Guaca needs re-pairing,
+enter this code" is the whole attack, and it works over a chat message.
+
+That is the correct trade for a television. It is not the correct trade for an
+application that has a browser on the same machine, which is the case RFC 8252
+is written about. A loopback redirect cannot be phished across machines: the
+code is delivered to `127.0.0.1` on the machine that started the flow, and it is
+worth nothing without a verifier that never left the process.
+
+Both were not kept, because two doors to one account means the weaker one
+decides what the account is worth. `migrations/0001_oauth_provider.sql` on the
+service drops the device table.
+
+### The dance
+
+1. `GET https://guaca.bot/.well-known/oauth-authorization-server` (RFC 8414).
+2. Bind `127.0.0.1:0`. Only now is the redirect URI known.
+3. Open the operator's browser at the authorization endpoint, with a PKCE
+   challenge and a state.
+4. Catch the redirect on that port. Check the state before writing a success
+   page, so a mismatch is never told it worked.
+5. `POST` the code and the verifier to the token endpoint.
+6. Spend the token once, on `/api/connectors`, before anything is written.
+
+Steps 3 to 5 are `oauth.rs`'s own helpers, reused rather than reimplemented.
+Step 6 is this module's, and it is the difference between a sign-in that reports
+success and one that works: it is also where the account's email comes from, so
+there is no second call to make.
+
+**The client is fixed and public.** `guaca-desktop`, seeded by the service's
+migration, `token_endpoint_auth_method: "none"`, no secret. `oauth.rs` registers
+a client dynamically because MCP vendors require it; here that would mean an
+open registration endpoint on a database whose job is holding other people's
+refresh tokens, and a consent screen naming an application a stranger asserted.
+The fixed client is the smaller surface and the more honest screen.
+
+**The redirect URI is registered with no port.** RFC 8252 §7.3 has the
+authorization server compare a loopback redirect on scheme, host, path and query
+while ignoring the port. That is what makes "bind first, then ask" possible at
+all, and it is the one thing the service must not stop honouring.
+
+## Where the service is
+
+`DEFAULT_ORIGIN`, a constant. `GUACA_ACCOUNT_ORIGIN` moves it and exists so the
+flow can be run end to end against a Worker on this machine.
+
+It is an environment variable rather than a setting, and `subscription.rs` gives
+the reason: a sign-in service an operator can type into a box is a credential
+sent somewhere nobody chose. Three things guard it anyway, because an
+environment variable is still an input:
+
+- **HTTPS, or loopback.** Anything else is refused before a request is made. The
+  failure this prevents is a credential on a plaintext connection across a
+  network; loopback is exempt because it does not cross one.
+- **Discovered endpoints must be on the origin that published them.** A metadata
+  document is the one place discovery could move a credential to a third party,
+  and the check costs one string comparison.
+- **An override is logged at startup, and shown in the pane.** A machine left
+  pointed at a development service is not a silent state, and the two hold
+  different accounts.
+
+## What is stored
+
+Its own file, `account.json`, 0600, temp-then-rename.
+
+Not `config.json`, for the reason `subscription.rs` gives: the token set rotates
+on refresh, which is Guaca writing in the background, while `config.json` is
+rewritten wholesale whenever the operator presses Save. Two writers on one file
+lose a refreshed token to a stale in-memory copy, and the symptom is a sign-in
+that works until an unrelated setting changes.
+
+Plaintext, with the same caveat and more force. This credential is not Guaca's
+to lose: it stands for an account that can mint access tokens for the operator's
+mail. The honest fix is the OS keychain, and it is the first thing to reach for
+if this file grows a second reader.
+
+`Status` is what crosses IPC, and it has no token and no field one could arrive
+in. A test asserts its exact serialization, because a field added there is a
+token one serialization away from the webview.
+
+## What the account holds is read, never kept
+
+`/api/connectors` is asked every time the pane needs it. The answer changes when
+the operator authorizes something in a browser, not when this app does anything,
+and a cached copy would be a list of capabilities an agent is told it has and
+does not.
+
+The service is also the only thing that can change that list, because the
+consent screens are Google's and GitHub's. The pane has a link and no controls,
+which is the truthful shape: a tick box here would be a control that cannot
+work.
+
+## What is not built yet
+
+`POST /api/connectors/:provider/token` exists on the service and nothing in the
+app calls it. That is the step where an authorized connector becomes something
+an agent can use, and it is a change to prompts, tool definitions and the trust
+boundary rather than to this module. When it lands, the rule from
+`docs/MACHINES.md` applies unchanged and is the hard part: **a secret never
+reaches a model.** A provider access token fetched here must reach the process
+making the call and nothing else — not a prompt, not a transcript, not an event,
+not the webview.

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -473,7 +473,7 @@ back to the message being opened, bounded at a thousand; past that the operator
 lands in the right channel at its newest end. Anything that jumps to a message
 goes through `openMessage` rather than `select`.
 
-## Settings is eight places, because it stopped being one subject
+## Settings is nine places, because it stopped being one subject
 
 An endpoint, a set of limits, a machine's credentials, how large the window
 draws and what is allowed to interrupt you are five different questions, and one
@@ -481,11 +481,23 @@ scroll made the operator read all five to change one. So it is a nav and a pane,
 on the Cafeteria's shape: a panel that owns its own height, a head and a foot
 pinned to it, one scrolling half.
 
-Two of those eight are defaults rather than orders. Whatever Provider and Limits
+Two of those nine are defaults rather than orders. Whatever Provider and Limits
 say is what a group falls back to, and a group that answers for itself is not
 affected by either. What stays app-wide is what is genuinely one of: the
 operator's name, the machine and browser accounts, and everything about how the
 app looks and when it may interrupt.
+
+One of them is optional in a way none of the others are. Account is the only
+pane that talks to a service Guaca's author runs, and an install that never
+opens it never sends that service a request: both of its reads happen when the
+pane is opened rather than at startup. That is the shape the feature has to keep.
+Most people will never sign in, everything else in the app works identically
+either way, and the pane says so in its first sentence rather than leaving an
+operator to work out whether they are missing something. What signing in buys is
+one thing that genuinely cannot be done from here: an OAuth client for a service
+that will only issue programmatic access to a registered application. A client
+secret shipped inside an open-source download is not a secret, so the client has
+to live somewhere else or not exist. `docs/ACCOUNT.md` is the long version.
 
 Every value lives in the shell rather than in the pane that draws it, and that is
 not tidiness. The shell is unmounted when the dialog closes, so a pane holding

--- a/src-tauri/src/account.rs
+++ b/src-tauri/src/account.rs
@@ -1,0 +1,738 @@
+//! Signing in to a Guaca account, which nobody has to do.
+//!
+//! Guaca runs on this machine with the operator's own keys and stays that way.
+//! An account is one optional thing: a hosted OAuth client, so an agent can
+//! reach a service that will only issue programmatic access to a registered
+//! application. Gmail is the example. Guaca cannot be that application, because
+//! its client secret would be in the download, and no amount of local
+//! cleverness changes that. `guaca.bot` can be, and holds the refresh token so
+//! this machine never has to.
+//!
+//! An install that never signs in never talks to it. Everything else in the app
+//! works exactly the same either way, and that is a property to keep rather than
+//! a phase to grow out of.
+//!
+//! ## Why this is the third OAuth flow and not a copy of the first
+//!
+//! [`crate::subscription`] uses the device flow and argues for it: a fixed
+//! loopback port may already belong to something else, and a URL scheme is
+//! claimed by whichever build registered last. [`crate::oauth`] answers both
+//! objections for MCP plugins by binding `127.0.0.1:0` *before* naming the
+//! redirect, so the port is one the operating system has already handed out.
+//! This module is that second answer pointed at one known server.
+//!
+//! The choice matters more here than anywhere else in the app. A device code is
+//! a bearer secret carried by a human, and RFC 8628 section 5.4 says what
+//! follows: nothing binds the code to the machine that asked for it, so anyone
+//! who can talk an operator into approving one walks away with a token that
+//! mints Gmail access tokens on that operator's account. RFC 8252 is the
+//! standing advice for a native application with a browser, and this is it: an
+//! authorization code, bound to this process by a PKCE verifier that never
+//! leaves it, delivered to a port on this machine. A code lifted off the wire is
+//! worth nothing without the verifier, and a code delivered to `127.0.0.1` on
+//! somebody else's machine never reaches this one.
+//!
+//! ## Where the service is, and where it is not
+//!
+//! [`DEFAULT_ORIGIN`], a constant, overridable only through the environment and
+//! never through settings. The reason is `subscription.rs`'s: a mistyped sign-in
+//! service is a credential sent somewhere nobody chose. The override exists so
+//! the flow can be run end to end against a Worker on this machine, and it is
+//! refused for anything that is neither HTTPS nor loopback.
+//!
+//! ## What is stored, and where
+//!
+//! Its own file, for the reason `subscription.rs` gives: the token set rotates
+//! on refresh, which is Guaca writing in the background, and `config.json` is
+//! rewritten wholesale whenever the operator presses Save. Two writers on one
+//! file lose a refreshed token to a stale in-memory copy.
+//!
+//! Plaintext and 0600, and the same caveat applies with the same force. This
+//! credential is not Guaca's to lose: it stands for an account that can mint
+//! access tokens for the operator's mail. The honest fix is the OS keychain, and
+//! it is the first thing to reach for if this file grows a second reader.
+
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use tokio::net::TcpListener;
+
+use crate::oauth::{self, OauthError};
+
+/// The service, and the only one a build ships pointed at.
+pub const DEFAULT_ORIGIN: &str = "https://guaca.bot";
+
+/// What the app is registered as there.
+///
+/// Not a secret and not capable of being one: this is a public client, and PKCE
+/// is what proves a code belongs to the copy of Guaca that asked for it. The
+/// same string is a row in the service's own migration, which is what keeps the
+/// consent screen naming an application the service chose rather than one a
+/// stranger registered.
+pub const CLIENT_ID: &str = "guaca-desktop";
+
+/// Everything the app asks for, which is everything it has a use for.
+///
+/// `openid` is what lets the service turn this token back into a person on its
+/// own endpoints, `email` is so the operator can see which account they linked,
+/// `offline_access` is the refresh token, and `connectors` is the one that does
+/// anything. Asking for less would mean asking again later, which is another
+/// consent screen for a person who has already said yes.
+pub const SCOPE: &str = "openid email offline_access connectors";
+
+/// Refresh this far ahead of expiry rather than on rejection, for the reason
+/// `subscription.rs` gives: a call that discovers the token expired has already
+/// spent the wait on a round trip that was never going to work.
+const REFRESH_SKEW_MS: i64 = 5 * 60 * 1000;
+
+/// Long enough for a slow exchange, short enough that a hung service does not
+/// park the dialog forever.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, thiserror::Error)]
+pub enum AccountError {
+    #[error(
+        "{origin} is not a sign-in service Guaca will use. It has to be HTTPS, or a loopback \
+         address for local development."
+    )]
+    UnsafeOrigin { origin: String },
+    #[error(
+        "{origin} does not publish where to sign in, so Guaca cannot start. Check the address, or \
+         that the service is running."
+    )]
+    NoMetadata { origin: String },
+    #[error(
+        "{origin} published a sign-in address at {endpoint}, which is somewhere else. Guaca will \
+         not send a credential there."
+    )]
+    ForeignEndpoint { origin: String, endpoint: String },
+    #[error("could not listen for the answer from your browser: {source}")]
+    NoPort {
+        #[source]
+        source: io::Error,
+    },
+    #[error("could not open your browser: {detail}")]
+    NoBrowser { detail: String },
+    #[error("nothing came back from your browser within five minutes; the sign-in was abandoned")]
+    TimedOut,
+    #[error("the sign-in was refused: {error}{}", .description.as_deref().map(|d| format!(" — {d}")).unwrap_or_default())]
+    Refused { error: String, description: Option<String> },
+    #[error("the answer from your browser did not match the sign-in that was started")]
+    StateMismatch,
+    #[error("{origin} answered HTTP {status}: {message}")]
+    Upstream { origin: String, status: u16, message: String },
+    #[error("could not reach {origin}: {detail}")]
+    Transport { origin: String, detail: String },
+    #[error("not signed in to a Guaca account")]
+    NotSignedIn,
+    #[error("the sign-in to {origin} has expired. Sign in again.")]
+    Expired { origin: String },
+    #[error("could not save the sign-in to {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+}
+
+impl From<OauthError> for AccountError {
+    fn from(err: OauthError) -> Self {
+        match err {
+            OauthError::NoPort { source } => AccountError::NoPort { source },
+            OauthError::TimedOut => AccountError::TimedOut,
+            OauthError::Refused { error, description } => {
+                AccountError::Refused { error, description }
+            }
+            OauthError::StateMismatch => AccountError::StateMismatch,
+            OauthError::NoMetadata { url, .. } => AccountError::NoMetadata { origin: url },
+            OauthError::Status { url, status, body, .. } => {
+                AccountError::Upstream { origin: url, status, message: body }
+            }
+            OauthError::Transport { url, source, .. } => {
+                AccountError::Transport { origin: url, detail: source.to_string() }
+            }
+            other => AccountError::Transport { origin: String::new(), detail: other.to_string() },
+        }
+    }
+}
+
+/// The token set, as stored. Never crosses IPC: see [`Status`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+struct Stored {
+    access_token: String,
+    /// Absent means a service that issued no refresh token, which is a sign-in
+    /// that ends when the access token does rather than one that is broken.
+    #[serde(default)]
+    refresh_token: Option<String>,
+    /// Milliseconds since the epoch. Absent means the service did not say, and
+    /// a token with no stated expiry is used until it is refused.
+    #[serde(default)]
+    expires_at: Option<i64>,
+    /// Denormalised so a signed-in status can be answered without a round trip.
+    #[serde(default)]
+    email: String,
+    /// Kept with the tokens because a refresh needs it, and rediscovering the
+    /// endpoint on every refresh is a second round trip in front of every call.
+    token_endpoint: String,
+    /// Which service issued this, so a build pointed somewhere else does not
+    /// read it as its own.
+    ///
+    /// One profile per bundle identifier, so the development build and the real
+    /// one share this file. Without this field, signing in to a Worker on this
+    /// machine and then opening the real app presents a localhost token to
+    /// `guaca.bot`, which refuses it: an operator sees a sign-in that used to
+    /// work and now reports itself expired, with nothing on screen to say why.
+    /// Absent means a file written before this field existed, which can only
+    /// have been the default service.
+    #[serde(default)]
+    origin: String,
+}
+
+/// What the webview is allowed to know about an account.
+///
+/// No token, and no field one could arrive in. The origin is here because in
+/// development it is not `guaca.bot`, and an operator who cannot see which
+/// service they linked to cannot tell the two apart.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Status {
+    pub signed_in: bool,
+    pub email: String,
+    pub origin: String,
+}
+
+/// One thing an authorized provider can do, as the service describes it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Capability {
+    pub id: String,
+    pub label: String,
+    pub granted: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Provider {
+    pub id: String,
+    pub label: String,
+    pub capabilities: Vec<Capability>,
+}
+
+/// What the account holds, as the service reports it.
+///
+/// Read rather than kept. The authoritative answer is the service's, it changes
+/// when the operator authorizes something in a browser rather than when this
+/// app does anything, and a stale local copy would be a list of capabilities an
+/// agent is told it has and does not.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Connectors {
+    pub email: String,
+    pub providers: Vec<Provider>,
+}
+
+/// A signed-in Guaca account, and the file it lives in.
+///
+/// Cheap to clone behind the `Arc` its owner holds. The mutex is held only to
+/// read or replace the token set, never across a request.
+#[derive(Debug)]
+pub struct Account {
+    path: PathBuf,
+    origin: String,
+    http: reqwest::Client,
+    tokens: Mutex<Option<Stored>>,
+}
+
+impl Account {
+    /// Opens the store at `path`, against the service this build ships with.
+    pub fn open(path: PathBuf) -> Self {
+        Self::open_at(path, DEFAULT_ORIGIN)
+    }
+
+    /// The same, against a named service.
+    ///
+    /// The seam for the test suite and for running the real flow against a
+    /// Worker on this machine. Deliberately not reachable from settings: see the
+    /// module comment.
+    pub fn open_at(path: PathBuf, origin: impl Into<String>) -> Self {
+        let origin = origin.into().trim_end_matches('/').to_string();
+        let tokens = match fs::read_to_string(&path) {
+            Ok(raw) => match serde_json::from_str::<Stored>(&raw) {
+                Ok(stored) if stored.access_token.is_empty() => None,
+                Ok(stored) if !belongs_to(&stored, &origin) => {
+                    tracing::info!(
+                        stored = %stored.origin,
+                        configured = %origin,
+                        "ignoring an account signed in to a different service"
+                    );
+                    None
+                }
+                Ok(stored) => Some(stored),
+                Err(err) => {
+                    tracing::warn!(%err, path = %path.display(), "ignoring an unreadable account file");
+                    None
+                }
+            },
+            Err(err) if err.kind() == io::ErrorKind::NotFound => None,
+            Err(err) => {
+                tracing::warn!(%err, path = %path.display(), "could not read the account file");
+                None
+            }
+        };
+
+        Self {
+            path,
+            origin,
+            http: reqwest::Client::builder().timeout(HTTP_TIMEOUT).build().unwrap_or_default(),
+            tokens: Mutex::new(tokens),
+        }
+    }
+
+    pub fn origin(&self) -> &str {
+        &self.origin
+    }
+
+    pub fn status(&self) -> Status {
+        match &*self.tokens.lock() {
+            Some(stored) => {
+                Status { signed_in: true, email: stored.email.clone(), origin: self.origin.clone() }
+            }
+            None => Status { signed_in: false, email: String::new(), origin: self.origin.clone() },
+        }
+    }
+
+    pub fn is_signed_in(&self) -> bool {
+        self.tokens.lock().is_some()
+    }
+
+    /// The whole sign-in, from discovery to a stored token.
+    ///
+    /// Long-running by design: it returns when the operator has finished in the
+    /// browser, refused, or taken longer than five minutes. The caller is an IPC
+    /// command the dialog awaits, so abandoning it costs one parked call and
+    /// leaves nothing behind but a closed socket.
+    pub async fn sign_in(
+        &self,
+        open: impl FnOnce(&str) -> Result<(), String>,
+    ) -> Result<Status, AccountError> {
+        let server = self.discover().await?;
+
+        // Bound before the redirect URI is built, which is the whole reason a
+        // loopback redirect is safe: the port is one the operating system has
+        // already given out, so nothing can take it between choosing it and
+        // listening on it. The service registered this redirect with no port at
+        // all, because RFC 8252 section 7.3 has it compare everything but.
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .map_err(|source| AccountError::NoPort { source })?;
+        let port = listener.local_addr().map_err(|source| AccountError::NoPort { source })?.port();
+        let redirect_uri = format!("http://127.0.0.1:{port}/callback");
+
+        let verifier = oauth::secret();
+        let challenge = oauth::pkce_challenge(&verifier);
+        let state = oauth::secret();
+
+        let url = format!(
+            "{}?response_type=code&client_id={}&redirect_uri={}&scope={}&state={}\
+             &code_challenge={}&code_challenge_method=S256",
+            server.authorization_endpoint,
+            oauth::encode(CLIENT_ID),
+            oauth::encode(&redirect_uri),
+            oauth::encode(SCOPE),
+            oauth::encode(&state),
+            oauth::encode(&challenge),
+        );
+
+        open(&url).map_err(|detail| AccountError::NoBrowser { detail })?;
+
+        let code = oauth::wait_for_redirect(listener, &state).await?;
+
+        let issued = oauth::post_token(
+            &oauth::http()?,
+            &server.token_endpoint,
+            &[
+                ("grant_type".to_string(), "authorization_code".to_string()),
+                ("code".to_string(), code),
+                ("redirect_uri".to_string(), redirect_uri),
+                ("client_id".to_string(), CLIENT_ID.to_string()),
+                ("code_verifier".to_string(), verifier),
+            ],
+        )
+        .await?;
+
+        let stored = Stored {
+            access_token: issued.access_token,
+            refresh_token: issued.refresh_token,
+            expires_at: issued.expires_in.map(|secs| now_ms() + secs * 1000),
+            // Filled in below. The service is the only thing that knows which
+            // account this turned out to be.
+            email: String::new(),
+            token_endpoint: server.token_endpoint,
+            origin: self.origin.clone(),
+        };
+
+        // Spending the token once, before anything is written, is what makes a
+        // sign-in that reports success one that actually works. It is also where
+        // the email comes from, so there is no second call to make.
+        let held = self.fetch_connectors(&stored.access_token).await?;
+        self.store(Stored { email: held.email, ..stored })
+    }
+
+    /// Forgets the sign-in on this machine.
+    ///
+    /// Local only. Revoking centrally would be the service's business and would
+    /// end sign-ins on the operator's other machines, which this one does not
+    /// own. What it does end here is immediate: the file goes, and the next call
+    /// has nothing to present.
+    pub fn sign_out(&self) -> Result<(), AccountError> {
+        *self.tokens.lock() = None;
+        match fs::remove_file(&self.path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(source) => Err(AccountError::Io { path: self.path.clone(), source }),
+        }
+    }
+
+    /// What the account holds right now, asked of the service.
+    pub async fn connectors(&self) -> Result<Connectors, AccountError> {
+        let token = self.access().await?;
+        self.fetch_connectors(&token).await
+    }
+
+    /// A token that is good right now.
+    ///
+    /// Refreshes when the stored one is close enough to expiry to be a risk, so
+    /// every caller is spared deciding. A refresh the network refused leaves the
+    /// stored token in place: it may still have minutes left, and a call that
+    /// could have worked is worth more than a tidy cache. A refusal is different
+    /// and surfaces, because the operator has to sign in again.
+    pub async fn access(&self) -> Result<String, AccountError> {
+        let stored = self.tokens.lock().clone().ok_or(AccountError::NotSignedIn)?;
+
+        let expiring = stored.expires_at.is_some_and(|at| at - REFRESH_SKEW_MS <= now_ms());
+        if !expiring {
+            return Ok(stored.access_token);
+        }
+
+        let Some(refresh_token) = stored.refresh_token.clone() else {
+            // No way to renew, so the token stands until it is refused. Saying
+            // so here would sign the operator out of a sign-in that still works.
+            return Ok(stored.access_token);
+        };
+
+        match self.refresh(&stored, &refresh_token).await {
+            Ok(fresh) => Ok(fresh),
+            Err(AccountError::Transport { .. }) => {
+                tracing::warn!("using the stored account token: its refresh could not be reached");
+                Ok(stored.access_token)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn refresh(&self, stored: &Stored, refresh_token: &str) -> Result<String, AccountError> {
+        let issued = oauth::post_token(
+            &oauth::http()?,
+            &stored.token_endpoint,
+            &[
+                ("grant_type".to_string(), "refresh_token".to_string()),
+                ("refresh_token".to_string(), refresh_token.to_string()),
+                ("client_id".to_string(), CLIENT_ID.to_string()),
+            ],
+        )
+        .await?;
+
+        let access_token = issued.access_token.clone();
+        self.store(Stored {
+            access_token: issued.access_token,
+            // A rotation that issues a new refresh token says so; one that does
+            // not expects the old one to keep working. Storing nothing here
+            // would end the sign-in at the next renewal.
+            refresh_token: issued.refresh_token.or_else(|| Some(refresh_token.to_string())),
+            expires_at: issued.expires_in.map(|secs| now_ms() + secs * 1000),
+            email: stored.email.clone(),
+            token_endpoint: stored.token_endpoint.clone(),
+            origin: self.origin.clone(),
+        })?;
+        Ok(access_token)
+    }
+
+    /// Where the service says to sign in, read from the service.
+    ///
+    /// RFC 8414, at the root of the origin. Guaca could hard-code the two paths
+    /// and save a round trip, and then a service that moved one would be a
+    /// sign-in nobody could complete until every copy of the app was updated.
+    ///
+    /// Both endpoints are checked to be on the origin that published them. That
+    /// is not defensiveness about a document Guaca fetched over TLS from the one
+    /// place it trusts: it is the difference between a service that can change
+    /// its own paths and a service that can redirect an operator's credential to
+    /// a third party, and the check costs one string comparison.
+    async fn discover(&self) -> Result<oauth::ServerMetadata, AccountError> {
+        if !self.is_safe_origin() {
+            return Err(AccountError::UnsafeOrigin { origin: self.origin.clone() });
+        }
+
+        let server = oauth::server_metadata(&self.http, &self.origin).await?;
+        for endpoint in [&server.authorization_endpoint, &server.token_endpoint] {
+            if !self.is_same_origin(endpoint) {
+                return Err(AccountError::ForeignEndpoint {
+                    origin: self.origin.clone(),
+                    endpoint: endpoint.clone(),
+                });
+            }
+        }
+        Ok(server)
+    }
+
+    /// HTTPS, or a loopback address for local development.
+    ///
+    /// The one thing an environment variable must not be able to do is send a
+    /// credential over plaintext to somewhere on the network. Loopback is
+    /// exempt because it does not cross one.
+    fn is_safe_origin(&self) -> bool {
+        if self.origin.starts_with("https://") {
+            return true;
+        }
+        let Some(rest) = self.origin.strip_prefix("http://") else {
+            return false;
+        };
+        let host = rest.split('/').next().unwrap_or("").rsplit_once(':').map_or(rest, |(h, _)| h);
+        matches!(host, "localhost" | "127.0.0.1" | "[::1]" | "::1")
+    }
+
+    fn is_same_origin(&self, url: &str) -> bool {
+        oauth::split_origin(url).is_some_and(|(origin, _)| origin == self.origin)
+    }
+
+    async fn fetch_connectors(&self, token: &str) -> Result<Connectors, AccountError> {
+        #[derive(Deserialize)]
+        struct Body {
+            user: User,
+            providers: Vec<Provider>,
+        }
+        #[derive(Deserialize)]
+        struct User {
+            email: String,
+        }
+
+        let url = format!("{}/api/connectors", self.origin);
+        let response = self.http.get(&url).bearer_auth(token).send().await.map_err(|err| {
+            AccountError::Transport { origin: self.origin.clone(), detail: err.to_string() }
+        })?;
+
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(AccountError::Expired { origin: self.origin.clone() });
+        }
+        let body = response.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(AccountError::Upstream {
+                origin: self.origin.clone(),
+                status: status.as_u16(),
+                message: body.chars().take(300).collect(),
+            });
+        }
+
+        let parsed: Body = serde_json::from_str(&body).map_err(|err| AccountError::Transport {
+            origin: self.origin.clone(),
+            detail: format!("its answer did not parse: {err}"),
+        })?;
+        Ok(Connectors { email: parsed.user.email, providers: parsed.providers })
+    }
+
+    fn store(&self, stored: Stored) -> Result<Status, AccountError> {
+        let status =
+            Status { signed_in: true, email: stored.email.clone(), origin: self.origin.clone() };
+        self.write(&stored)?;
+        *self.tokens.lock() = Some(stored);
+        Ok(status)
+    }
+
+    fn write(&self, stored: &Stored) -> Result<(), AccountError> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|source| AccountError::Io { path: parent.to_path_buf(), source })?;
+        }
+
+        let json = serde_json::to_string_pretty(stored).map_err(|err| AccountError::Transport {
+            origin: self.origin.clone(),
+            detail: err.to_string(),
+        })?;
+
+        // Same temp-then-rename as the config and the subscription, for the
+        // same reason: a crash mid-write must not leave a file that parses as a
+        // partial sign-in. Permissions go on before the rename, so the file is
+        // never briefly world-readable under its real name.
+        let tmp = self.path.with_extension("json.tmp");
+        fs::write(&tmp, json).map_err(|source| AccountError::Io { path: tmp.clone(), source })?;
+        restrict(&tmp)?;
+        fs::rename(&tmp, &self.path)
+            .map_err(|source| AccountError::Io { path: self.path.clone(), source })?;
+        Ok(())
+    }
+}
+
+/// Whether a stored sign-in is one this build may present.
+///
+/// An empty stored origin is a file written before the field existed, and the
+/// only service there has ever been is the default one.
+fn belongs_to(stored: &Stored, origin: &str) -> bool {
+    if stored.origin.is_empty() {
+        return origin == DEFAULT_ORIGIN;
+    }
+    stored.origin == origin
+}
+
+fn now_ms() -> i64 {
+    crate::domain::now_ms()
+}
+
+/// 0600, where the platform has such a thing.
+#[cfg(unix)]
+fn restrict(path: &std::path::Path) -> Result<(), AccountError> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .map_err(|source| AccountError::Io { path: path.to_path_buf(), source })
+}
+
+#[cfg(not(unix))]
+fn restrict(_path: &std::path::Path) -> Result<(), AccountError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn account(origin: &str) -> Account {
+        let dir = std::env::temp_dir().join(format!("guaca-account-{}", uuid::Uuid::new_v4()));
+        Account::open_at(dir.join("account.json"), origin)
+    }
+
+    #[test]
+    fn an_absent_file_is_signed_out_rather_than_a_failure() {
+        let held = account(DEFAULT_ORIGIN);
+        assert!(!held.is_signed_in());
+        assert!(!held.status().signed_in);
+        assert_eq!(held.status().origin, DEFAULT_ORIGIN);
+    }
+
+    #[test]
+    fn a_file_that_does_not_parse_is_signed_out_rather_than_a_failure() {
+        // The app is fully usable without an account, so an unreadable file is
+        // a sign-in to redo, not a reason to refuse to start.
+        let dir = std::env::temp_dir().join(format!("guaca-account-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("account.json");
+        fs::write(&path, "{ not json").unwrap();
+        assert!(!Account::open(path).is_signed_in());
+    }
+
+    #[test]
+    fn a_stored_file_with_no_token_is_not_a_sign_in() {
+        let dir = std::env::temp_dir().join(format!("guaca-account-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("account.json");
+        fs::write(&path, r#"{"access_token":"","token_endpoint":"x"}"#).unwrap();
+        assert!(!Account::open(path).is_signed_in());
+    }
+
+    /// A file written by a development build, and the real build reading it.
+    fn write_stored(origin: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("guaca-account-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("account.json");
+        let stored = Stored {
+            access_token: "token".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            email: "a@b.com".to_string(),
+            token_endpoint: format!("{origin}/api/auth/oauth2/token"),
+            origin: origin.to_string(),
+        };
+        fs::write(&path, serde_json::to_string(&stored).unwrap()).unwrap();
+        path
+    }
+
+    #[test]
+    fn a_sign_in_to_another_service_is_not_read_as_this_ones() {
+        // One profile per bundle identifier, so a development build and the real
+        // one share this file. Without the check, the real app presents a
+        // localhost token to guaca.bot and reports a sign-in that used to work
+        // as expired, with nothing on screen to say why.
+        let path = write_stored("http://localhost:8787");
+        assert!(!Account::open(path.clone()).is_signed_in());
+        assert!(Account::open_at(path, "http://localhost:8787").is_signed_in());
+    }
+
+    #[test]
+    fn a_file_written_before_the_service_was_recorded_is_the_default_one() {
+        let dir = std::env::temp_dir().join(format!("guaca-account-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("account.json");
+        fs::write(&path, r#"{"access_token":"t","token_endpoint":"x"}"#).unwrap();
+
+        assert!(Account::open(path.clone()).is_signed_in(), "the only service there has been");
+        assert!(!Account::open_at(path, "http://localhost:8787").is_signed_in());
+    }
+
+    #[test]
+    fn signing_out_when_signed_out_is_not_an_error() {
+        assert!(account(DEFAULT_ORIGIN).sign_out().is_ok());
+    }
+
+    #[test]
+    fn https_and_loopback_are_the_only_services_a_credential_goes_to() {
+        for origin in [
+            "https://guaca.bot",
+            "https://example.test",
+            "http://localhost:8787",
+            "http://127.0.0.1:8787",
+            "http://[::1]:8787",
+        ] {
+            assert!(account(origin).is_safe_origin(), "{origin} should be allowed");
+        }
+        // The whole point of the check: an environment variable must not be
+        // able to put a credential on a plaintext connection across a network.
+        for origin in ["http://guaca.bot", "http://evil.example", "ftp://guaca.bot", "guaca.bot"] {
+            assert!(!account(origin).is_safe_origin(), "{origin} should be refused");
+        }
+    }
+
+    #[test]
+    fn an_endpoint_somewhere_else_is_not_followed() {
+        let held = account("https://guaca.bot");
+        assert!(held.is_same_origin("https://guaca.bot/api/auth/oauth2/token"));
+        assert!(held.is_same_origin("https://guaca.bot"));
+        // A published document that names another host is the one way discovery
+        // could move a credential, so it is refused rather than followed.
+        assert!(!held.is_same_origin("https://evil.example/token"));
+        assert!(!held.is_same_origin("https://guaca.bot.evil.example/token"));
+        assert!(!held.is_same_origin("http://guaca.bot/token"));
+    }
+
+    #[test]
+    fn a_trailing_slash_on_the_service_is_not_a_second_service() {
+        // Otherwise every discovered endpoint fails the same-origin check
+        // against an origin nobody would look at twice.
+        assert_eq!(account("https://guaca.bot/").origin(), "https://guaca.bot");
+    }
+
+    #[test]
+    fn the_status_that_crosses_ipc_carries_no_token() {
+        // The one invariant this type exists for. A field added here is a token
+        // one serialization away from the webview.
+        let json = serde_json::to_string(&Status {
+            signed_in: true,
+            email: "a@b.com".to_string(),
+            origin: DEFAULT_ORIGIN.to_string(),
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"signedIn":true,"email":"a@b.com","origin":"https://guaca.bot"}"#);
+    }
+}

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -4,11 +4,13 @@
 //! Everything below them is a plain Rust library with plain tests, which is why
 //! the cascade tests can drive the real runtime without a window.
 
+use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 
 use tauri::http::{Request, Response};
 use tauri::{Emitter, Manager, UriSchemeContext};
 
+use crate::account::Account;
 use crate::commands::{self, AppState};
 use crate::config;
 use crate::db::Store;
@@ -202,6 +204,26 @@ fn hide_rather_than_quit(window: &tauri::Window, event: &tauri::WindowEvent) {
     tracing::info!("window closed; Guaca is still running in the menu bar");
 }
 
+/// The Guaca account store, pointed at the service this build ships with.
+///
+/// `GUACA_ACCOUNT_ORIGIN` moves it, and exists so the sign-in can be run end to
+/// end against a Worker on this machine. It is an environment variable rather
+/// than a setting on purpose, and `account.rs` says why: a sign-in service an
+/// operator can type into a box is a credential sent somewhere nobody chose.
+/// `Account` refuses anything that is neither HTTPS nor loopback, and an
+/// override is logged at startup so a machine left pointed at a development
+/// service is not a silent state.
+fn account_store(path: PathBuf) -> Account {
+    match std::env::var("GUACA_ACCOUNT_ORIGIN") {
+        Ok(origin) if !origin.trim().is_empty() => {
+            let origin = origin.trim().to_string();
+            tracing::warn!(%origin, "signing in to a Guaca account somewhere other than the default");
+            Account::open_at(path, origin)
+        }
+        _ => Account::open(path),
+    }
+}
+
 pub fn run() {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -256,6 +278,9 @@ pub fn run() {
             // `subscription.rs` says why: the two files have different writers
             // and one of them writes in the background.
             let subscription = Arc::new(Subscription::open(config_dir.join("subscription.json")));
+            // The Guaca account, in its own file for the same reason. Optional,
+            // and an install that never signs in never talks to the service.
+            let account = Arc::new(account_store(config_dir.join("account.json")));
             let menubar = Arc::new(OnceLock::new());
             let sink = Arc::new(TauriSink { app: app.handle().clone(), tray: menubar.clone() });
 
@@ -343,7 +368,7 @@ pub fn run() {
                 .or_else(|_| app.path().home_dir())
                 .unwrap_or_else(|_| data_dir.clone());
 
-            app.manage(AppState { runtime, config_path, downloads, subscription });
+            app.manage(AppState { runtime, config_path, downloads, subscription, account });
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -414,6 +439,10 @@ pub fn run() {
             commands::get_settings,
             commands::update_settings,
             commands::test_connection,
+            commands::account_status,
+            commands::sign_in_account,
+            commands::account_connectors,
+            commands::sign_out_account,
             commands::subscription_status,
             commands::begin_subscription_signin,
             commands::complete_subscription_signin,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
+use crate::account::{Account, AccountError, Connectors};
 use crate::config::{self, AppConfig, RedactedConfig};
 use crate::domain::agent::{copy_name, hire_names, AgentCard, AgentDraft, Lifecycle};
 use crate::domain::approval::{Approval, ApprovalState, Decision, ProtectedAction};
@@ -45,6 +46,9 @@ pub struct AppState {
     /// The ChatGPT sign-in. The same one the runtime makes calls with, so a
     /// sign-in completed here is usable by the next turn without a restart.
     pub subscription: Arc<Subscription>,
+    /// The Guaca account, which is optional and which nothing else in the app
+    /// depends on. An install that never signs in never reaches the service.
+    pub account: Arc<Account>,
 }
 
 /// A structured error the UI can render as more than a toast.
@@ -99,6 +103,19 @@ impl From<crate::runtime::RuntimeError> for CommandError {
             RuntimeError::UnknownAgent(_) => CommandError::new("notFound", err.to_string()),
             RuntimeError::AgentTerminated(_) => CommandError::new("terminated", err.to_string()),
             RuntimeError::NothingToRetry => CommandError::new("notFound", err.to_string()),
+        }
+    }
+}
+
+impl From<AccountError> for CommandError {
+    fn from(err: AccountError) -> Self {
+        match err {
+            // Its own kind: the UI redraws itself as signed out rather than
+            // showing a failure for a sign-in that simply ended.
+            AccountError::NotSignedIn | AccountError::Expired { .. } => {
+                CommandError::new("signedOut", err.to_string())
+            }
+            other => CommandError::new("account", other.to_string()),
         }
     }
 }
@@ -1385,6 +1402,62 @@ pub struct SettingsPatch {
 #[tauri::command]
 pub fn get_settings(state: State<'_, AppState>) -> Reply<RedactedConfig> {
     Ok(state.runtime.config().redacted())
+}
+
+// ---- the Guaca account ---------------------------------------------------
+
+/// Whether an account is signed in, and which service it is.
+///
+/// The origin is on it because in development it is not `guaca.bot`, and an
+/// operator who cannot see which service they linked cannot tell the two apart.
+#[tauri::command]
+pub fn account_status(state: State<'_, AppState>) -> Reply<crate::account::Status> {
+    Ok(state.account.status())
+}
+
+/// The whole sign-in, in one call.
+///
+/// One command rather than the subscription's two, because there is no code for
+/// the operator to carry: the browser opens, they say yes, and the answer comes
+/// back to a port this process is already listening on. Nothing needs drawing
+/// in between, so nothing needs a second round trip to draw it.
+///
+/// Parks for up to five minutes on purpose. An operator who closes the dialog
+/// abandons it, and what is left behind is a closed socket.
+#[tauri::command]
+pub async fn sign_in_account(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Reply<crate::account::Status> {
+    let account = state.account.clone();
+    Ok(account
+        .sign_in(|url| {
+            // The system browser, not the webview. The sign-in belongs to a
+            // session this app has no business holding, and the whole argument
+            // for a loopback redirect is that the browser is the operator's.
+            tauri_plugin_opener::OpenerExt::opener(&app)
+                .open_url(url, None::<&str>)
+                .map_err(|err| err.to_string())
+        })
+        .await?)
+}
+
+/// What the account holds, asked of the service rather than remembered.
+///
+/// The answer changes when the operator authorizes something in a browser, not
+/// when this app does anything, so a cached copy would be a list of
+/// capabilities an agent is told it has and does not.
+#[tauri::command]
+pub async fn account_connectors(state: State<'_, AppState>) -> Reply<Connectors> {
+    let account = state.account.clone();
+    Ok(account.connectors().await?)
+}
+
+/// Forgets the sign-in on this machine.
+#[tauri::command]
+pub fn sign_out_account(state: State<'_, AppState>) -> Reply<crate::account::Status> {
+    state.account.sign_out()?;
+    Ok(state.account.status())
 }
 
 // ---- the ChatGPT sign-in -------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod account;
 pub mod app;
 pub mod cdp;
 pub mod commands;

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -323,7 +323,7 @@ pub struct ServerMetadata {
     pub code_challenge_methods_supported: Vec<String>,
 }
 
-async fn server_metadata(
+pub(crate) async fn server_metadata(
     http: &reqwest::Client,
     issuer: &str,
 ) -> Result<ServerMetadata, OauthError> {
@@ -371,7 +371,7 @@ fn well_known(url: &str, name: &str) -> Vec<String> {
 
 /// `https://host:port` and the path after it, without pulling in a URL crate
 /// for two `find` calls.
-fn split_origin(url: &str) -> Option<(String, String)> {
+pub(crate) fn split_origin(url: &str) -> Option<(String, String)> {
     let (scheme, rest) = url.split_once("://")?;
     match rest.find('/') {
         Some(at) => Some((format!("{scheme}://{}", &rest[..at]), rest[at..].to_string())),
@@ -502,7 +502,10 @@ async fn register(
 /// waiting: a browser asks for `/favicon.ico` while it is showing the page, and
 /// taking the first connection as the answer would abandon the sign-in the
 /// moment the operator's browser was being thorough.
-async fn wait_for_redirect(listener: TcpListener, state: &str) -> Result<String, OauthError> {
+pub(crate) async fn wait_for_redirect(
+    listener: TcpListener,
+    state: &str,
+) -> Result<String, OauthError> {
     let deadline = tokio::time::sleep(WAIT_FOR_OPERATOR);
     tokio::pin!(deadline);
 
@@ -583,12 +586,12 @@ fn parse_query(query: &str) -> Vec<(String, String)> {
 // ---- the exchange --------------------------------------------------------
 
 #[derive(Debug, Deserialize)]
-struct Issued {
-    access_token: String,
+pub(crate) struct Issued {
+    pub access_token: String,
     #[serde(default)]
-    refresh_token: Option<String>,
+    pub refresh_token: Option<String>,
     #[serde(default)]
-    expires_in: Option<i64>,
+    pub expires_in: Option<i64>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -632,7 +635,7 @@ async fn exchange(
     })
 }
 
-async fn post_token(
+pub(crate) async fn post_token(
     http: &reqwest::Client,
     endpoint: &str,
     form: &[(String, String)],
@@ -661,7 +664,7 @@ async fn post_token(
 
 // ---- the small things ----------------------------------------------------
 
-fn http() -> Result<reqwest::Client, OauthError> {
+pub(crate) fn http() -> Result<reqwest::Client, OauthError> {
     reqwest::Client::builder().build().map_err(|source| OauthError::Transport {
         what: "to build a client",
         url: String::new(),
@@ -674,14 +677,14 @@ fn http() -> Result<reqwest::Client, OauthError> {
 /// Two v4 UUIDs rather than a random-number crate: both are drawn from the
 /// operating system's generator, and this is the only place in the app that
 /// needs unguessable bytes that are not already an id.
-fn secret() -> String {
+pub(crate) fn secret() -> String {
     let mut bytes = [0u8; 32];
     bytes[..16].copy_from_slice(uuid::Uuid::new_v4().as_bytes());
     bytes[16..].copy_from_slice(uuid::Uuid::new_v4().as_bytes());
     base64url(&bytes)
 }
 
-fn pkce_challenge(verifier: &str) -> String {
+pub(crate) fn pkce_challenge(verifier: &str) -> String {
     base64url(&Sha256::digest(verifier.as_bytes()))
 }
 
@@ -710,7 +713,7 @@ fn base64url(raw: &[u8]) -> String {
 }
 
 /// Percent-encoding for a query parameter: everything but the unreserved set.
-fn encode(raw: &str) -> String {
+pub(crate) fn encode(raw: &str) -> String {
     let mut out = String::with_capacity(raw.len());
     for byte in raw.as_bytes() {
         match byte {

--- a/src-tauri/tests/account.rs
+++ b/src-tauri/tests/account.rs
@@ -1,0 +1,503 @@
+//! End-to-end tests for signing in to a Guaca account.
+//!
+//! A scripted authorization server, and the real [`Account`] driven against it:
+//! discovery, the loopback listener, the PKCE challenge, the redirect, the
+//! exchange, and the first call the token is spent on. Nothing is stubbed
+//! inside the module, because the failures worth catching here are all seams.
+//! `account.rs`'s own unit tests cover what can be decided without a network,
+//! and every one of them would pass with the flow never completing.
+//!
+//! The stub asserts the parts of the protocol the service is holding up its end
+//! of: a challenge is sent and it is S256, the client is the public one, the
+//! redirect is loopback, and the verifier presented at the token endpoint
+//! actually hashes to the challenge that was sent. A regression in the last one
+//! is a sign-in that still works and no longer proves anything.
+
+use std::sync::Arc;
+
+use axum::extract::Query;
+use axum::response::{IntoResponse, Redirect};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use parking_lot::Mutex;
+use sha2::{Digest, Sha256};
+
+use guac_lib::account::{Account, AccountError, CLIENT_ID};
+
+/// What the browser did with the authorization request, as the stub saw it.
+#[derive(Debug, Clone, Default)]
+struct Asked {
+    client_id: String,
+    redirect_uri: String,
+    scope: String,
+    state: String,
+    challenge: String,
+    method: String,
+}
+
+/// One posted form, as name/value pairs in the order they arrived.
+type Form = Vec<(String, String)>;
+
+struct Stub {
+    origin: String,
+    asked: Arc<Mutex<Option<Asked>>>,
+    /// Bearer tokens the connectors endpoint was called with.
+    presented: Arc<Mutex<Vec<String>>>,
+    /// Every post to the token endpoint, so a refresh can be told from a grant.
+    exchanges: Arc<Mutex<Vec<Form>>>,
+}
+
+/// How the stub should behave, so one server covers the failure paths too.
+#[derive(Debug, Clone, Default)]
+struct Script {
+    /// Refuse in the browser rather than redirecting with a code.
+    deny: bool,
+    /// Answer the redirect with a state the app never sent.
+    wrong_state: bool,
+    /// Publish endpoints on another origin, which is the one thing discovery
+    /// could do to move a credential.
+    foreign_endpoints: bool,
+    /// Refuse the bearer on the connectors endpoint.
+    reject_token: bool,
+    /// Seconds of life on the access token. `None` means the server did not say.
+    expires_in: Option<i64>,
+}
+
+fn base64url(raw: &[u8]) -> String {
+    const TABLE: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::new();
+    for chunk in raw.chunks(3) {
+        let b = [chunk[0], *chunk.get(1).unwrap_or(&0), *chunk.get(2).unwrap_or(&0)];
+        let n = ((b[0] as u32) << 16) | ((b[1] as u32) << 8) | b[2] as u32;
+        out.push(TABLE[(n >> 18) as usize & 63] as char);
+        out.push(TABLE[(n >> 12) as usize & 63] as char);
+        if chunk.len() > 1 {
+            out.push(TABLE[(n >> 6) as usize & 63] as char);
+        }
+        if chunk.len() > 2 {
+            out.push(TABLE[n as usize & 63] as char);
+        }
+    }
+    out
+}
+
+async fn serve(script: Script) -> Stub {
+    let asked: Arc<Mutex<Option<Asked>>> = Arc::new(Mutex::new(None));
+    let presented: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let exchanges: Arc<Mutex<Vec<Form>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let origin = format!("http://{addr}");
+
+    let metadata_origin =
+        if script.foreign_endpoints { "http://127.0.0.1:9".to_string() } else { origin.clone() };
+
+    let app = Router::new()
+        .route(
+            "/.well-known/oauth-authorization-server",
+            get(move || {
+                let base = metadata_origin.clone();
+                async move {
+                    Json(serde_json::json!({
+                        "issuer": base,
+                        "authorization_endpoint": format!("{base}/oauth2/authorize"),
+                        "token_endpoint": format!("{base}/oauth2/token"),
+                        "code_challenge_methods_supported": ["S256"],
+                        "scopes_supported": ["openid", "email", "offline_access", "connectors"],
+                    }))
+                }
+            }),
+        )
+        .route(
+            "/oauth2/authorize",
+            get({
+                let asked = asked.clone();
+                let script = script.clone();
+                move |Query(query): Query<std::collections::HashMap<String, String>>| {
+                    let (asked, script) = (asked.clone(), script.clone());
+                    async move {
+                        let seen = Asked {
+                            client_id: query.get("client_id").cloned().unwrap_or_default(),
+                            redirect_uri: query.get("redirect_uri").cloned().unwrap_or_default(),
+                            scope: query.get("scope").cloned().unwrap_or_default(),
+                            state: query.get("state").cloned().unwrap_or_default(),
+                            challenge: query.get("code_challenge").cloned().unwrap_or_default(),
+                            method: query.get("code_challenge_method").cloned().unwrap_or_default(),
+                        };
+
+                        // The protocol this end is holding up. A sign-in that
+                        // still completes without a challenge is one that has
+                        // stopped proving anything.
+                        assert_eq!(seen.method, "S256", "only S256 is sent");
+                        assert!(!seen.challenge.is_empty(), "a challenge is always sent");
+                        assert!(
+                            seen.redirect_uri.starts_with("http://127.0.0.1:"),
+                            "the redirect must be a loopback port: {}",
+                            seen.redirect_uri
+                        );
+
+                        let back = seen.redirect_uri.clone();
+                        let state = if script.wrong_state {
+                            "not-the-state".to_string()
+                        } else {
+                            seen.state.clone()
+                        };
+                        *asked.lock() = Some(seen);
+
+                        let to = if script.deny {
+                            format!(
+                                "{back}?error=access_denied&error_description=Nope&state={state}"
+                            )
+                        } else {
+                            format!("{back}?code=the-code&state={state}")
+                        };
+                        Redirect::temporary(&to)
+                    }
+                }
+            }),
+        )
+        .route(
+            "/oauth2/token",
+            post({
+                let asked = asked.clone();
+                let exchanges = exchanges.clone();
+                let script = script.clone();
+                move |body: String| {
+                    let (asked, exchanges, script) =
+                        (asked.clone(), exchanges.clone(), script.clone());
+                    async move {
+                        let fields: Form = body
+                            .split('&')
+                            .filter_map(|pair| pair.split_once('='))
+                            .map(|(k, v)| (k.to_string(), urlencoding_decode(v)))
+                            .collect();
+                        let get = |name: &str| {
+                            fields
+                                .iter()
+                                .find(|(k, _)| k == name)
+                                .map(|(_, v)| v.clone())
+                                .unwrap_or_default()
+                        };
+
+                        if get("grant_type") == "authorization_code" {
+                            // The whole point of PKCE, checked rather than
+                            // assumed: the verifier presented here has to hash
+                            // to the challenge sent to the browser.
+                            let challenge = asked
+                                .lock()
+                                .as_ref()
+                                .map(|a| a.challenge.clone())
+                                .unwrap_or_default();
+                            let verifier = get("code_verifier");
+                            assert!(!verifier.is_empty(), "a verifier is always presented");
+                            assert_eq!(
+                                base64url(&Sha256::digest(verifier.as_bytes())),
+                                challenge,
+                                "the verifier must hash to the challenge that was sent"
+                            );
+                            assert_eq!(get("client_id"), CLIENT_ID);
+                        }
+
+                        exchanges.lock().push(fields);
+                        let mut answer = serde_json::json!({
+                            "access_token": "at-1",
+                            "refresh_token": "rt-1",
+                            "token_type": "Bearer",
+                        });
+                        if let Some(secs) = script.expires_in {
+                            answer["expires_in"] = secs.into();
+                        }
+                        Json(answer)
+                    }
+                }
+            }),
+        )
+        .route(
+            "/api/connectors",
+            get({
+                let presented = presented.clone();
+                let script = script.clone();
+                move |headers: axum::http::HeaderMap| {
+                    let (presented, script) = (presented.clone(), script.clone());
+                    async move {
+                        let token = headers
+                            .get("authorization")
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or_default()
+                            .trim_start_matches("Bearer ")
+                            .to_string();
+                        presented.lock().push(token);
+
+                        if script.reject_token {
+                            return (axum::http::StatusCode::UNAUTHORIZED, "no").into_response();
+                        }
+                        Json(serde_json::json!({
+                            "user": { "email": "robert@example.com" },
+                            "providers": [{
+                                "id": "google",
+                                "label": "Google",
+                                "capabilities": [
+                                    { "id": "gmail", "label": "Gmail", "granted": true },
+                                    { "id": "drive", "label": "Drive", "granted": false },
+                                ],
+                            }],
+                        }))
+                        .into_response()
+                    }
+                }
+            }),
+        );
+
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    Stub { origin, asked, presented, exchanges }
+}
+
+fn urlencoding_decode(raw: &str) -> String {
+    let bytes = raw.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut at = 0;
+    while at < bytes.len() {
+        match bytes[at] {
+            b'%' if at + 2 < bytes.len() => match u8::from_str_radix(&raw[at + 1..at + 3], 16) {
+                Ok(byte) => {
+                    out.push(byte);
+                    at += 3;
+                }
+                Err(_) => {
+                    out.push(bytes[at]);
+                    at += 1;
+                }
+            },
+            b'+' => {
+                out.push(b' ');
+                at += 1;
+            }
+            byte => {
+                out.push(byte);
+                at += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).to_string()
+}
+
+/// A place to keep an account file that no other test shares.
+fn scratch() -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("guaca-account-it-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.join("account.json")
+}
+
+/// Plays the operator's browser: fetches the URL Guaca opened and follows the
+/// redirect back to the loopback port, which is what the app is waiting on.
+///
+/// Spawned rather than awaited, because `sign_in` calls this and *then* starts
+/// listening. Doing it inline would deadlock on a redirect nothing is accepting
+/// yet, which is also exactly the ordering a real browser has.
+fn browse(url: &str) -> Result<(), String> {
+    let url = url.to_string();
+    tokio::spawn(async move {
+        let client =
+            reqwest::Client::builder().timeout(std::time::Duration::from_secs(10)).build().unwrap();
+        let _ = client.get(&url).send().await;
+    });
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_sign_in_completes_and_reports_the_account_it_reached() {
+    let stub = serve(Script { expires_in: Some(3600), ..Script::default() }).await;
+    let account = Account::open_at(scratch(), &stub.origin);
+
+    let status = account.sign_in(browse).await.expect("the sign-in should complete");
+
+    assert!(status.signed_in);
+    assert_eq!(status.email, "robert@example.com", "read from the service, not guessed");
+    assert_eq!(status.origin, stub.origin);
+
+    let asked = stub.asked.lock().clone().expect("the browser was sent somewhere");
+    assert_eq!(asked.client_id, CLIENT_ID);
+    // Everything in one consent screen rather than asking again later.
+    for scope in ["openid", "email", "offline_access", "connectors"] {
+        assert!(asked.scope.contains(scope), "{scope} was not asked for: {}", asked.scope);
+    }
+
+    // The token was spent before anything was written, which is what makes a
+    // reported success one that actually works.
+    assert_eq!(stub.presented.lock().as_slice(), ["at-1"]);
+}
+
+#[tokio::test]
+async fn the_sign_in_survives_a_restart() {
+    let stub = serve(Script { expires_in: Some(3600), ..Script::default() }).await;
+    let path = scratch();
+    Account::open_at(path.clone(), &stub.origin).sign_in(browse).await.unwrap();
+
+    // A second `Account` over the same file is what a relaunch is.
+    let reopened = Account::open_at(path, &stub.origin);
+    assert!(reopened.is_signed_in());
+    assert_eq!(reopened.status().email, "robert@example.com");
+    assert_eq!(reopened.connectors().await.unwrap().email, "robert@example.com");
+}
+
+#[tokio::test]
+async fn what_the_account_holds_is_asked_of_the_service() {
+    let stub = serve(Script { expires_in: Some(3600), ..Script::default() }).await;
+    let account = Account::open_at(scratch(), &stub.origin);
+    account.sign_in(browse).await.unwrap();
+
+    let held = account.connectors().await.unwrap();
+    let google = held.providers.iter().find(|p| p.id == "google").expect("google");
+    assert!(google.capabilities.iter().any(|c| c.id == "gmail" && c.granted));
+    assert!(google.capabilities.iter().any(|c| c.id == "drive" && !c.granted));
+
+    // Two calls, not one cached answer. What is authorized changes in a browser
+    // rather than here, so a kept copy is a list an agent is told is true.
+    assert_eq!(stub.presented.lock().len(), 2);
+}
+
+#[tokio::test]
+async fn a_refusal_in_the_browser_is_reported_rather_than_waited_out() {
+    let stub = serve(Script { deny: true, ..Script::default() }).await;
+    let account = Account::open_at(scratch(), &stub.origin);
+
+    match account.sign_in(browse).await {
+        Err(AccountError::Refused { error, .. }) => assert_eq!(error, "access_denied"),
+        other => panic!("expected a refusal, got {other:?}"),
+    }
+    assert!(!account.is_signed_in(), "nothing is stored by a refused sign-in");
+}
+
+#[tokio::test]
+async fn an_answer_that_does_not_match_the_request_is_treated_as_an_attack() {
+    // Nothing else can arrive on that port with the wrong state, so this is not
+    // a mistake to recover from.
+    let stub = serve(Script { wrong_state: true, ..Script::default() }).await;
+    let account = Account::open_at(scratch(), &stub.origin);
+
+    assert!(matches!(account.sign_in(browse).await, Err(AccountError::StateMismatch)));
+    assert!(!account.is_signed_in());
+}
+
+#[tokio::test]
+async fn a_service_that_publishes_endpoints_somewhere_else_is_refused() {
+    // The one thing discovery could do to move a credential. Refused before a
+    // browser is opened, so nothing is sent anywhere.
+    let stub = serve(Script { foreign_endpoints: true, ..Script::default() }).await;
+    let account = Account::open_at(scratch(), &stub.origin);
+
+    match account.sign_in(browse).await {
+        Err(AccountError::ForeignEndpoint { endpoint, .. }) => {
+            assert!(endpoint.starts_with("http://127.0.0.1:9"), "{endpoint}");
+        }
+        other => panic!("expected a refused endpoint, got {other:?}"),
+    }
+    assert!(stub.asked.lock().is_none(), "the browser was never opened");
+}
+
+#[tokio::test]
+async fn a_token_the_service_will_not_take_is_not_stored_as_a_sign_in() {
+    // Spending it once before writing is what stops "signed in" meaning "held a
+    // token the service has never accepted".
+    let stub = serve(Script { reject_token: true, ..Script::default() }).await;
+    let account = Account::open_at(scratch(), &stub.origin);
+
+    assert!(matches!(account.sign_in(browse).await, Err(AccountError::Expired { .. })));
+    assert!(!account.is_signed_in());
+}
+
+#[tokio::test]
+async fn an_expiring_token_is_refreshed_before_it_is_used() {
+    // Already expired as far as the skew is concerned, so the first read of it
+    // has to renew rather than hand back something a call would be refused for.
+    let stub = serve(Script { expires_in: Some(1), ..Script::default() }).await;
+    let account = Account::open_at(scratch(), &stub.origin);
+    account.sign_in(browse).await.unwrap();
+
+    account.connectors().await.unwrap();
+
+    let grants: Vec<String> = stub
+        .exchanges
+        .lock()
+        .iter()
+        .map(|fields| {
+            fields
+                .iter()
+                .find(|(k, _)| k == "grant_type")
+                .map(|(_, v)| v.clone())
+                .unwrap_or_default()
+        })
+        .collect();
+    assert_eq!(grants, ["authorization_code", "refresh_token"]);
+}
+
+#[tokio::test]
+async fn a_token_with_no_stated_expiry_is_used_rather_than_renewed_every_call() {
+    // A server that does not say is not a server saying "expired".
+    let stub = serve(Script { expires_in: None, ..Script::default() }).await;
+    let account = Account::open_at(scratch(), &stub.origin);
+    account.sign_in(browse).await.unwrap();
+
+    account.connectors().await.unwrap();
+    assert_eq!(stub.exchanges.lock().len(), 1, "no refresh was asked for");
+}
+
+#[tokio::test]
+async fn signing_out_leaves_nothing_a_later_call_could_present() {
+    let stub = serve(Script { expires_in: Some(3600), ..Script::default() }).await;
+    let path = scratch();
+    let account = Account::open_at(path.clone(), &stub.origin);
+    account.sign_in(browse).await.unwrap();
+
+    account.sign_out().unwrap();
+    assert!(!account.is_signed_in());
+    assert!(!path.exists(), "the file goes, not just the copy in memory");
+    assert!(matches!(account.connectors().await, Err(AccountError::NotSignedIn)));
+    // And a relaunch finds nothing either.
+    assert!(!Account::open_at(path, &stub.origin).is_signed_in());
+}
+
+/// Whether the real service still publishes what this build knows how to read.
+///
+/// The failure no offline test can see: `guaca.bot` moves an endpoint, or stops
+/// publishing RFC 8414 metadata at the root of the origin, and every sign-in
+/// fails at step one. It authorizes nothing and stores nothing.
+///
+/// `GUACA_ACCOUNT_ORIGIN` points it at a Worker on this machine instead.
+///
+/// ```sh
+/// cargo test --manifest-path src-tauri/Cargo.toml --test account -- --ignored
+/// ```
+#[tokio::test]
+#[ignore = "reaches the internet"]
+async fn the_real_service_still_publishes_where_to_sign_in() {
+    let origin = std::env::var("GUACA_ACCOUNT_ORIGIN")
+        .unwrap_or_else(|_| guac_lib::account::DEFAULT_ORIGIN.to_string());
+    let account = Account::open_at(scratch(), &origin);
+
+    // Not a sign-in: this stops at discovery, which is the half a machine can
+    // check. `sign_in` would need a browser and a person.
+    match account.connectors().await {
+        Err(AccountError::NotSignedIn) => {}
+        other => panic!("expected the local check to refuse, got {other:?}"),
+    }
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/.well-known/oauth-authorization-server", origin.trim_end_matches('/'));
+    let body: serde_json::Value =
+        http.get(&url).send().await.expect("metadata unreachable").json().await.expect("not json");
+
+    for field in ["authorization_endpoint", "token_endpoint"] {
+        let endpoint = body[field].as_str().unwrap_or_default();
+        assert!(endpoint.starts_with(origin.trim_end_matches('/')), "{field} is {endpoint}");
+    }
+    let methods = body["code_challenge_methods_supported"].as_array().cloned().unwrap_or_default();
+    assert!(
+        methods.iter().any(|m| m == "S256"),
+        "S256 is the only challenge this build sends: {methods:?}"
+    );
+    // An open registration endpoint on this origin would mean the consent
+    // screen can name an application a stranger asserted.
+    assert!(body.get("registration_endpoint").is_none(), "client registration should be off");
+}

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Prefs } from "../lib/prefs";
 import type {
+  AccountConnectors,
+  AccountStatus,
   DeviceCode,
   GuardLimits,
   Settings,
@@ -14,7 +16,7 @@ import type { Section } from "./SettingsDialog";
 /**
  * The settings dialog, over a mocked runtime.
  *
- * Eight panes, and every field of every one of them held by the shell. That is
+ * Nine panes, and every field of every one of them held by the shell. That is
  * where the risk is, and none of it is visible in the markup: the patch the
  * Save button sends is assembled by omission, so a box left blank has to be
  * absent from that object rather than present and empty. An empty string sent
@@ -94,6 +96,41 @@ const signOutSubscription = vi.fn<() => Promise<Settings>>(async () =>
 );
 const openExternal = vi.fn<(url: string) => Promise<void>>(async () => {});
 
+/** No Guaca account, which is what an install that never signs in looks like. */
+function noAccount(over: Partial<AccountStatus> = {}): AccountStatus {
+  return { signedIn: false, email: "", origin: "https://guaca.bot", ...over };
+}
+
+function linked(over: Partial<AccountStatus> = {}): AccountStatus {
+  return {
+    signedIn: true,
+    email: "robert@example.com",
+    origin: "https://guaca.bot",
+    ...over,
+  };
+}
+
+function held(granted = true): AccountConnectors {
+  return {
+    email: "robert@example.com",
+    providers: [
+      {
+        id: "google",
+        label: "Google",
+        capabilities: [
+          { id: "gmail", label: "Gmail", granted },
+          { id: "drive", label: "Drive", granted: false },
+        ],
+      },
+    ],
+  };
+}
+
+const accountStatus = vi.fn<() => Promise<AccountStatus>>(async () => noAccount());
+const signInAccount = vi.fn<() => Promise<AccountStatus>>(async () => linked());
+const accountConnectors = vi.fn<() => Promise<AccountConnectors>>(async () => held());
+const signOutAccount = vi.fn<() => Promise<AccountStatus>>(async () => noAccount());
+
 vi.mock("../lib/ipc", () => ({
   api: {
     updateSettings: (patch: SettingsPatch) => updateSettings(patch),
@@ -102,6 +139,10 @@ vi.mock("../lib/ipc", () => ({
     beginSubscriptionSignin: () => beginSubscriptionSignin(),
     completeSubscriptionSignin: (code: DeviceCode) => completeSubscriptionSignin(code),
     signOutSubscription: () => signOutSubscription(),
+    accountStatus: () => accountStatus(),
+    signInAccount: () => signInAccount(),
+    accountConnectors: () => accountConnectors(),
+    signOutAccount: () => signOutAccount(),
   },
   notifyOperator: (title: string, body: string) => notifyOperator(title, body),
   openExternal: (url: string) => openExternal(url),
@@ -208,6 +249,10 @@ beforeEach(() => {
   subscriptionStatus.mockResolvedValue(signedOut());
   completeSubscriptionSignin.mockResolvedValue(signedIn());
   signOutSubscription.mockResolvedValue(stored({ provider: "compatible" }));
+  accountStatus.mockResolvedValue(noAccount());
+  signInAccount.mockResolvedValue(linked());
+  accountConnectors.mockResolvedValue(held());
+  signOutAccount.mockResolvedValue(noAccount());
   // No Tauri host behind this webview, which is the state the About pane is
   // built to shrug off. The one test that wants a version asks for one.
   getVersion.mockRejectedValue(new Error("no host"));
@@ -885,6 +930,177 @@ describe("the ChatGPT subscription", () => {
     // Left on the subscription, every agent's next turn is the same refusal.
     expect(button("Sign in")).toBeTruthy();
     expect(row().textContent).not.toContain("In use");
+  });
+});
+
+/**
+ * The Guaca account.
+ *
+ * The thing worth testing here is that it is optional and behaves like it. An
+ * install that never opens this pane must never reach the service, a sign-in
+ * that fails must leave the pane signed out rather than half linked, and a
+ * service that no longer recognises a stored sign-in has to redraw as signed
+ * out rather than as an account with an empty list under it.
+ */
+describe("the Guaca account", () => {
+  function row(): HTMLElement {
+    const label = screen.getByText("Guaca account", { selector: ".preset__name" });
+    const found = label.closest(".preset");
+    if (!found) throw new Error("no account row");
+    return found as HTMLElement;
+  }
+
+  function button(name: string): HTMLButtonElement {
+    return screen.getByRole("button", { name }) as HTMLButtonElement;
+  }
+
+  it("asks the service nothing until the pane is opened", async () => {
+    open();
+    expect(accountStatus).not.toHaveBeenCalled();
+    expect(accountConnectors).not.toHaveBeenCalled();
+
+    pane("Account");
+    await waitFor(() => expect(accountStatus).toHaveBeenCalledTimes(1));
+  });
+
+  it("says it is optional, and what an account is for", async () => {
+    open(stored(), DEFAULT_PREFS, "account");
+    await waitFor(() => expect(accountStatus).toHaveBeenCalled());
+    // The one claim that has to survive an edit: nothing here is required.
+    expect(screen.getByText(/Optional, and it stays that way/)).toBeTruthy();
+    expect(screen.getByText(/client secret would be inside a download/)).toBeTruthy();
+  });
+
+  it("offers a sign-in when there is none", async () => {
+    open(stored(), DEFAULT_PREFS, "account");
+    await waitFor(() => expect(accountStatus).toHaveBeenCalled());
+    expect(row().textContent).toContain("Sign in to authorize");
+    expect(button("Sign in")).toBeTruthy();
+  });
+
+  it("says which account it linked, and offers the way out", async () => {
+    accountStatus.mockResolvedValue(linked());
+    open(stored(), DEFAULT_PREFS, "account");
+
+    await waitFor(() => expect(row().textContent).toContain("robert@example.com"));
+    expect(button("Sign out")).toBeTruthy();
+    expect(button("Manage")).toBeTruthy();
+  });
+
+  it("says what is happening while the browser has it, and offers nothing to carry", async () => {
+    // Unlike the subscription there is no code: the answer comes back to a port
+    // this process already holds, so this state is a sentence, not a task.
+    let release: (status: AccountStatus) => void = () => {};
+    signInAccount.mockReturnValue(
+      new Promise<AccountStatus>((resolve) => {
+        release = resolve;
+      }),
+    );
+    open(stored(), DEFAULT_PREFS, "account");
+    await waitFor(() => expect(accountStatus).toHaveBeenCalled());
+    fireEvent.click(button("Sign in"));
+
+    await waitFor(() => expect(screen.getByRole("status")).toBeTruthy());
+    expect(screen.getByRole("status").textContent).toContain("Finish in the browser window");
+    expect(screen.getByRole("status").textContent).toContain("Only continue if you started this");
+
+    release(linked());
+    await waitFor(() => expect(row().textContent).toContain("robert@example.com"));
+  });
+
+  it("keeps a sign-in in flight across a glance at another section", async () => {
+    // The shell holds it. A pane that held its own would discard a sign-in the
+    // operator is in the middle of.
+    signInAccount.mockReturnValue(new Promise<AccountStatus>(() => {}));
+    open(stored(), DEFAULT_PREFS, "account");
+    await waitFor(() => expect(accountStatus).toHaveBeenCalled());
+    fireEvent.click(button("Sign in"));
+    await waitFor(() => expect(screen.getByRole("status")).toBeTruthy());
+
+    pane("Limits");
+    pane("Account");
+    expect(screen.getByRole("status").textContent).toContain("Finish in the browser window");
+  });
+
+  it("stays signed out when the sign-in fails, and says why", async () => {
+    signInAccount.mockRejectedValue({ kind: "account", message: "could not reach guaca.bot" });
+    open(stored(), DEFAULT_PREFS, "account");
+    await waitFor(() => expect(accountStatus).toHaveBeenCalled());
+    fireEvent.click(button("Sign in"));
+
+    await waitFor(() => expect(screen.getByText(/could not reach guaca\.bot/)).toBeTruthy());
+    expect(row().textContent).toContain("Sign in to authorize");
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("shows what the account has authorized, and what it has not", async () => {
+    accountStatus.mockResolvedValue(linked());
+    open(stored(), DEFAULT_PREFS, "account");
+
+    await waitFor(() => expect(accountConnectors).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByText("Gmail")).toBeTruthy());
+    // Drive is in the list and not granted, so it must not be named as one the
+    // agents can reach.
+    expect(screen.queryByText(/Drive/)).toBeNull();
+  });
+
+  it("says so rather than showing an empty list when nothing is authorized", async () => {
+    accountStatus.mockResolvedValue(linked());
+    accountConnectors.mockResolvedValue(held(false));
+    open(stored(), DEFAULT_PREFS, "account");
+
+    await waitFor(() => expect(screen.getByText("Nothing authorized yet.")).toBeTruthy());
+  });
+
+  it("redraws as signed out when the service no longer knows the sign-in", async () => {
+    // A stored token the service has revoked. Drawing an account with an empty
+    // list under it would tell the operator they are linked when they are not.
+    accountStatus.mockResolvedValue(linked());
+    accountConnectors.mockRejectedValue({ kind: "signedOut", message: "sign in again" });
+    open(stored(), DEFAULT_PREFS, "account");
+
+    await waitFor(() => expect(row().textContent).toContain("Sign in to authorize"));
+  });
+
+  it("forgets the sign-in and the list it came with", async () => {
+    accountStatus.mockResolvedValue(linked());
+    open(stored(), DEFAULT_PREFS, "account");
+    await waitFor(() => expect(screen.getByText("Gmail")).toBeTruthy());
+
+    fireEvent.click(button("Sign out"));
+    await waitFor(() => expect(row().textContent).toContain("Sign in to authorize"));
+    // The list went with it. Leaving it on screen would be a list of what an
+    // account this machine no longer holds can reach.
+    expect(screen.queryByText("Gmail")).toBeNull();
+  });
+
+  it("opens the service's own page to change what is authorized", async () => {
+    // The consent screens are Google's and GitHub's, reached through guaca.bot.
+    // There is nothing to tick here and pretending otherwise would be a control
+    // that cannot work.
+    accountStatus.mockResolvedValue(linked());
+    open(stored(), DEFAULT_PREFS, "account");
+    await waitFor(() => expect(row().textContent).toContain("robert@example.com"));
+
+    fireEvent.click(button("Manage"));
+    expect(openExternal).toHaveBeenCalledWith("https://guaca.bot/app");
+  });
+
+  it("says out loud when this build signs in somewhere other than guaca.bot", async () => {
+    // Development, or a self-hosted service. The two hold different accounts
+    // and only one of them is the real one.
+    accountStatus.mockResolvedValue(linked({ origin: "http://localhost:8787" }));
+    open(stored(), DEFAULT_PREFS, "account");
+
+    await waitFor(() => expect(screen.getByText(/not guaca\.bot/)).toBeTruthy());
+    expect(screen.getByText("http://localhost:8787")).toBeTruthy();
+  });
+
+  it("does not say that on a build pointed at guaca.bot", async () => {
+    accountStatus.mockResolvedValue(linked());
+    open(stored(), DEFAULT_PREFS, "account");
+    await waitFor(() => expect(row().textContent).toContain("robert@example.com"));
+    expect(screen.queryByText(/not guaca\.bot/)).toBeNull();
   });
 });
 

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1,5 +1,5 @@
 /**
- * Settings, as eight places rather than one scroll.
+ * Settings, as nine places rather than one scroll.
  *
  * Every piece of state lives here, in the shell, and the panes are given values
  * and setters. That is not tidiness: the shell is unmounted when the dialog
@@ -23,6 +23,8 @@ import { NOTIFY_KINDS, type NotifyKind, type SurfaceMode, UI_SCALES } from "../l
 import { type Provider as Preset, planLabel } from "../lib/providers";
 import { useStore } from "../lib/store";
 import {
+  type AccountConnectors,
+  type AccountStatus,
   type DeviceCode,
   errorMessage,
   type GuardLimits,
@@ -44,6 +46,7 @@ const SECTIONS = [
   "provider",
   "limits",
   "machines",
+  "account",
   "appearance",
   "notifications",
   "shortcuts",
@@ -57,6 +60,7 @@ const SECTION_LABELS: Record<Section, string> = {
   provider: "Provider",
   limits: "Limits",
   machines: "Machines",
+  account: "Account",
   appearance: "Appearance",
   notifications: "Notifications",
   shortcuts: "Shortcuts",
@@ -130,6 +134,15 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
   // be discarded by a glance at Limits.
   const [subscription, setSubscription] = useState<SubscriptionStatus | null>(null);
   const [pendingCode, setPendingCode] = useState<DeviceCode | null>(null);
+
+  // The Guaca account, which is three states for the same reason: signed out,
+  // waiting on a browser, and signed in. `connectors` is what the service says
+  // the account holds, and it is read rather than kept because it changes when
+  // the operator authorizes something in a browser rather than when this app
+  // does anything.
+  const [account, setAccount] = useState<AccountStatus | null>(null);
+  const [connectors, setConnectors] = useState<AccountConnectors | null>(null);
+  const [linking, setLinking] = useState(false);
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
@@ -252,6 +265,87 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
       live = false;
     };
   }, [section, subscription]);
+
+  // Same rule as above: read when the pane is opened. An install that never
+  // opens this pane never asks the service anything, which is the whole point
+  // of the account being optional.
+  useEffect(() => {
+    if (section !== "account" || account) return;
+    let live = true;
+    void api
+      .accountStatus()
+      .then((value) => {
+        if (live) setAccount(value);
+      })
+      .catch(() => {
+        if (live) setAccount({ signedIn: false, email: "", origin: "" });
+      });
+    return () => {
+      live = false;
+    };
+  }, [section, account]);
+
+  // What the account holds, once there is one. Separate from the status because
+  // it is a network call to the service and the status is a local read, so a
+  // service that is slow or down still draws the account correctly.
+  useEffect(() => {
+    if (section !== "account" || !account?.signedIn || connectors) return;
+    let live = true;
+    void api
+      .accountConnectors()
+      .then((value) => {
+        if (live) setConnectors(value);
+      })
+      .catch((error) => {
+        // A sign-in the service no longer recognises comes back as `signedOut`,
+        // and the honest thing to draw is a signed-out pane rather than an
+        // account with an empty list under it.
+        if (!live) return;
+        if ((error as { kind?: string })?.kind === "signedOut") {
+          setAccount({ signedIn: false, email: "", origin: account.origin });
+        }
+      });
+    return () => {
+      live = false;
+    };
+  }, [section, account, connectors]);
+
+  /**
+   * The whole account sign-in, in one call.
+   *
+   * A browser opens and the answer comes back to a port Rust bound before it
+   * asked, so there is nothing for the operator to carry and nothing to draw in
+   * between. Closing the dialog abandons it and leaves nothing behind.
+   */
+  const linkAccount = async () => {
+    setStatus(null);
+    setLinking(true);
+    try {
+      const next = await api.signInAccount();
+      setAccount(next);
+      setConnectors(null);
+      setStatus({ tone: "ok", text: `Signed in as ${next.email || "your Guaca account"}.` });
+    } catch (error) {
+      setStatus({ tone: "error", text: errorMessage(error) });
+    } finally {
+      setLinking(false);
+    }
+  };
+
+  const unlinkAccount = async () => {
+    setLinking(true);
+    setStatus(null);
+    try {
+      const next = await api.signOutAccount();
+      setAccount(next);
+      setConnectors(null);
+      setStatus({ tone: "ok", text: "Signed out." });
+    } catch (error) {
+      setStatus({ tone: "error", text: errorMessage(error) });
+    } finally {
+      setLinking(false);
+    }
+  };
 
   /**
    * Starts the sign-in and then waits for it, in one action.
@@ -682,6 +776,126 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
                     </span>
                   </span>
                 </label>
+              </>
+            )}
+
+            {section === "account" && (
+              <>
+                <h3 className="settings__title">Account</h3>
+                <p className="settings__lede">
+                  Optional, and it stays that way. Guaca runs on this machine with your own keys,
+                  and everything it does today it does without an account. Signing in adds one
+                  thing: guaca.bot holds an OAuth client, so an agent can reach a service that only
+                  issues access to a registered application. Gmail is the example. Guaca cannot be
+                  that application, because its client secret would be inside a download anybody can
+                  read.
+                </p>
+
+                <div className="preset preset--plain" aria-current={account?.signedIn === true}>
+                  <span className="preset__text">
+                    <span className="preset__name">Guaca account</span>
+                    <span className="preset__url">
+                      {account?.signedIn
+                        ? account.email || "signed in"
+                        : "Sign in to authorize Gmail, Drive or a GitHub repository for your agents"}
+                    </span>
+                  </span>
+                  {account?.signedIn ? (
+                    <span className="preset__actions">
+                      <button
+                        type="button"
+                        className="btn btn--small"
+                        disabled={linking}
+                        onClick={() => void openExternal(`${account.origin}/app`)}
+                      >
+                        Manage
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn--small"
+                        disabled={linking}
+                        onClick={() => void unlinkAccount()}
+                      >
+                        Sign out
+                      </button>
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      className="btn btn--small"
+                      disabled={linking}
+                      onClick={() => void linkAccount()}
+                    >
+                      Sign in
+                    </button>
+                  )}
+                </div>
+
+                {/* Shown for as long as the browser has it. There is no code to
+                    carry here, so this says what is happening rather than
+                    giving the operator something to do. */}
+                {linking && (
+                  <div className="devicecode" role="status">
+                    <p className="devicecode__lede">
+                      Finish in the browser window that just opened. Guaca is listening on a port on
+                      this machine for the answer, and gives up after five minutes.
+                    </p>
+                    <p className="hint">
+                      Only continue if you started this here. Nothing else can have opened it.
+                    </p>
+                  </div>
+                )}
+
+                {account?.signedIn && (
+                  <>
+                    <p className="settings__lede" style={{ marginTop: "1.4rem" }}>
+                      What this account has authorized. Ticking and unticking happens on guaca.bot,
+                      in a browser, because that is where the consent screens are.
+                    </p>
+                    {connectors ? (
+                      <ul className="settings__list">
+                        {connectors.providers.map((provider) => {
+                          const granted = provider.capabilities.filter((c) => c.granted);
+                          return (
+                            <li key={provider.id}>
+                              <span className="field__label">{provider.label}</span>
+                              <span className="field__hint">
+                                {granted.length > 0
+                                  ? granted.map((c) => c.label).join(", ")
+                                  : "Nothing authorized yet."}
+                              </span>
+                            </li>
+                          );
+                        })}
+                        {connectors.providers.length === 0 && (
+                          <li>
+                            <span className="field__hint">
+                              This deployment offers no connectors.
+                            </span>
+                          </li>
+                        )}
+                      </ul>
+                    ) : (
+                      <p className="field__hint">Asking the service&hellip;</p>
+                    )}
+                  </>
+                )}
+
+                <p className="field__hint" style={{ marginTop: "1.4rem" }}>
+                  What leaves this machine, and only once you have signed in: a request for an
+                  access token when an agent uses a connector you authorized. Your conversations,
+                  your agents and your keys are not sent anywhere, with or without an account.
+                  Signing out here forgets the sign-in on this machine immediately.
+                </p>
+
+                {account && account.origin !== "https://guaca.bot" && account.origin !== "" && (
+                  /* Development, or a self-hosted service. Worth saying out loud
+                     rather than leaving an operator to assume guaca.bot: the two
+                     hold different accounts and only one of them is the real one. */
+                  <p className="field__hint">
+                    This build signs in to <code>{account.origin}</code>, not guaca.bot.
+                  </p>
+                )}
               </>
             )}
 

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -16,6 +16,8 @@ import {
 import { openUrl } from "@tauri-apps/plugin-opener";
 
 import type {
+  AccountConnectors,
+  AccountStatus,
   Activity,
   AgentCard,
   AgentDraft,
@@ -381,6 +383,25 @@ export const api = {
 
   /** Forgets the sign-in, and moves the provider off it if it was in use. */
   signOutSubscription: () => invoke<Settings>("sign_out_subscription"),
+
+  accountStatus: () => invoke<AccountStatus>("account_status"),
+
+  /**
+   * The whole sign-in, in one call.
+   *
+   * One rather than the subscription's two, because there is no code for the
+   * operator to carry: a browser opens, they say yes, and the answer arrives on
+   * a port Rust is already listening on. Parks for up to five minutes, so the
+   * caller keeps its own "waiting" state; closing the dialog abandons it and
+   * leaves nothing behind.
+   */
+  signInAccount: () => invoke<AccountStatus>("sign_in_account"),
+
+  /** What the account holds, asked of the service rather than remembered. */
+  accountConnectors: () => invoke<AccountConnectors>("account_connectors"),
+
+  /** Forgets the sign-in on this machine. */
+  signOutAccount: () => invoke<AccountStatus>("sign_out_account"),
 };
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -469,6 +469,43 @@ export interface SubscriptionStatus {
   includesCodex: boolean;
 }
 
+/**
+ * Whether a Guaca account is signed in, and which service it is.
+ *
+ * No token, for the same reason as above. The origin is on it because in
+ * development it is not `guaca.bot`, and an operator who cannot see which
+ * service they linked to cannot tell the two apart.
+ */
+export interface AccountStatus {
+  signedIn: boolean;
+  email: string;
+  origin: string;
+}
+
+/** One thing an authorized provider can do, as the service describes it. */
+export interface AccountCapability {
+  id: string;
+  label: string;
+  granted: boolean;
+}
+
+export interface AccountProvider {
+  id: string;
+  label: string;
+  capabilities: AccountCapability[];
+}
+
+/**
+ * What the account holds, as the service reports it.
+ *
+ * Read rather than kept. It changes when the operator authorizes something in
+ * a browser rather than when this app does anything.
+ */
+export interface AccountConnectors {
+  email: string;
+  providers: AccountProvider[];
+}
+
 /** What the operator carries to a browser to finish signing in. */
 export interface DeviceCode {
   verificationUrl: string;

--- a/src/styles.css
+++ b/src/styles.css
@@ -4569,6 +4569,23 @@ button {
   max-width: 34rem;
 }
 
+/* What an account has authorized, which is read from the service and never
+   edited here. A list rather than the field rows above it, because none of it
+   is a control: the ticking happens on guaca.bot, where the consent screens
+   are. */
+.settings__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.settings__list .field__label,
+.settings__list .field__hint {
+  display: block;
+}
+
 .settings__foot {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Signing in to guaca.bot buys one thing Guaca cannot do from here: a hosted
OAuth client, for the services that will only issue programmatic access to a
registered application. Gmail is the example. An app you downloaded cannot be
that application, because its client secret would be in the download.

Nothing depends on it, and the code is arranged so that stays true rather than
so it reads well in a README. `Account` is a field on `AppState` that no turn,
prompt, tool or guard reads, and both of its reads happen when the Settings
pane is opened rather than at startup, so an install that never opens that pane
never contacts the service. Deleting the module would remove one pane and break
nothing else.

The flow is authorization code with PKCE on a loopback port, which is RFC 8252
and also `oauth.rs`'s existing argument pointed at one known server: the port is
bound before the redirect URI is named, so it is one the operating system has
already handed out. That module's helpers are reused rather than reimplemented,
so there is no new crypto here. The service's device grant is gone, and
`docs/ACCOUNT.md` says why at length: nothing binds a device code to the machine
that asked for it.

Three things guard the one input this has. The service is a constant, moved only
by `GUACA_ACCOUNT_ORIGIN` and refused unless it is HTTPS or loopback; a
discovered endpoint must be on the origin that published it, which is the one
way discovery could move a credential; and an override is logged at startup and
shown in the pane, because a machine left pointed at a development service is
not a silent state.

The stored token is stamped with the service that issued it. There is one
profile per bundle identifier, so a development build and the real one share
that file, and without the stamp a localhost token reaches guaca.bot as a
sign-in that used to work and now reports itself expired.

`tests/account.rs` drives the real `Account` against a scripted authorization
server through every leg, and its stub checks that the verifier presented at the
token endpoint actually hashes to the challenge that was sent: a sign-in that
stops proving that still works.