### PR TITLE
feat: a plugin is signed in once, and each of its tools is switched on or off

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ repo: the frontend renders state and forwards intent.
 | Which of the two a piece of work belongs on, and credentials | *Connectors* in `docs/PROTOCOL.md`, then both files above |
 | Plugins: what is on the list, signing one in, calling its tools | `docs/PLUGINS.md`, then `oauth.rs` and `mcp.rs` |
 | Which agents in a crew get a plugin | *Signing in is one decision, and handing it out is another* in `docs/PLUGINS.md`, then `domain/plugin.rs` and `Store::plugin_tools`, which has to agree with `Store::plugin_reach` |
+| Which of a plugin's tools a crew may call at all | *And which of its tools, which is a third decision* in `docs/PLUGINS.md`, then `Store::set_plugin_tool` and both readers of `plugin_denied_tools` |
 | The guaca.bot account: signing in, what it is for, why it is optional | `docs/ACCOUNT.md`, then `account.rs` |
 | Channels, the rail, search: what the operator sees | `docs/WORKSPACE.md`, then `src/lib/transcript.ts` |
 | A turn's tool calls in a channel: what folds, what a chip says, what opens | *A turn's own work is chips* in `docs/WORKSPACE.md`, then `src/lib/trail.ts` |
@@ -241,6 +242,32 @@ the model takes a screenshot to see what `browse` did.
   path, from the same SQL fragment, and its two refusals are different
   sentences: "nobody connected this" is the operator's to fix, "connected, but
   not for you" is a peer's to do.
+- **A plugin's switched-off tools are stored as refusals, not as an allow
+  list.** A plugin with no rows in `plugin_denied_tools` offers everything it
+  published, which is what every plugin connected before this control existed
+  does and what a tool the vendor ships next month does. An allow list would
+  switch that new tool off with nothing on screen saying a decision had been
+  taken about it, and it is the same reading `access` takes with `everyone`:
+  the default has to cover what nobody has seen yet. Reconnecting keeps the
+  refusals and switches the new tool on.
+- **A switched-off tool is refused before a not-chosen agent is.** Both can be
+  true of one call, and the tool-level answer is the one that is true of
+  everybody. `PluginError::NotChosen` sends an agent to a peer, which is right
+  for a narrowed plugin and a wasted turn for a tool nobody has, so
+  `plugin_reach` checks the tool first and `ToolDenied` says outright not to
+  ask around.
+- **The tool half of that rule is Rust and the agent half is SQL, and that is
+  not an oversight.** `PLUGIN_REACHED_BY_AGENT` is one fragment pasted into two
+  queries; the tools cannot be, because the tool list is a JSON column and
+  there is nothing for SQL to filter without taking it apart inside the
+  database. `Store::plugin_tools` partitions it in Rust, `Store::plugin_reach`
+  asks in SQL, both compare the server's own unprefixed name, and a store test
+  drives one refusal through both.
+- **A tool an agent cannot call is named in its prompt anyway.** The name only:
+  no description, no schema, and never a definition. An agent that is simply
+  not shown `create_refund` answers "we cannot do refunds" to the one person
+  who could switch it back on, which is the same failure the roster's `reaches`
+  exists to prevent one level up.
 - **A plugin's tool list is read once and kept.** `tools/list` on every turn is
   a network round trip in front of every model call, paid by every agent in the
   crew, to re-learn something that changes when a vendor ships rather than when

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -262,6 +262,60 @@ the SQL and in `PluginAccess::from_row`. A permission that cannot be read has to
 fail closed: a crew losing a plugin is visible and one click to fix, and a crew
 silently gaining one is neither.
 
+## And which of its tools, which is a third decision
+
+Signing in covers a server. It does not cover a capability, because a server
+does not publish one kind of thing. Stripe lists the call that reads an invoice
+beside the one that refunds it; Neon lists `run_sql` beside the call that
+deletes a project; AgentMail lists reading a thread beside sending as the
+operator. Until this existed, the only control over the second half of each of
+those pairs was Disconnect, which also takes the first half away.
+
+So each connected plugin carries a decision per tool: on, or off for the whole
+crew. `plugins.tools` is still what the server published; `plugin_denied_tools`
+is the operator's exceptions to it.
+
+**The refusals are what is written down.** A plugin with no rows in that table
+offers everything it published, which is what every plugin connected before this
+existed does. It is the same reading `access` takes with `everyone`, and for the
+same reason: the default has to cover what nobody has seen yet. A vendor ships a
+tool between one connection and the next, and an allow-list would leave that
+tool switched off with nothing on screen saying a decision had been made about
+it. Connecting again keeps the refusals and switches the new tool on.
+
+**Reconnecting does not switch one back on.** `save_plugin` replaces the tool
+list and touches nothing in `plugin_denied_tools`, for the reason it leaves
+`access` alone: fixing a grant that the vendor revoked is not a decision about
+what the crew may do, and one that quietly handed `drop_project` back would undo
+the decision at the moment the operator was fixing something else.
+
+**Off is off for the crew, not for one agent.** The two questions compose: who
+may spend the sign-in, and what may be spent. Asking them per agent instead
+would be a matrix (five plugins, twenty tools, six agents), which is a control
+nobody can hold in their head and a permission nobody can audit. The two axes
+are enough to say the thing operators actually want to say, which is "the
+revenue agent gets Stripe, and nobody refunds anything".
+
+**A switched-off tool is refused before a not-chosen agent is.** Both can be
+true at once, and the tool-level answer is the one that is true of everybody.
+An agent told "ask a peer" about a tool nobody has spends a turn proving it, and
+a peer told the same thing spends another. `plugin_reach` therefore checks the
+tool first, and `PluginError::ToolDenied` says outright not to ask around.
+
+**The decision reaches the agent, in three places.** The tool never becomes a
+definition, so the model cannot call it by accident. The prompt names it under
+its plugin, the name alone with no description and no schema, because an agent
+that is simply not shown `create_refund` answers "we cannot do refunds" to the
+one person who could switch it back on. And the call path refuses it by name if
+the model emits it anyway, for the reason the tool list is never the
+enforcement: a model names tools it read somewhere.
+
+The rule is read twice, like the one above it, but not from one SQL fragment.
+The tool list is a JSON column, so `Store::plugin_tools` partitions it in Rust
+and `Store::plugin_reach` asks in SQL. Both compare the server's own unprefixed
+name to the same stored string, and a store test drives one refusal through both
+queries so that the two cannot drift.
+
 ## A tool name is `plugin__tool`
 
 Two underscores, because MCP servers use one inside tool names constantly and
@@ -310,8 +364,16 @@ a sign-in the operator has to redo, and the refusal says exactly that.
 operator's name outside the workspace, and a plugin call qualifies. It is not
 gated, because a prompt on every call would make plugins unusable, and the
 existing gate is aimed at the case where a page an agent has just read chose the
-button. The prompt carries the warning instead. This is the open question worth
-revisiting first.
+button. The prompt carries the warning instead.
+
+Switching a tool off is not that gate and does not replace it. It is decided
+once, in advance, by an operator who is looking at the whole tool list, and it
+never interrupts anybody: a tool is on or it is off, and nothing about the
+particular call changes the answer. An approval gate is the other shape, where
+the turn parks and the operator answers that one call, and it is still the open
+question worth revisiting first. What this does remove is the worst case that
+gate was being asked to cover, which is the one destructive tool on an otherwise
+useful server.
 
 **No per-agent sign-in.** An agent is chosen from the crew's one grant; it does
 not get its own. Two sign-ins to the same vendor for one group would be two sets
@@ -337,7 +399,8 @@ Three layers, and each catches something the others cannot.
 - **Scripted**, in `tests/plugins.rs`: the real `oauth`, `mcp`, `plugins` and
   store code against a server that publishes all four metadata documents and
   answers MCP as an event stream. Includes a full runtime turn, so the tool
-  definitions, the dispatch and the grant being spent are proved to meet.
+  definitions, the dispatch and the grant being spent are proved to meet, and
+  one turn per axis where a model calls something it was not offered.
 - **Live**, `./scripts/plugins.sh`: whether the five vendors still publish what
   this build expects. It runs `oauth::discover` — the same call a sign-in makes
   — rather than rebuilding the metadata URLs beside it, because a test with its

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -389,6 +389,7 @@ pub fn run() {
             commands::plugin_catalogue,
             commands::group_plugins,
             commands::set_plugin_access,
+            commands::set_plugin_tool,
             commands::connect_plugin,
             commands::disconnect_plugin,
             commands::scan_agent_signins,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -518,6 +518,26 @@ pub fn set_plugin_access(
     Ok(plugin)
 }
 
+/// Switches one of a connected plugin's tools on or off for the whole crew.
+///
+/// One tool per call, and the answer explicitly rather than a toggle, so that
+/// two panels open on the same group cannot swap a decision between them. The
+/// plugin comes back so the caller draws what was stored rather than what it
+/// asked for.
+#[tauri::command]
+pub fn set_plugin_tool(
+    state: State<'_, AppState>,
+    id: PluginId,
+    tool: String,
+    allowed: bool,
+) -> Reply<Plugin> {
+    let plugin = state.runtime.store().set_plugin_tool(id, &tool, allowed)?;
+    // Changes the tool definitions every agent in the crew is offered on its
+    // next turn, and the line in each of their prompts that says what is off.
+    state.runtime.emit(UiEvent::AgentsChanged);
+    Ok(plugin)
+}
+
 /// Forgets a plugin, and the grant with it.
 ///
 /// The grant is dropped locally rather than revoked at the vendor: not every

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -790,6 +790,38 @@ UPDATE agents SET has_computer = 1 WHERE sandbox_id IS NOT NULL;
 UPDATE agents SET has_browser  = 1 WHERE browser_id IS NOT NULL;
 "#,
     ),
+    (
+        29,
+        r#"
+-- Which of a plugin's tools a crew may call, which until now was "all of
+-- them". Connecting a server was one decision covering everything it publishes,
+-- and a server does not publish one kind of thing: Stripe lists the call that
+-- reads an invoice beside the one that refunds it, and Neon lists `run_sql`
+-- beside the call that deletes a project. An operator who wanted the reading
+-- and not the writing had one control, and it was Disconnect.
+--
+-- The refusals are what is written down, not the permissions. A row here is a
+-- tool the operator switched off; everything else is on. That is the same
+-- reading `access` takes with 'everyone', and for the same reason: the default
+-- has to cover what nobody has seen yet. A vendor ships a tool between one
+-- connection and the next, and an allow-list would leave it switched off with
+-- nothing on screen saying a decision had been made about it.
+--
+-- Keyed by name rather than by an index into the stored list, because that
+-- list is replaced wholesale every time the plugin is connected again. An
+-- index would silently move a refusal onto whatever tool the vendor put in
+-- that position.
+--
+-- No ON DELETE CASCADE, for the reason `plugin_agents` has none: foreign keys
+-- are off while migrations run, so the deletes are written out at every call
+-- site instead.
+CREATE TABLE plugin_denied_tools (
+    plugin_id TEXT NOT NULL REFERENCES plugins(id),
+    tool      TEXT NOT NULL,
+    PRIMARY KEY (plugin_id, tool)
+);
+"#,
+    ),
 ];
 
 /// The group every agent starts in, and the one the UI keeps out of the way
@@ -993,6 +1025,32 @@ mod tests {
         let named: i64 =
             conn.query_row("SELECT count(*) FROM plugin_agents", [], |row| row.get(0)).unwrap();
         assert_eq!(named, 0, "nobody was named, and nobody needs to be");
+    }
+
+    #[test]
+    fn a_plugin_connected_before_tools_could_be_switched_off_keeps_all_of_them() {
+        // The same thing this migration must not do, one axis over. Nothing is
+        // written down, and nothing written down is what "everything is on"
+        // means: the refusals are the rows.
+        let mut conn = memory();
+        for (version, sql) in MIGRATIONS.iter().filter(|(v, _)| *v < 29) {
+            conn.execute_batch(sql).unwrap();
+            conn.pragma_update(None, "user_version", *version).unwrap();
+        }
+        conn.execute(
+            "INSERT INTO plugins (id,group_id,kind,account,tools,connected_at)
+             VALUES ('p1',?1,'neon','','[{\"name\":\"run_sql\",\"description\":\"\",
+                                          \"inputSchema\":{}}]',0)",
+            rusqlite::params![DEFAULT_GROUP_ID],
+        )
+        .unwrap();
+
+        run(&mut conn).unwrap();
+
+        let off: i64 = conn
+            .query_row("SELECT count(*) FROM plugin_denied_tools", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(off, 0, "a migration that switched anything off would break a working crew");
     }
 
     #[test]

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -21,7 +21,9 @@ use crate::domain::ids::{
     AgentId, ApprovalId, ConnectorId, GroupId, MessageId, PluginId, RoutineId, RunId,
 };
 use crate::domain::now_ms;
-use crate::domain::plugin::{Plugin, PluginAccess, PluginKind, PluginTool};
+use crate::domain::plugin::{
+    Plugin, PluginAccess, PluginKind, PluginTool, PluginToolCard, PluginToolset,
+};
 use crate::domain::routine::{NextSlot, Routine, RoutineRun, RunKind, Trigger};
 use crate::domain::search::{
     contains_fold, excerpt, like_pattern, links_in, FileHit, LinkHit, MessageHit, SearchHits,
@@ -59,6 +61,11 @@ pub enum StoreError {
     PluginNotFound(PluginId),
     #[error("agent {0} is not in this group, so it cannot be given one of the group's plugins")]
     AgentNotInGroup(AgentId),
+    #[error(
+        "this plugin publishes no tool called {1:?}, so there is nothing to allow or deny; the \
+         list on screen is older than the one the server last sent, so connect it again"
+    )]
+    PluginToolNotFound(PluginId, String),
     #[error("no permission request with id {0}")]
     ApprovalNotFound(ApprovalId),
     #[error("that request was already answered ({})", state.as_str())]
@@ -1106,9 +1113,11 @@ impl Store {
     pub fn group_plugins(&self, group: GroupId) -> Result<Vec<Plugin>, StoreError> {
         let conn = self.conn()?;
         let chosen = self.chosen_agents(&conn, group)?;
+        let denied = self.denied_tools(&conn, group)?;
         let mut stmt =
             conn.prepare(&format!("{PLUGIN_COLUMNS} WHERE group_id=?1 ORDER BY kind, rowid"))?;
-        let rows = stmt.query_map(params![group.to_string()], |row| row_to_plugin(row, &chosen))?;
+        let rows =
+            stmt.query_map(params![group.to_string()], |row| row_to_plugin(row, &chosen, &denied))?;
         let mut out = Vec::new();
         for row in rows {
             // A row whose kind is not one this build knows is skipped rather
@@ -1158,7 +1167,44 @@ impl Store {
         Ok(out)
     }
 
-    /// What one agent can call, with the schemas the model is shown.
+    /// The tools one group has switched off, by the plugin they belong to.
+    ///
+    /// Refusals rather than permissions, so a plugin with no rows here offers
+    /// everything it published, which is what every plugin connected before
+    /// this control existed does and what a tool a vendor ships next month
+    /// does. One query for the whole group, for the reason
+    /// [`Store::chosen_agents`] is one: this is read to draw a panel and to
+    /// build a turn, and neither wants five queries for five tiles.
+    fn denied_tools(
+        &self,
+        conn: &Conn,
+        group: GroupId,
+    ) -> Result<HashMap<PluginId, HashSet<String>>, StoreError> {
+        let mut stmt = conn.prepare(
+            "SELECT plugin_denied_tools.plugin_id, plugin_denied_tools.tool
+               FROM plugin_denied_tools
+               JOIN plugins ON plugins.id = plugin_denied_tools.plugin_id
+              WHERE plugins.group_id = ?1",
+        )?;
+        let rows = stmt.query_map(params![group.to_string()], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+
+        let mut out: HashMap<PluginId, HashSet<String>> = HashMap::new();
+        for row in rows {
+            let (plugin, tool) = row?;
+            // An id that will not parse names no plugin this can be read
+            // against: every reader of this map looks up a row whose own id
+            // parsed, and a row whose id does not parse raises rather than
+            // being offered. Dropping it here loses nothing.
+            let Ok(plugin) = plugin.parse::<PluginId>() else { continue };
+            out.entry(plugin).or_default().insert(tool);
+        }
+        Ok(out)
+    }
+
+    /// What one agent can call, with the schemas the model is shown, and what
+    /// the operator switched off.
     ///
     /// Separate from `group_plugins` for the reason `connector_env` is separate
     /// from `group_connectors`: this is the bulk nothing but the turn needs,
@@ -1168,55 +1214,97 @@ impl Store {
     /// model has to be what that model may actually call. The prompt is built
     /// from the same list on the same turn, so an agent is never told about a
     /// plugin it would be refused.
+    ///
+    /// The switched-off ones come back beside them rather than being dropped
+    /// here, because the prompt names them: an agent that is simply not shown
+    /// `refund` answers "we cannot do refunds", when the true answer is that
+    /// the operator switched refunds off and can switch them back on. Nothing
+    /// about them reaches the tool definitions.
+    ///
+    /// The tool half of the rule is applied here, in Rust, and in SQL in
+    /// [`Store::plugin_reach`]. Both compare the server's own unprefixed name
+    /// to the same stored string, and a test drives one refusal through both.
+    /// It is not the fragment `PLUGIN_REACHED_BY_AGENT` is, because the tool
+    /// list is a JSON column: there is nothing for SQL to filter here without
+    /// taking the tools apart inside the database.
     pub fn plugin_tools(
         &self,
         group: GroupId,
         agent: AgentId,
-    ) -> Result<Vec<(PluginKind, Vec<PluginTool>)>, StoreError> {
+    ) -> Result<Vec<PluginToolset>, StoreError> {
         let conn = self.conn()?;
+        let denied = self.denied_tools(&conn, group)?;
         let mut stmt = conn.prepare(&format!(
-            "SELECT kind, tools FROM plugins
+            "SELECT id, kind, tools FROM plugins
               WHERE group_id=:group AND {PLUGIN_REACHED_BY_AGENT}
               ORDER BY kind, rowid"
         ))?;
         let rows = stmt.query_map(
             named_params! { ":group": group.to_string(), ":agent": agent.to_string() },
-            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+            },
         )?;
 
         let mut out = Vec::new();
         for row in rows {
-            let (kind, tools) = row?;
+            let (id, kind, tools) = row?;
             let Some(kind) = PluginKind::from_slug(&kind) else { continue };
             let tools: Vec<PluginTool> = serde_json::from_str(&tools)
                 .map_err(|e| StoreError::Corrupt(format!("bad tool list for {kind:?}: {e}")))?;
-            out.push((kind, tools));
+            // Raised rather than skipped, so that a row whose id cannot be read
+            // fails the turn instead of quietly losing every refusal filed
+            // against it. `group_plugins` reads the same id the same way.
+            let id = id
+                .parse::<PluginId>()
+                .map_err(|e| StoreError::Corrupt(format!("bad plugin id {id:?}: {e}")))?;
+            let off = denied.get(&id);
+
+            let mut set = PluginToolset { kind, offered: Vec::new(), withheld: Vec::new() };
+            for tool in tools {
+                if off.is_some_and(|off| off.contains(&tool.name)) {
+                    set.withheld.push(tool.name);
+                } else {
+                    set.offered.push(tool);
+                }
+            }
+            out.push(set);
         }
         Ok(out)
     }
 
-    /// What one agent gets when it names one of its crew's plugins.
+    /// What one agent gets when it calls one tool on one of its crew's plugins.
     ///
     /// The only path a stored token takes out of this table, and it leads
     /// straight back to the server that issued it. Nothing here reaches a
     /// prompt, a transcript, an event or the webview.
     ///
-    /// Three answers rather than an `Option`, because two of them are refusals
-    /// an agent reads mid-turn and they call for opposite things. "Nobody has
+    /// Four answers rather than an `Option`, because three of them are refusals
+    /// an agent reads mid-turn and they call for different things. "Nobody has
     /// connected this" is something to tell the operator about; "you are not
-    /// one of the agents it was connected for" is something to hand to a peer.
-    /// Collapsing them would have an agent asking an operator to connect a
-    /// plugin they are looking at in the settings panel, already connected.
+    /// one of the agents it was connected for" is something to hand to a peer;
+    /// "this tool is switched off" is neither, because no peer has it either.
+    /// Collapsing any two would have an agent asking an operator to connect a
+    /// plugin they are looking at in the settings panel, or handing a peer work
+    /// nobody in the crew can do.
+    ///
+    /// The tool is asked about here and not only where the definitions are
+    /// built, because a model names tools it was never offered. Asked in that
+    /// order, too: a switched-off tool is switched off for the whole crew, so
+    /// an agent that is neither chosen nor allowed this tool is told the thing
+    /// that is true of everybody rather than sent to a peer who would be
+    /// refused in turn.
     pub fn plugin_reach(
         &self,
         group: GroupId,
         agent: AgentId,
         kind: PluginKind,
+        tool: &str,
     ) -> Result<PluginReach, StoreError> {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(&format!(
             "SELECT id,access_token,refresh_token,expires_at,client_id,client_secret,
-                    token_endpoint,{PLUGIN_REACHED_BY_AGENT}
+                    token_endpoint,{PLUGIN_REACHED_BY_AGENT},{PLUGIN_TOOL_ALLOWED}
                FROM plugins WHERE group_id=:group AND kind=:kind",
         ))?;
         let row = stmt
@@ -1225,6 +1313,7 @@ impl Store {
                     ":group": group.to_string(),
                     ":kind": kind.slug(),
                     ":agent": agent.to_string(),
+                    ":tool": tool,
                 },
                 |row| {
                     Ok((
@@ -1236,6 +1325,7 @@ impl Store {
                         row.get::<_, String>(5)?,
                         row.get::<_, String>(6)?,
                         row.get::<_, i64>(7)? != 0,
+                        row.get::<_, i64>(8)? != 0,
                     ))
                 },
             )
@@ -1250,10 +1340,14 @@ impl Store {
             client_secret,
             token_endpoint,
             reached,
+            allowed,
         )) = row
         else {
             return Ok(PluginReach::NotConnected);
         };
+        if !allowed {
+            return Ok(PluginReach::ToolDenied);
+        }
         if !reached {
             return Ok(PluginReach::NotChosen);
         }
@@ -1334,6 +1428,63 @@ impl Store {
             }
         }
         tx.commit()?;
+
+        let group = group
+            .parse::<GroupId>()
+            .map_err(|e| StoreError::Corrupt(format!("bad group id {group:?}: {e}")))?;
+        self.group_plugins(group)?
+            .into_iter()
+            .find(|plugin| plugin.id == id)
+            .ok_or(StoreError::PluginNotFound(id))
+    }
+
+    /// Switches one of a connected plugin's tools on or off for the crew.
+    ///
+    /// One named tool and one answer, rather than the whole set the way
+    /// [`Store::set_plugin_access`] takes it, and the difference is what the
+    /// two are. Who may use a plugin is a set, and a caller that sent the part
+    /// of it it happened to know would narrow the plugin by forgetting
+    /// somebody. A tool is a switch: naming it and saying which way it goes
+    /// cannot be ambiguous, and a whole-set write from a panel that can only
+    /// see today's tool list would drop a refusal filed against a tool the
+    /// vendor has temporarily stopped publishing.
+    ///
+    /// Refused for a tool this plugin does not publish. Storing one would be a
+    /// refusal that names nothing, in a table nothing can show the operator,
+    /// and it means the panel is looking at a list older than the server's.
+    pub fn set_plugin_tool(
+        &self,
+        id: PluginId,
+        tool: &str,
+        allowed: bool,
+    ) -> Result<Plugin, StoreError> {
+        let conn = self.conn()?;
+        let row: Option<(String, String)> = conn
+            .query_row(
+                "SELECT group_id, tools FROM plugins WHERE id=?1",
+                params![id.to_string()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        let (group, tools) = row.ok_or(StoreError::PluginNotFound(id))?;
+
+        let published: Vec<PluginTool> = serde_json::from_str(&tools)
+            .map_err(|e| StoreError::Corrupt(format!("bad tool list for plugin {id}: {e}")))?;
+        if !published.iter().any(|published| published.name == tool) {
+            return Err(StoreError::PluginToolNotFound(id, tool.to_string()));
+        }
+
+        if allowed {
+            conn.execute(
+                "DELETE FROM plugin_denied_tools WHERE plugin_id=?1 AND tool=?2",
+                params![id.to_string(), tool],
+            )?;
+        } else {
+            conn.execute(
+                "INSERT OR IGNORE INTO plugin_denied_tools (plugin_id, tool) VALUES (?1, ?2)",
+                params![id.to_string(), tool],
+            )?;
+        }
 
         let group = group
             .parse::<GroupId>()
@@ -1445,6 +1596,7 @@ impl Store {
         let mut conn = self.conn()?;
         let tx = conn.transaction()?;
         tx.execute("DELETE FROM plugin_agents WHERE plugin_id=?1", params![id.to_string()])?;
+        tx.execute("DELETE FROM plugin_denied_tools WHERE plugin_id=?1", params![id.to_string()])?;
         let removed = tx.execute("DELETE FROM plugins WHERE id=?1", params![id.to_string()])?;
         tx.commit()?;
         Ok(removed > 0)
@@ -1781,9 +1933,15 @@ impl Store {
         // And its plugins, for both of those reasons and one more: the row
         // holds a grant against the operator's own Neon or Cloudflare account,
         // and a disbanded crew is not a reason to keep one. Whoever was named
-        // on one goes first, or the foreign key refuses the line below.
+        // on one goes first, along with whatever was switched off on it, or the
+        // foreign key refuses the line below.
         conn.execute(
             "DELETE FROM plugin_agents WHERE plugin_id IN
+                 (SELECT id FROM plugins WHERE group_id=?1)",
+            params![id.to_string()],
+        )?;
+        conn.execute(
+            "DELETE FROM plugin_denied_tools WHERE plugin_id IN
                  (SELECT id FROM plugins WHERE group_id=?1)",
             params![id.to_string()],
         )?;
@@ -2560,6 +2718,8 @@ pub enum PluginReach {
     NotConnected,
     /// Connected, and this agent is not one of the ones it was connected for.
     NotChosen,
+    /// Connected, and the operator switched this tool off for the whole crew.
+    ToolDenied,
     /// The row, and the grant to spend against it. `None` for a server that
     /// authorised nobody because it asked for nothing.
     Granted { id: PluginId, grant: Option<crate::oauth::Grant> },
@@ -2585,15 +2745,30 @@ const PLUGIN_REACHED_BY_AGENT: &str = "(plugins.access = 'everyone'
                  WHERE plugin_agents.plugin_id = plugins.id
                    AND plugin_agents.agent_id = :agent))";
 
+/// Whether one named tool is one the operator left switched on.
+///
+/// The refusals are what is stored, so the absence of a row is a yes: a plugin
+/// nobody has narrowed offers everything it published, and so does a tool the
+/// vendor added after the operator last looked. The other way round, an
+/// allow-list, would switch off every tool a server started publishing between
+/// one connection and the next, with nothing on screen saying a decision had
+/// been taken.
+const PLUGIN_TOOL_ALLOWED: &str = "NOT EXISTS (SELECT 1 FROM plugin_denied_tools
+                 WHERE plugin_denied_tools.plugin_id = plugins.id
+                   AND plugin_denied_tools.tool = :tool)";
+
 /// `None` for a row naming a plugin this build does not have, which is what a
 /// downgrade leaves behind. Corrupt rows still raise: a tool list that will not
 /// parse is a bug here, not a version skew.
 ///
-/// `chosen` is the row's named agents, read separately because they are a
-/// second table. A plugin missing from that map is one with nobody named.
+/// `chosen` is the row's named agents and `denied` is the tools switched off on
+/// it, both read separately because both are second tables. A plugin missing
+/// from the first map is one with nobody named; missing from the second is one
+/// with everything it published switched on, which is where every plugin starts.
 fn row_to_plugin(
     row: &Row<'_>,
     chosen: &HashMap<PluginId, Vec<AgentId>>,
+    denied: &HashMap<PluginId, HashSet<String>>,
 ) -> RowResult<Option<Plugin>> {
     let id_raw: String = row.get(0)?;
     let group_raw: String = row.get(1)?;
@@ -2617,7 +2792,14 @@ fn row_to_plugin(
                 .map_err(|e| StoreError::Corrupt(format!("bad group id {group_raw:?}: {e}")))?,
             kind,
             account: row.get(3)?,
-            tools: tools.into_iter().map(|tool| tool.name).collect(),
+            tools: tools
+                .into_iter()
+                .map(|tool| PluginToolCard {
+                    allowed: !denied.get(&id).is_some_and(|off| off.contains(&tool.name)),
+                    name: tool.name,
+                    description: tool.description,
+                })
+                .collect(),
             access: PluginAccess::from_row(&reach, chosen.get(&id).cloned().unwrap_or_default()),
             signed_in: !access.is_empty(),
             connected_at: row.get(6)?,
@@ -4836,7 +5018,7 @@ mod tests {
         f.store.delete_group(group.id).unwrap();
         assert!(f.store.group_plugins(group.id).unwrap().is_empty());
         assert!(matches!(
-            f.store.plugin_reach(group.id, AgentId::new(), PluginKind::Neon).unwrap(),
+            f.store.plugin_reach(group.id, AgentId::new(), PluginKind::Neon, "run_sql").unwrap(),
             PluginReach::NotConnected
         ));
     }
@@ -4853,7 +5035,7 @@ mod tests {
 
         let agent = f.store.create_agent(&draft("Manager")).unwrap();
         let PluginReach::Granted { grant, .. } =
-            f.store.plugin_reach(group, agent.id, PluginKind::Neon).unwrap()
+            f.store.plugin_reach(group, agent.id, PluginKind::Neon, "run_sql").unwrap()
         else {
             panic!("a connected plugin is reachable by the crew it was connected for")
         };
@@ -4901,11 +5083,11 @@ mod tests {
         // And the tool list and the grant agree, because a model can name a
         // tool it was never offered.
         assert!(matches!(
-            f.store.plugin_reach(group, revenue.id, PluginKind::Stripe).unwrap(),
+            f.store.plugin_reach(group, revenue.id, PluginKind::Stripe, "refund").unwrap(),
             PluginReach::Granted { .. }
         ));
         assert!(matches!(
-            f.store.plugin_reach(group, scribe.id, PluginKind::Stripe).unwrap(),
+            f.store.plugin_reach(group, scribe.id, PluginKind::Stripe, "refund").unwrap(),
             PluginReach::NotChosen
         ));
     }
@@ -4925,7 +5107,7 @@ mod tests {
 
         assert!(f.store.plugin_tools(group, manager.id).unwrap().is_empty());
         assert!(matches!(
-            f.store.plugin_reach(group, manager.id, PluginKind::Stripe).unwrap(),
+            f.store.plugin_reach(group, manager.id, PluginKind::Stripe, "refund").unwrap(),
             PluginReach::NotChosen
         ));
     }
@@ -5042,6 +5224,237 @@ mod tests {
     }
 
     #[test]
+    fn a_plugin_arrives_with_everything_it_published_switched_on() {
+        // The default, and what every plugin connected before this control
+        // existed keeps. An operator who never opens the tool list has a crew
+        // that works exactly as it did.
+        let f = fixture();
+        let group = default_group_id();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        f.store
+            .save_plugin(
+                group,
+                PluginKind::Neon,
+                "",
+                &[tool("run_sql"), tool("drop_project")],
+                None,
+            )
+            .unwrap();
+
+        let drawn = f.store.group_plugins(group).unwrap().remove(0);
+        assert!(drawn.tools.iter().all(|tool| tool.allowed), "{:?}", drawn.tools);
+
+        let offered = f.store.plugin_tools(group, manager.id).unwrap().remove(0);
+        assert_eq!(offered.offered.len(), 2);
+        assert!(offered.withheld.is_empty());
+    }
+
+    #[test]
+    fn a_switched_off_tool_leaves_the_turn_and_the_call_path_saying_the_same_thing() {
+        // The one that matters. A model names tools it was never offered, so
+        // the definitions being right is not the enforcement: the call path
+        // asks again. The two disagreeing is either a tool an agent is offered
+        // and refused, or one it is refused and could have had.
+        let f = fixture();
+        let group = default_group_id();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let plugin = f
+            .store
+            .save_plugin(
+                group,
+                PluginKind::Neon,
+                "",
+                &[tool("run_sql"), tool("drop_project")],
+                None,
+            )
+            .unwrap();
+
+        let saved = f.store.set_plugin_tool(plugin.id, "drop_project", false).unwrap();
+        assert_eq!(
+            saved.tools.iter().find(|tool| tool.name == "drop_project").map(|tool| tool.allowed),
+            Some(false),
+            "the panel draws what was stored"
+        );
+
+        // Told: one tool, and the other named as switched off rather than
+        // silently missing.
+        let offered = f.store.plugin_tools(group, manager.id).unwrap().remove(0);
+        assert_eq!(
+            offered.offered.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
+            ["run_sql"]
+        );
+        assert_eq!(offered.withheld, vec!["drop_project".to_string()]);
+
+        // And got: the same answer, from the other query.
+        assert!(matches!(
+            f.store.plugin_reach(group, manager.id, PluginKind::Neon, "drop_project").unwrap(),
+            PluginReach::ToolDenied
+        ));
+        assert!(matches!(
+            f.store.plugin_reach(group, manager.id, PluginKind::Neon, "run_sql").unwrap(),
+            PluginReach::Granted { .. }
+        ));
+    }
+
+    #[test]
+    fn a_tool_switched_off_is_off_for_the_agent_the_plugin_was_narrowed_to() {
+        // The two axes are not one axis. Being chosen for a plugin is not being
+        // handed every tool on it, and the refusal an agent gets says the thing
+        // that is true of the whole crew rather than sending it to a peer who
+        // would be refused in turn.
+        let f = fixture();
+        let group = default_group_id();
+        let revenue = f.store.create_agent(&draft("Revenue")).unwrap();
+        let scribe = f.store.create_agent(&draft("Scribe")).unwrap();
+        let plugin = f
+            .store
+            .save_plugin(group, PluginKind::Stripe, "", &[tool("charges"), tool("refund")], None)
+            .unwrap();
+
+        f.store
+            .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![revenue.id] })
+            .unwrap();
+        f.store.set_plugin_tool(plugin.id, "refund", false).unwrap();
+
+        assert!(matches!(
+            f.store.plugin_reach(group, revenue.id, PluginKind::Stripe, "refund").unwrap(),
+            PluginReach::ToolDenied
+        ));
+        assert!(matches!(
+            f.store.plugin_reach(group, scribe.id, PluginKind::Stripe, "refund").unwrap(),
+            PluginReach::ToolDenied,
+        ));
+        assert!(matches!(
+            f.store.plugin_reach(group, scribe.id, PluginKind::Stripe, "charges").unwrap(),
+            PluginReach::NotChosen
+        ));
+    }
+
+    #[test]
+    fn switching_a_tool_back_on_leaves_nothing_behind_that_still_refuses_it() {
+        // The stored state has to be what is true. A remembered refusal is a
+        // decision the operator has already changed, waiting to come back the
+        // next time anything reads the table.
+        let f = fixture();
+        let group = default_group_id();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let plugin =
+            f.store.save_plugin(group, PluginKind::Neon, "", &[tool("run_sql")], None).unwrap();
+
+        f.store.set_plugin_tool(plugin.id, "run_sql", false).unwrap();
+        let back = f.store.set_plugin_tool(plugin.id, "run_sql", true).unwrap();
+
+        assert!(back.tools[0].allowed);
+        assert!(f.store.plugin_tools(group, manager.id).unwrap()[0].withheld.is_empty());
+        let left: i64 = f
+            .store
+            .conn()
+            .unwrap()
+            .query_row("SELECT count(*) FROM plugin_denied_tools", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(left, 0);
+    }
+
+    #[test]
+    fn a_tool_the_server_never_published_cannot_be_switched_off() {
+        // A refusal filed against a name nothing publishes is a row no panel
+        // can show and no call can hit. It means the list on screen is older
+        // than the one the server last sent, which is what the error says.
+        let f = fixture();
+        let plugin = f
+            .store
+            .save_plugin(default_group_id(), PluginKind::Neon, "", &[tool("run_sql")], None)
+            .unwrap();
+
+        let refused = f.store.set_plugin_tool(plugin.id, "drop_project", false).unwrap_err();
+        assert!(
+            matches!(&refused, StoreError::PluginToolNotFound(id, name)
+                if *id == plugin.id && name == "drop_project"),
+            "{refused}"
+        );
+        assert!(refused.to_string().contains("connect it again"), "{refused}");
+    }
+
+    #[test]
+    fn connecting_again_does_not_switch_a_denied_tool_back_on() {
+        // Reconnecting is how an operator fixes a grant revoked at the vendor,
+        // exactly as it is for who may use the plugin. One that quietly handed
+        // `drop_project` back would undo the decision at the moment the
+        // operator was fixing something else.
+        let f = fixture();
+        let group = default_group_id();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let published = [tool("run_sql"), tool("drop_project")];
+        let plugin = f.store.save_plugin(group, PluginKind::Neon, "", &published, None).unwrap();
+        f.store.set_plugin_tool(plugin.id, "drop_project", false).unwrap();
+
+        // And a tool the vendor started publishing since arrives switched on,
+        // which is the half an allow-list could not express: nobody has made a
+        // decision about it, and the decision that was made was about the
+        // plugin.
+        let again = f
+            .store
+            .save_plugin(
+                group,
+                PluginKind::Neon,
+                "",
+                &[tool("run_sql"), tool("drop_project"), tool("list_branches")],
+                None,
+            )
+            .unwrap();
+
+        let off: Vec<&str> =
+            again.tools.iter().filter(|t| !t.allowed).map(|t| t.name.as_str()).collect();
+        assert_eq!(off, ["drop_project"]);
+        assert_eq!(
+            f.store.plugin_tools(group, manager.id).unwrap()[0].offered.len(),
+            2,
+            "the new tool is offered and the refused one is not"
+        );
+    }
+
+    #[test]
+    fn disconnecting_a_plugin_takes_the_tools_it_had_switched_off_with_it() {
+        // A refusal naming a plugin that is gone is a decision attached to
+        // nothing, waiting to attach itself to whatever takes the id next.
+        let f = fixture();
+        let group = default_group_id();
+        let plugin =
+            f.store.save_plugin(group, PluginKind::Neon, "", &[tool("run_sql")], None).unwrap();
+        f.store.set_plugin_tool(plugin.id, "run_sql", false).unwrap();
+
+        assert!(f.store.delete_plugin(plugin.id).unwrap());
+        let left: i64 = f
+            .store
+            .conn()
+            .unwrap()
+            .query_row("SELECT count(*) FROM plugin_denied_tools", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(left, 0);
+    }
+
+    #[test]
+    fn deleting_a_group_takes_what_its_plugins_had_switched_off_too() {
+        let f = fixture();
+        let group = f
+            .store
+            .create_group(&CleanGroup { name: "Crew".into(), ..Default::default() })
+            .unwrap();
+        let plugin =
+            f.store.save_plugin(group.id, PluginKind::Neon, "", &[tool("run_sql")], None).unwrap();
+        f.store.set_plugin_tool(plugin.id, "run_sql", false).unwrap();
+
+        f.store.delete_group(group.id).unwrap();
+        let left: i64 = f
+            .store
+            .conn()
+            .unwrap()
+            .query_row("SELECT count(*) FROM plugin_denied_tools", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(left, 0);
+    }
+
+    #[test]
     fn an_access_value_this_build_does_not_know_shuts_the_plugin_rather_than_opening_it() {
         // What a downgrade leaves behind. A permission that cannot be read has
         // to fail closed: the crew losing a plugin is visible and fixable, and
@@ -5062,7 +5475,7 @@ mod tests {
 
         assert!(f.store.plugin_tools(group, manager.id).unwrap().is_empty());
         assert!(matches!(
-            f.store.plugin_reach(group, manager.id, PluginKind::Neon).unwrap(),
+            f.store.plugin_reach(group, manager.id, PluginKind::Neon, "run_sql").unwrap(),
             PluginReach::NotChosen
         ));
         assert_eq!(

--- a/src-tauri/src/domain/plugin.rs
+++ b/src-tauri/src/domain/plugin.rs
@@ -195,6 +195,44 @@ pub struct PluginTool {
     pub input_schema: serde_json::Value,
 }
 
+/// One of a connected plugin's tools, as the panel draws it.
+///
+/// The schema is not here and the description is, and that split is what the
+/// row is for: an operator deciding whether a crew may call `delete_customer`
+/// needs the sentence the vendor wrote about it, and has no use for the shape
+/// of its arguments.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginToolCard {
+    /// The server's own name for it, unprefixed. Prefixed with the plugin's
+    /// slug it becomes the name a model calls.
+    pub name: String,
+    pub description: String,
+    /// Whether the crew may call it. True unless the operator switched it off,
+    /// which is the way round the store keeps it too: what is written down is
+    /// the refusals, so a tool a vendor ships next month arrives allowed.
+    pub allowed: bool,
+}
+
+/// What one agent may call on one of its crew's plugins this turn, and what the
+/// operator has switched off.
+///
+/// Both halves, from one read, because both are used on the same turn and by
+/// different consumers: `offered` becomes the tool definitions the model is
+/// given, and `withheld` becomes the line in the prompt that says a capability
+/// exists and is off. An agent that is only shown `offered` reports "we cannot
+/// do refunds" when the true answer is "the operator switched refunds off, and
+/// can switch them back on".
+#[derive(Debug, Clone, PartialEq)]
+pub struct PluginToolset {
+    pub kind: PluginKind,
+    /// Callable, in the server's own order.
+    pub offered: Vec<PluginTool>,
+    /// Names only. A description and a schema for something that cannot be
+    /// called is context paid for on every turn to describe an absence.
+    pub withheld: Vec<String>,
+}
+
 /// Who in a crew may call one plugin's tools.
 ///
 /// A plugin is signed in once, for the group, and until this existed that
@@ -278,10 +316,15 @@ pub struct Plugin {
     /// an MCP server is under no obligation to name the account it authorised,
     /// and inventing a label would be worse than an empty one.
     pub account: String,
-    /// What this crew can call, by unprefixed name. The schemas are not here:
-    /// they are bulk the webview has no use for, and the runtime reads them
-    /// from the store on the turn that needs them.
-    pub tools: Vec<String>,
+    /// Every tool this server published, each with what the operator has
+    /// decided about it. The schemas are not here: they are bulk the webview
+    /// has no use for, and the runtime reads them from the store on the turn
+    /// that needs them.
+    ///
+    /// The whole list, including the switched-off ones. A panel that only drew
+    /// the allowed ones would be a panel with no way to switch anything back
+    /// on, and no way to see what the crew is not being offered.
+    pub tools: Vec<PluginToolCard>,
     /// Which of the crew may call them. The sign-in behind this row is the
     /// group's either way: this decides who is allowed to spend it, not who
     /// holds it.

--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -14,7 +14,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::domain::envelope::Intent;
-use crate::domain::plugin::{PluginKind, PluginTool};
+use crate::domain::plugin::{PluginKind, PluginToolset};
 use crate::domain::routine::{Cadence, Trigger};
 use crate::llm::openrouter::{ToolCall, ToolSpec};
 
@@ -115,10 +115,14 @@ const MAX_TOOL_NAME: usize = 64;
 /// A tool whose prefixed name a provider would refuse is dropped rather than
 /// renamed. Renaming would need a mapping back at call time, and a mapping
 /// nothing can see is how a tool call lands on the wrong tool.
-pub fn plugin_specs(connected: &[(PluginKind, Vec<PluginTool>)]) -> Vec<ToolSpec> {
+/// The switched-off half of each set is not here and is not a filter applied
+/// later either: it never becomes a definition. A model offered a tool the
+/// operator switched off would call it, be refused, and spend the turn
+/// rewording the arguments.
+pub fn plugin_specs(connected: &[PluginToolset]) -> Vec<ToolSpec> {
     let mut out = Vec::new();
-    for (kind, tools) in connected {
-        for tool in tools {
+    for PluginToolset { kind, offered, .. } in connected {
+        for tool in offered {
             let name = format!("{}{PLUGIN_SEPARATOR}{}", kind.slug(), tool.name);
             if name.len() > MAX_TOOL_NAME
                 || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
@@ -1454,6 +1458,7 @@ pub fn render_deliveries(results: &[Delivery]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::plugin::PluginTool;
 
     fn call(name: &str, arguments: &str) -> ToolCall {
         ToolCall { id: "call_1".into(), name: name.into(), arguments: arguments.into() }
@@ -2475,9 +2480,15 @@ mod tests {
         }
     }
 
+    /// One connected plugin with every tool switched on, which is where every
+    /// plugin starts.
+    fn toolset(kind: PluginKind, offered: Vec<PluginTool>) -> PluginToolset {
+        PluginToolset { kind, offered, withheld: Vec::new() }
+    }
+
     #[test]
     fn a_plugin_tool_is_offered_under_its_plugin() {
-        let specs = plugin_specs(&[(PluginKind::Neon, vec![plugin_tool("run_sql")])]);
+        let specs = plugin_specs(&[toolset(PluginKind::Neon, vec![plugin_tool("run_sql")])]);
         assert_eq!(specs.len(), 1);
         assert_eq!(specs[0].name, "neon__run_sql");
         // The description says where the call reaches. A model reading twenty
@@ -2491,7 +2502,7 @@ mod tests {
         // Providers validate a function name against `[A-Za-z0-9_-]{1,64}`.
         // Renaming to fit would need a mapping back at call time, and a mapping
         // nothing can see is how a call lands on the wrong tool.
-        let offered = plugin_specs(&[(
+        let offered = plugin_specs(&[toolset(
             PluginKind::Neon,
             vec![
                 plugin_tool("run sql"),
@@ -2502,6 +2513,21 @@ mod tests {
         )]);
         let names: Vec<&str> = offered.iter().map(|spec| spec.name.as_str()).collect();
         assert_eq!(names, vec!["neon__fine"]);
+    }
+
+    #[test]
+    fn a_switched_off_tool_never_becomes_a_definition() {
+        // Not filtered out of the definitions later: it never becomes one. A
+        // model offered a tool the operator switched off calls it, is refused
+        // on the call path, and spends the rest of the turn rewording the
+        // arguments it was refused for.
+        let offered = plugin_specs(&[PluginToolset {
+            kind: PluginKind::Stripe,
+            offered: vec![plugin_tool("list_charges")],
+            withheld: vec!["create_refund".to_string()],
+        }]);
+        let names: Vec<&str> = offered.iter().map(|spec| spec.name.as_str()).collect();
+        assert_eq!(names, vec!["stripe__list_charges"]);
     }
 
     #[test]

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -53,6 +53,14 @@ pub enum PluginError {
     )]
     NotChosen { label: &'static str },
     #[error(
+        "{label}'s `{tool}` is switched off for this group: the operator decides which of a \
+         plugin's tools the crew may call, and this one is off for everybody. Do not ask a peer, \
+         because no peer has it. Use another of {label}'s tools if one will do, or tell the \
+         operator which tool you need and that it is switched off in the group's Plugins \
+         settings."
+    )]
+    ToolDenied { label: &'static str, tool: String },
+    #[error(
         "{label}'s sign-in is no longer accepted, and renewing it did not work. Ask the operator \
          to connect it again in the group's Plugins settings."
     )]
@@ -119,10 +127,10 @@ pub async fn connect(
 
 /// Runs one of a plugin's tools on behalf of an agent.
 ///
-/// Asked of the agent rather than of its group, and that is the check rather
-/// than a second one: a model can name a tool it was never offered, so
-/// filtering the definitions decides what an agent is *told* it has and this
-/// decides what it *gets*. The two read the same rule, in `plugin_reach`.
+/// Asked of the agent and of the tool, and that is the check rather than a
+/// second one: a model can name a tool it was never offered, so filtering the
+/// definitions decides what an agent is *told* it has and this decides what it
+/// *gets*. Both halves of the rule are read again here, in `plugin_reach`.
 ///
 /// Renews the grant first when it is close to expiring, and once more if the
 /// server rejects it anyway: a token can be revoked at the vendor between one
@@ -138,10 +146,13 @@ pub async fn call(
     tool: &str,
     arguments: &serde_json::Value,
 ) -> Result<String, PluginError> {
-    let (id, grant) = match store.plugin_reach(group, agent, kind)? {
+    let (id, grant) = match store.plugin_reach(group, agent, kind, tool)? {
         PluginReach::Granted { id, grant } => (id, grant),
         PluginReach::NotConnected => return Err(PluginError::NotConnected { label: kind.label() }),
         PluginReach::NotChosen => return Err(PluginError::NotChosen { label: kind.label() }),
+        PluginReach::ToolDenied => {
+            return Err(PluginError::ToolDenied { label: kind.label(), tool: tool.to_string() })
+        }
     };
 
     let grant = match grant {
@@ -215,6 +226,23 @@ mod tests {
         assert!(refusal.contains("not for you"), "{refusal}");
         assert!(refusal.contains("peer"), "the way forward is delegation: {refusal}");
         assert!(!refusal.contains("is not connected"), "{refusal}");
+    }
+
+    #[test]
+    fn a_switched_off_tool_does_not_send_the_agent_round_the_crew() {
+        // The difference from `NotChosen`, and it is the whole reason this is a
+        // third sentence rather than a reuse of that one. Narrowing a plugin
+        // leaves a peer who can; switching a tool off leaves nobody, so an
+        // agent told to ask around spends a turn proving it.
+        let refusal =
+            PluginError::ToolDenied { label: "Stripe", tool: "create_refund".into() }.to_string();
+        assert!(refusal.contains("create_refund"), "{refusal}");
+        assert!(refusal.contains("off for everybody"), "{refusal}");
+        assert!(refusal.contains("Do not ask a peer"), "{refusal}");
+        assert!(
+            refusal.contains("operator"),
+            "the way forward is the one person who can: {refusal}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -4041,6 +4041,14 @@ impl Runtime {
             if plugin.access.allows(me) {
                 continue;
             }
+            // And not one the operator has switched off entirely. A plugin with
+            // nothing left on is a plugin its own crew cannot call, so naming
+            // the peer who holds it is the failure this loop exists to prevent
+            // rather than the one it prevents: work routed to an agent that
+            // will be refused in turn, having spent a turn finding out.
+            if plugin.tools.iter().all(|tool| !tool.allowed) {
+                continue;
+            }
             for card in &agents {
                 if card.id != me && card.group_id == group && plugin.access.allows(card.id) {
                     reaches

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -13,7 +13,7 @@ use crate::domain::attachment::Attachment;
 use crate::domain::connector::Connector;
 use crate::domain::envelope::{Envelope, Part, Participant};
 use crate::domain::ids::AgentId;
-use crate::domain::plugin::{PluginKind, PluginTool};
+use crate::domain::plugin::PluginToolset;
 use crate::domain::routine::Routine;
 use crate::domain::signin::Signin;
 use crate::llm::openrouter::ChatMessage;
@@ -58,7 +58,7 @@ pub fn system_prompt(
     // The servers this agent's crew has signed in to, and what each offers. A
     // third kind of reach, and the only one where the agent holds nothing: the
     // call is made by Guaca with the group's own grant on it.
-    plugins: &[(PluginKind, Vec<PluginTool>)],
+    plugins: &[PluginToolset],
     notes: &str,
     // What this agent already has standing, newest firing first. In the prompt
     // rather than behind a tool call: an agent asked to change something it
@@ -238,15 +238,29 @@ pub fn system_prompt(
                  operator's, held by Guaca: there is nothing for you to authenticate, no key to \
                  find, and no command to run.\n",
             );
-            for (kind, tools) in plugins {
+            for set in plugins {
                 out.push_str(&format!(
                     "- {} — {} tool{}, called as `{}{}…`\n",
-                    kind.label(),
-                    tools.len(),
-                    if tools.len() == 1 { "" } else { "s" },
-                    kind.slug(),
+                    set.kind.label(),
+                    set.offered.len(),
+                    if set.offered.len() == 1 { "" } else { "s" },
+                    set.kind.slug(),
                     crate::llm::tools::PLUGIN_SEPARATOR,
                 ));
+                // Named, not counted, and not left out. An agent that is simply
+                // not offered `refund` answers "we cannot do refunds", which is
+                // wrong twice: the crew can, and the one person who can switch
+                // it back on is the one being told it is impossible. Naming it
+                // turns a dead end into a sentence the operator can act on.
+                // Withheld tools do not appear in the tool list, so this is the
+                // only place the decision is visible at all.
+                if !set.withheld.is_empty() {
+                    out.push_str(&format!(
+                        "  Switched off by the operator, and not yours to turn back on: {}. Say \
+                         so if one is what the task needs; nobody in the crew has it either.\n",
+                        set.withheld.join(", "),
+                    ));
+                }
             }
             out.push_str(
                 "\nThese act on the operator's real account, not a copy of it: a database you \
@@ -657,7 +671,7 @@ pub fn build_messages(
     roster: &[DirectoryEntry],
     credentials: &[Connector],
     signins: &[Signin],
-    plugins: &[(PluginKind, Vec<PluginTool>)],
+    plugins: &[PluginToolset],
     names: &NameTable,
     notes: &str,
     routines: &[Routine],
@@ -794,6 +808,7 @@ mod tests {
     use crate::domain::envelope::Intent;
     use crate::domain::envelope::{Part, Trust};
     use crate::domain::ids::{GroupId, MessageId, RoutineId, RunId};
+    use crate::domain::plugin::{PluginKind, PluginTool};
     use crate::domain::routine::{Cadence, Trigger};
     use crate::domain::signin::Surface;
 
@@ -981,10 +996,10 @@ mod tests {
     }
 
     /// One connected plugin, as the store would hand it over.
-    fn plugin(kind: PluginKind, tools: &[&str]) -> (PluginKind, Vec<PluginTool>) {
-        (
+    fn plugin(kind: PluginKind, tools: &[&str]) -> PluginToolset {
+        PluginToolset {
             kind,
-            tools
+            offered: tools
                 .iter()
                 .map(|name| PluginTool {
                     name: name.to_string(),
@@ -992,7 +1007,8 @@ mod tests {
                     input_schema: serde_json::json!({ "type": "object" }),
                 })
                 .collect(),
-        )
+            withheld: Vec::new(),
+        }
     }
 
     #[test]
@@ -1021,6 +1037,36 @@ mod tests {
         );
         // And the warning that these are not a sandbox.
         assert!(prompt.contains("operator's real account"), "{prompt}");
+    }
+
+    #[test]
+    fn a_tool_the_operator_switched_off_is_named_rather_than_left_out() {
+        // The alternative is an agent that answers "we cannot do refunds" about
+        // a crew that can, to the one person who could switch it back on. It is
+        // named and nothing else about it is: no description, no schema, and no
+        // definition, so the model cannot call it and can say what is missing.
+        let c = card("Revenue");
+        let mut set = plugin(PluginKind::Stripe, &["list_charges"]);
+        set.withheld = vec!["create_refund".to_string()];
+        let prompt = system_prompt(
+            &c,
+            "",
+            &[],
+            &[],
+            &[],
+            &[set],
+            "",
+            &[],
+            ReplyMode::ToOperator,
+            Surfaces::none(),
+        );
+
+        assert!(prompt.contains("- Stripe — 1 tool, called as `stripe__…`"), "{prompt}");
+        assert!(prompt.contains("Switched off by the operator"), "{prompt}");
+        assert!(prompt.contains("create_refund"), "{prompt}");
+        // And it does not send the agent to a peer: a switched-off tool is off
+        // for the whole crew, so asking around is a wasted turn.
+        assert!(prompt.contains("nobody in the crew has it either"), "{prompt}");
     }
 
     #[test]

--- a/src-tauri/tests/plugins.rs
+++ b/src-tauri/tests/plugins.rs
@@ -429,7 +429,9 @@ async fn a_server_that_asks_for_nothing_connects_without_sending_anybody_to_a_br
     .expect("a public server connects");
 
     assert!(!plugin.signed_in, "nothing was authorised, so nothing may claim to have been");
-    assert_eq!(plugin.tools, vec!["run_sql".to_string(), "list_projects".to_string()]);
+    let named: Vec<&str> = plugin.tools.iter().map(|tool| tool.name.as_str()).collect();
+    assert_eq!(named, vec!["run_sql", "list_projects"]);
+    assert!(plugin.tools.iter().all(|tool| tool.allowed), "a plugin arrives with nothing off");
     assert_eq!(server.registrations.load(Ordering::SeqCst), 0);
 }
 
@@ -651,7 +653,7 @@ async fn a_grant_revoked_at_the_vendor_is_renewed_once_and_the_call_retried() {
     // And the renewed grant is written back, or every later turn pays for the
     // same discovery.
     let PluginReach::Granted { grant, .. } =
-        store.plugin_reach(group, agent, PluginKind::Neon).unwrap()
+        store.plugin_reach(group, agent, PluginKind::Neon, "run_sql").unwrap()
     else {
         panic!("the plugin is connected and this agent was not excluded from it")
     };
@@ -672,7 +674,7 @@ async fn disconnecting_forgets_the_plugin_and_its_grant() {
     assert!(store.delete_plugin(plugin.id).unwrap());
     assert!(store.group_plugins(group).unwrap().is_empty());
     assert!(matches!(
-        store.plugin_reach(group, agent, PluginKind::Neon).unwrap(),
+        store.plugin_reach(group, agent, PluginKind::Neon, "run_sql").unwrap(),
         PluginReach::NotConnected
     ));
 }
@@ -695,7 +697,7 @@ async fn connecting_twice_replaces_the_grant_rather_than_refusing() {
 
     assert_eq!(store.group_plugins(group).unwrap().len(), 1);
     let PluginReach::Granted { grant, .. } =
-        store.plugin_reach(group, agent, PluginKind::Neon).unwrap()
+        store.plugin_reach(group, agent, PluginKind::Neon, "run_sql").unwrap()
     else {
         panic!("connecting again leaves a plugin the crew can use")
     };
@@ -921,6 +923,75 @@ async fn an_agent_the_plugin_was_narrowed_away_from_is_neither_told_nor_allowed(
 }
 
 #[tokio::test]
+async fn a_tool_the_operator_switched_off_is_named_in_the_prompt_and_refused_on_the_call() {
+    // The other axis, on the same three seams. Being chosen for a plugin is not
+    // being handed every tool on it: the operator decides that per tool, for
+    // the whole crew, and the agent has to be able to tell the difference
+    // between a capability that does not exist and one that is switched off.
+    // Named in the prompt, missing from the definitions, refused on the call.
+    let server = serve(Rules::default()).await;
+    let endpoint = format!("{}/mcp", server.base());
+
+    let model = harness::serve(|body| {
+        if harness::has_tool_result(body) {
+            harness::Script::Say("Told the operator.".into())
+        } else {
+            harness::Script::Plugin {
+                name: "neon__run_sql".into(),
+                arguments: serde_json::json!({ "sql": "select 1" }),
+            }
+        }
+    })
+    .await;
+
+    let h =
+        harness::harness(&model, &["Manager"], guac_lib::runtime::guard::GuardLimits::default());
+    h.runtime.plugins_at(HashMap::from([(PluginKind::Neon, endpoint.clone())]));
+
+    let group = h.runtime.store().get_agent(h.id("Manager")).unwrap().unwrap().group_id;
+    let plugin = plugins::connect(
+        h.runtime.store(),
+        group,
+        PluginKind::Neon,
+        &endpoint,
+        browser(Outcome::Allowed),
+    )
+    .await
+    .unwrap();
+    h.runtime.store().set_plugin_tool(plugin.id, "run_sql", false).unwrap();
+
+    let run = h.runtime.send_from_human(h.id("Manager"), "Check the database.").unwrap();
+    h.settle(run).await;
+
+    // Not offered, and the plugin's other tool still is: switching one off is
+    // not disconnecting the plugin.
+    let offered: Vec<String> = model.transcript.lock()[0]["tools"]
+        .as_array()
+        .expect("a turn carries tool definitions")
+        .iter()
+        .map(|tool| tool["function"]["name"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(!offered.contains(&"neon__run_sql".to_string()), "offered {offered:?}");
+    assert!(offered.contains(&"neon__list_projects".to_string()), "offered {offered:?}");
+
+    // And said out loud, because the alternative is an agent answering "we
+    // cannot query the database" to the one person who can switch it back on.
+    let prompt = harness::prompts_by_agent(&model).remove("Manager").expect("Manager had a turn");
+    assert!(prompt.contains("Switched off by the operator"), "{prompt}");
+    assert!(prompt.contains("run_sql"), "{prompt}");
+
+    // The call it made anyway was refused here rather than at Neon, and the
+    // refusal does not send it round the crew: nobody has it.
+    let results = harness::tool_results(&model);
+    assert!(
+        results.iter().any(|r| r.contains("switched off") && r.contains("Do not ask a peer")),
+        "got {results:?}"
+    );
+    assert!(server.called.lock().is_empty(), "a switched-off tool must not reach the vendor");
+    assert_eq!(h.channel_texts("Manager").len(), 2, "the operator is answered either way");
+}
+
+#[tokio::test]
 async fn a_narrowed_plugin_shows_up_as_a_peer_who_can_do_it() {
     // What narrowing costs if nothing replaces it: an agent that can only say
     // no, sitting beside the one that can say yes. The roster is where the crew
@@ -963,6 +1034,47 @@ async fn a_narrowed_plugin_shows_up_as_a_peer_who_can_do_it() {
     h.settle(run).await;
     let revenue = harness::prompts_by_agent(&model).remove("Revenue").expect("Revenue had a turn");
     assert!(!revenue.contains("the Neon plugin"), "{revenue}");
+}
+
+#[tokio::test]
+async fn a_plugin_with_everything_switched_off_is_not_a_peer_worth_asking() {
+    // The roster's whole job is to stop work being routed to an agent that
+    // cannot do it. A plugin narrowed to one agent and then switched off tool
+    // by tool is exactly that case from the other end: the peer holds it and
+    // can call none of it, so naming them costs two turns to find out.
+    let server = serve(Rules::default()).await;
+    let endpoint = format!("{}/mcp", server.base());
+    let model = harness::serve(|_| harness::Script::Say("Noted.".into())).await;
+
+    let h = harness::harness(
+        &model,
+        &["Revenue", "Scribe"],
+        guac_lib::runtime::guard::GuardLimits::default(),
+    );
+    h.runtime.plugins_at(HashMap::from([(PluginKind::Neon, endpoint.clone())]));
+
+    let group = h.runtime.store().get_agent(h.id("Revenue")).unwrap().unwrap().group_id;
+    let plugin = plugins::connect(
+        h.runtime.store(),
+        group,
+        PluginKind::Neon,
+        &endpoint,
+        browser(Outcome::Allowed),
+    )
+    .await
+    .unwrap();
+    h.runtime
+        .store()
+        .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![h.id("Revenue")] })
+        .unwrap();
+    for tool in ["run_sql", "list_projects"] {
+        h.runtime.store().set_plugin_tool(plugin.id, tool, false).unwrap();
+    }
+
+    let run = h.runtime.send_from_human(h.id("Scribe"), "Anything to report?").unwrap();
+    h.settle(run).await;
+    let scribe = harness::prompts_by_agent(&model).remove("Scribe").expect("Scribe had a turn");
+    assert!(!scribe.contains("the Neon plugin"), "{scribe}");
 }
 
 #[tokio::test]

--- a/src/components/PluginList.test.tsx
+++ b/src/components/PluginList.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { AgentCard, Plugin, PluginAccess, PluginOffer } from "../lib/types";
+import type { AgentCard, Plugin, PluginAccess, PluginOffer, PluginToolCard } from "../lib/types";
 import { PluginList } from "./PluginList";
 
 const pluginCatalogue = vi.fn<() => Promise<PluginOffer[]>>();
@@ -9,6 +9,7 @@ const groupPlugins = vi.fn<() => Promise<Plugin[]>>();
 const connectPlugin = vi.fn<(groupId: string, kind: string) => Promise<Plugin>>();
 const disconnectPlugin = vi.fn();
 const setPluginAccess = vi.fn<(id: string, access: PluginAccess) => Promise<Plugin>>();
+const setPluginTool = vi.fn<(id: string, tool: string, allowed: boolean) => Promise<Plugin>>();
 const openExternal = vi.fn();
 
 vi.mock("../lib/ipc", () => ({
@@ -18,6 +19,7 @@ vi.mock("../lib/ipc", () => ({
     connectPlugin: (groupId: string, kind: string) => connectPlugin(groupId, kind),
     disconnectPlugin: (id: string) => disconnectPlugin(id),
     setPluginAccess: (id: string, access: PluginAccess) => setPluginAccess(id, access),
+    setPluginTool: (id: string, tool: string, allowed: boolean) => setPluginTool(id, tool, allowed),
   },
   openExternal: (url: string) => openExternal(url),
 }));
@@ -42,13 +44,18 @@ const OFFERS: PluginOffer[] = [
   },
 ];
 
+/** One tool as the server published it, switched on unless said otherwise. */
+function tool(name: string, allowed = true): PluginToolCard {
+  return { name, description: `Runs ${name}.`, allowed };
+}
+
 function plugin(over: Partial<Plugin> = {}): Plugin {
   return {
     id: "p1",
     groupId: GROUP,
     kind: "neon",
     account: "",
-    tools: ["run_sql", "create_branch"],
+    tools: [tool("run_sql"), tool("create_branch")],
     access: { mode: "everyone" },
     signedIn: true,
     connectedAt: 0,
@@ -89,6 +96,7 @@ describe("PluginList", () => {
     connectPlugin.mockReset();
     disconnectPlugin.mockReset();
     setPluginAccess.mockReset();
+    setPluginTool.mockReset();
     openExternal.mockReset();
     pluginCatalogue.mockResolvedValue(OFFERS);
     groupPlugins.mockResolvedValue([]);
@@ -142,7 +150,9 @@ describe("PluginList", () => {
     // Every server on the list asks for one today. This is what the row says
     // if one stops, because reporting it as signed in would be a claim about
     // the operator's account that is not true.
-    groupPlugins.mockResolvedValue([plugin({ kind: "stripe", signedIn: false, tools: ["docs"] })]);
+    groupPlugins.mockResolvedValue([
+      plugin({ kind: "stripe", signedIn: false, tools: [tool("docs")] }),
+    ]);
     render(<PluginList groupId={GROUP} crew={CREW} />);
 
     expect(await screen.findByText(/asked for no sign-in/)).toBeTruthy();
@@ -232,6 +242,73 @@ describe("PluginList", () => {
     expect(screen.getByRole("button", { name: "Scribe" }).getAttribute("aria-pressed")).toBe(
       "false",
     );
+  });
+
+  it("keeps the tool list shut until it is asked for", async () => {
+    // A crew with three plugins connected has sixty of these between the
+    // operator and the button they came here for. The count on the line above
+    // is what says whether opening one is worth it.
+    groupPlugins.mockResolvedValue([plugin()]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    expect(await screen.findByText("Show all 2")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Deny run_sql" })).toBe(null);
+
+    fireEvent.click(screen.getByText("Show all 2"));
+    expect(screen.getByText("run_sql")).toBeTruthy();
+    // The vendor's own sentence, because `execute` and `create_refund` are not
+    // decisions anybody can make off the name alone.
+    expect(screen.getByText("Runs run_sql.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Allow run_sql" }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+  });
+
+  it("switches one tool off, and back on again", async () => {
+    const off = plugin({ tools: [tool("run_sql", false), tool("create_branch")] });
+    groupPlugins.mockResolvedValueOnce([plugin()]);
+    groupPlugins.mockResolvedValue([off]);
+    setPluginTool.mockResolvedValue(off);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    fireEvent.click(await screen.findByText("Show all 2"));
+    fireEvent.click(screen.getByRole("button", { name: "Deny run_sql" }));
+
+    // The tool by name and the answer it should have, never a toggle: two
+    // panels open on one group cannot swap a decision between them.
+    await waitFor(() => expect(setPluginTool).toHaveBeenCalledWith("p1", "run_sql", false));
+    // And the row draws what came back, not what was clicked.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Deny run_sql" }).getAttribute("aria-pressed"),
+      ).toBe("true"),
+    );
+    expect(screen.getByText(/1 switched off/)).toBeTruthy();
+
+    setPluginTool.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "Allow run_sql" }));
+    await waitFor(() => expect(setPluginTool).toHaveBeenCalledWith("p1", "run_sql", true));
+  });
+
+  it("says when a connected plugin has nothing left switched on", async () => {
+    // The same state the crew-of-nobody row says out loud, one axis over: a
+    // plugin that is signed in and can call nothing looks identical to a
+    // working one until something says so.
+    groupPlugins.mockResolvedValue([
+      plugin({ tools: [tool("run_sql", false), tool("create_branch", false)] }),
+    ]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    expect(await screen.findByText(/all switched off/)).toBeTruthy();
+  });
+
+  it("asks nothing about tools of a plugin nobody has connected", async () => {
+    // There is nothing to switch off, and the question is noise on four tiles.
+    groupPlugins.mockResolvedValue([]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    await screen.findAllByText("Connect");
+    expect(screen.queryByText(/Show all/)).toBe(null);
   });
 
   it("asks nothing about who can use a plugin nobody has connected", async () => {

--- a/src/components/PluginList.tsx
+++ b/src/components/PluginList.tsx
@@ -10,6 +10,7 @@ import {
   type Plugin,
   type PluginAccess,
   type PluginOffer,
+  type PluginToolCard,
 } from "../lib/types";
 
 interface Props {
@@ -42,6 +43,23 @@ function offeredTo(access: PluginAccess, crew: AgentCard[]): string {
   const named = crew.filter((agent) => access.agents.includes(agent.id));
   if (named.length === 0) return "offered to nobody: tick an agent, or nothing here can be called";
   return `offered to ${named.map((agent) => agent.name).join(", ")}`;
+}
+
+/**
+ * How much of what a plugin publishes the crew may actually call.
+ *
+ * The count is of everything the server published, not of what is left on,
+ * because that number is what the row below expands into. Every tool switched
+ * off is said out loud for the same reason a plugin narrowed to nobody is: a
+ * connected plugin the crew cannot call is indistinguishable from a working one
+ * until something says so.
+ */
+function offering(tools: PluginToolCard[]): string {
+  const off = tools.filter((tool) => !tool.allowed).length;
+  const count = `${tools.length} tool${tools.length === 1 ? "" : "s"}`;
+  if (off === 0) return count;
+  if (off === tools.length) return `${count}, all switched off: none of them can be called`;
+  return `${count}, ${off} switched off`;
 }
 
 /**
@@ -80,6 +98,11 @@ export function PluginList({ groupId, crew }: Props) {
   const [connected, setConnected] = useState<Plugin[] | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Which plugins have their tool list open. Shut by default and not
+  // remembered anywhere: a crew with three plugins connected has sixty rows
+  // between the operator and the button they came here for, and the counts on
+  // the line above are what says whether opening one is worth it.
+  const [opened, setOpened] = useState<string[]>([]);
 
   const load = useCallback(async () => {
     try {
@@ -166,8 +189,8 @@ export function PluginList({ groupId, crew }: Props) {
             {held ? (
               <>
                 <p className="field__hint">
-                  {held.tools.length} tool{held.tools.length === 1 ? "" : "s"},{" "}
-                  {offeredTo(held.access, crew)}.{held.account && ` Signed in as ${held.account}.`}
+                  {offering(held.tools)}, {offeredTo(held.access, crew)}.
+                  {held.account && ` Signed in as ${held.account}.`}
                   {!held.signedIn &&
                     " This server asked for no sign-in, so nothing was authorised."}
                 </p>
@@ -240,6 +263,87 @@ export function PluginList({ groupId, crew }: Props) {
                       })
                     )}
                   </div>
+                )}
+
+                {/* The second axis, and a different question from the first.
+                    Who may spend the sign-in is about the crew; which tools may
+                    be spent is about the server, and it is the same everywhere
+                    the plugin goes. A server does not publish one kind of
+                    thing: Stripe lists the call that reads an invoice beside
+                    the one that refunds it, and until this existed the only
+                    control over that was Disconnect. */}
+                {held.tools.length > 0 && (
+                  <>
+                    <span className="field__label">Which of its tools they can call</span>
+                    <button
+                      type="button"
+                      className="toolset__more"
+                      aria-expanded={opened.includes(offer.kind)}
+                      onClick={() =>
+                        setOpened((open) =>
+                          open.includes(offer.kind)
+                            ? open.filter((kind) => kind !== offer.kind)
+                            : [...open, offer.kind],
+                        )
+                      }
+                    >
+                      {opened.includes(offer.kind) ? "Hide them" : `Show all ${held.tools.length}`}
+                    </button>
+                  </>
+                )}
+
+                {opened.includes(offer.kind) && (
+                  <ul className="toolset">
+                    {held.tools.map((tool) => (
+                      <li className="toolset__item" key={tool.name}>
+                        <div className="toolset__text">
+                          <code className="toolset__name">{tool.name}</code>
+                          {/* The vendor's own sentence, and the reason this is
+                              a list rather than a row of names: `execute` and
+                              `create_refund` are not decisions anybody can make
+                              off the name alone. */}
+                          {tool.description && (
+                            <span className="toolset__blurb">{tool.description}</span>
+                          )}
+                        </div>
+                        <div className="choices">
+                          {/* Named for a reader who cannot see which row they
+                              are on. Forty buttons all called "Allow" is a list
+                              only usable with a mouse. */}
+                          <button
+                            type="button"
+                            className="choice choice--tight"
+                            aria-label={`Allow ${tool.name}`}
+                            aria-pressed={tool.allowed}
+                            disabled={busy !== null}
+                            onClick={() => {
+                              if (tool.allowed) return;
+                              void run(`${offer.kind}-${tool.name}`, () =>
+                                api.setPluginTool(held.id, tool.name, true),
+                              );
+                            }}
+                          >
+                            Allow
+                          </button>
+                          <button
+                            type="button"
+                            className="choice choice--tight"
+                            aria-label={`Deny ${tool.name}`}
+                            aria-pressed={!tool.allowed}
+                            disabled={busy !== null}
+                            onClick={() => {
+                              if (!tool.allowed) return;
+                              void run(`${offer.kind}-${tool.name}`, () =>
+                                api.setPluginTool(held.id, tool.name, false),
+                              );
+                            }}
+                          >
+                            Deny
+                          </button>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
                 )}
               </>
             ) : (

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -149,6 +149,18 @@ export const api = {
   setPluginAccess: (id: PluginId, access: PluginAccess) =>
     invoke<Plugin>("set_plugin_access", { id, access }),
 
+  /**
+   * Switches one of a connected plugin's tools on or off for the whole crew.
+   *
+   * One tool and the answer it should have, rather than the whole set the way
+   * `setPluginAccess` takes it. A tool is a switch and naming it cannot be
+   * ambiguous; sending the whole set from a panel that can only see today's
+   * tool list would drop a refusal filed against one the vendor has stopped
+   * publishing.
+   */
+  setPluginTool: (id: PluginId, tool: string, allowed: boolean) =>
+    invoke<Plugin>("set_plugin_tool", { id, tool, allowed }),
+
   disconnectPlugin: (id: PluginId) => invoke<void>("disconnect_plugin", { id }),
 
   /** The last scan's result. Does not touch the machine, so it is free. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -253,6 +253,22 @@ export interface PluginOffer {
 export type PluginAccess = { mode: "everyone" } | { mode: "chosen"; agents: AgentId[] };
 
 /**
+ * One of a connected plugin's tools, and what the operator decided about it.
+ *
+ * The description and not the schema: an operator deciding whether the crew may
+ * call `delete_customer` needs the sentence the vendor wrote about it and has
+ * no use for the shape of its arguments. `allowed` is true unless it was
+ * switched off, which is the way round the store keeps it too, so a tool a
+ * vendor ships next month arrives switched on rather than invisible.
+ */
+export interface PluginToolCard {
+  /** The server's own name for it. Prefixed with the plugin, a model calls it. */
+  name: string;
+  description: string;
+  allowed: boolean;
+}
+
+/**
  * A plugin a group has connected.
  *
  * The grant is never on this side of the boundary: there is no command that
@@ -265,8 +281,11 @@ export interface Plugin {
   kind: PluginKind;
   /** Whose account, when the server said. Usually blank. */
   account: string;
-  /** What the crew can call, by the server's own name for each. */
-  tools: string[];
+  /**
+   * Every tool the server published, switched off ones included: a list that
+   * left them out would be a panel with no way to switch one back on.
+   */
+  tools: PluginToolCard[];
   /** Which of the crew is offered them. `everyone` until somebody says else. */
   access: PluginAccess;
   signedIn: boolean;

--- a/src/styles.css
+++ b/src/styles.css
@@ -3141,6 +3141,71 @@ button {
   margin-left: auto;
 }
 
+/* One connected plugin's tools, one to a row, each with what the operator
+   decided about it. Shut until asked for: a crew with three plugins connected
+   has sixty of these between the operator and the Disconnect button. */
+.toolset {
+  list-style: none;
+  margin: 0.2rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.toolset__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0;
+  border-top: 1px solid var(--edge);
+}
+
+.toolset__item:first-child {
+  border-top: 0;
+}
+
+/* The name and the vendor's sentence take whatever is left, and the two
+   buttons keep their width: a tool with a paragraph of description must not
+   push Allow and Deny off the end of the row. */
+.toolset__text {
+  flex: 1;
+  min-width: 0;
+}
+
+.toolset__name {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--text);
+}
+
+/* Clamped rather than truncated to one line. Some servers write a paragraph
+   per tool and some write four words, and two lines is enough of either to
+   decide with. */
+.toolset__blurb {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+  font-size: 0.66rem;
+  color: var(--muted);
+}
+
+/* The disclosure. A link's weight rather than a button's, because it reveals
+   what is already there rather than changing anything. */
+.toolset__more {
+  align-self: flex-start;
+  padding: 0;
+  background: none;
+  border: 0;
+  color: var(--flesh);
+  font-size: 0.68rem;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 .access__ok,
 .access__warn {
   margin: 0;
@@ -4628,6 +4693,13 @@ button {
 .choice:hover:not([aria-pressed="true"]):not([aria-checked="true"]) {
   color: var(--text);
   border-color: color-mix(in oklab, var(--flesh) 40%, var(--edge));
+}
+
+/* Two words in a row that already carries a name and a sentence. The base
+   size would make the pair as tall as the text beside them. */
+.choice--tight {
+  padding: 0.18rem 0.45rem;
+  font-size: 0.68rem;
 }
 
 .choice:disabled {


### PR DESCRIPTION
Connecting a plugin was one decision covering every tool the server publishes, and a server does not publish one kind of thing: Stripe lists the call that reads an invoice beside the one that refunds it, and the only control over the second half of that pair was Disconnect. Each connected plugin now carries an Allow/Deny per tool for the whole crew, beside the existing decision about which agents may spend the sign-in, drawn as a collapsible breakdown in the Plugins tab with each tool's name and the vendor's own description. The refusals are what is stored (migration 29), so a plugin nobody has narrowed offers everything it published, a tool the vendor ships next month arrives switched on, and reconnecting keeps the refusals exactly as it already keeps `access`. The decision reaches the agent three ways: a switched-off tool never becomes a tool definition, its name is in the prompt so an agent can say what is missing rather than that the crew cannot do it, and `plugin_reach` refuses it on the call path with a sentence that does not send the agent round the crew, since no peer has it either. The roster also stops naming a peer for a plugin whose tools are all off, and `./scripts/ci.sh` plus the trajectory suite pass.