### PR TITLE
feat: the account's Google is a plugin, so a crew's agents can actually use it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,17 +135,21 @@ choose, and no price on the answer. The two meet in exactly one function,
 sees one shape of request. Keep it that way: a provider branch in the runtime, the
 prompt or the guard is the wrong half of the repo.
 
-**An account is optional and nothing depends on it.** `guaca.bot` holds one
-thing Guaca cannot: an OAuth client, for the services that will only issue
-programmatic access to a registered application. `Account` is a field on
-`AppState` that no turn, prompt, tool or guard reads, and both of its reads
-happen when the Settings pane is opened rather than at startup, so an install
-that never opens that pane never contacts the service. Signing in is
-authorization code with PKCE on a loopback port bound before the redirect is
-named, which is `oauth.rs`'s argument pointed at one known server; the device
-grant that was there first is gone rather than kept beside it, because two doors
-to one account means the weaker one decides what the account is worth.
-`docs/ACCOUNT.md`.
+**An account is optional, and an install that never signs in never contacts
+it.** `guaca.bot` holds one thing Guaca cannot: an OAuth client, for the
+services that will only issue programmatic access to a registered application.
+Signing in is authorization code with PKCE on a loopback port bound before the
+redirect is named, which is `oauth.rs`'s argument pointed at one known server;
+the device grant that was there first is gone rather than kept beside it,
+because two doors to one account means the weaker one decides what the account
+is worth. `docs/ACCOUNT.md`.
+
+One thing does depend on it, and only one: the Google plugin, whose server is
+that account. `Runtime::account_token` is read on a turn that calls one of its
+tools and nowhere else, so a machine with no account is a machine where that
+plugin refuses to connect and every other part of the app is unchanged. Keep it
+that way: the account is a credential for one plugin, not a thing the runtime,
+the prompt or the guard may consult.
 
 **A Claude subscription cannot pay for a turn, and this is not an oversight.**
 Anthropic restricts consumer OAuth tokens to Claude Code and Claude.ai, enforced

--- a/docs/ACCOUNT.md
+++ b/docs/ACCOUNT.md
@@ -161,13 +161,23 @@ consent screens are Google's and GitHub's. The pane has a link and no controls,
 which is the truthful shape: a tick box here would be a control that cannot
 work.
 
+## How an agent actually reaches it
+
+As a plugin. `guaca.bot` serves an MCP server at `/mcp`, authenticated by the
+same account token, and Google appears in a group's Plugins list like any other.
+`docs/PLUGINS.md`, *Google is a plugin whose sign-in is the account's*, has the
+argument; the short version is that it makes per-agent reach, the trust boundary
+and the tool plumbing all work without a line of new machinery.
+
+`POST /api/connectors/:provider/token` still exists on the service and the app
+still does not call it. That is deliberate rather than unfinished: it would put
+a live Google credential on a laptop for an hour at a time, and the rule from
+`docs/MACHINES.md` is the one that decides it — **a secret never reaches a
+model.** Keeping the token at the origin that holds the refresh token is the
+stronger position, and the app gets tools instead.
+
 ## What is not built yet
 
-`POST /api/connectors/:provider/token` exists on the service and nothing in the
-app calls it. That is the step where an authorized connector becomes something
-an agent can use, and it is a change to prompts, tool definitions and the trust
-boundary rather than to this module. When it lands, the rule from
-`docs/MACHINES.md` applies unchanged and is the hard part: **a secret never
-reaches a model.** A provider access token fetched here must reach the process
-making the call and nothing else — not a prompt, not a transcript, not an event,
-not the webview.
+Cloud-run agents and managed provider keys, both of which were named as reasons
+an account might exist and neither of which has been argued. Nothing in this
+module assumes them.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -184,12 +184,55 @@ tile says "Connect" and one consent screen fixes it.
 | Client registration | `plugins.client_id`, `client_secret` | No | No |
 | Tool names and schemas | `plugins.tools` | Yes, as tool definitions | Names only |
 | Which plugins are connected | `plugins` | Yes, one line each | Yes |
+| The account token, for Google | `account.json`, read per call | No | No |
 
 This is the boundary `connector_env` draws around a pasted secret, moved one
 layer further out. A credential is at least handed to a sandbox, where the agent
 can echo it; a plugin's grant never leaves the host process except onto the wire
 back to the server that issued it. There is no field on `Plugin` for a token to
 arrive in, and no command that returns one.
+
+## Google is a plugin whose sign-in is the account's
+
+Five of the six plugins are somebody else's server, and a crew signs in to each
+one separately because there is nothing else it could do. Google is not a
+server. It is the operator's own account at `guaca.bot`, which already holds the
+Google grant, already refreshes it, and already knows which capabilities were
+authorized. `PluginKind::account_backed` is the one bit that says so.
+
+Running the ordinary flow for it would be wrong twice. It would send an operator
+to a consent screen to authorise something they authorised when they signed in
+to the account, and it would leave a per-group grant sitting beside a
+per-account one for the same access, each expiring on its own clock, each
+renewable independently, and only one of them the truth.
+
+So the credential is the account's and the *decision to use it* stays the
+group's. Connecting Google in a crew is what puts its tools in front of that
+crew, and `PluginAccess` still decides which of its agents. Nothing else about a
+plugin changes:
+
+- The tool list is read once, on connect, the same way.
+- The call still goes out of Guaca, never off an agent's machine.
+- The token still never reaches a prompt, a transcript, an event or a sandbox.
+- The reach check runs before the server is dialled, so an agent the operator
+  did not choose is refused here rather than there.
+
+The row stores no grant, and that is the point rather than an omission: the
+account rotates its own token, so a copy on the row would be a second thing to
+keep fresh, a second thing to be stale, and a renewal path racing the account's.
+`Runtime::account_token` reads a live one per call.
+
+**What the tools are is decided at `guaca.bot`, not here.** The server offers a
+tool only when every scope it needs came back from Google, so a grant that can
+read mail and not send it offers `gmail_search` and not `gmail_send`. A crew
+that sees a tool it cannot use is a turn spent discovering a 403.
+
+**Why the tools live there rather than here.** Guaca could have asked for a
+Google access token and called Google itself: `/api/connectors/:provider/token`
+exists and does exactly that. It would mean a live Google credential sitting on
+a laptop for an hour at a time, and the app becoming responsible for it. Serving
+tools instead keeps the token beside the refresh token that produced it, and
+means the app needs no new machinery at all — it already speaks MCP.
 
 ## Signing in is one decision, and handing it out is another
 

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -368,6 +368,20 @@ pub fn run() {
                 .or_else(|_| app.path().home_dir())
                 .unwrap_or_else(|_| data_dir.clone());
 
+            // The account, and where its MCP server is. Both are one write at
+            // startup: the runtime is what makes a plugin call, and the Google
+            // plugin's server is the operator's own account rather than a
+            // vendor's, so a build pointed at a development service has to
+            // point that plugin there too or it would sign in to one origin and
+            // call another.
+            runtime.with_account(account.clone());
+            if account.origin() != crate::account::DEFAULT_ORIGIN {
+                runtime.plugins_at(std::collections::HashMap::from([(
+                    crate::domain::plugin::PluginKind::Google,
+                    format!("{}/mcp", account.origin()),
+                )]));
+            }
+
             app.manage(AppState { runtime, config_path, downloads, subscription, account });
             Ok(())
         })

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -473,11 +473,17 @@ pub async fn connect_plugin(
     group_id: GroupId,
     kind: PluginKind,
 ) -> Reply<Plugin> {
+    // Read here rather than inside the flow, so a machine that is not signed in
+    // is told so before a browser opens. An account-backed plugin has no
+    // sign-in of its own: see `PluginKind::account_backed`.
+    let account = if kind.account_backed() { state.account.access().await.ok() } else { None };
+
     let plugin = crate::plugins::connect(
         state.runtime.store(),
         group_id,
         kind,
-        kind.endpoint(),
+        state.runtime.plugin_endpoint(kind),
+        account.as_deref(),
         move |url| {
             // The one line in this feature that knows the app is a Tauri app. The
             // flow itself takes a callback so that `oauth.rs` does not have to.

--- a/src-tauri/src/domain/plugin.rs
+++ b/src-tauri/src/domain/plugin.rs
@@ -61,15 +61,18 @@ pub enum PluginKind {
     Linear,
     Stripe,
     Agentmail,
+    /// The operator's own Guaca account, as a server. See [`PluginKind::account_backed`].
+    Google,
 }
 
 impl PluginKind {
-    pub const ALL: [PluginKind; 5] = [
+    pub const ALL: [PluginKind; 6] = [
         PluginKind::Neon,
         PluginKind::Cloudflare,
         PluginKind::Linear,
         PluginKind::Stripe,
         PluginKind::Agentmail,
+        PluginKind::Google,
     ];
 
     /// The stored form, and the prefix every one of its tools is offered under.
@@ -83,6 +86,7 @@ impl PluginKind {
             PluginKind::Linear => "linear",
             PluginKind::Stripe => "stripe",
             PluginKind::Agentmail => "agentmail",
+            PluginKind::Google => "google",
         }
     }
 
@@ -97,6 +101,7 @@ impl PluginKind {
             PluginKind::Linear => "Linear",
             PluginKind::Stripe => "Stripe",
             PluginKind::Agentmail => "AgentMail",
+            PluginKind::Google => "Google",
         }
     }
 
@@ -125,7 +130,32 @@ impl PluginKind {
             PluginKind::Linear => "https://mcp.linear.app/mcp",
             PluginKind::Stripe => "https://mcp.stripe.com",
             PluginKind::Agentmail => "https://mcp.agentmail.to/mcp",
+            // The operator's own account. `account.rs` may be pointed elsewhere
+            // for development, and `Runtime::plugin_endpoint` is what moves it;
+            // this is the address a bundled build talks to and the one the tile
+            // shows before anything is connected.
+            PluginKind::Google => "https://guaca.bot/mcp",
         }
+    }
+
+    /// Whether this plugin's credential is the machine's Guaca account rather
+    /// than a grant of its own.
+    ///
+    /// The other five are somebody else's servers, and a crew signs in to each
+    /// one separately because there is nothing else it could do. Google is not
+    /// a server: it is the operator's own account at `guaca.bot`, which already
+    /// holds the grant and already refreshes it. Running a second OAuth dance
+    /// for it would send an operator to a consent screen to authorise something
+    /// they authorised when they signed in, and would leave a per-group grant
+    /// beside a per-account one for the same access, expiring on its own clock.
+    ///
+    /// So the sign-in is the account's and the *decision to use it* stays the
+    /// group's. Connecting it in a crew is what puts the tools in front of that
+    /// crew's agents, and `PluginAccess` still decides which of them. Nothing
+    /// else about a plugin changes: the call still goes out of Guaca, the token
+    /// still never reaches a model, and the tool list is still read once.
+    pub const fn account_backed(self) -> bool {
+        matches!(self, PluginKind::Google)
     }
 
     /// One line on the tile, in terms of what the crew gets.
@@ -136,6 +166,9 @@ impl PluginKind {
             PluginKind::Linear => "Issues and projects: find them, file them, move them on.",
             PluginKind::Stripe => "The live account: payments, customers, invoices, refunds.",
             PluginKind::Agentmail => "Inboxes an agent owns: read a thread, send, reply, forward.",
+            PluginKind::Google => {
+                "Your Gmail, Calendar and Drive, through the Guaca account you signed in to."
+            }
         }
     }
 
@@ -149,6 +182,7 @@ impl PluginKind {
             PluginKind::Linear => "https://linear.app/docs/mcp",
             PluginKind::Stripe => "https://docs.stripe.com/mcp",
             PluginKind::Agentmail => "https://www.agentmail.to/docs/integrations/mcp",
+            PluginKind::Google => "https://guaca.bot/app",
         }
     }
 }

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -47,6 +47,12 @@ pub enum PluginError {
     )]
     NotConnected { label: &'static str },
     #[error(
+        "{label} comes from your Guaca account, and this machine is not signed in to one. Ask the \
+         operator to sign in under Settings, Account, and to authorize {label} at guaca.bot; \
+         nothing you can do from here will do it."
+    )]
+    NoAccount { label: &'static str },
+    #[error(
         "{label} is connected for this group, but not for you: the operator chose which agents \
          may use it. Ask a peer who has it to do that part, or ask the operator to add you in \
          the group's Plugins settings. Nothing you can do from here will add you."
@@ -85,8 +91,25 @@ pub async fn connect(
     // and there is no other seam wide enough to put one behind. Production
     // passes `kind.endpoint()` and nothing else ever should.
     endpoint: &str,
+    // The machine's Guaca account token, for a plugin whose credential is that
+    // account rather than a grant of its own. `None` for every other kind, and
+    // for an account-backed one it is the caller saying the operator is signed
+    // in: see [`PluginKind::account_backed`].
+    account: Option<&str>,
     open: impl FnOnce(&str) -> Result<(), String>,
 ) -> Result<Plugin, PluginError> {
+    // An account-backed plugin never runs the browser dance. Its server is the
+    // operator's own account, which is already signed in, and the row stores no
+    // grant: the token rotates on the account's clock, so a copy here would be
+    // a second thing to keep fresh and a second thing to be stale.
+    if kind.account_backed() {
+        let token = account.ok_or(PluginError::NoAccount { label: kind.label() })?;
+        let session = mcp::open(endpoint, Some(token)).await?;
+        let tools = read_tools(&session).await?;
+        let account_label = account_label(&session, kind);
+        return Ok(store.save_plugin(group, kind, &account_label, &tools, None)?);
+    }
+
     let (session, grant) = match mcp::open(endpoint, None).await {
         Ok(session) => (session, None),
         Err(err) if err.is_unauthorized() => {
@@ -101,7 +124,14 @@ pub async fn connect(
         Err(err) => return Err(err.into()),
     };
 
-    let tools: Vec<PluginTool> = mcp::list_tools(&session)
+    let tools = read_tools(&session).await?;
+    let account_label = account_label(&session, kind);
+
+    Ok(store.save_plugin(group, kind, &account_label, &tools, grant.as_ref())?)
+}
+
+async fn read_tools(session: &mcp::Session) -> Result<Vec<PluginTool>, PluginError> {
+    Ok(mcp::list_tools(session)
         .await?
         .into_iter()
         .map(|tool| PluginTool {
@@ -114,15 +144,21 @@ pub async fn connect(
                 .input_schema
                 .unwrap_or_else(|| serde_json::json!({ "type": "object", "properties": {} })),
         })
-        .collect();
+        .collect())
+}
 
-    // Only when it says something other than its own product name. "Neon MCP
-    // Server" as an account label is worse than a blank one: it looks like an
-    // answer to "whose account is this" and is not.
-    let account = session.server_name.clone();
-    let account = if account.eq_ignore_ascii_case(kind.label()) { String::new() } else { account };
-
-    Ok(store.save_plugin(group, kind, &account, &tools, grant.as_ref())?)
+/// Whose account the grant turned out to be for, when the server said.
+///
+/// Only when it says something other than its own product name. "Neon MCP
+/// Server" as an account label is worse than a blank one: it looks like an
+/// answer to "whose account is this" and is not.
+fn account_label(session: &mcp::Session, kind: PluginKind) -> String {
+    let name = session.server_name.clone();
+    if name.eq_ignore_ascii_case(kind.label()) {
+        String::new()
+    } else {
+        name
+    }
 }
 
 /// Runs one of a plugin's tools on behalf of an agent.
@@ -136,16 +172,29 @@ pub async fn connect(
 /// server rejects it anyway: a token can be revoked at the vendor between one
 /// turn and the next, and a clock that is a little wrong makes "close to
 /// expiring" a guess rather than a fact.
+/// Which plugin a call is for, and on whose behalf.
+///
+/// Grouped rather than passed loose because the five travel together and mean
+/// nothing apart: the reach check needs the first three, the transport needs
+/// the last two, and a caller that had four of them would be about to guess the
+/// fifth.
+pub struct Target<'a> {
+    pub group: GroupId,
+    pub agent: AgentId,
+    pub kind: PluginKind,
+    /// See `connect`: production passes `kind.endpoint()`.
+    pub endpoint: &'a str,
+    /// See `connect`: the machine's account token, for an account-backed kind.
+    pub account: Option<&'a str>,
+}
+
 pub async fn call(
     store: &Store,
-    group: GroupId,
-    agent: AgentId,
-    kind: PluginKind,
-    // See `connect`: production passes `kind.endpoint()`.
-    endpoint: &str,
+    target: Target<'_>,
     tool: &str,
     arguments: &serde_json::Value,
 ) -> Result<String, PluginError> {
+    let Target { group, agent, kind, endpoint, account } = target;
     let (id, grant) = match store.plugin_reach(group, agent, kind, tool)? {
         PluginReach::Granted { id, grant } => (id, grant),
         PluginReach::NotConnected => return Err(PluginError::NotConnected { label: kind.label() }),
@@ -154,6 +203,19 @@ pub async fn call(
             return Err(PluginError::ToolDenied { label: kind.label(), tool: tool.to_string() })
         }
     };
+
+    // The reach check above is the same one every plugin gets — the crew, the
+    // agent and the tool — and running it before this branch is what makes both
+    // of those decisions mean something for an account-backed plugin too. What
+    // differs is only the credential: this one is the account's, freshly read,
+    // so there is nothing stored to renew and nothing to retry a 401 with. An
+    // account that has been signed out reads as no token at all, which says so
+    // rather than failing on the wire.
+    if kind.account_backed() {
+        let token = account.ok_or(PluginError::NoAccount { label: kind.label() })?;
+        let session = mcp::open(endpoint, Some(token)).await?;
+        return Ok(mcp::call_tool(&session, tool, arguments).await?);
+    }
 
     let grant = match grant {
         Some(held) if held.stale(now_ms()) => Some(renew(store, id, &held, kind).await?),

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -457,6 +457,14 @@ struct Inner {
     ///
     /// Empty in the app, and written at most once. See `Runtime::plugins_at`.
     plugin_endpoints: std::sync::OnceLock<HashMap<PluginKind, String>>,
+    /// The machine's Guaca account, when it has one.
+    ///
+    /// Absent in every test that does not care and in any install that never
+    /// signed in, which is the state this has to keep working in: nothing here
+    /// reads it except a plugin whose credential is the account, and an absent
+    /// account makes that plugin refuse with a sentence rather than making the
+    /// runtime behave differently. See `PluginKind::account_backed`.
+    account: std::sync::OnceLock<Arc<crate::account::Account>>,
     /// Actor tasks currently running. Registration and the task are separate
     /// things, and a leaked task is invisible without counting it.
     live_actors: Arc<AtomicUsize>,
@@ -514,6 +522,7 @@ impl Runtime {
                 last_signin_scan: Mutex::new(HashMap::new()),
                 viewer_port: AtomicU16::new(0),
                 plugin_endpoints: std::sync::OnceLock::new(),
+                account: std::sync::OnceLock::new(),
                 live_actors: Arc::new(AtomicUsize::new(0)),
                 events,
             }),
@@ -533,6 +542,26 @@ impl Runtime {
     /// lives, and a mistyped one is a crew's sign-in sent somewhere nobody chose.
     pub fn plugins_at(&self, endpoints: HashMap<PluginKind, String>) {
         let _ = self.inner.plugin_endpoints.set(endpoints);
+    }
+
+    /// Hands the runtime the machine's Guaca account, once, at startup.
+    ///
+    /// Written rather than passed to the constructor because it is optional and
+    /// almost nothing reads it: threading it through every call site would make
+    /// every test that builds a runtime say something about an account it does
+    /// not have.
+    pub fn with_account(&self, account: Arc<crate::account::Account>) {
+        let _ = self.inner.account.set(account);
+    }
+
+    /// A token for the machine's account, or nothing.
+    ///
+    /// Nothing means either no account was handed over or the operator is not
+    /// signed in, and those are the same thing to a caller: there is no
+    /// credential, so the plugin that wanted one refuses and says why.
+    pub async fn account_token(&self) -> Option<String> {
+        let account = self.inner.account.get()?;
+        account.access().await.ok()
     }
 
     /// Where one plugin's server is for this runtime.
@@ -2697,12 +2726,19 @@ impl Runtime {
                 // work went to; `run_sql` on its own is not a chip anybody can
                 // read a week later.
                 let name = format!("{}{}{tool}", kind.slug(), tools::PLUGIN_SEPARATOR);
+                // Read per call rather than held: the account refreshes its own
+                // token, and a copy taken when the turn started is one that can
+                // be stale by the time the tool is reached.
+                let account = if kind.account_backed() { self.account_token().await } else { None };
                 let called = plugins::call(
                     self.store(),
-                    card.group_id,
-                    card.id,
-                    kind,
-                    self.plugin_endpoint(kind),
+                    plugins::Target {
+                        group: card.group_id,
+                        agent: card.id,
+                        kind,
+                        endpoint: self.plugin_endpoint(kind),
+                        account: account.as_deref(),
+                    },
                     &tool,
                     &sent,
                 )

--- a/src-tauri/tests/plugins.rs
+++ b/src-tauri/tests/plugins.rs
@@ -56,11 +56,21 @@ struct Rules {
     /// True makes the first token stale on arrival, so a call has to refresh
     /// before it can be made.
     issue_expired: bool,
+    /// A bearer the server accepts without ever having issued it, which is what
+    /// an account-backed plugin presents: the token is the machine's Guaca
+    /// account, minted somewhere this server's sign-in never ran.
+    account_token: Option<String>,
 }
 
 impl Default for Rules {
     fn default() -> Self {
-        Rules { needs_token: true, registers: true, expires_in: Some(3600), issue_expired: false }
+        Rules {
+            needs_token: true,
+            registers: true,
+            expires_in: Some(3600),
+            issue_expired: false,
+            account_token: None,
+        }
     }
 }
 
@@ -92,6 +102,9 @@ impl Server {
     fn accepts(&self, token: &str) -> bool {
         if self.revoked.lock().iter().any(|dead| dead == token) {
             return false;
+        }
+        if self.rules.account_token.as_deref() == Some(token) {
+            return true;
         }
         self.issued.lock().iter().any(|held| held == token)
     }
@@ -423,6 +436,7 @@ async fn a_server_that_asks_for_nothing_connects_without_sending_anybody_to_a_br
         group,
         PluginKind::Neon,
         &format!("{}/mcp", server.base()),
+        None,
         |_| panic!("a public server must not open a browser"),
     )
     .await
@@ -445,6 +459,7 @@ async fn a_protected_server_signs_in_and_the_grant_stays_in_the_store() {
         group,
         PluginKind::Neon,
         &format!("{}/mcp", server.base()),
+        None,
         browser(Outcome::Allowed),
     )
     .await
@@ -475,6 +490,7 @@ async fn a_redirect_that_does_not_match_is_refused() {
         group,
         PluginKind::Neon,
         &format!("{}/mcp", server.base()),
+        None,
         browser(Outcome::WrongState),
     )
     .await
@@ -494,6 +510,7 @@ async fn a_refusal_in_the_browser_is_reported_as_one() {
         group,
         PluginKind::Neon,
         &format!("{}/mcp", server.base()),
+        None,
         browser(Outcome::Refused),
     )
     .await
@@ -519,6 +536,7 @@ async fn a_server_with_no_registration_says_so_rather_than_failing_obscurely() {
         group,
         PluginKind::Neon,
         &format!("{}/mcp", server.base()),
+        None,
         browser(Outcome::Allowed),
     )
     .await
@@ -533,16 +551,19 @@ async fn a_tool_call_carries_the_grant_and_the_answer_comes_back() {
     let endpoint = format!("{}/mcp", server.base());
     let (_dir, store, group, agent) = workspace();
 
-    plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
+    plugins::connect(&store, group, PluginKind::Neon, &endpoint, None, browser(Outcome::Allowed))
         .await
         .unwrap();
 
     let answer = plugins::call(
         &store,
-        group,
-        agent,
-        PluginKind::Neon,
-        &endpoint,
+        plugins::Target {
+            group,
+            agent,
+            kind: PluginKind::Neon,
+            endpoint: &endpoint,
+            account: None,
+        },
         "run_sql",
         &serde_json::json!({ "sql": "select 1" }),
     )
@@ -561,16 +582,287 @@ async fn a_tool_call_carries_the_grant_and_the_answer_comes_back() {
     );
 }
 
+/// A plugin whose credential is the operator's own Guaca account.
+///
+/// Google is the one of these today. It is not a vendor's server the crew signs
+/// in to: it is `guaca.bot`, which already holds the Google grant and already
+/// refreshes it, so the sign-in is the account's and the only decision left is
+/// the group's. Everything else about a plugin has to keep working unchanged,
+/// and that is what these check: the tool list is read the same way, the reach
+/// rule still decides who may call it, and the token still never appears
+/// anywhere an agent could read it.
+mod account_backed {
+    use super::*;
+
+    const ACCOUNT: &str = "account-access-token";
+
+    async fn account_server() -> Server {
+        serve(Rules { account_token: Some(ACCOUNT.to_string()), ..Default::default() }).await
+    }
+
+    #[tokio::test]
+    async fn it_connects_with_the_account_and_never_opens_a_browser() {
+        let server = account_server().await;
+        let (_dir, store, group, _agent) = workspace();
+
+        let plugin = plugins::connect(
+            &store,
+            group,
+            PluginKind::Google,
+            &format!("{}/mcp", server.base()),
+            Some(ACCOUNT),
+            |_| panic!("an account-backed plugin must not send anyone to a browser"),
+        )
+        .await
+        .expect("the account token is the sign-in");
+
+        assert_eq!(plugin.kind, PluginKind::Google);
+        assert!(!plugin.tools.is_empty(), "the tool list is read the same way as any other");
+        // Nothing was registered, because no client was: the account's own
+        // sign-in already happened somewhere this server never saw.
+        assert_eq!(server.registrations.load(Ordering::SeqCst), 0);
+        assert!(
+            server.seen.lock().iter().flatten().any(|token| token == ACCOUNT),
+            "the account token has to reach the server or nothing is authenticated"
+        );
+    }
+
+    #[tokio::test]
+    async fn it_stores_no_grant_of_its_own() {
+        // The account rotates its own token. A copy on this row would be a
+        // second thing to keep fresh and a second thing to be stale, and the
+        // renewal path would race the account's.
+        let server = account_server().await;
+        let (_dir, store, group, agent) = workspace();
+        let endpoint = format!("{}/mcp", server.base());
+
+        plugins::connect(&store, group, PluginKind::Google, &endpoint, Some(ACCOUNT), |_| Ok(()))
+            .await
+            .unwrap();
+
+        match store.plugin_reach(group, agent, PluginKind::Google, "gmail_search").unwrap() {
+            guac_lib::db::store::PluginReach::Granted { grant, .. } => {
+                assert!(grant.is_none(), "an account-backed plugin holds no grant of its own");
+            }
+            other => panic!("expected the plugin to be reachable, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn connecting_without_an_account_says_what_to_do_about_it() {
+        let server = account_server().await;
+        let (_dir, store, group, _agent) = workspace();
+
+        let failed = plugins::connect(
+            &store,
+            group,
+            PluginKind::Google,
+            &format!("{}/mcp", server.base()),
+            None,
+            |_| Ok(()),
+        )
+        .await
+        .expect_err("there is no account to sign in with");
+
+        let said = failed.to_string();
+        assert!(said.contains("Guaca account"), "{said}");
+        assert!(said.contains("Settings"), "{said}");
+        assert!(said.contains("guaca.bot"), "{said}");
+    }
+
+    #[tokio::test]
+    async fn a_call_carries_the_account_token() {
+        let server = account_server().await;
+        let (_dir, store, group, agent) = workspace();
+        let endpoint = format!("{}/mcp", server.base());
+
+        plugins::connect(&store, group, PluginKind::Google, &endpoint, Some(ACCOUNT), |_| Ok(()))
+            .await
+            .unwrap();
+
+        let answer = plugins::call(
+            &store,
+            plugins::Target {
+                group,
+                agent,
+                kind: PluginKind::Google,
+                endpoint: &endpoint,
+                account: Some(ACCOUNT),
+            },
+            "run_sql",
+            &serde_json::json!({ "sql": "select 1" }),
+        )
+        .await
+        .expect("the call goes through on the account's token");
+
+        assert_eq!(answer, "run_sql ran");
+    }
+
+    #[tokio::test]
+    async fn a_call_after_signing_out_says_so_rather_than_failing_on_the_wire() {
+        // Signing the account out mid-session reads as no token at all. The
+        // agent gets the sentence about signing in, not a transport error it
+        // would reword and retry.
+        let server = account_server().await;
+        let (_dir, store, group, agent) = workspace();
+        let endpoint = format!("{}/mcp", server.base());
+
+        plugins::connect(&store, group, PluginKind::Google, &endpoint, Some(ACCOUNT), |_| Ok(()))
+            .await
+            .unwrap();
+
+        let failed = plugins::call(
+            &store,
+            plugins::Target {
+                group,
+                agent,
+                kind: PluginKind::Google,
+                endpoint: &endpoint,
+                account: None,
+            },
+            "run_sql",
+            &serde_json::json!({}),
+        )
+        .await
+        .expect_err("there is no account token any more");
+
+        assert!(failed.to_string().contains("Guaca account"), "{failed}");
+    }
+
+    #[tokio::test]
+    async fn an_agent_the_operator_did_not_choose_still_cannot_call_it() {
+        // The whole reason this is a plugin rather than a second kind of
+        // credential. The reach rule is the same one every other plugin gets,
+        // and the account being the credential must not quietly widen it.
+        let server = account_server().await;
+        let (_dir, store, group, agent) = workspace();
+        let endpoint = format!("{}/mcp", server.base());
+
+        let plugin =
+            plugins::connect(&store, group, PluginKind::Google, &endpoint, Some(ACCOUNT), |_| {
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        // Chosen, and this agent is not among them.
+        store
+            .set_plugin_access(
+                plugin.id,
+                &guac_lib::domain::plugin::PluginAccess::Chosen { agents: Vec::new() },
+            )
+            .unwrap();
+
+        let failed = plugins::call(
+            &store,
+            plugins::Target {
+                group,
+                agent,
+                kind: PluginKind::Google,
+                endpoint: &endpoint,
+                account: Some(ACCOUNT),
+            },
+            "run_sql",
+            &serde_json::json!({}),
+        )
+        .await
+        .expect_err("this agent was not chosen");
+
+        let said = failed.to_string();
+        assert!(said.contains("not for you"), "{said}");
+        assert_eq!(
+            server.called.lock().len(),
+            0,
+            "a refusal must happen before the server is dialled, or the check is decoration"
+        );
+    }
+}
+
+/// The real client against a real `guaca.bot`, which no stub can stand in for.
+///
+/// Everything above drives `plugins::connect` against a scripted server that
+/// this repository also wrote, so the two agree by construction. The failure
+/// worth catching is the one where they stop agreeing with the service: a
+/// header the Worker does not read, a content type Guaca does not sniff, a
+/// session id one side invents. It reaches the network, authorises nothing and
+/// spends nothing.
+///
+/// Needs an account token, because the sign-in behind one is a browser and a
+/// person. `scripts/account.sh` in guaca-bot prints one against a local Worker.
+///
+/// ```sh
+/// GUACA_ACCOUNT_ORIGIN=http://localhost:8787 GUACA_ACCOUNT_TOKEN=... \
+///   cargo test --manifest-path src-tauri/Cargo.toml --test plugins -- --ignored
+/// ```
+#[tokio::test]
+#[ignore = "reaches a running guaca.bot"]
+async fn the_real_account_server_still_speaks_what_this_client_sends() {
+    let Ok(token) = std::env::var("GUACA_ACCOUNT_TOKEN") else {
+        panic!("set GUACA_ACCOUNT_TOKEN to an account access token");
+    };
+    let origin = std::env::var("GUACA_ACCOUNT_ORIGIN")
+        .unwrap_or_else(|_| guac_lib::account::DEFAULT_ORIGIN.to_string());
+    let endpoint = format!("{}/mcp", origin.trim_end_matches('/'));
+
+    let (_dir, store, group, agent) = workspace();
+
+    let plugin =
+        plugins::connect(&store, group, PluginKind::Google, &endpoint, Some(&token), |_| {
+            panic!("an account-backed plugin must not open a browser")
+        })
+        .await
+        .expect("the account token should connect");
+
+    // A grant with nothing authorised offers nothing, which is a real state and
+    // not a failure: it means the operator has not authorised Google yet.
+    let offered: Vec<&str> = plugin.tools.iter().map(|card| card.name.as_str()).collect();
+    println!("connected with {} tool(s): {offered:?}", offered.len());
+
+    if let Some(tool) = offered.first().copied() {
+        // Whatever it answers, it has to answer as MCP rather than as a
+        // transport failure. A refusal from Google is a legitimate result here.
+        let called = plugins::call(
+            &store,
+            plugins::Target {
+                group,
+                agent,
+                kind: PluginKind::Google,
+                endpoint: &endpoint,
+                account: Some(&token),
+            },
+            tool,
+            &serde_json::json!({}),
+        )
+        .await;
+        match called {
+            Ok(answer) => {
+                println!("{tool} answered: {}", answer.chars().take(200).collect::<String>())
+            }
+            // A tool that ran and said no is an MCP answer, not a broken one:
+            // calling it with no arguments is exactly how a tool refuses. What
+            // must not happen is a transport or protocol failure, which is
+            // every other variant.
+            Err(guac_lib::plugins::PluginError::Server(guac_lib::mcp::McpError::Rejected {
+                message,
+            })) => println!("{tool} refused, which is an answer: {message}"),
+            Err(err) => panic!("{tool} did not answer as MCP: {err}"),
+        }
+    }
+}
+
 #[tokio::test]
 async fn a_call_on_an_unconnected_plugin_says_who_can_connect_it() {
     let (_dir, store, group, agent) = workspace();
 
     let failed = plugins::call(
         &store,
-        group,
-        agent,
-        PluginKind::Neon,
-        "http://127.0.0.1:1/mcp",
+        plugins::Target {
+            group,
+            agent,
+            kind: PluginKind::Neon,
+            endpoint: "http://127.0.0.1:1/mcp",
+            account: None,
+        },
         "run_sql",
         &serde_json::json!({}),
     )
@@ -592,7 +884,7 @@ async fn a_stale_grant_is_renewed_before_it_is_spent() {
     let endpoint = format!("{}/mcp", server.base());
     let (_dir, store, group, agent) = workspace();
 
-    plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
+    plugins::connect(&store, group, PluginKind::Neon, &endpoint, None, browser(Outcome::Allowed))
         .await
         .unwrap();
 
@@ -603,10 +895,13 @@ async fn a_stale_grant_is_renewed_before_it_is_spent() {
 
     plugins::call(
         &store,
-        group,
-        agent,
-        PluginKind::Neon,
-        &endpoint,
+        plugins::Target {
+            group,
+            agent,
+            kind: PluginKind::Neon,
+            endpoint: &endpoint,
+            account: None,
+        },
         "run_sql",
         &serde_json::json!({}),
     )
@@ -629,7 +924,7 @@ async fn a_grant_revoked_at_the_vendor_is_renewed_once_and_the_call_retried() {
     let endpoint = format!("{}/mcp", server.base());
     let (_dir, store, group, agent) = workspace();
 
-    plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
+    plugins::connect(&store, group, PluginKind::Neon, &endpoint, None, browser(Outcome::Allowed))
         .await
         .unwrap();
 
@@ -637,10 +932,13 @@ async fn a_grant_revoked_at_the_vendor_is_renewed_once_and_the_call_retried() {
 
     let answer = plugins::call(
         &store,
-        group,
-        agent,
-        PluginKind::Neon,
-        &endpoint,
+        plugins::Target {
+            group,
+            agent,
+            kind: PluginKind::Neon,
+            endpoint: &endpoint,
+            account: None,
+        },
         "run_sql",
         &serde_json::json!({}),
     )
@@ -666,10 +964,16 @@ async fn disconnecting_forgets_the_plugin_and_its_grant() {
     let endpoint = format!("{}/mcp", server.base());
     let (_dir, store, group, agent) = workspace();
 
-    let plugin =
-        plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
-            .await
-            .unwrap();
+    let plugin = plugins::connect(
+        &store,
+        group,
+        PluginKind::Neon,
+        &endpoint,
+        None,
+        browser(Outcome::Allowed),
+    )
+    .await
+    .unwrap();
 
     assert!(store.delete_plugin(plugin.id).unwrap());
     assert!(store.group_plugins(group).unwrap().is_empty());
@@ -688,10 +992,10 @@ async fn connecting_twice_replaces_the_grant_rather_than_refusing() {
     let endpoint = format!("{}/mcp", server.base());
     let (_dir, store, group, agent) = workspace();
 
-    plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
+    plugins::connect(&store, group, PluginKind::Neon, &endpoint, None, browser(Outcome::Allowed))
         .await
         .unwrap();
-    plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
+    plugins::connect(&store, group, PluginKind::Neon, &endpoint, None, browser(Outcome::Allowed))
         .await
         .unwrap();
 
@@ -713,7 +1017,7 @@ async fn what_the_crew_connected_is_what_the_model_is_offered() {
     let endpoint = format!("{}/mcp", server.base());
     let (_dir, store, group, agent) = workspace();
 
-    plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
+    plugins::connect(&store, group, PluginKind::Neon, &endpoint, None, browser(Outcome::Allowed))
         .await
         .unwrap();
 
@@ -780,6 +1084,7 @@ async fn a_crew_with_a_plugin_calls_it_through_a_real_turn() {
         group,
         PluginKind::Neon,
         &endpoint,
+        None,
         browser(Outcome::Allowed),
     )
     .await
@@ -883,6 +1188,7 @@ async fn an_agent_the_plugin_was_narrowed_away_from_is_neither_told_nor_allowed(
         group,
         PluginKind::Neon,
         &endpoint,
+        None,
         browser(Outcome::Allowed),
     )
     .await
@@ -954,6 +1260,7 @@ async fn a_tool_the_operator_switched_off_is_named_in_the_prompt_and_refused_on_
         group,
         PluginKind::Neon,
         &endpoint,
+        None,
         browser(Outcome::Allowed),
     )
     .await
@@ -1014,6 +1321,7 @@ async fn a_narrowed_plugin_shows_up_as_a_peer_who_can_do_it() {
         group,
         PluginKind::Neon,
         &endpoint,
+        None,
         browser(Outcome::Allowed),
     )
     .await
@@ -1059,6 +1367,7 @@ async fn a_plugin_with_everything_switched_off_is_not_a_peer_worth_asking() {
         group,
         PluginKind::Neon,
         &endpoint,
+        None,
         browser(Outcome::Allowed),
     )
     .await
@@ -1086,7 +1395,7 @@ async fn a_plugin_call_from_an_agent_outside_the_crew_is_refused() {
     let endpoint = format!("{}/mcp", server.base());
     let (_dir, store, group, agent) = workspace();
 
-    plugins::connect(&store, group, PluginKind::Neon, &endpoint, browser(Outcome::Allowed))
+    plugins::connect(&store, group, PluginKind::Neon, &endpoint, None, browser(Outcome::Allowed))
         .await
         .unwrap();
 
@@ -1098,10 +1407,13 @@ async fn a_plugin_call_from_an_agent_outside_the_crew_is_refused() {
 
     let failed = plugins::call(
         &store,
-        other,
-        outsider,
-        PluginKind::Neon,
-        &endpoint,
+        plugins::Target {
+            group: other,
+            agent: outsider,
+            kind: PluginKind::Neon,
+            endpoint: &endpoint,
+            account: None,
+        },
         "run_sql",
         &serde_json::json!({}),
     )
@@ -1112,10 +1424,13 @@ async fn a_plugin_call_from_an_agent_outside_the_crew_is_refused() {
     // And the crew that did connect it is unaffected.
     plugins::call(
         &store,
-        group,
-        agent,
-        PluginKind::Neon,
-        &endpoint,
+        plugins::Target {
+            group,
+            agent,
+            kind: PluginKind::Neon,
+            endpoint: &endpoint,
+            account: None,
+        },
         "run_sql",
         &serde_json::json!({}),
     )

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -13,6 +13,10 @@
  * AgentMail is the exception and is drawn here, because it is not in that set.
  * A generic envelope rather than an approximation of their logo: a mark nobody
  * can check against the original is a mark that quietly becomes wrong.
+ *
+ * Google is the one row whose server is not the vendor's: the tools come from
+ * the operator's own Guaca account, which holds the grant. The mark is still
+ * Google's, because what the crew reaches is Google.
  */
 
 import type { PluginKind } from "./types";
@@ -44,6 +48,10 @@ export const BRANDS: Record<PluginKind, Brand> = {
   agentmail: {
     path: "M21.9 4.1H2.1L12 10.9ZM1.2 6.4v11.9a1.6 1.6 0 0 0 1.6 1.6h18.4a1.6 1.6 0 0 0 1.6-1.6V6.4L12 13.5Z",
     color: "#0a0a0a",
+  },
+  google: {
+    path: "M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z",
+    color: "#4285f4",
   },
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -247,7 +247,7 @@ export interface ConnectorDraft {
 export type PluginId = string;
 
 /** The servers Guaca knows how to sign in to. Closed, and the same everywhere. */
-export type PluginKind = "neon" | "cloudflare" | "linear" | "stripe" | "agentmail";
+export type PluginKind = "neon" | "cloudflare" | "linear" | "stripe" | "agentmail" | "google";
 
 /** A plugin on offer, before anybody has connected it. */
 export interface PluginOffer {


### PR DESCRIPTION
Authorizing Google at guaca.bot put a grant on the account and stopped there.
Settings showed Gmail, Calendar and Drive; the group's Plugins list did not, so
no agent knew any of it existed and the per-agent permissions had nothing to
apply to. The account was a report rather than a capability.

`guaca.bot` now serves an MCP server, and Google joins the plugin catalogue as
one more entry. Everything that makes a plugin useful comes for free: the tool
list is read once and kept, the tools are offered to a model with the schemas
the server published, the plugin is named in the prompt, and `PluginAccess`
decides which agents in the crew may call it.

What is new is one bit, `PluginKind::account_backed`. The other five plugins are
somebody else's server and a crew signs in to each separately because there is
nothing else it could do. Google is not a server: it is the operator's own
account, which already holds the grant and already refreshes it. Running the
ordinary flow would send someone to a consent screen to authorise what they
authorised when they signed in, and would leave a per-group grant beside a
per-account one for the same access, each on its own clock and only one of them
the truth. So the credential is the account's and the decision to use it stays
the group's.

The row stores no grant, deliberately. The account rotates its own token, so a
copy here would be a second thing to keep fresh, a second thing to be stale, and
a renewal path racing the account's. `Runtime::account_token` reads a live one
per call and an absent account reads as no token, which refuses with a sentence
naming what the operator has to do rather than failing on the wire.

`plugins::call` grew past the argument limit and its five positional arguments
became `Target`, which is a readability improvement independent of this change:
the reach check needs three of them and the transport needs two, and a caller
holding four was about to guess the fifth.

The invariant in AGENTS.md is corrected rather than quietly broken. An account
is still optional and an install that never signs in still never contacts the
service, but it is no longer true that nothing depends on it: one plugin does,
in one function, and that is now written down as the boundary to keep.