### PR TITLE
feat: a memory rewrite is shown against the version it replaced

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ src/                  React + TypeScript. A view over the runtime, nothing more.
   lib/orb.ts          How a crew stands inside its circle, and when it counts.
   lib/search.ts       One ranking over hits from SQLite and from the store.
   lib/trail.ts        A turn's own tool calls: what folds into one chip.
+  lib/diff.ts         Two versions of a page, as the lines between them.
   lib/cafeteria.ts    Preset agents, waiting to be hired. Content, not runtime.
   lib/plugins.ts      A plugin's mark and colour. Everything else is Rust's.
   lib/ipc.ts          Every call into Rust.
@@ -93,6 +94,7 @@ repo: the frontend renders state and forwards intent.
 | Which agents in a crew get a plugin | *Signing in is one decision, and handing it out is another* in `docs/PLUGINS.md`, then `domain/plugin.rs` and `Store::plugin_tools`, which has to agree with `Store::plugin_reach` |
 | Channels, the rail, search: what the operator sees | `docs/WORKSPACE.md`, then `src/lib/transcript.ts` |
 | A turn's tool calls in a channel: what folds, what a chip says, what opens | *A turn's own work is chips* in `docs/WORKSPACE.md`, then `src/lib/trail.ts` |
+| What an agent changed about its own memory, and where the version before it came from | *A memory rewrite opens as a diff* in `docs/WORKSPACE.md`, then `Workspace::write` and `src/lib/diff.ts` |
 | Anything announced to a screen reader, or a live region | *A transcript is a log, and says one thing out loud* in `docs/WORKSPACE.md` |
 | Scrolling a transcript, following the newest line, when the view may move | *A transcript follows the end for whoever is at the end, and nobody else* in `docs/WORKSPACE.md`, then `src/lib/follow.ts` |
 | The menu bar: the glyph, the count, what the menu offers, closing the window | *The menu bar is Guaca with the window shut* in `docs/WORKSPACE.md`, then `src-tauri/src/menubar.rs` |
@@ -181,6 +183,14 @@ the model takes a screenshot to see what `browse` did.
   A one-class modifier above the base rule loses every property they share on
   source order, which is invisible in a diff: the reading view opened at the
   ordinary 38rem for that reason. `styles.test.ts` walks the modifiers.
+- **What a memory rewrite replaced is absent, empty or a page, and the three
+  mean different things.** Absent is a call that replaced nothing, which is
+  every other tool and every write recorded before the field existed: there is
+  nothing to compare and the content is drawn as it always was. Empty is an
+  agent's first memory, which replaced nothing because there was nothing, and
+  draws as a page that is all new. A truthiness check collapses the first two
+  and loses the only write where the whole page is the news. `Part::ToolCall`
+  in `domain/envelope.rs`, then `trailStep`.
 - **`emit_reply` delivers a reply that carries a file and no text.** Handing over
   a document with nothing typed is normal, and judging the reply empty by its
   text alone drops the thing the turn was spent producing.

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -72,7 +72,37 @@ worth reading and a byte count can be ignored in peace.
 
 **A chip that opens nothing is not a button.** A directory lookup is one call
 whose whole content is the sentence already on it. A control that does nothing
-is one the operator stops trusting the rest of.
+is one the operator stops trusting the rest of. A memory that was cleared is the
+one call with no content and something to say anyway: what was thrown away is
+the whole of what happened, so it opens on that.
+
+**A memory rewrite opens as a diff, because the call is always the whole page.**
+`update_notes` replaces the file rather than appending to it, which is the right
+interface for an agent — it has to reconcile what it believed against what it
+just learned — and the wrong one for whoever reads the result. Opening a rewrite
+used to show a page of markdown, and "what did it decide to remember this time"
+meant holding two near-identical pages in your head. So the call carries what it
+overwrote, and `lib/diff.ts` draws the lines between the two.
+
+That previous version is recorded by the runtime at the moment of the write and
+cannot be worked out later by anybody. The same memory is written from an
+agent's wall and from every thread it holds, and the operator can edit it by
+hand from the agent's panel, so a previous version recovered from the transcript
+this call happens to sit in is wrong exactly when something interesting
+happened. It is on the call rather than in its arguments because the arguments
+are the model's own JSON, verbatim, and a reader has to be able to tell what the
+model asked for from what the runtime found. Calls recorded before any of this
+have nothing to compare against and draw as they always did.
+
+Every unchanged line is kept, unlike a patch. A page is short enough to show
+whole, and an operator opening this has a second question the changed lines
+alone do not answer: not only what the agent changed its mind about, but what it
+now believes. The marker in the gutter is a character rather than only a colour,
+because red and green either side of a line are the one distinction a reader may
+not have, and because it is what makes a diff copied out of the window still
+read as one. How much moved is said in words, in the place the runtime's own
+summary would have gone — that summary is a character count printed directly
+above the characters it counts.
 
 Nobody is named on any of it. There is exactly one agent whose own work this can
 be, its portrait and name are at the top of the pane, and the rows this replaced

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -4472,11 +4472,11 @@ mod tests {
             Part::text("hello"),
             Part::Json { name: "report".into(), value: serde_json::json!({"ok": true, "n": 3}) },
             Part::Notice { kind: NoticeKind::GuardStop, text: "hop limit".into() },
-            Part::ToolCall {
-                name: "send_message".into(),
-                arguments: serde_json::json!({"to": "Chef"}),
-                outcome: ToolOutcome::Refused { reason: "duplicate".into() },
-            },
+            Part::tool_call(
+                "send_message",
+                serde_json::json!({"to": "Chef"}),
+                ToolOutcome::Refused { reason: "duplicate".into() },
+            ),
         ];
         f.store.append(&e).unwrap();
 

--- a/src-tauri/src/domain/envelope.rs
+++ b/src-tauri/src/domain/envelope.rs
@@ -160,6 +160,23 @@ pub enum Part {
         name: String,
         arguments: serde_json::Value,
         outcome: ToolOutcome,
+        /// What the call overwrote, where it overwrote something whole.
+        ///
+        /// Only a memory rewrite fills this in, and it is here rather than in
+        /// `arguments` because `arguments` is the model's own JSON, verbatim:
+        /// a reader has to be able to tell what the model asked for from what
+        /// the runtime found. It is recorded at the moment of the write rather
+        /// than worked out later because nothing can work it out later. One
+        /// agent's memory is written from its wall and from every thread it
+        /// holds, and the operator can edit it by hand, so a previous version
+        /// taken from the transcript the call happens to appear in is wrong
+        /// exactly when something interesting happened.
+        ///
+        /// `None` on every other call and on every call that was refused or
+        /// failed, which is the plain truth: nothing was replaced. Absent in
+        /// rows written before this existed, which read as they always did.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        replaced: Option<String>,
     },
     /// A file this message carries.
     ///
@@ -235,6 +252,30 @@ pub struct RefusedRecipient {
 impl Part {
     pub fn text(value: impl Into<String>) -> Self {
         Part::Text { text: value.into() }
+    }
+
+    /// A call that replaced nothing, which is every call but a memory rewrite.
+    ///
+    /// A constructor rather than a struct literal at each site, so that the one
+    /// tool with something to say about what it overwrote is the only place
+    /// that mentions it. Two dozen refusals declaring that they replaced
+    /// nothing is a field asking a question none of them was ever asked.
+    pub fn tool_call(
+        name: impl Into<String>,
+        arguments: serde_json::Value,
+        outcome: ToolOutcome,
+    ) -> Self {
+        Part::ToolCall { name: name.into(), arguments, outcome, replaced: None }
+    }
+
+    /// A call that overwrote something whole, carrying what was there first.
+    pub fn tool_call_replacing(
+        name: impl Into<String>,
+        arguments: serde_json::Value,
+        outcome: ToolOutcome,
+        replaced: impl Into<String>,
+    ) -> Self {
+        Part::ToolCall { name: name.into(), arguments, outcome, replaced: Some(replaced.into()) }
     }
 
     /// The plain-text projection, used for prompts, dedup hashing, and search.

--- a/src-tauri/src/eval.rs
+++ b/src-tauri/src/eval.rs
@@ -482,11 +482,11 @@ mod tests {
         // was a channel with no words in it.
         let (a, b) = agents();
         let trail = Envelope {
-            parts: vec![Part::ToolCall {
-                name: "run_command".into(),
-                arguments: serde_json::Value::Null,
-                outcome: crate::domain::envelope::ToolOutcome::Ok { summary: "ran it".into() },
-            }],
+            parts: vec![Part::tool_call(
+                "run_command",
+                serde_json::Value::Null,
+                crate::domain::envelope::ToolOutcome::Ok { summary: "ran it".into() },
+            )],
             ..msg(Participant::Agent { id: b }, Participant::System, "", 2, false)
         };
         let run = [

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -2317,11 +2317,11 @@ impl Runtime {
             Err(err) => {
                 return (
                     err.guidance(),
-                    Part::ToolCall {
-                        name: call.name.clone(),
+                    Part::tool_call(
+                        call.name.clone(),
                         arguments,
-                        outcome: ToolOutcome::Failed { error: err.to_string() },
-                    },
+                        ToolOutcome::Failed { error: err.to_string() },
+                    ),
                     None,
                 );
             }
@@ -2334,11 +2334,11 @@ impl Runtime {
         if let Some(refusal) = self.not_given(card, &invocation) {
             return (
                 refusal.clone(),
-                Part::ToolCall {
-                    name: call.name.clone(),
+                Part::tool_call(
+                    call.name.clone(),
                     arguments,
-                    outcome: ToolOutcome::Refused { reason: refusal },
-                },
+                    ToolOutcome::Refused { reason: refusal },
+                ),
                 None,
             );
         }
@@ -2385,14 +2385,7 @@ impl Runtime {
                         roster.iter().map(|e| e.name.as_str()).collect::<Vec<_>>().join(", ")
                     )
                 };
-                (
-                    payload,
-                    Part::ToolCall {
-                        name: tools::DIRECTORY.to_string(),
-                        arguments,
-                        outcome: ToolOutcome::Ok { summary },
-                    },
-                )
+                (payload, Part::tool_call(tools::DIRECTORY, arguments, ToolOutcome::Ok { summary }))
             }
 
             ToolInvocation::UpdateNotes { content } => {
@@ -2412,20 +2405,24 @@ impl Runtime {
                         };
                         (
                             summary.clone(),
-                            Part::ToolCall {
-                                name: tools::UPDATE_NOTES.to_string(),
+                            // Carrying what it replaced, so the transcript can
+                            // show what changed rather than a page of memory
+                            // the operator has to read twice to compare.
+                            Part::tool_call_replacing(
+                                tools::UPDATE_NOTES,
                                 arguments,
-                                outcome: ToolOutcome::Ok { summary },
-                            },
+                                ToolOutcome::Ok { summary },
+                                stored.before,
+                            ),
                         )
                     }
                     Err(err) => (
                         format!("Error: your memory could not be saved ({err})."),
-                        Part::ToolCall {
-                            name: tools::UPDATE_NOTES.to_string(),
+                        Part::tool_call(
+                            tools::UPDATE_NOTES,
                             arguments,
-                            outcome: ToolOutcome::Failed { error: err.to_string() },
-                        },
+                            ToolOutcome::Failed { error: err.to_string() },
+                        ),
                     ),
                 }
             }
@@ -2456,10 +2453,7 @@ impl Runtime {
                         ToolOutcome::Failed { error: err.to_string() },
                     ),
                 };
-                (
-                    rendered,
-                    Part::ToolCall { name: tools::RUN_COMMAND.to_string(), arguments, outcome },
-                )
+                (rendered, Part::tool_call(tools::RUN_COMMAND, arguments, outcome))
             }
 
             ToolInvocation::Schedule { action } => {
@@ -2469,7 +2463,7 @@ impl Runtime {
                         (format!("Error: {err}"), ToolOutcome::Failed { error: err.to_string() })
                     }
                 };
-                (rendered, Part::ToolCall { name: tools::SCHEDULE.to_string(), arguments, outcome })
+                (rendered, Part::tool_call(tools::SCHEDULE, arguments, outcome))
             }
 
             ToolInvocation::Browse { action, args } => {
@@ -2482,11 +2476,11 @@ impl Runtime {
                 if let Some(refusal) = self.may_act_on(card, run_id, &action, reading).await {
                     return (
                         refusal.clone(),
-                        Part::ToolCall {
-                            name: tools::BROWSE.to_string(),
+                        Part::tool_call(
+                            tools::BROWSE,
                             arguments,
-                            outcome: ToolOutcome::Refused { reason: refusal },
-                        },
+                            ToolOutcome::Refused { reason: refusal },
+                        ),
                         None,
                     );
                 }
@@ -2515,7 +2509,7 @@ impl Runtime {
                         (format!("Error: {err}"), ToolOutcome::Failed { error: err.to_string() })
                     }
                 };
-                (rendered, Part::ToolCall { name: tools::BROWSE.to_string(), arguments, outcome })
+                (rendered, Part::tool_call(tools::BROWSE, arguments, outcome))
             }
 
             ToolInvocation::OpenOnDesktop { command } => {
@@ -2553,10 +2547,7 @@ impl Runtime {
                         ToolOutcome::Failed { error: err.to_string() },
                     ),
                 };
-                (
-                    rendered,
-                    Part::ToolCall { name: tools::OPEN_ON_DESKTOP.to_string(), arguments, outcome },
-                )
+                (rendered, Part::tool_call(tools::OPEN_ON_DESKTOP, arguments, outcome))
             }
 
             ToolInvocation::SendMessage { to, text, intent, files } => {
@@ -2616,10 +2607,7 @@ impl Runtime {
                 } else {
                     format!("{rendered}\n{}", missing.join("\n"))
                 };
-                (
-                    rendered,
-                    Part::ToolCall { name: tools::SEND_MESSAGE.to_string(), arguments, outcome },
-                )
+                (rendered, Part::tool_call(tools::SEND_MESSAGE, arguments, outcome))
             }
 
             ToolInvocation::AttachFile { files } => {
@@ -2673,10 +2661,7 @@ impl Runtime {
                     rendered.push_str(&missing.join("\n"));
                 }
 
-                (
-                    rendered,
-                    Part::ToolCall { name: tools::ATTACH_FILE.to_string(), arguments, outcome },
-                )
+                (rendered, Part::tool_call(tools::ATTACH_FILE, arguments, outcome))
             }
 
             ToolInvocation::Plugin { kind, tool, arguments: sent } => {
@@ -2709,7 +2694,7 @@ impl Runtime {
                         (format!("Error: {err}"), ToolOutcome::Failed { error: err.to_string() })
                     }
                 };
-                (rendered, Part::ToolCall { name, arguments, outcome })
+                (rendered, Part::tool_call(name, arguments, outcome))
             }
         };
 
@@ -2916,11 +2901,11 @@ impl Runtime {
                  and that they can give you a computer or a browser from your panel, then carry \
                  on with the part you can do from here."
                     .to_string(),
-                Part::ToolCall {
-                    name: tools::REQUEST_PERMISSION.to_string(),
+                Part::tool_call(
+                    tools::REQUEST_PERMISSION,
                     arguments,
-                    outcome: ToolOutcome::Refused { reason },
-                },
+                    ToolOutcome::Refused { reason },
+                ),
             );
         }
 
@@ -2943,14 +2928,7 @@ impl Runtime {
             .await;
 
         let outcome = |status: ToolOutcome, text: String| {
-            (
-                text,
-                Part::ToolCall {
-                    name: tools::REQUEST_PERMISSION.to_string(),
-                    arguments: arguments.clone(),
-                    outcome: status,
-                },
-            )
+            (text, Part::tool_call(tools::REQUEST_PERMISSION, arguments.clone(), status))
         };
 
         match permission {
@@ -2995,11 +2973,7 @@ impl Runtime {
         let failed = |message: String, error: String, arguments: serde_json::Value| {
             (
                 message,
-                Part::ToolCall {
-                    name: tools::CREATE_AGENT.to_string(),
-                    arguments,
-                    outcome: ToolOutcome::Failed { error },
-                },
+                Part::tool_call(tools::CREATE_AGENT, arguments, ToolOutcome::Failed { error }),
             )
         };
 
@@ -3089,11 +3063,11 @@ impl Runtime {
                      do if it matters.",
                     clean.name
                 ),
-                Part::ToolCall {
-                    name: tools::CREATE_AGENT.to_string(),
+                Part::tool_call(
+                    tools::CREATE_AGENT,
                     arguments,
-                    outcome: ToolOutcome::Refused { reason: "the operator declined".to_string() },
-                },
+                    ToolOutcome::Refused { reason: "the operator declined".to_string() },
+                ),
             ),
             Permission::Unanswered => (
                 format!(
@@ -3103,13 +3077,11 @@ impl Runtime {
                      they are back.",
                     clean.name
                 ),
-                Part::ToolCall {
-                    name: tools::CREATE_AGENT.to_string(),
+                Part::tool_call(
+                    tools::CREATE_AGENT,
                     arguments,
-                    outcome: ToolOutcome::Refused {
-                        reason: "the operator did not answer".to_string(),
-                    },
-                },
+                    ToolOutcome::Refused { reason: "the operator did not answer".to_string() },
+                ),
             ),
             Permission::Failed(err) => failed(
                 format!(
@@ -3135,11 +3107,11 @@ impl Runtime {
             Err(err) => {
                 return (
                     format!("Error: {} could not be created ({err}).", clean.name),
-                    Part::ToolCall {
-                        name: tools::CREATE_AGENT.to_string(),
+                    Part::tool_call(
+                        tools::CREATE_AGENT,
                         arguments,
-                        outcome: ToolOutcome::Failed { error: err.to_string() },
-                    },
+                        ToolOutcome::Failed { error: err.to_string() },
+                    ),
                 )
             }
         };
@@ -3177,11 +3149,11 @@ impl Runtime {
                  work is ready, send it.{bare}",
                 name = card.name
             ),
-            Part::ToolCall {
-                name: tools::CREATE_AGENT.to_string(),
+            Part::tool_call(
+                tools::CREATE_AGENT,
                 arguments,
-                outcome: ToolOutcome::Ok { summary: format!("created {}", card.name) },
-            },
+                ToolOutcome::Ok { summary: format!("created {}", card.name) },
+            ),
         )
     }
 
@@ -3245,11 +3217,7 @@ impl Runtime {
         let failed = |message: String, err: String, arguments: serde_json::Value| {
             (
                 message,
-                Part::ToolCall {
-                    name: tools::USE_SCREEN.to_string(),
-                    arguments,
-                    outcome: ToolOutcome::Failed { error: err },
-                },
+                Part::tool_call(tools::USE_SCREEN, arguments, ToolOutcome::Failed { error: err }),
                 None,
             )
         };
@@ -3350,11 +3318,7 @@ impl Runtime {
 
         (
             rendered,
-            Part::ToolCall {
-                name: tools::USE_SCREEN.to_string(),
-                arguments,
-                outcome: ToolOutcome::Ok { summary },
-            },
+            Part::tool_call(tools::USE_SCREEN, arguments, ToolOutcome::Ok { summary }),
             Some(screen.image),
         )
     }

--- a/src-tauri/src/trajectory.rs
+++ b/src-tauri/src/trajectory.rs
@@ -998,18 +998,16 @@ mod tests {
                 Participant::Agent { id: agent },
                 Participant::Human,
                 vec![
-                    Part::ToolCall {
-                        name: "send_message".into(),
-                        arguments: serde_json::json!({}),
-                        outcome: ToolOutcome::Refused {
-                            reason: "Refused: hop limit reached.".into(),
-                        },
-                    },
-                    Part::ToolCall {
-                        name: "browse".into(),
-                        arguments: serde_json::json!({}),
-                        outcome: ToolOutcome::Failed { error: "the machine went away".into() },
-                    },
+                    Part::tool_call(
+                        "send_message",
+                        serde_json::json!({}),
+                        ToolOutcome::Refused { reason: "Refused: hop limit reached.".into() },
+                    ),
+                    Part::tool_call(
+                        "browse",
+                        serde_json::json!({}),
+                        ToolOutcome::Failed { error: "the machine went away".into() },
+                    ),
                 ],
             ),
         );

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -119,6 +119,13 @@ impl Workspace {
     /// ran over the cap, cut at a line boundary with a marker. Silently storing
     /// a truncated file would let an agent believe it had recorded something it
     /// had not.
+    ///
+    /// It also returns what was there first. Replacing is the only write this
+    /// interface has, so the version it replaced exists nowhere else a moment
+    /// later, and this is the only place it can be read without a race: the
+    /// same memory is written from every thread an agent holds and edited by
+    /// the operator by hand, so anything that reads the file afterwards is
+    /// reading somebody else's write.
     pub fn write(&self, id: AgentId, name: &str, content: &str) -> Result<Stored, WorkspaceError> {
         fs::create_dir_all(&self.root)
             .map_err(|source| WorkspaceError::Io { path: self.root.clone(), source })?;
@@ -138,8 +145,11 @@ impl Workspace {
         };
 
         let target = self.preferred_path(id, name);
+        let current = self.existing_path(id);
+        let before =
+            current.as_ref().and_then(|path| fs::read_to_string(path).ok()).unwrap_or_default();
         // Renaming is cosmetic: lookup is by id, so a failure here is harmless.
-        if let Some(current) = self.existing_path(id) {
+        if let Some(current) = current {
             if current != target {
                 let _ = fs::rename(&current, &target);
             }
@@ -148,7 +158,7 @@ impl Workspace {
         fs::write(&target, &body)
             .map_err(|source| WorkspaceError::Io { path: target.clone(), source })?;
 
-        Ok(Stored { characters: body.chars().count(), truncated, path: target })
+        Ok(Stored { before, characters: body.chars().count(), truncated, path: target })
     }
 
     /// Deletes an agent's notes. Called when the agent is deleted.
@@ -161,6 +171,8 @@ impl Workspace {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Stored {
+    /// The version this write replaced, empty where there was none.
+    pub before: String,
     pub characters: usize,
     pub truncated: bool,
     pub path: PathBuf,
@@ -194,6 +206,33 @@ mod tests {
         ws.write(id, "Manager", "first belief").unwrap();
         ws.write(id, "Manager", "corrected belief").unwrap();
         assert_eq!(ws.read(id), "corrected belief");
+    }
+
+    #[test]
+    fn a_write_hands_back_the_version_it_replaced() {
+        // The transcript shows the operator what an agent changed about itself,
+        // and this is the only moment the version before it still exists.
+        let (ws, _dir) = workspace();
+        let id = AgentId::new();
+
+        let first = ws.write(id, "Manager", "first belief").unwrap();
+        assert_eq!(first.before, "", "an agent's first memory replaced nothing");
+
+        let second = ws.write(id, "Manager", "corrected belief").unwrap();
+        assert_eq!(second.before, "first belief");
+    }
+
+    #[test]
+    fn the_replaced_version_survives_a_rename() {
+        // Lookup is by id, and so is this: an agent renamed between two writes
+        // must not read as one that has just written its memory for the first
+        // time.
+        let (ws, _dir) = workspace();
+        let id = AgentId::new();
+        ws.write(id, "Manager", "kept").unwrap();
+
+        let stored = ws.write(id, "Coordinator", "revised").unwrap();
+        assert_eq!(stored.before, "kept");
     }
 
     #[test]

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -582,6 +582,51 @@ async fn an_agent_asked_for_its_memory_writes_the_same_file_as_its_notes() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_memory_write_records_the_version_it_replaced() {
+    // What the operator wants from the transcript is what changed, and a
+    // rewrite is the whole file either way: two pages of near-identical
+    // markdown compared by eye. So the call carries what it overwrote, and it
+    // is carried rather than looked up because by the time anybody reads the
+    // channel the file says something else again.
+    let stub = serve(|body| {
+        let system = body["messages"][0]["content"].as_str().unwrap_or_default();
+        if has_tool_result(body) {
+            Script::Say("Done.".into())
+        } else if system.contains("Smith handles verification.") {
+            Script::Notes("Smith handles verification.\nJones signs off.".into())
+        } else {
+            Script::Notes("Smith handles verification.".into())
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let first = h.runtime.send_from_human(h.id("Manager"), "remember who verifies").unwrap();
+    h.settle(first).await;
+    let second = h.runtime.send_from_human(h.id("Manager"), "and who signs off").unwrap();
+    h.settle(second).await;
+
+    let replaced: Vec<Option<String>> = h
+        .runtime
+        .store()
+        .channel_messages(h.id("Manager"), 200)
+        .unwrap()
+        .iter()
+        .flat_map(|m| m.parts.clone())
+        .filter_map(|part| match part {
+            Part::ToolCall { name, replaced, .. } if name == "update_notes" => Some(replaced),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        replaced,
+        vec![Some(String::new()), Some("Smith handles verification.".to_string())],
+        "the first write replaced nothing and the second replaced the first"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn what_one_agent_remembers_is_never_shown_to_another() {
     // A memory is written by an agent for itself, in whatever shorthand suits
     // it, and it holds whatever the operator has told that one agent in

--- a/src/components/MessageItem.test.tsx
+++ b/src/components/MessageItem.test.tsx
@@ -206,6 +206,71 @@ describe("an agent's own record of what it did", () => {
     expect(screen.getByText("Smith handles verification.")).toBeTruthy();
   });
 
+  it("opens a memory rewrite against the version it replaced", () => {
+    // The tool replaces the file, so every write arrives as the whole page and
+    // the content alone never says what the agent changed its mind about.
+    show(
+      record({
+        type: "toolCall",
+        name: "update_notes",
+        arguments: { content: "Smith handles verification.\nJones signs off." },
+        outcome: { status: "ok", summary: "Memory saved (44 characters)." },
+        replaced: "Smith handles verification.\nPatel signs off.",
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Updated its memory/ }));
+
+    const kind = (text: string) =>
+      screen.getByText(text).closest("[data-kind]")?.getAttribute("data-kind");
+    expect(kind("Smith handles verification.")).toBe("same");
+    expect(kind("Patel signs off.")).toBe("removed");
+    expect(kind("Jones signs off.")).toBe("added");
+    // Marked as well as coloured. Red and green either side of a line are the
+    // one distinction a reader may not have, and the marker is also what keeps
+    // a diff copied out of the window reading as one.
+    const marks = [...document.querySelectorAll(".diff__mark")].map((node) => node.textContent);
+    expect(marks).toEqual([" ", "-", "+"]);
+    // How much moved, in the place the runtime's character count would have
+    // gone. That count is printed directly above the characters it counts.
+    expect(screen.getByText("1 line added, 1 removed")).toBeTruthy();
+    expect(screen.queryByText(/44 characters/)).toBeNull();
+  });
+
+  it("opens a memory that was cleared, which has nothing to show but the loss", () => {
+    // No content, so nothing that reads the arguments finds anything to draw,
+    // and what was thrown away is the whole of what happened.
+    show(
+      record({
+        type: "toolCall",
+        name: "update_notes",
+        arguments: { content: "" },
+        outcome: { status: "ok", summary: "Memory cleared." },
+        replaced: "Smith handles verification.",
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Updated its memory/ }));
+    const line = screen.getByText("Smith handles verification.").closest("[data-kind]");
+    expect(line?.getAttribute("data-kind")).toBe("removed");
+  });
+
+  it("draws a memory recorded before any of this as what it wrote, and no diff", () => {
+    // Every write already in a channel has no previous version stored against
+    // it, and inventing one from whatever else is in the channel would be wrong
+    // exactly where it mattered: the same memory is written from every thread
+    // an agent holds.
+    show(
+      record({
+        type: "toolCall",
+        name: "update_notes",
+        arguments: { content: "Smith handles verification.\nJones signs off." },
+        outcome: { status: "ok", summary: "Memory saved (44 characters)." },
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Updated its memory/ }));
+    expect(document.querySelector(".diff")).toBeNull();
+    expect(screen.getByText(/Smith handles verification/)).toBeTruthy();
+  });
+
   it("names an unrecognised tool rather than guessing it was a send", () => {
     show(
       record({

--- a/src/components/Trail.tsx
+++ b/src/components/Trail.tsx
@@ -1,10 +1,12 @@
 import { useId, useState } from "react";
 
+import { type DiffLine, diffSummary } from "../lib/diff";
 import {
   foldTrail,
   hasDetail,
   type Step,
   saysMore,
+  stepDiff,
   type TrailGroup,
   tellsMore,
 } from "../lib/trail";
@@ -134,18 +136,29 @@ function TrailChip({
  * exactly as it was: this is a record of what happened, so it is never markdown
  * and never anything a model could format its way out of. Long ones scroll
  * rather than push the transcript sideways.
+ *
+ * A call that overwrote something is drawn against what it overwrote instead,
+ * however short it is: the whole reason to open a memory rewrite is to find out
+ * what the agent changed its mind about, and the content alone never says.
  */
 function StepRow({ step }: { step: Step }) {
+  const changed = stepDiff(step);
   // A url, a pair of coordinates or an element number is a few characters, and
   // a few characters in a block of their own is a grey rectangle drawn around
   // nothing. A command and a rewritten memory are the reason the block exists.
-  const inline = step.target !== null && step.target.length <= 48 && !step.target.includes("\n");
+  const inline =
+    !changed && step.target !== null && step.target.length <= 48 && !step.target.includes("\n");
 
   return (
     <li className="trail__step" data-failed={step.failed || undefined}>
       <div className="trail__step-head">
         <span className="trail__step-title">{step.title}</span>
         {inline && <span className="trail__inline">{step.target}</span>}
+        {/* In the place the runtime's own summary would have gone, and for a
+            memory rewrite that summary is a character count printed directly
+            above the characters. How much of the page moved is the thing the
+            operator came here to find out. */}
+        {changed && <span className="trail__said">{diffSummary(changed)}</span>}
         {step.said && tellsMore(step) && <span className="trail__said">{step.said}</span>}
         {step.spent.map((credential) => (
           <span className="trail__spent" key={credential}>
@@ -153,7 +166,35 @@ function StepRow({ step }: { step: Step }) {
           </span>
         ))}
       </div>
-      {step.target && !inline && <pre className="trail__target">{step.target}</pre>}
+      {changed && <DiffBlock lines={changed} />}
+      {!changed && step.target && !inline && <pre className="trail__target">{step.target}</pre>}
     </li>
+  );
+}
+
+/**
+ * Two versions of a page, drawn as the lines between them.
+ *
+ * Every line of both is here, unchanged ones included, so the panel answers
+ * what the agent now believes as well as what it just decided. A page is short
+ * enough to show whole; folding the parts that held still is a saving worth
+ * making in a repository and not in a paragraph.
+ *
+ * The marker is a character rather than only a colour, because red and green
+ * either side of a line are the one distinction a reader may not have, and
+ * because it is what makes a copied diff still read as one.
+ */
+function DiffBlock({ lines }: { lines: DiffLine[] }) {
+  const mark = { same: " ", added: "+", removed: "-" };
+  return (
+    <pre className="diff">
+      {lines.map((line, at) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: two identical lines in one document are ordinary, and the list is rebuilt whole rather than reordered
+        <span className="diff__line" data-kind={line.kind} key={at}>
+          <span className="diff__mark">{mark[line.kind]}</span>
+          <span className="diff__text">{line.text}</span>
+        </span>
+      ))}
+    </pre>
   );
 }

--- a/src/lib/diff.test.ts
+++ b/src/lib/diff.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { type DiffLine, diffSummary, diffTally, lineDiff } from "./diff";
+
+/** A diff as a patch would write it, which is the shortest way to assert one. */
+function marked(diff: DiffLine[]): string[] {
+  const mark = { same: " ", added: "+", removed: "-" };
+  return diff.map((line) => `${mark[line.kind]}${line.text}`);
+}
+
+describe("an empty side", () => {
+  it("is no lines rather than one blank one", () => {
+    // `"".split("\n")` is `[""]`. Left alone, an agent's first memory reads as
+    // having replaced a blank line that was never there.
+    expect(marked(lineDiff("", "Smith verifies."))).toEqual(["+Smith verifies."]);
+    expect(marked(lineDiff("Smith verifies.", ""))).toEqual(["-Smith verifies."]);
+    expect(lineDiff("", "")).toEqual([]);
+  });
+});
+
+describe("what changed", () => {
+  it("keeps the lines that did not, so the page is still readable", () => {
+    // Not a patch. The operator opening this wants what the agent now believes
+    // as much as they want what it just decided.
+    const diff = lineDiff("one\ntwo\nthree", "one\ntwo\nthree\nfour");
+    expect(marked(diff)).toEqual([" one", " two", " three", "+four"]);
+  });
+
+  it("finds a line taken out of the middle without moving the rest", () => {
+    const diff = lineDiff("one\ntwo\nthree", "one\nthree");
+    expect(marked(diff)).toEqual([" one", "-two", " three"]);
+  });
+
+  it("reads a rewritten line as the old one and then the new one", () => {
+    // Adjacent, so the two sentences can be compared. Anything else puts the
+    // replacement below everything else the rewrite touched.
+    const diff = lineDiff("one\ntwo\nthree", "one\nTWO\nthree");
+    expect(marked(diff)).toEqual([" one", "-two", "+TWO", " three"]);
+  });
+
+  it("holds an insertion apart from the line it was inserted before", () => {
+    const diff = lineDiff("a\nb", "a\nnew\nb");
+    expect(marked(diff)).toEqual([" a", "+new", " b"]);
+  });
+
+  it("says nothing changed when an agent rewrites what it already had", () => {
+    // A real turn: asked to remember something it already remembers, an agent
+    // writes the file again. Drawn as a page of additions that is a page of
+    // additions in a diff, it reads as having thrown its memory away.
+    const same = "Smith verifies.\nJones signs off.";
+    const diff = lineDiff(same, same);
+    expect(diffTally(diff)).toEqual({ added: 0, removed: 0 });
+    expect(diffSummary(diff)).toBe("rewritten unchanged");
+  });
+
+  it("keeps every line of both versions, whatever it decided about them", () => {
+    // The invariant that stops a line being lost between the two: a removal
+    // nobody drew is a fact about an agent the operator never gets told.
+    const before = "a\nb\nc\nd\ne";
+    const after = "a\nx\nc\ny\ne\nf";
+    const diff = lineDiff(before, after);
+    const kept = (kinds: string[]) =>
+      diff.filter((line) => kinds.includes(line.kind)).map((line) => line.text);
+
+    expect(kept(["same", "removed"])).toEqual(before.split("\n"));
+    expect(kept(["same", "added"])).toEqual(after.split("\n"));
+  });
+});
+
+describe("a document too large to compare line by line", () => {
+  it("is shown as a wholesale replacement rather than left working it out", () => {
+    // Well past what memory can hold, so this is the shape of a bug rather than
+    // of a page. It has to end, and it has to end without dropping a line.
+    const before = Array.from({ length: 700 }, (_, i) => `old ${i}`).join("\n");
+    const after = Array.from({ length: 700 }, (_, i) => `new ${i}`).join("\n");
+
+    const diff = lineDiff(before, after);
+    expect(diffTally(diff)).toEqual({ added: 700, removed: 700 });
+    expect(diff.slice(0, 700).every((line) => line.kind === "removed")).toBe(true);
+  });
+
+  it("still matches the ends first, which is what makes a real page cheap", () => {
+    // A page rewritten with one line changed is two short middles, however long
+    // the page is: the table is never built for the part that did not move.
+    const body = Array.from({ length: 700 }, (_, i) => `line ${i}`);
+    const after = [...body];
+    after[350] = "changed";
+
+    const diff = lineDiff(body.join("\n"), after.join("\n"));
+    expect(diffTally(diff)).toEqual({ added: 1, removed: 1 });
+  });
+});
+
+describe("the tally", () => {
+  it("counts in words, since it is the one part of a diff that is read aloud", () => {
+    expect(diffSummary(lineDiff("a", "a\nb"))).toBe("1 line added");
+    expect(diffSummary(lineDiff("a\nb", "a"))).toBe("1 line removed");
+    expect(diffSummary(lineDiff("a\nb", "a\nc\nd"))).toBe("2 lines added, 1 removed");
+  });
+});

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -1,0 +1,154 @@
+/**
+ * Two versions of one small document, as the lines between them.
+ *
+ * There is one caller: an agent rewriting its own memory. The tool replaces the
+ * file rather than appending to it, which is the right interface for a model
+ * and the wrong one for whoever has to read the result: every write arrives as
+ * the whole page, and "what did it decide to remember this time" means holding
+ * two near-identical pages in your head and comparing them by eye.
+ *
+ * Line-level and nothing finer. A memory is a page of markdown written in
+ * sentences, so a line is the unit an agent changes and the unit a person
+ * reads; picking out the three words inside a rewritten sentence would draw
+ * attention to the smallest part of the smallest change.
+ *
+ * Every unchanged line is kept, unlike a patch, which folds them away. A page
+ * is short enough to show whole, and showing it whole answers the other
+ * question the operator has when they open this: not only what changed, but
+ * what the agent now believes.
+ */
+
+export type DiffKind = "same" | "added" | "removed";
+
+export interface DiffLine {
+  kind: DiffKind;
+  text: string;
+}
+
+/**
+ * Beyond this many cells the table is not worth building.
+ *
+ * The exact diff costs one cell per pair of lines. Memory is capped at a page
+ * by `MAX_NOTES`, so the ordinary case is tens of lines against tens of lines
+ * and nowhere near this; a document that reaches it is one where a line-by-line
+ * comparison was never going to be read anyway, and it is shown as a wholesale
+ * replacement rather than left to lock up the window working out otherwise.
+ */
+const CELLS = 250_000;
+
+/**
+ * Lines, with the empty document having none rather than one blank one.
+ *
+ * `"".split("\n")` is `[""]`, and one empty line is what makes a first memory
+ * read as having replaced a blank line that was never there.
+ */
+function lines(value: string): string[] {
+  return value.length === 0 ? [] : value.split(/\r?\n/);
+}
+
+/**
+ * What changed between two versions, in order.
+ *
+ * Removals come before additions within a run, which is the arrangement a
+ * rewritten line wants: the old sentence and the new one end up adjacent
+ * instead of separated by everything else the turn touched.
+ */
+export function lineDiff(before: string, after: string): DiffLine[] {
+  const old = lines(before);
+  const now = lines(after);
+
+  // Matching ends first. It is what makes the ordinary case cheap — a page
+  // rewritten with one sentence changed is two short middles — and it also
+  // stops the table from being built at all when nothing moved.
+  let head = 0;
+  while (head < old.length && head < now.length && old[head] === now[head]) head++;
+
+  let tail = 0;
+  while (
+    tail < old.length - head &&
+    tail < now.length - head &&
+    old[old.length - 1 - tail] === now[now.length - 1 - tail]
+  ) {
+    tail++;
+  }
+
+  const gone = old.slice(head, old.length - tail);
+  const fresh = now.slice(head, now.length - tail);
+
+  const out: DiffLine[] = old.slice(0, head).map((text) => ({ kind: "same", text }) as DiffLine);
+  out.push(...middle(gone, fresh));
+  out.push(...old.slice(old.length - tail).map((text) => ({ kind: "same", text }) as DiffLine));
+  return out;
+}
+
+/** The part that actually differs, matched line for line where it can be. */
+function middle(gone: string[], fresh: string[]): DiffLine[] {
+  if (gone.length === 0 || fresh.length === 0 || gone.length * fresh.length > CELLS) {
+    return [
+      ...gone.map((text) => ({ kind: "removed", text }) as DiffLine),
+      ...fresh.map((text) => ({ kind: "added", text }) as DiffLine),
+    ];
+  }
+
+  // The longest run of lines the two versions still share, counted from the
+  // end back so the walk forward can follow the larger number.
+  const wide = fresh.length + 1;
+  const kept = new Uint32Array((gone.length + 1) * wide);
+  for (let i = gone.length - 1; i >= 0; i--) {
+    for (let j = fresh.length - 1; j >= 0; j--) {
+      kept[i * wide + j] =
+        gone[i] === fresh[j]
+          ? kept[(i + 1) * wide + j + 1]! + 1
+          : Math.max(kept[(i + 1) * wide + j]!, kept[i * wide + j + 1]!);
+    }
+  }
+
+  const out: DiffLine[] = [];
+  // Held back so a rewritten line reads as the old one and then the new one,
+  // rather than as whatever order the walk happened to take them in.
+  let added: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < gone.length && j < fresh.length) {
+    if (gone[i] === fresh[j]) {
+      out.push(...added, { kind: "same", text: gone[i]! });
+      added = [];
+      i++;
+      j++;
+    } else if (kept[(i + 1) * wide + j]! >= kept[i * wide + j + 1]!) {
+      out.push({ kind: "removed", text: gone[i]! });
+      i++;
+    } else {
+      added.push({ kind: "added", text: fresh[j]! });
+      j++;
+    }
+  }
+  out.push(...gone.slice(i).map((text) => ({ kind: "removed", text }) as DiffLine));
+  out.push(...added);
+  out.push(...fresh.slice(j).map((text) => ({ kind: "added", text }) as DiffLine));
+  return out;
+}
+
+/** How much of it changed, which is the part that goes next to the title. */
+export function diffTally(diff: DiffLine[]): { added: number; removed: number } {
+  return {
+    added: diff.filter((line) => line.kind === "added").length,
+    removed: diff.filter((line) => line.kind === "removed").length,
+  };
+}
+
+/**
+ * The tally in words.
+ *
+ * Words rather than `+3 −1` because the rest of a channel is written in them,
+ * and because a plus sign is a symbol a screen reader may not say at all: this
+ * sentence is the only part of a diff that reads as anything out loud.
+ */
+export function diffSummary(diff: DiffLine[]): string {
+  const { added, removed } = diffTally(diff);
+  const count = (n: number, word: string) => `${n} line${n === 1 ? "" : "s"} ${word}`;
+  if (added > 0 && removed > 0) return `${count(added, "added")}, ${removed} removed`;
+  if (added > 0) return count(added, "added");
+  if (removed > 0) return count(removed, "removed");
+  return "rewritten unchanged";
+}

--- a/src/lib/trail.test.ts
+++ b/src/lib/trail.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { foldTrail, hasDetail, readSpent, type Step, tellsMore, trailStep } from "./trail";
+import {
+  foldTrail,
+  hasDetail,
+  readSpent,
+  type Step,
+  stepDiff,
+  tellsMore,
+  trailStep,
+} from "./trail";
 import type { Part, ToolOutcome } from "./types";
 
 type ToolCall = Extract<Part, { type: "toolCall" }>;
@@ -9,6 +17,11 @@ const ok = (summary: string): ToolOutcome => ({ status: "ok", summary });
 
 function call(name: string, args: unknown, outcome: ToolOutcome = ok("done")): ToolCall {
   return { type: "toolCall", name, arguments: args, outcome };
+}
+
+/** A memory rewrite, which is the only call that carries what it overwrote. */
+function rewrote(content: string, replaced: string): ToolCall {
+  return { ...call("update_notes", { content }, ok("Memory saved.")), replaced };
 }
 
 function steps(...calls: ToolCall[]): Step[] {
@@ -229,5 +242,49 @@ describe("whether a chip opens anything", () => {
     );
     expect(hasDetail(groups[0]!)).toBe(true);
     expect(groups[0]?.steps[0]?.target).toBe("Smith handles verification.");
+  });
+
+  it("opens a memory that was cleared, which has no content and still lost one", () => {
+    // Nothing in the arguments to draw, so the rule that reads them alone made
+    // this the one memory write the operator could not open: the one where the
+    // agent threw the whole page away.
+    const groups = foldTrail(steps(rewrote("", "Smith handles verification.")));
+    expect(groups[0]?.steps[0]?.target).toBeNull();
+    expect(hasDetail(groups[0]!)).toBe(true);
+  });
+});
+
+describe("what a rewrite changed", () => {
+  it("compares against the version the runtime says it replaced", () => {
+    const [step] = steps(rewrote("Smith verifies.\nJones signs off.", "Smith verifies."));
+    expect(stepDiff(step!)?.map((line) => `${line.kind}:${line.text}`)).toEqual([
+      "same:Smith verifies.",
+      "added:Jones signs off.",
+    ]);
+  });
+
+  it("reads an empty previous version as a first memory, not as a missing one", () => {
+    // The difference is a falsy string. Read as nothing to compare against, an
+    // agent's first memory draws as a page with no history rather than as a
+    // page that is all new.
+    const [step] = steps(rewrote("Smith verifies.", ""));
+    expect(step?.replaced).toBe("");
+    expect(stepDiff(step!)).toEqual([{ kind: "added", text: "Smith verifies." }]);
+  });
+
+  it("has nothing to compare where the runtime recorded nothing", () => {
+    // Every write already in a channel, and every other tool there is.
+    const [written] = steps(call("update_notes", { content: "Smith verifies." }));
+    expect(stepDiff(written!)).toBeNull();
+
+    const [ran] = steps(call("run_command", { command: "ls" }));
+    expect(stepDiff(ran!)).toBeNull();
+  });
+
+  it("has nothing to draw where a rewrite cleared a memory that was empty", () => {
+    // Both sides empty, so the diff is no lines at all and the panel it would
+    // open is a control that opens onto nothing.
+    const [step] = steps(rewrote("", ""));
+    expect(stepDiff(step!)).toBeNull();
   });
 });

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -20,6 +20,7 @@
  * name of a function in a file they do not have.
  */
 
+import { type DiffLine, lineDiff } from "./diff";
 import { asRecord, attachedNames, sendRecipients } from "./toolArgs";
 import type { Part, ToolOutcome } from "./types";
 
@@ -38,6 +39,17 @@ export interface Step {
    * makes a chip unclickable.
    */
   target: string | null;
+  /**
+   * The version this call overwrote, where it overwrote something whole.
+   *
+   * Only a memory rewrite has one, and only the runtime could have supplied it:
+   * one agent's memory is written from its wall and from every thread it holds,
+   * so a previous version read back out of the channel this call happens to sit
+   * in is wrong exactly when something interesting happened. Empty string where
+   * there was nothing to overwrite, which is a first memory and not a missing
+   * one; null where nothing was overwritten at all.
+   */
+  replaced: string | null;
   /**
    * The place this call happened, where it has one a group can be named after.
    * A browsing turn that stayed on one site is a turn that can say which site.
@@ -258,6 +270,10 @@ export function trailStep(part: ToolCall, key: string): Step {
     tool: part.name,
     title,
     target,
+    // Checked for the type rather than for truth: an empty previous version is
+    // an agent's first memory, and reading it as nothing to compare against
+    // draws that page as a document with no history instead of as all new.
+    replaced: typeof part.replaced === "string" ? part.replaced : null,
     where: where ?? null,
     said: rest,
     failed: part.outcome.status === "refused" || part.outcome.status === "failed",
@@ -384,12 +400,34 @@ export function saysMore(step: Step): boolean {
 }
 
 /**
+ * What the call changed about what it overwrote, where it overwrote something.
+ *
+ * A memory rewrite is the whole page every time, because replacing is the only
+ * write the tool has: that is right for the agent, which has to reconcile what
+ * it believed against what it just learned, and useless for the operator, who
+ * is handed two near-identical pages and left to compare them by eye.
+ *
+ * Null where there is nothing to compare, which includes a call that replaced
+ * nothing and the one degenerate case of clearing a memory that was already
+ * empty. An empty diff drawn as a panel is a control that opens onto nothing.
+ */
+export function stepDiff(step: Step): DiffLine[] | null {
+  if (step.replaced === null) return null;
+  const diff = lineDiff(step.replaced, step.target ?? "");
+  return diff.length > 0 ? diff : null;
+}
+
+/**
  * Whether a chip has anything behind it.
  *
  * A directory lookup is one call with nothing to show but the sentence already
  * on the chip, and a button that opens nothing is a button the operator learns
  * to distrust.
+ *
+ * A memory that was cleared has no content to show and is still worth opening:
+ * what was thrown away is the whole of what happened.
  */
 export function hasDetail(group: TrailGroup): boolean {
-  return group.steps.length > 1 || group.steps[0]!.target !== null;
+  const only = group.steps[0]!;
+  return group.steps.length > 1 || only.target !== null || stepDiff(only) !== null;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,7 +56,19 @@ export type Part =
   | { type: "text"; text: string }
   | { type: "json"; name: string; value: unknown }
   | { type: "notice"; kind: NoticeKind; text: string }
-  | { type: "toolCall"; name: string; arguments: unknown; outcome: ToolOutcome }
+  /**
+   * A call this agent made. `replaced` is what it overwrote, carried only by a
+   * memory rewrite and absent everywhere else, including on calls recorded
+   * before it existed. Empty means the call overwrote nothing, which is not the
+   * same as a call that overwrites nothing.
+   */
+  | {
+      type: "toolCall";
+      name: string;
+      arguments: unknown;
+      outcome: ToolOutcome;
+      replaced?: string;
+    }
   | ({ type: "file" } & Attachment)
   /**
    * A routine coming due, drawn as one line the operator can open rather than

--- a/src/styles.css
+++ b/src/styles.css
@@ -2097,6 +2097,72 @@ button {
   overflow-wrap: anywhere;
 }
 
+/* Two versions of a small page, drawn as the lines between them. Same block as
+   the one above and the same reasons for it, with a gutter down the left for
+   what happened to each line.
+
+   Colour is the fast read and never the only one: the marker is a character in
+   the text, so the distinction survives a reader who cannot tell the two hues
+   apart and survives being copied out. The grounds are mixed rather than named
+   because they have to sit on paper and on ink at the same weight, and a pair
+   of literals chosen against white turns into two glowing bars on a dark page.
+   Unchanged lines are the memory itself and are left alone: tinting them too
+   would make a rewrite of one sentence look like a rewrite of the page. */
+.diff {
+  margin: 0.15rem 0 0;
+  padding: 0.35rem 0;
+  max-height: 16rem;
+  overflow: auto;
+  border-radius: var(--radius-sm);
+  background: var(--sunken);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  line-height: 1.5;
+  color: var(--muted);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* A row rather than a block, so a line too long for the column wraps under
+   itself and not under its own marker. A memory is prose in markdown and half
+   of it wraps; wrapped into the gutter, the markers stop being a column and the
+   diff stops being scannable, which is the only thing it had. */
+.diff__line {
+  display: flex;
+  padding-right: 0.5rem;
+}
+
+.diff__text {
+  min-width: 0;
+}
+
+.diff__line[data-kind="added"] {
+  background: color-mix(in oklab, var(--mint) 14%, transparent);
+  color: var(--text);
+}
+
+.diff__line[data-kind="removed"] {
+  background: color-mix(in oklab, var(--alarm) 13%, transparent);
+  color: var(--text);
+}
+
+/* Aligned down one column so the page reads as a page and the markers read as
+   a margin, which is the whole of what makes a diff scannable. */
+.diff__mark {
+  flex: none;
+  width: 1.5rem;
+  padding-left: 0.5rem;
+  color: var(--faint);
+}
+
+.diff__line[data-kind="added"] .diff__mark {
+  color: var(--mint);
+}
+
+.diff__line[data-kind="removed"] .diff__mark {
+  color: var(--alarm);
+}
+
 /* ==========================================================================
    Permission requests
 


### PR DESCRIPTION
`update_notes` replaces the file rather than appending to it, so every write arrived in the transcript as the whole page and the operator had to compare two near-identical documents by eye. The runtime now records what a write overwrote, on the call, at the moment it overwrote it: nothing else can supply it, because the same memory is written from an agent's wall and from every thread it holds and the operator can edit it by hand, so a previous version recovered from the channel this call happens to sit in is wrong exactly when something interesting happened. It is on the call rather than in `arguments`, which is the model's own JSON verbatim, and absent, empty and a page stay three different things: a call that replaced nothing, an agent's first memory, and a real comparison.

`lib/diff.ts` draws the lines between the two versions, unchanged ones included, with the gutter marked by a character rather than only a colour. To keep two dozen refusal paths from declaring that they replaced nothing, `Part::tool_call` joins the existing `Part::text` constructor, which leaves `runtime/mod.rs` shorter than it was.