### PR TITLE
feat: the model field suggests three, and is still a text box

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ src/                  React + TypeScript. A view over the runtime, nothing more.
   lib/trail.ts        A turn's own tool calls: what folds into one chip.
   lib/diff.ts         Two versions of a page, as the lines between them.
   lib/cafeteria.ts    Preset agents, waiting to be hired. Content, not runtime.
+  lib/roles.ts        What an agent is for, in OpenRouter's twelve words.
   lib/plugins.ts      A plugin's mark and colour. Everything else is Rust's.
   lib/ipc.ts          Every call into Rust.
   lib/prefs.ts        What the operator sets and the runtime never reads.
@@ -41,6 +42,7 @@ src-tauri/src/
     events.rs         Events pushed to the UI.
   llm/                OpenAI-compatible client, SSE decoding, tool definitions.
     codex.rs          The other protocol: where a ChatGPT subscription is spent.
+    catalogue.rs      Which models OpenRouter sees doing which kind of work.
   subscription.rs     Signing in to that subscription. A credential, not a wire.
   account.rs          The optional Guaca account. Nothing else depends on it.
   mcp.rs              The client end of MCP. Three methods, one POST each.
@@ -105,6 +107,7 @@ repo: the frontend renders state and forwards intent.
 | Preset agents, hiring a crew | *The cafeteria is a copy machine* in `docs/WORKSPACE.md`, then `src/lib/cafeteria.ts` |
 | Settings, the surface, the scale, what may interrupt the operator | *Settings is nine places*, *The reading column has two surfaces* and *An interruption has to earn it* in `docs/WORKSPACE.md` |
 | The group editor: what a crew overrides and what it inherits | *A group's settings are the app's, with the crew's answer on top* in `docs/WORKSPACE.md`, then `src/components/GroupEditor.tsx` |
+| What model an agent is offered, and how its job is guessed at | *The model field suggests three, and is still a text box* in `docs/WORKSPACE.md`, then `src/lib/roles.ts` and `llm/catalogue.rs`, whose twelve use cases have to agree |
 | A prompt, or anything that changes how much a crew talks | *Three test suites, asking different questions*, then run the live evals |
 
 Unqualified section names are headings in `docs/ARCHITECTURE.md`.
@@ -371,6 +374,28 @@ the model takes a screenshot to see what `browse` did.
   `&` as a mnemonic marker and eats it, so an agent called `R&D` draws as `RD`.
   `menubar::escape_mnemonic` is applied on the way into an item and nowhere
   earlier, so the rows a test reads are the words a person would.
+- **A model suggestion is ranked by capability inside a use case, never by
+  OpenRouter's default order.** That order is tokens routed, which is bulk
+  traffic: the same cheap high-throughput model tops eleven of the twelve use
+  cases, so three suggestions built on it are the same three under every agent
+  with a different sentence above them each time. The category picks the pool
+  and `sort=intelligence-high-to-low` picks the order inside it. The price on
+  each row is not decoration either: capability ordering ignores price, so
+  without it the button is a one-click way to make every turn forty times
+  dearer.
+- **An unknown category is refused in `catalogue.rs`, not by OpenRouter.**
+  OpenRouter answers one with 200 and an empty list, so a slug it has renamed is
+  indistinguishable from a use case nobody sends work to, and the dialog would
+  draw nothing for exactly the agents it was built for. `ipc.contract.test.ts`
+  compares the twelve in `CATEGORIES` against the twelve in `ROLES`, and the
+  `#[ignore]`d test in `catalogue.rs` asks the live service whether it still
+  ranks all of them, which is the failure no offline suite can see.
+- **`roleFor` returning nothing is the common answer, and a tie returns
+  nothing too.** Most agents are a Manager or an Inbox and OpenRouter has no
+  category for either. A scorer that always names its best guess puts a legal
+  model under a scheduling agent, and one bad suggestion is what teaches an
+  operator to ignore the good ones. Sales is the single deliberate bend: nothing
+  ranks it, so its vocabulary scores into marketing.
 - **Closing the window hides it, and only while the tray exists.** Tauri exits
   when the last window closes, which for this app means a routine set for every
   morning stops firing the first time somebody tidies their screen. A hidden
@@ -476,4 +501,16 @@ build expects, which is the failure no offline test can see. It reaches the inte
 
 ```sh
 ./scripts/plugins.sh
+```
+
+The model suggestions beside an agent's model field have the same shape again,
+without a script because it is one test. It asks the live OpenRouter whether it
+still ranks models for all twelve of the use cases this build believes in, which
+is the one failure the offline suite cannot see: a category renamed there answers
+200 with an empty list. It reaches the internet, authorises nothing and spends
+nothing.
+
+```sh
+cargo test --manifest-path src-tauri/Cargo.toml --lib \
+  llm::catalogue::tests::every_use_case -- --ignored --nocapture
 ```

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -474,6 +474,50 @@ preset prompt states a stopping condition. A prompt without one makes a crew
 that talks to itself, no automated suite can see it, and the evals are what
 catch it. Run `./scripts/evals.sh` after touching a preset.
 
+## The model field suggests three, and is still a text box
+
+An agent's model is any slug its endpoint accepts, and the endpoint is the
+operator's to choose. That is right, and it also means somebody who has just
+decided they want an agent that reads contracts is looking at a blank box with
+no way to find out what to put in it. Under the box are three models, and
+pressing one fills the box in. It is the same edit as typing: nothing is saved
+by it, and nothing about the field changed.
+
+Deriving what the agent is for is a keyword scan over the name, the skills and
+the instructions, in `src/lib/roles.ts`. Not a model call: it runs on every
+keystroke in three fields, it would cost money and a round trip to answer a
+question a keyword answers, and it would answer it differently on two openings
+of the same dialog. It is also the one place a wrong answer is invisible, since
+an operator cannot tell a considered "marketing" from a guessed one. Keywords
+are free, the same twice, and wrong in ways a person can see and ignore.
+
+Saying nothing is the common answer and not a failure. OpenRouter classifies
+traffic into twelve use cases and most agents are none of them: a Manager, a
+Router, an Inbox. There is a floor under the evidence and a tie is not a winner,
+because an agent described as equally legal and financial has no single best
+model, and a confident wrong suggestion is what teaches an operator to ignore
+the right ones. Sales is the one word bent to fit: OpenRouter ranks nothing for
+it, and an agent called Sales is the second thing anybody builds here, so sales
+vocabulary scores into marketing rather than into silence.
+
+Nothing is offered unless OpenRouter is what pays for that agent's turns,
+resolved crew over app the way the backend resolves it. A slug only means
+something at the endpoint it was ranked at, and `anthropic/claude-opus-5` put
+into a field pointed at `api.openai.com` is a refusal by name on the next turn,
+an hour after the button was pressed and with nothing connecting the two.
+
+The order is not the one OpenRouter returns by default, and that is the whole
+design. Its default is how many tokens it routed to each model for that kind of
+work, which is bulk traffic: the same cheap high-throughput model tops eleven of
+the twelve, so a picker built on it suggests one model for every agent while
+claiming a different reason each time. So the use case chooses the pool, the
+models people actually send that work to, and capability orders the pool. Every
+row carries its price, because capability ordering ignores price and the most
+capable model in a pool is regularly the dearest thing in it: a one-click swap
+that hid the number would be a one-click way to make every turn forty times
+dearer. `llm/catalogue.rs` has the rest, including why the twelve are checked
+before a request is spent rather than after.
+
 ## A duplicate copies the card and nothing an agent went and did
 
 Look, model, skills and instructions; not the sandbox, the memory, the schedule,

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -15,6 +15,7 @@ use crate::commands::{self, AppState};
 use crate::config;
 use crate::db::Store;
 use crate::files::FileStore;
+use crate::llm::catalogue::Catalogue;
 use crate::llm::openrouter::LlmClient;
 use crate::proxy;
 use crate::runtime::events::{EventSink, UiEvent, CHANNEL};
@@ -368,7 +369,14 @@ pub fn run() {
                 .or_else(|_| app.path().home_dir())
                 .unwrap_or_else(|_| data_dir.clone());
 
-            app.manage(AppState { runtime, config_path, downloads, subscription, account });
+            app.manage(AppState {
+                runtime,
+                config_path,
+                downloads,
+                subscription,
+                account,
+                catalogue: Arc::new(Catalogue::new()),
+            });
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -439,6 +447,7 @@ pub fn run() {
             commands::get_settings,
             commands::update_settings,
             commands::test_connection,
+            commands::ranked_models,
             commands::account_status,
             commands::sign_in_account,
             commands::account_connectors,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -31,6 +31,7 @@ use crate::domain::signin::Signin;
 use crate::domain::usage::{GroupUsage, RunUsage};
 use crate::e2b::{Computer, E2bClient, E2bError};
 use crate::kernel::{Browser, KernelClient, KernelError};
+use crate::llm::catalogue::{Catalogue, CatalogueError, RankedModel};
 use crate::runtime::events::{Activity, UiEvent};
 use crate::runtime::guard::GuardLimits;
 use crate::runtime::Runtime;
@@ -49,6 +50,10 @@ pub struct AppState {
     /// The Guaca account, which is optional and which nothing else in the app
     /// depends on. An install that never signs in never reaches the service.
     pub account: Arc<Account>,
+    /// OpenRouter's ranked model list, read while an agent's dialog is open and
+    /// at no other time. Like the account, no turn, prompt, tool or guard reads
+    /// it, and an install that never opens that dialog never asks for it.
+    pub catalogue: Arc<Catalogue>,
 }
 
 /// A structured error the UI can render as more than a toast.
@@ -187,6 +192,21 @@ impl From<SigninError> for CommandError {
             // in time. Nothing is wrong and nothing needs fixing.
             SigninError::TimedOut => CommandError::new("signinExpired", err.to_string()),
             other => CommandError::new("signin", other.to_string()),
+        }
+    }
+}
+
+impl From<CatalogueError> for CommandError {
+    fn from(err: CatalogueError) -> Self {
+        match err {
+            // Its own kind because it is this app's defect, not OpenRouter's:
+            // the webview asked for a use case the vendor does not rank, so the
+            // two lists have drifted. Nothing an operator can do about it, and
+            // nothing an operator should be shown a network failure for.
+            CatalogueError::Unsupported { .. } | CatalogueError::Withdrawn(_) => {
+                CommandError::new("useCase", err.to_string())
+            }
+            other => CommandError::new("catalogue", other.to_string()),
         }
     }
 }
@@ -1600,6 +1620,23 @@ pub async fn test_connection(
         .probe(&config)
         .await
         .map_err(|err| CommandError::new("inference", err.to_string()))
+}
+
+/// The models OpenRouter sees doing one kind of work, most capable first.
+///
+/// The one command that reads a catalogue rather than this install's own state,
+/// and it is still not the frontend performing network access: the host is a
+/// constant here and the use case is checked against a published set before a
+/// request is spent, so the webview names a use case rather than a URL.
+///
+/// Offered beside an agent's model field, so it is asked for while a dialog is
+/// open and at no other time. Nothing is blocked on it and no turn reads it.
+#[tauri::command]
+pub async fn ranked_models(
+    state: State<'_, AppState>,
+    category: String,
+) -> Reply<Vec<RankedModel>> {
+    Ok(state.catalogue.ranked(&category).await?)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/llm/catalogue.rs
+++ b/src-tauri/src/llm/catalogue.rs
@@ -1,0 +1,540 @@
+//! What OpenRouter is asked to do, and which models it hands that work to.
+//!
+//! Beside `openrouter.rs` because it is the same vendor, and separate from it
+//! because it is not the same conversation: that file is how a turn is spent,
+//! this one is read once while a dialog is open and never during a turn. No
+//! agent, prompt, tool or guard reads anything here.
+//!
+//! ## Why the ranking is not the one the endpoint returns by default
+//!
+//! `?category=` orders by how many tokens OpenRouter routed to each model for
+//! that kind of work, which sounds like the answer and is not. Bulk traffic
+//! dominates it: the same cheap high-throughput model tops eleven of the twelve
+//! use cases, so a picker built on that order suggests one model for every
+//! agent and says something different each time about why. The category is
+//! still what makes the list relevant — it is the set of models people actually
+//! send this kind of work to — so it decides the pool, and `sort=` decides the
+//! order inside it. Capability, from the index OpenRouter publishes on the same
+//! response, is what makes twelve pools read as twelve answers.
+//!
+//! ## Why the use cases are checked here
+//!
+//! OpenRouter answers an unrecognised category with 200 and an empty list, so a
+//! slug that has been renamed on their side is indistinguishable from a use case
+//! nobody sends work to. Checking against the published set before spending a
+//! request turns the first case into a sentence naming what was asked for, and
+//! leaves the empty answer meaning only one thing.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+
+/// The catalogue is OpenRouter's, so this is not the operator's endpoint.
+///
+/// Suggestions are only offered when OpenRouter is what the agent's turns are
+/// paid through, and the ranking is still OpenRouter's own even then. Pointing
+/// this at a configured base URL would ask a local LM Studio to rank the world.
+const DEFAULT_BASE: &str = "https://openrouter.ai/api/v1";
+
+/// The use cases OpenRouter classifies traffic into, as it spells them.
+///
+/// Written out rather than discovered, because there is no endpoint that lists
+/// them: they are an enum in the vendor's OpenAPI document. `src/lib/roles.ts`
+/// holds the same twelve and `ipc.contract.test.ts` compares the two files, so a
+/// use case added on one side fails the build rather than a click.
+pub const CATEGORIES: [&str; 12] = [
+    "programming",
+    "roleplay",
+    "marketing",
+    "marketing/seo",
+    "technology",
+    "science",
+    "translation",
+    "legal",
+    "finance",
+    "health",
+    "trivia",
+    "academia",
+];
+
+/// Long enough that opening the same dialog twice costs one request, short
+/// enough that "today" is true. The ranking moves when a vendor ships, which is
+/// weeks, not minutes.
+const TTL: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// How many of the twenty are worth carrying across IPC.
+///
+/// The dialog offers three and drops the model already in the box, so four is
+/// the most it can draw. The other sixteen are a payload nothing renders.
+const KEEP: usize = 4;
+
+/// Long enough for a cold edge, short enough that a dialog does not sit there.
+/// Nothing is blocked on this: the field works while it is in flight.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Debug, thiserror::Error)]
+pub enum CatalogueError {
+    /// Caught here rather than at OpenRouter, which answers this with an empty
+    /// list. See the module comment.
+    #[error("OpenRouter does not rank models for {asked}; ask for one of: {}", CATEGORIES.join(", "))]
+    Unsupported { asked: String },
+    #[error("could not reach OpenRouter for {category}: {detail}")]
+    Transport { category: String, detail: String },
+    #[error("OpenRouter returned HTTP {status} ranking models for {category}")]
+    Status { category: String, status: u16 },
+    #[error("OpenRouter sent something that is not a model list for {category}: {detail}")]
+    Malformed { category: String, detail: String },
+    /// A use case this build believes in, that the vendor now ranks nothing for.
+    /// Distinct from the refusal above because there is nothing the caller can
+    /// spell differently: the set above has gone stale and wants updating.
+    #[error("OpenRouter ranks no models for {0} any more; the use case has been withdrawn")]
+    Withdrawn(String),
+}
+
+/// One model, as much of it as a suggestion has to say.
+///
+/// Price is on it because the ranking is by capability alone, and the most
+/// capable model for a use case is regularly the most expensive one in the pool.
+/// A row that names a model and hides what it costs is a one-click way to make
+/// every turn of an agent forty times dearer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RankedModel {
+    /// The slug a turn is made with, which is what the model field holds.
+    pub id: String,
+    /// How the vendor writes it for a person, e.g. "Anthropic: Claude Opus 5".
+    pub name: String,
+    pub context_length: u32,
+    /// Dollars per million prompt tokens. Converted here rather than in the
+    /// webview so the number that crosses IPC is the number that is drawn, and
+    /// `None` when the vendor quoted no price rather than a misleading zero.
+    pub prompt_per_million: Option<f64>,
+    /// Dollars per million completion tokens.
+    pub completion_per_million: Option<f64>,
+}
+
+/// OpenRouter's ranked catalogue, with what has already been asked for.
+///
+/// Cheap to clone behind the `Arc` its owner holds. The mutex is held to read or
+/// replace a cache entry and never across a request, so two dialogs opening at
+/// once make two requests rather than one blocking the other.
+#[derive(Debug)]
+pub struct Catalogue {
+    base: String,
+    http: reqwest::Client,
+    cached: Mutex<HashMap<String, Cached>>,
+}
+
+#[derive(Debug, Clone)]
+struct Cached {
+    at: Instant,
+    models: Vec<RankedModel>,
+}
+
+impl Catalogue {
+    /// Against OpenRouter, which is the only place this data exists.
+    pub fn new() -> Self {
+        Self::against(DEFAULT_BASE)
+    }
+
+    /// The same, against a named base. The seam for the test suite; deliberately
+    /// not reachable from settings, for the reason on `DEFAULT_BASE`.
+    pub fn against(base: impl Into<String>) -> Self {
+        Self {
+            base: base.into().trim_end_matches('/').to_string(),
+            http: reqwest::Client::builder().timeout(HTTP_TIMEOUT).build().unwrap_or_default(),
+            cached: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// The models OpenRouter sees doing this kind of work, most capable first.
+    pub async fn ranked(&self, category: &str) -> Result<Vec<RankedModel>, CatalogueError> {
+        let category = category.trim().to_ascii_lowercase();
+        if !CATEGORIES.contains(&category.as_str()) {
+            return Err(CatalogueError::Unsupported { asked: category });
+        }
+        if let Some(fresh) = self.fresh(&category) {
+            return Ok(fresh);
+        }
+
+        let response = self
+            .http
+            .get(format!("{}/models", self.base))
+            // `query` rather than a formatted URL: one of the twelve has a
+            // slash in it, and `marketing/seo` spliced into a path is a request
+            // for a page that does not exist.
+            .query(&[("category", category.as_str()), ("sort", "intelligence-high-to-low")])
+            .send()
+            .await
+            .map_err(|err| CatalogueError::Transport {
+                category: category.clone(),
+                detail: err.to_string(),
+            })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(CatalogueError::Status { category, status: status.as_u16() });
+        }
+
+        let body: Listing = response.json().await.map_err(|err| CatalogueError::Malformed {
+            category: category.clone(),
+            detail: err.to_string(),
+        })?;
+
+        let models: Vec<RankedModel> =
+            body.data.into_iter().filter_map(RankedModel::from_wire).take(KEEP).collect();
+        if models.is_empty() {
+            return Err(CatalogueError::Withdrawn(category));
+        }
+
+        self.cached.lock().insert(category, Cached { at: Instant::now(), models: models.clone() });
+        Ok(models)
+    }
+
+    fn fresh(&self, category: &str) -> Option<Vec<RankedModel>> {
+        let held = self.cached.lock();
+        let entry = held.get(category)?;
+        (entry.at.elapsed() < TTL).then(|| entry.models.clone())
+    }
+}
+
+impl Default for Catalogue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---- the wire ------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct Listing {
+    data: Vec<WireModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireModel {
+    id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    context_length: u32,
+    #[serde(default)]
+    pricing: Option<WirePricing>,
+}
+
+/// Only the two prices a turn is actually billed on. The vendor sends a dozen
+/// more — image, audio, web search, four kinds of cache — and a suggestion row
+/// that quoted any of them would be quoting a price this app does not pay.
+#[derive(Debug, Deserialize)]
+struct WirePricing {
+    prompt: Option<String>,
+    completion: Option<String>,
+}
+
+impl RankedModel {
+    /// `None` for a row with no id, which is nothing this can offer.
+    fn from_wire(wire: WireModel) -> Option<Self> {
+        if wire.id.trim().is_empty() {
+            return None;
+        }
+        let (prompt, completion) = match wire.pricing {
+            Some(pricing) => (per_million(pricing.prompt), per_million(pricing.completion)),
+            None => (None, None),
+        };
+        Some(Self {
+            name: if wire.name.trim().is_empty() { wire.id.clone() } else { wire.name },
+            id: wire.id,
+            context_length: wire.context_length,
+            prompt_per_million: prompt,
+            completion_per_million: completion,
+        })
+    }
+}
+
+/// Dollars per token, as the vendor quotes it, into dollars per million.
+///
+/// A string on the wire because the numbers run to eleven decimal places and
+/// the vendor would rather not argue with a JSON parser about them. Anything
+/// unparseable is no price rather than zero: a free model quotes "0", and the
+/// two must not read the same.
+fn per_million(quoted: Option<String>) -> Option<f64> {
+    let parsed: f64 = quoted?.trim().parse().ok()?;
+    parsed.is_finite().then_some(parsed * 1_000_000.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use axum::extract::Query;
+    use axum::response::IntoResponse;
+    use axum::routing::get;
+    use axum::Router;
+
+    /// Spins a stub catalogue and returns its base URL, the queries it saw, and
+    /// how many requests it answered.
+    async fn stub(
+        answer: impl Fn() -> axum::response::Response + Clone + Send + Sync + 'static,
+    ) -> (String, Arc<Mutex<Vec<HashMap<String, String>>>>, Arc<AtomicUsize>) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let count = Arc::new(AtomicUsize::new(0));
+        let recorder = seen.clone();
+        let counter = count.clone();
+
+        let app = Router::new().route(
+            "/v1/models",
+            get(move |Query(query): Query<HashMap<String, String>>| {
+                let answer = answer.clone();
+                let recorder = recorder.clone();
+                let counter = counter.clone();
+                async move {
+                    recorder.lock().push(query);
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    answer()
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        (format!("http://{addr}/v1"), seen, count)
+    }
+
+    fn listing(models: serde_json::Value) -> axum::response::Response {
+        axum::Json(serde_json::json!({ "data": models })).into_response()
+    }
+
+    fn two() -> serde_json::Value {
+        serde_json::json!([
+            {
+                "id": "openai/gpt-5.6-sol",
+                "name": "OpenAI: GPT-5.6 Sol",
+                "context_length": 400000,
+                "pricing": { "prompt": "0.000002", "completion": "0.000012" },
+            },
+            {
+                "id": "z-ai/glm-5.2",
+                "name": "Z.AI: GLM 5.2",
+                "context_length": 200000,
+                "pricing": { "prompt": "0", "completion": "0" },
+            },
+        ])
+    }
+
+    /// The refusal that costs nothing. OpenRouter answers a use case it does not
+    /// know with 200 and an empty list, so asking it would report the typo as an
+    /// absence of models and the operator would go looking for the wrong thing.
+    #[tokio::test]
+    async fn a_use_case_openrouter_does_not_rank_is_refused_without_asking() {
+        let (base, _seen, count) = stub(|| listing(two())).await;
+
+        let refused = Catalogue::against(base).ranked("sales").await.unwrap_err();
+
+        assert!(matches!(refused, CatalogueError::Unsupported { ref asked } if asked == "sales"));
+        // The whole point: no request was spent finding that out.
+        assert_eq!(count.load(Ordering::SeqCst), 0);
+        // And the refusal says what may be asked for instead.
+        assert!(refused.to_string().contains("marketing"));
+    }
+
+    #[tokio::test]
+    async fn a_use_case_is_asked_for_by_capability_inside_its_own_pool() {
+        let (base, seen, _count) = stub(|| listing(two())).await;
+
+        Catalogue::against(base).ranked("legal").await.unwrap();
+
+        let query = seen.lock()[0].clone();
+        assert_eq!(query["category"], "legal");
+        // Popularity would hand back the same three models for all twelve; see
+        // the module comment.
+        assert_eq!(query["sort"], "intelligence-high-to-low");
+    }
+
+    /// The one use case with a slash in it. Spliced into a path it asks for a
+    /// page rather than a list, and the answer is a 404 the operator reads as
+    /// OpenRouter being down.
+    #[tokio::test]
+    async fn the_use_case_with_a_slash_in_it_survives_the_query_string() {
+        let (base, seen, _count) = stub(|| listing(two())).await;
+
+        Catalogue::against(base).ranked("marketing/seo").await.unwrap();
+
+        assert_eq!(seen.lock()[0]["category"], "marketing/seo");
+    }
+
+    #[tokio::test]
+    async fn a_price_crosses_as_dollars_per_million_and_a_free_model_as_zero() {
+        let (base, _seen, _count) = stub(|| listing(two())).await;
+
+        let ranked = Catalogue::against(base).ranked("legal").await.unwrap();
+
+        assert_eq!(ranked[0].id, "openai/gpt-5.6-sol");
+        assert_eq!(ranked[0].name, "OpenAI: GPT-5.6 Sol");
+        assert_eq!(ranked[0].prompt_per_million, Some(2.0));
+        assert_eq!(ranked[0].completion_per_million, Some(12.0));
+        // A free model quotes a real zero, which is not the same as no quote.
+        assert_eq!(ranked[1].prompt_per_million, Some(0.0));
+    }
+
+    /// A model quoted no price is offered with no price beside it. Rendering the
+    /// absence as $0.00 advertises a free model that is not one.
+    #[tokio::test]
+    async fn a_model_with_no_quoted_price_carries_no_price() {
+        let unpriced = serde_json::json!([
+            { "id": "local/whatever", "name": "Local", "context_length": 8192 },
+            { "id": "odd/one", "name": "Odd", "pricing": { "prompt": "free", "completion": null } },
+        ]);
+        let (base, _seen, _count) = stub(move || listing(unpriced.clone())).await;
+
+        let ranked = Catalogue::against(base).ranked("legal").await.unwrap();
+
+        assert_eq!(ranked[0].prompt_per_million, None);
+        assert_eq!(ranked[1].prompt_per_million, None);
+        assert_eq!(ranked[1].completion_per_million, None);
+    }
+
+    /// A row with no slug is a row nothing can be swapped to, and a name with no
+    /// slug behind it is worse than no row: it is a button that cannot work.
+    #[tokio::test]
+    async fn a_row_with_no_slug_is_dropped_and_a_row_with_no_name_keeps_its_slug() {
+        let ragged = serde_json::json!([
+            { "id": "  ", "name": "Nameless" },
+            { "id": "vendor/model" },
+        ]);
+        let (base, _seen, _count) = stub(move || listing(ragged.clone())).await;
+
+        let ranked = Catalogue::against(base).ranked("legal").await.unwrap();
+
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].id, "vendor/model");
+        assert_eq!(ranked[0].name, "vendor/model");
+    }
+
+    /// Four is what the dialog can draw. The rest is a payload nothing renders,
+    /// paid for on every keystroke that changes which use case an agent reads as.
+    #[tokio::test]
+    async fn only_what_the_dialog_can_draw_crosses_ipc() {
+        let twenty = serde_json::json!((0..20)
+            .map(|n| serde_json::json!({ "id": format!("v/m{n}"), "name": format!("M{n}") }))
+            .collect::<Vec<_>>());
+        let (base, _seen, _count) = stub(move || listing(twenty.clone())).await;
+
+        let ranked = Catalogue::against(base).ranked("legal").await.unwrap();
+
+        assert_eq!(ranked.len(), KEEP);
+        assert_eq!(ranked[0].id, "v/m0");
+    }
+
+    /// A network round trip in front of a text field, on a list that changes
+    /// when a vendor ships rather than when an operator types.
+    #[tokio::test]
+    async fn the_same_use_case_is_asked_for_once() {
+        let (base, _seen, count) = stub(|| listing(two())).await;
+        let catalogue = Catalogue::against(base);
+
+        let first = catalogue.ranked("legal").await.unwrap();
+        let again = catalogue.ranked("  LEGAL  ").await.unwrap();
+
+        assert_eq!(first, again);
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+        // Two use cases are two lists, so the second one is still a request.
+        catalogue.ranked("finance").await.unwrap();
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+    }
+
+    /// A use case this build believes in and the vendor no longer ranks. Its own
+    /// error because nothing the caller spells differently would fix it: the set
+    /// in `CATEGORIES` has gone stale.
+    #[tokio::test]
+    async fn a_use_case_that_has_been_withdrawn_says_so() {
+        let (base, _seen, count) = stub(|| listing(serde_json::json!([]))).await;
+        let catalogue = Catalogue::against(base);
+
+        let refused = catalogue.ranked("legal").await.unwrap_err();
+
+        assert!(matches!(refused, CatalogueError::Withdrawn(ref what) if what == "legal"));
+        // Nothing empty is cached, so a vendor putting the use case back is one
+        // dialog away rather than a restart.
+        assert!(catalogue.fresh("legal").is_none());
+        catalogue.ranked("legal").await.unwrap_err();
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn a_refusal_from_openrouter_names_the_status_and_is_not_cached() {
+        let (base, _seen, count) =
+            stub(|| (axum::http::StatusCode::TOO_MANY_REQUESTS, "slow down").into_response()).await;
+        let catalogue = Catalogue::against(base);
+
+        let refused = catalogue.ranked("legal").await.unwrap_err();
+
+        assert!(matches!(refused, CatalogueError::Status { status: 429, .. }));
+        assert!(refused.to_string().contains("legal"));
+        catalogue.ranked("legal").await.unwrap_err();
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn an_answer_that_is_not_a_model_list_says_which_use_case_it_was_for() {
+        let (base, _seen, _count) =
+            stub(|| axum::Json(serde_json::json!({ "models": [] })).into_response()).await;
+
+        let refused = Catalogue::against(base).ranked("science").await.unwrap_err();
+
+        assert!(matches!(refused, CatalogueError::Malformed { .. }));
+        assert!(refused.to_string().contains("science"));
+    }
+
+    /// The failure no stub can see.
+    ///
+    /// Every test above is this build agreeing with itself about a protocol, and
+    /// the twelve use cases are the half of that agreement OpenRouter can change
+    /// without telling anyone: a category renamed there answers 200 with an empty
+    /// list, so the dialog would draw nothing for exactly the agents it was built
+    /// for, silently, and no offline suite would notice. Same shape as the live
+    /// halves of `tests/plugins.rs` and `tests/account.rs`.
+    ///
+    /// Reaches the internet, authorises nothing and spends nothing.
+    ///
+    ///   cargo test --manifest-path src-tauri/Cargo.toml \
+    ///     llm::catalogue::tests::every_use_case -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "reaches OpenRouter"]
+    async fn every_use_case_this_build_believes_in_is_one_openrouter_still_ranks() {
+        let catalogue = Catalogue::new();
+        let mut missing = Vec::new();
+
+        for use_case in CATEGORIES {
+            match catalogue.ranked(use_case).await {
+                Ok(models) => {
+                    println!("{use_case:<14} {}", models[0].id);
+                    // Capability ordering is the whole reason this is not the
+                    // endpoint's default order, and a `sort` value the vendor
+                    // stops accepting is a 400 rather than a quiet reordering.
+                    assert!(!models[0].id.is_empty(), "{use_case} ranked a model with no slug");
+                }
+                Err(err) => missing.push(format!("{use_case}: {err}")),
+            }
+        }
+
+        assert!(missing.is_empty(), "OpenRouter no longer ranks: {}", missing.join("; "));
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_catalogue_names_openrouter_rather_than_a_port() {
+        // Nothing is listening here, and nothing ever will be.
+        let refused =
+            Catalogue::against("http://127.0.0.1:1/v1").ranked("legal").await.unwrap_err();
+
+        assert!(matches!(refused, CatalogueError::Transport { .. }));
+        assert!(refused.to_string().contains("OpenRouter"));
+    }
+}

--- a/src-tauri/src/llm/mod.rs
+++ b/src-tauri/src/llm/mod.rs
@@ -1,3 +1,4 @@
+pub mod catalogue;
 pub mod codex;
 pub mod openrouter;
 pub mod sse;

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import type { AgentCard, Routine, Settings } from "./lib/types";
+import { aGroup } from "./test-fixtures";
 
 /**
  * Smoke test for the shell.
@@ -47,28 +47,10 @@ const getSettings = vi.fn<() => Promise<Settings>>(async () => ({
 vi.mock("./lib/ipc", () => ({
   api: {
     listAgents: () => listAgents(),
-    listGroups: async () => [
-      {
-        id: "00000000-0000-4000-8000-000000000001",
-        name: "Everyone",
-        agentCount: 3,
-        createdAt: 0,
-        baseUrl: null,
-        defaultModel: null,
-        provider: "compatible",
-        subscriptionModel: "gpt-5.6-luna",
-        subscriptionModels: ["gpt-5.6-luna", "gpt-5.4-mini"],
-        apiKeySet: false,
-        e2bKeySet: false,
-        e2bKeyHint: "",
-        computerIdleMinutes: 15,
-        kernelKeySet: false,
-        kernelKeyHint: "",
-        browserIdleMinutes: 60,
-        browserStealth: false,
-        apiKeyHint: "",
-      },
-    ],
+    // The shared fixture rather than a hand-built object: this one had drifted
+    // into a mixture of a group and the app's settings, with a group's own
+    // `inference` block missing entirely, and nothing typechecks a mock.
+    listGroups: async () => [aGroup({ agentCount: 3 })],
     agentActivity: () => agentActivity(),
     usageSummary: async () => [],
     approvalStates: async () => ({}),

--- a/src/components/AgentEditor.tsx
+++ b/src/components/AgentEditor.tsx
@@ -9,9 +9,11 @@ import {
   suggestCharacter,
 } from "../avatars/catalog";
 import { api } from "../lib/ipc";
+import { onOpenRouter } from "../lib/providers";
 import { useStore } from "../lib/store";
 import { type AgentCard, type AgentDraft, errorMessage } from "../lib/types";
 import { GrantList } from "./GrantList";
+import { ModelSuggestions } from "./ModelSuggestions";
 import { SigninList } from "./SigninList";
 
 interface Props {
@@ -84,16 +86,23 @@ export function AgentEditor({ agent, onClose }: Props) {
 
   const patch = (fields: Partial<AgentDraft>) => setDraft((current) => ({ ...current, ...fields }));
 
+  // The field is one string and a card holds a list, so the split is what both
+  // saving and the model suggestions read the skills through.
+  const skills = skillText
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  // Which crew's settings decide how this agent's turns are paid for. The
+  // select below defaults to the first group, so an agent that has not been
+  // given one yet is already in it. Named for the crew rather than the group
+  // because the character picker below binds `group` to something else.
+  const crew = groups.find((entry) => entry.id === draft.groupId) ?? groups[0];
+
   const save = async () => {
     setBusy(true);
     setError(null);
-    const payload: AgentDraft = {
-      ...draft,
-      skills: skillText
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean),
-    };
+    const payload: AgentDraft = { ...draft, skills };
     try {
       if (agent) {
         await api.updateAgent(agent.id, payload);
@@ -246,6 +255,15 @@ export function AgentEditor({ agent, onClose }: Props) {
             Any model slug your endpoint accepts. Agents can each use a different one.
           </span>
         </label>
+
+        <ModelSuggestions
+          name={draft.name}
+          skills={skills}
+          instructions={draft.systemPrompt}
+          model={draft.model}
+          active={onOpenRouter(crew, settings)}
+          onChoose={(model) => patch({ model })}
+        />
 
         <label className="field">
           <span className="field__label">Skills</span>

--- a/src/components/ModelSuggestions.test.tsx
+++ b/src/components/ModelSuggestions.test.tsx
@@ -1,0 +1,216 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RankedModel } from "../lib/types";
+import { ModelSuggestions } from "./ModelSuggestions";
+
+const rankedModels = vi.fn<(category: string) => Promise<RankedModel[]>>();
+
+vi.mock("../lib/ipc", () => ({
+  api: { rankedModels: (category: string) => rankedModels(category) },
+}));
+
+function model(over: Partial<RankedModel> = {}): RankedModel {
+  return {
+    id: "openai/gpt-5.6-sol",
+    name: "OpenAI: GPT-5.6 Sol",
+    contextLength: 400_000,
+    promptPerMillion: 2,
+    completionPerMillion: 12,
+    ...over,
+  };
+}
+
+const THREE = [
+  model(),
+  model({ id: "x-ai/grok-4.6", name: "xAI: Grok 4.6", promptPerMillion: 3 }),
+  model({ id: "z-ai/glm-5.2", name: "Z.AI: GLM 5.2", promptPerMillion: 0.6 }),
+];
+
+/** A legal agent on OpenRouter, which is the case everything else varies from. */
+function draw(over: Partial<Parameters<typeof ModelSuggestions>[0]> = {}) {
+  const onChoose = vi.fn();
+  render(
+    <ModelSuggestions
+      name="Counsel"
+      skills={["contract review"]}
+      instructions=""
+      model=""
+      active={true}
+      onChoose={onChoose}
+      {...over}
+    />,
+  );
+  return onChoose;
+}
+
+describe("ModelSuggestions", () => {
+  beforeEach(() => {
+    rankedModels.mockReset();
+    rankedModels.mockResolvedValue(THREE);
+  });
+
+  it("asks for the use case the agent reads as, and offers what comes back", async () => {
+    draw();
+
+    await waitFor(() => expect(rankedModels).toHaveBeenCalledWith("legal"));
+    expect(await screen.findByText("OpenAI: GPT-5.6 Sol")).toBeTruthy();
+    expect(screen.getByText("x-ai/grok-4.6")).toBeTruthy();
+    expect(screen.getByText(/reads as legal work/i)).toBeTruthy();
+  });
+
+  it("puts the slug in the field and nothing else", async () => {
+    const onChoose = draw();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Use xAI: Grok 4.6 for legal work" }),
+    );
+
+    expect(onChoose).toHaveBeenCalledWith("x-ai/grok-4.6");
+    expect(onChoose).toHaveBeenCalledTimes(1);
+  });
+
+  // A slug ranked at OpenRouter means nothing at api.openai.com. Offering one
+  // there is a button that breaks every turn the agent takes afterwards, with a
+  // refusal an operator has no way to connect back to this dialog.
+  it("says nothing when OpenRouter is not what pays", () => {
+    draw({ active: false });
+
+    expect(rankedModels).not.toHaveBeenCalled();
+    expect(screen.queryByText(/reads as/i)).toBeNull();
+  });
+
+  // The common case. Most agents are a Manager or an Inbox, and OpenRouter has
+  // no category for either.
+  it("says nothing about an agent that is not one of the twelve", () => {
+    draw({ name: "Manager", skills: [], instructions: "You coordinate the others." });
+
+    expect(rankedModels).not.toHaveBeenCalled();
+    expect(screen.queryByText(/reads as/i)).toBeNull();
+  });
+
+  // A button that puts back what is already there does nothing, and a button
+  // that does nothing reads as one that is broken.
+  it("does not offer the model already in the field", async () => {
+    draw({ model: "openai/gpt-5.6-sol" });
+
+    expect(await screen.findByText("xAI: Grok 4.6")).toBeTruthy();
+    expect(screen.queryByText("OpenAI: GPT-5.6 Sol")).toBeNull();
+  });
+
+  it("offers three at most, however many come back", async () => {
+    rankedModels.mockResolvedValue([...THREE, model({ id: "a/b", name: "A: B" })]);
+    draw();
+
+    await screen.findByText("OpenAI: GPT-5.6 Sol");
+    expect(screen.getAllByRole("button")).toHaveLength(3);
+  });
+
+  // The ranking is by capability and ignores price, so the dearest model in a
+  // pool regularly tops it. A row that hides the price is a one-click way to
+  // make every turn of this agent forty times dearer.
+  it("prices every row", async () => {
+    draw();
+
+    expect(await screen.findByText("$2.00 / $12.00")).toBeTruthy();
+    // Under a cent is the same answer to the question being asked. Six leading
+    // zeros in a narrow monospace slot answer a different one.
+    expect(screen.getByText("$0.60 / $12.00")).toBeTruthy();
+  });
+
+  it("tells a free model apart from one that quoted no price", async () => {
+    rankedModels.mockResolvedValue([
+      model({ id: "free/one", name: "Free One", promptPerMillion: 0, completionPerMillion: 0 }),
+      model({
+        id: "quiet/one",
+        name: "Quiet One",
+        promptPerMillion: null,
+        completionPerMillion: null,
+      }),
+    ]);
+    draw();
+
+    expect(await screen.findByText("free")).toBeTruthy();
+    expect(screen.getByText("no price")).toBeTruthy();
+  });
+
+  it("floors a fraction of a cent rather than spelling it out", async () => {
+    rankedModels.mockResolvedValue([
+      model({ id: "cheap/one", name: "Cheap One", promptPerMillion: 0.0000488 }),
+    ]);
+    draw();
+
+    expect(await screen.findByText("<$0.01 / $12.00")).toBeTruthy();
+  });
+
+  // This sits beside a field that works perfectly well without it, so a failure
+  // is a sentence rather than a banner, and it still says what to do.
+  it("says so quietly when OpenRouter does not answer", async () => {
+    rankedModels.mockRejectedValue(new Error("no route to host"));
+    draw();
+
+    expect(await screen.findByText(/did not answer/i)).toBeTruthy();
+    expect(screen.getByText(/type a slug as usual/i)).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  // A request per keystroke would be five round trips for one answer, and the
+  // last one to come back would decide what is on screen.
+  it("asks once while the evidence is still being typed", async () => {
+    const { rerender } = render(
+      <ModelSuggestions
+        name="Leg"
+        skills={["contract review"]}
+        instructions=""
+        model=""
+        active={true}
+        onChoose={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(rankedModels).toHaveBeenCalledTimes(1));
+
+    for (const name of ["Lega", "Legal", "Legal Counsel"]) {
+      rerender(
+        <ModelSuggestions
+          name={name}
+          skills={["contract review"]}
+          instructions=""
+          model=""
+          active={true}
+          onChoose={vi.fn()}
+        />,
+      );
+    }
+
+    expect(rankedModels).toHaveBeenCalledTimes(1);
+    expect(rankedModels).toHaveBeenCalledWith("legal");
+  });
+
+  it("asks again when the agent starts reading as something else", async () => {
+    const { rerender } = render(
+      <ModelSuggestions
+        name="Counsel"
+        skills={[]}
+        instructions=""
+        model=""
+        active={true}
+        onChoose={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(rankedModels).toHaveBeenCalledWith("legal"));
+
+    rerender(
+      <ModelSuggestions
+        name="Accountant"
+        skills={[]}
+        instructions=""
+        model=""
+        active={true}
+        onChoose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(rankedModels).toHaveBeenCalledWith("finance"));
+    expect(rankedModels).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/ModelSuggestions.tsx
+++ b/src/components/ModelSuggestions.tsx
@@ -1,0 +1,170 @@
+/**
+ * Three models for the agent being written, under the field that holds one.
+ *
+ * The model field is a text box on purpose: any slug the endpoint accepts, and
+ * the endpoint is the operator's to choose. That is right and it is also a blank
+ * box, and a blank box is no help at all to somebody who has just decided they
+ * want an agent that reads contracts. This is the help, and it stays a text box.
+ *
+ * Nothing here is a setting. It reads what the operator has already written into
+ * the dialog, asks OpenRouter which models get that kind of work, and offers to
+ * fill the field in. Pressing one is the same edit as typing, and the dialog is
+ * not saved by it.
+ *
+ * ## When it says nothing
+ *
+ * Three ways, and all three are the common case rather than a failure:
+ *
+ * - The agent is not any of OpenRouter's twelve use cases. Most are not.
+ * - The agent's turns are not paid for by OpenRouter, so a slug ranked there
+ *   would be a model the endpoint refuses by name.
+ * - OpenRouter did not answer. Then it says so, once, quietly: this sits beside
+ *   a field that works perfectly well without it.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import { api } from "../lib/ipc";
+import { roleFor } from "../lib/roles";
+import type { RankedModel } from "../lib/types";
+
+interface Props {
+  /** The draft as it stands, not the saved card: a suggestion should follow
+   *  what is being typed rather than what was typed last time. */
+  name: string;
+  skills: string[];
+  instructions: string;
+  /** What is in the model field now, so it is not offered back. */
+  model: string;
+  /** Whether OpenRouter is what this agent's turns are paid through. */
+  active: boolean;
+  onChoose: (model: string) => void;
+}
+
+/** As many as fit under a field without becoming the field. */
+const OFFERED = 3;
+
+export function ModelSuggestions({ name, skills, instructions, model, active, onChoose }: Props) {
+  const [ranked, setRanked] = useState<RankedModel[]>([]);
+  const [unreachable, setUnreachable] = useState(false);
+
+  // Every keystroke in three fields runs this, so it is a keyword scan and not
+  // a model call: `lib/roles.ts` has the argument.
+  const role = useMemo(() => roleFor({ name, skills, instructions }), [name, skills, instructions]);
+
+  // Keyed on the use case rather than on the evidence. Typing "Leg" through to
+  // "Legal Counsel" derives the same role five times over, and a request per
+  // keystroke would be five round trips for one answer. The backend caches for
+  // hours on top of that, so re-opening the dialog costs nothing at all.
+  const useCase = active ? role?.id : undefined;
+  useEffect(() => {
+    if (!useCase) {
+      setRanked([]);
+      setUnreachable(false);
+      return;
+    }
+    let cancelled = false;
+    void api
+      .rankedModels(useCase)
+      .then((models) => {
+        if (cancelled) return;
+        setRanked(models);
+        setUnreachable(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setRanked([]);
+        setUnreachable(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [useCase]);
+
+  if (!role || !active) return null;
+
+  // The model already in the box is not a suggestion. Offering it back gives
+  // the operator a button that does nothing and reads as one that is broken.
+  const offers = ranked.filter((entry) => entry.id !== model.trim()).slice(0, OFFERED);
+  if (offers.length === 0 && !unreachable) return null;
+
+  return (
+    <div className="field">
+      <span className="field__hint" style={{ display: "block", marginBottom: "0.35rem" }}>
+        {unreachable ? (
+          <>
+            This reads as {role.label} work, but OpenRouter did not answer when asked which models
+            get it. Type a slug as usual.
+          </>
+        ) : (
+          <>
+            This reads as {role.label} work. These are the models OpenRouter ranks highest for it
+            today, most capable first. Pressing one fills the field in.
+          </>
+        )}
+      </span>
+
+      {offers.map((offer) => (
+        <button
+          key={offer.id}
+          type="button"
+          className="preset"
+          aria-label={`Use ${offer.name} for ${role.label} work`}
+          onClick={() => onChoose(offer.id)}
+        >
+          <span className="preset__text">
+            <span className="preset__name">{offer.name}</span>
+            <span className="preset__url">{offer.id}</span>
+          </span>
+          {/* The ranking is by capability and ignores price, and the most
+              capable model in a pool is regularly the dearest thing in it. A
+              row that names a model and hides what it costs is a one-click way
+              to make every turn of this agent forty times dearer. */}
+          <span className="preset__state" title={exactly(offer)}>
+            {roughly(offer)}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Prompt and completion price, at the width of the slot it goes in.
+ *
+ * Rounded hard on purpose: this is here to say cheap or dear at a glance, and a
+ * model that costs $0.0000488 per million tokens deserves fewer characters than
+ * one that costs $15. The exact figures are on the title, which is where
+ * somebody comparing two models rather than glancing at one will look.
+ */
+function roughly(model: RankedModel): string {
+  const { promptPerMillion: prompt, completionPerMillion: completion } = model;
+  if (prompt === null || completion === null) return "no price";
+  if (prompt === 0 && completion === 0) return "free";
+  return `${dollars(prompt)} / ${dollars(completion)}`;
+}
+
+function dollars(value: number): string {
+  if (value === 0) return "$0";
+  // Everything under a cent is the same answer to the question being asked, and
+  // spelling out six leading zeros in a 0.6rem monospace slot answers a
+  // different one.
+  if (value < 0.01) return "<$0.01";
+  return `$${value.toFixed(2)}`;
+}
+
+function exactly(model: RankedModel): string {
+  const { promptPerMillion: prompt, completionPerMillion: completion } = model;
+  if (prompt === null || completion === null) {
+    return `${model.name} quotes no price on OpenRouter`;
+  }
+  const context = `${Math.round(model.contextLength / 1000)}K context`;
+  return `$${trim(prompt)} per million prompt tokens, $${trim(completion)} per million completion tokens · ${context}`;
+}
+
+/** Three significant figures, without the exponent or the trailing zeros that
+ *  `toPrecision` leaves behind on a round number. */
+function trim(value: number): string {
+  if (value === 0) return "0";
+  return Number(value.toPrecision(3)).toString();
+}

--- a/src/lib/ipc.contract.test.ts
+++ b/src/lib/ipc.contract.test.ts
@@ -74,6 +74,27 @@ describe("IPC contract", () => {
     expect(source).not.toMatch(/->\s*Reply<AppConfig>/);
   });
 
+  it("knows the same twelve use cases on both sides", () => {
+    // A suggestion is asked for by use case, and the backend refuses anything
+    // that is not one of these before it spends a request. So a category
+    // renamed at OpenRouter and updated on one side only is a dialog that draws
+    // nothing, silently, for exactly the agents it was built for. Neither list
+    // is the source — OpenRouter is — and the pair failing together is how a
+    // rename there gets noticed here.
+    const rust = read("src-tauri/src/llm/catalogue.rs").match(
+      /CATEGORIES: \[&str; \d+\] = \[([\s\S]*?)\];/,
+    );
+    const web = read("src/lib/roles.ts").match(/export const ROLES: Role\[\] = \[([\s\S]*?)\];/);
+    expect(rust, "no CATEGORIES in catalogue.rs").not.toBeNull();
+    expect(web, "no ROLES in roles.ts").not.toBeNull();
+
+    const quoted = (block: string) => [...block.matchAll(/"([^"]+)"/g)].map((m) => m[1]!);
+    // The web list is `{ id, label }` pairs and only the id crosses IPC.
+    const ids = [...web![1]!.matchAll(/id:\s*"([^"]+)"/g)].map((m) => m[1]!);
+
+    expect(ids).toEqual(quoted(rust![1]!));
+  });
+
   it("draws the same floor under a price on both sides", () => {
     // The rail's meters and the menu bar are two readings of one number, and
     // each decides on its own whether a cost is worth the width it takes. A

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -46,6 +46,7 @@ import type {
   PluginKind,
   PluginOffer,
   ProtectedAction,
+  RankedModel,
   Routine,
   RoutineDraft,
   RoutineId,
@@ -365,6 +366,16 @@ export const api = {
    * API key configured" for a key they can see, which reads as a bug.
    */
   testConnection: (patch?: SettingsPatch) => invoke<string>("test_connection", { patch }),
+
+  /**
+   * The models OpenRouter sees doing one kind of work, most capable first.
+   *
+   * The category is one of `ROLES` in `lib/roles.ts` and the backend refuses
+   * anything else, so this is a use case rather than a URL: the webview does not
+   * get to say where the request goes. Cached behind the command for hours, so
+   * calling it as an operator types costs one request per use case.
+   */
+  rankedModels: (category: string) => invoke<RankedModel[]>("ranked_models", { category }),
 
   subscriptionStatus: () => invoke<SubscriptionStatus>("subscription_status"),
 

--- a/src/lib/providers.test.ts
+++ b/src/lib/providers.test.ts
@@ -1,8 +1,10 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { aGroup } from "../test-fixtures";
 import type { Provider } from "./providers";
-import { PROVIDERS, providerFor, providerReady } from "./providers";
+import { onOpenRouter, PROVIDERS, providerFor, providerReady } from "./providers";
+import type { Settings } from "./types";
 
 /**
  * The preset list is data, and both of its jobs are answered from one string.
@@ -252,5 +254,61 @@ describe("what a fresh install starts on", () => {
     // The placeholder is a third copy of the default. One that drifts advertises
     // an endpoint the app would not actually call.
     expect(endpointPlaceholder()).toBe(rustConst("DEFAULT_BASE_URL"));
+  });
+});
+
+/**
+ * Whether OpenRouter's model rankings apply to this agent at all.
+ *
+ * A slug ranked at OpenRouter means nothing at any other endpoint, so offering
+ * one where it will be refused is a button that quietly breaks every turn the
+ * agent takes afterwards. The resolution has to match the backend's, because
+ * that is what actually decides where the call goes.
+ */
+describe("whether OpenRouter is what pays", () => {
+  const app = (over: Partial<Settings> = {}) =>
+    ({ provider: "compatible", baseUrl: "https://openrouter.ai/api/v1", ...over }) as Settings;
+
+  it("follows the app when the crew overrides nothing", () => {
+    expect(onOpenRouter(aGroup(), app())).toBe(true);
+    expect(onOpenRouter(aGroup(), app({ baseUrl: "https://api.openai.com/v1" }))).toBe(false);
+  });
+
+  it("lets a crew's own endpoint win, in both directions", () => {
+    const elsewhere = aGroup({
+      inference: { ...aGroup().inference, baseUrl: "https://api.groq.com/openai/v1" },
+    });
+    expect(onOpenRouter(elsewhere, app())).toBe(false);
+
+    const here = aGroup({
+      inference: { ...aGroup().inference, baseUrl: "https://openrouter.ai/api/v1" },
+    });
+    expect(onOpenRouter(here, app({ baseUrl: "http://localhost:1234/v1" }))).toBe(true);
+  });
+
+  // A subscription is not an endpoint with a different URL. It offers its own
+  // models, and none of them are OpenRouter's to rank.
+  it("is never true on a subscription, whatever endpoint is stored beside it", () => {
+    expect(onOpenRouter(aGroup(), app({ provider: "chatgpt" }))).toBe(false);
+
+    const paid = aGroup({ inference: { ...aGroup().inference, provider: "chatgpt" } });
+    expect(onOpenRouter(paid, app())).toBe(false);
+  });
+
+  // The dialog draws before the first settings load lands. Nothing known is
+  // not OpenRouter.
+  it("says no before anything is known", () => {
+    expect(onOpenRouter(undefined, null)).toBe(false);
+    expect(onOpenRouter(aGroup(), null)).toBe(false);
+  });
+
+  // The endpoint the operator pastes is the one their provider's documentation
+  // prints, and that one ends in /chat/completions. `providerFor` already
+  // normalises it; this is here so a rewrite of either cannot quietly stop.
+  it("recognises the endpoint the way it is actually pasted", () => {
+    expect(
+      onOpenRouter(aGroup(), app({ baseUrl: "https://openrouter.ai/api/v1/chat/completions" })),
+    ).toBe(true);
+    expect(onOpenRouter(aGroup(), app({ baseUrl: " HTTPS://OpenRouter.ai/api/v1/ " }))).toBe(true);
   });
 });

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -24,6 +24,8 @@
  * it does not have. It gets its own block in the pane, above this list.
  */
 
+import type { Group, Settings } from "./types";
+
 export interface Provider {
   id: string;
   name: string;
@@ -117,6 +119,30 @@ export function providerFor(baseUrl: string): Provider | undefined {
  */
 export function providerReady(provider: Provider, keySet: boolean): boolean {
   return provider.local === true || keySet;
+}
+
+/**
+ * Whether an agent in this group has its turns paid for by OpenRouter.
+ *
+ * Asked before OpenRouter's model rankings are offered as suggestions, because
+ * a suggestion is a slug and a slug only means something at the endpoint it was
+ * ranked at. `anthropic/claude-opus-5` pasted into a field pointed at
+ * `api.openai.com` is a refusal by name on the agent's next turn, and the
+ * operator has no way to connect that refusal to a button they pressed in a
+ * dialog an hour earlier.
+ *
+ * Resolves group over app, the same order the backend resolves in. A subscription
+ * is not this endpoint at all: it offers its own models, and none of them are
+ * OpenRouter's to rank.
+ */
+export function onOpenRouter(group: Group | undefined, settings: Settings | null): boolean {
+  // Optional all the way down, including a field the type says is always
+  // there. This decides whether an extra appears beside a field; a group that
+  // arrives half-shaped should cost the operator a suggestion, not the dialog.
+  const provider = group?.inference?.provider ?? settings?.provider;
+  if (provider !== "compatible") return false;
+  const baseUrl = group?.inference?.baseUrl || settings?.baseUrl || "";
+  return providerFor(baseUrl)?.id === "openrouter";
 }
 
 /**

--- a/src/lib/roles.test.ts
+++ b/src/lib/roles.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import { type Evidence, ROLES, roleFor } from "./roles";
+
+function agent(over: Partial<Evidence> = {}): Evidence {
+  return { name: "", skills: [], instructions: "", ...over };
+}
+
+describe("what an agent reads as", () => {
+  it("takes the name when the name says it", () => {
+    expect(roleFor(agent({ name: "Legal" }))?.id).toBe("legal");
+    expect(roleFor(agent({ name: "Marketing" }))?.id).toBe("marketing");
+    expect(roleFor(agent({ name: "Translator" }))?.id).toBe("translation");
+  });
+
+  // A name is a word, not a sentence, so the second half of it carries as much
+  // as the first. "Counsel" alone is the whole answer.
+  it("reads a name that is two words", () => {
+    expect(roleFor(agent({ name: "Legal Counsel" }))?.id).toBe("legal");
+    expect(roleFor(agent({ name: "Ada the Accountant" }))?.id).toBe("finance");
+  });
+
+  // Whole words. A role picked out of the middle of another word is the failure
+  // mode of every substring matcher, and the words here are short enough for it:
+  // "law" is inside "flawless", "dev" inside "device", "api" inside "rapid".
+  it.each([
+    ["a flawless outcome", "law"],
+    ["order a new device", "dev"],
+    ["rapid replies", "api"],
+    ["mow the lawn", "law"],
+    ["a companionable tone", "companion"],
+  ])("does not find a role inside another word: %s", (instructions) => {
+    expect(roleFor(agent({ instructions }))).toBeUndefined();
+  });
+
+  it("takes the skills when the name says nothing", () => {
+    const found = roleFor(agent({ name: "Ada", skills: ["contract review", "compliance"] }));
+    expect(found?.id).toBe("legal");
+  });
+
+  // The case the whole thing exists for: the operator wrote a paragraph about
+  // the job and never wrote the word in the name.
+  it("falls back to the instructions", () => {
+    const found = roleFor(
+      agent({
+        name: "Ada",
+        instructions:
+          "Draft the campaign copy for each launch and keep the brand voice consistent.",
+      }),
+    );
+    expect(found?.id).toBe("marketing");
+  });
+
+  // Prose mentions things in passing. One word of it is not a role, or every
+  // agent whose instructions say "keep a record of the invoice" is an accountant.
+  it("wants two words of prose, not one", () => {
+    expect(roleFor(agent({ instructions: "File the invoice." }))).toBeUndefined();
+    expect(roleFor(agent({ instructions: "File the invoice and update the budget." }))?.id).toBe(
+      "finance",
+    );
+  });
+
+  // The common answer. Most agents are a Manager, a Router or an Inbox, and
+  // OpenRouter has no category for any of them.
+  it.each([
+    ["Manager", "You coordinate the other agents. Delegate rather than doing work yourself."],
+    ["Inbox", "Read what arrives and pass it to whoever should see it."],
+    ["Scout", ""],
+    ["", ""],
+  ])("says nothing about %s", (name, instructions) => {
+    expect(roleFor(agent({ name, instructions }))).toBeUndefined();
+  });
+
+  // Evidence pointing two ways is not a coin to toss. An agent that is equally
+  // legal and financial genuinely has no single best model, and the operator
+  // reads a confident wrong answer as a reason to distrust the right ones.
+  it("says nothing when two use cases are level", () => {
+    expect(roleFor(agent({ name: "Legal Finance" }))).toBeUndefined();
+    expect(roleFor(agent({ skills: ["contracts", "invoicing"] }))).toBeUndefined();
+  });
+
+  it("breaks the tie when one side has more of the evidence", () => {
+    const found = roleFor(agent({ name: "Legal Finance", skills: ["litigation"] }));
+    expect(found?.id).toBe("legal");
+  });
+
+  // OpenRouter ranks no models for sales, and an agent called Sales is the
+  // second thing anybody builds here. Marketing is the nearest thing that
+  // exists; nothing at all reads as broken.
+  it("sends sales to marketing, which is where the models are", () => {
+    expect(roleFor(agent({ name: "Sales" }))?.id).toBe("marketing");
+    expect(roleFor(agent({ name: "Ada", skills: ["prospecting", "cold email"] }))?.id).toBe(
+      "marketing",
+    );
+  });
+
+  it("tells SEO apart from the rest of marketing", () => {
+    expect(roleFor(agent({ name: "Ada", skills: ["keyword research", "backlinks"] }))?.id).toBe(
+      "marketing/seo",
+    );
+  });
+
+  it("reads punctuation and case as nothing", () => {
+    expect(roleFor(agent({ name: "LEGAL" }))?.id).toBe("legal");
+    expect(roleFor(agent({ skills: ["contracts,", "  NDAs  "] }))?.id).toBe("legal");
+  });
+});
+
+describe("the twelve", () => {
+  it("names each use case once", () => {
+    expect(new Set(ROLES.map((role) => role.id)).size).toBe(ROLES.length);
+  });
+
+  // The label only ever appears in "this reads as ___ work", so an empty one
+  // renders a sentence with a hole in it.
+  it("gives every use case something to be called in a sentence", () => {
+    for (const role of ROLES) expect(role.label.trim().length).toBeGreaterThan(0);
+  });
+
+  // Every use case has to be reachable, or it is a category the app can never
+  // suggest and a list entry nothing reads.
+  it.each(ROLES.map((role) => [role.id, role.label]))("can reach %s", (id, label) => {
+    // The label is not always the word: "academic" for academia, "SEO" for
+    // marketing/seo. Both are in their own vocabulary, so both find themselves.
+    expect(roleFor(agent({ name: label }))?.id ?? roleFor(agent({ name: id }))?.id).toBe(id);
+  });
+});

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -1,0 +1,440 @@
+/**
+ * What an agent is for, in the only vocabulary OpenRouter ranks models in.
+ *
+ * OpenRouter classifies the traffic it routes into twelve use cases and will
+ * hand back the models doing each of them. An agent, meanwhile, is a name, a
+ * list of skills and a page of instructions. This is the join: it reads what
+ * the operator has already written and answers with one of the twelve, or with
+ * nothing.
+ *
+ * ## Nothing is an answer, and the common one
+ *
+ * Most agents are not any of the twelve. A Manager, a Router, an Inbox: they do
+ * work OpenRouter has no category for, and the honest reply is silence. A
+ * scoring function that always names its best guess would put a legal model
+ * under a scheduling agent and give the operator a reason to distrust every
+ * other suggestion it makes. So there is a floor, and a tie is not a winner.
+ *
+ * ## Why this is not a model call
+ *
+ * Deriving a role by asking a model would cost money and a round trip every
+ * time a dialog opens, to answer a question a keyword can answer, and would
+ * answer it differently on two openings of the same dialog. It is also the one
+ * place a wrong answer is invisible: an operator cannot tell a considered
+ * "marketing" from a guessed one. Keywords are free, instant, the same twice,
+ * and wrong in ways a person can see and ignore.
+ *
+ * ## Sales
+ *
+ * There is no sales category. OpenRouter's twelve go marketing, marketing/seo
+ * and no further, so sales vocabulary is scored into marketing: the models
+ * people send outreach and pitch copy to are the models they send campaign copy
+ * to. Leaving it unmatched would mean an agent called Sales, which is the second
+ * thing anybody builds here, gets nothing and reads as broken.
+ */
+
+/** One of the twelve, and how it is said in a sentence about an agent. */
+export interface Role {
+  /** The category slug, spelled as OpenRouter spells it. Crosses IPC. */
+  id: string;
+  /** Fits "reads as ___ work", which is the only sentence it appears in. */
+  label: string;
+}
+
+/**
+ * The twelve, in OpenRouter's own spelling.
+ *
+ * `llm/catalogue.rs` holds the same list because it refuses anything else
+ * before spending a request, and `ipc.contract.test.ts` compares the two files.
+ * Neither is the source: OpenRouter is, and the pair failing together is how a
+ * use case renamed there is noticed here.
+ */
+export const ROLES: Role[] = [
+  { id: "programming", label: "programming" },
+  { id: "roleplay", label: "roleplay" },
+  { id: "marketing", label: "marketing" },
+  { id: "marketing/seo", label: "SEO" },
+  { id: "technology", label: "technology" },
+  { id: "science", label: "science" },
+  { id: "translation", label: "translation" },
+  { id: "legal", label: "legal" },
+  { id: "finance", label: "finance" },
+  { id: "health", label: "health" },
+  { id: "trivia", label: "trivia" },
+  { id: "academia", label: "academic" },
+];
+
+/**
+ * What the dialog knows about an agent while it is being written.
+ *
+ * The draft rather than the saved card, so a suggestion follows what is being
+ * typed. An operator naming a new agent "Counsel" should see the answer before
+ * they press save, not after.
+ */
+export interface Evidence {
+  name: string;
+  skills: string[];
+  instructions: string;
+}
+
+/**
+ * How much each field is worth per distinct word it matches.
+ *
+ * A name and a skill list are short and deliberate: every word in them was
+ * chosen to describe the agent, so one hit in either is enough on its own.
+ * Instructions are prose about the work, and prose mentions things in passing,
+ * so two separate words are wanted before it decides anything.
+ */
+const WEIGHT = { name: 5, skills: 4, instructions: 2 } as const;
+
+/** One name hit, or one skill hit, or two words of prose. */
+const FLOOR = 4;
+
+/**
+ * The words that mean each use case.
+ *
+ * Nouns of the trade rather than anything an agent might mention once. Words
+ * that are ordinary English on their own are spelled as the phrase they belong
+ * to: "lead" is a verb every manager's instructions use and "lead generation"
+ * is not, so only the second is here.
+ *
+ * Overlap between lists is fine and expected. "devops" is both programming and
+ * technology, and an agent with one word of evidence either way should get no
+ * suggestion rather than an arbitrary one: that is the tie rule below doing its
+ * job, not a table that needs tidying.
+ */
+const WORDS: Record<string, string[]> = {
+  programming: [
+    "code",
+    "coding",
+    "coder",
+    "codebase",
+    "developer",
+    "dev",
+    "engineer",
+    "engineering",
+    "software",
+    "programmer",
+    "programming",
+    "debug",
+    "debugging",
+    "refactor",
+    "refactoring",
+    "api",
+    "backend",
+    "frontend",
+    "typescript",
+    "python",
+    "rust",
+    "golang",
+    "sql",
+    "repo",
+    "repository",
+    "pull request",
+    "code review",
+    "devops",
+    "compiler",
+    "unit test",
+    "unit tests",
+    "git",
+  ],
+  roleplay: [
+    "roleplay",
+    "role play",
+    "in character",
+    "persona",
+    "storytelling",
+    "fiction",
+    "narrative",
+    "dungeon master",
+    "npc",
+    "improv",
+    "companion",
+    "worldbuilding",
+    "screenplay",
+    "dialogue writing",
+  ],
+  marketing: [
+    "marketing",
+    "marketer",
+    "brand",
+    "branding",
+    "campaign",
+    "campaigns",
+    "copywriting",
+    "copywriter",
+    "copy",
+    "advertising",
+    "advert",
+    "adverts",
+    "social media",
+    "newsletter",
+    "positioning",
+    "messaging",
+    "growth",
+    // Sales has no category of its own. See the module comment.
+    "sales",
+    "salesperson",
+    "selling",
+    "prospect",
+    "prospecting",
+    "outreach",
+    "outbound",
+    "cold email",
+    "crm",
+    "lead generation",
+    "pitch deck",
+    "go to market",
+    "customer acquisition",
+  ],
+  "marketing/seo": [
+    "seo",
+    "search engine",
+    "keyword research",
+    "keywords",
+    "serp",
+    "backlink",
+    "backlinks",
+    "meta description",
+    "organic traffic",
+    "search ranking",
+    "content marketing",
+    "link building",
+    "on page",
+    "site audit",
+  ],
+  technology: [
+    "technology",
+    "tech",
+    "infrastructure",
+    "sysadmin",
+    "networking",
+    "hardware",
+    "cloud",
+    "server",
+    "servers",
+    "kubernetes",
+    "docker",
+    "linux",
+    "security",
+    "cybersecurity",
+    "database",
+    "architecture",
+    "technical support",
+    "helpdesk",
+    "troubleshooting",
+    "incident response",
+    "observability",
+    "devops",
+  ],
+  science: [
+    "science",
+    "scientific",
+    "scientist",
+    "physics",
+    "chemistry",
+    "biology",
+    "experiment",
+    "experiments",
+    "hypothesis",
+    "laboratory",
+    "bioinformatics",
+    "genomics",
+    "climate",
+    "empirical",
+    "statistics",
+    "research",
+  ],
+  translation: [
+    "translate",
+    "translation",
+    "translator",
+    "localise",
+    "localize",
+    "localisation",
+    "localization",
+    "multilingual",
+    "bilingual",
+    "interpreter",
+    "subtitles",
+    "transcreation",
+    "spanish",
+    "french",
+    "german",
+    "japanese",
+    "mandarin",
+    "portuguese",
+  ],
+  legal: [
+    "legal",
+    "law",
+    "lawyer",
+    "attorney",
+    "counsel",
+    "contract",
+    "contracts",
+    "compliance",
+    "regulatory",
+    "regulation",
+    "litigation",
+    "gdpr",
+    "nda",
+    "ndas",
+    "paralegal",
+    "statute",
+    "clause",
+    "clauses",
+    "jurisdiction",
+    "trademark",
+    "patent",
+    "intellectual property",
+    "privacy policy",
+    "terms of service",
+    "due diligence",
+  ],
+  finance: [
+    "finance",
+    "financial",
+    "accounting",
+    "accountant",
+    "bookkeeping",
+    "invoice",
+    "invoicing",
+    "budget",
+    "budgeting",
+    "forecast",
+    "forecasting",
+    "revenue",
+    "cash flow",
+    "valuation",
+    "investment",
+    "investor",
+    "portfolio",
+    "tax",
+    "taxes",
+    "audit",
+    "balance sheet",
+    "treasury",
+    "banking",
+    "equities",
+    "margin",
+    "payroll",
+  ],
+  health: [
+    "health",
+    "medical",
+    "medicine",
+    "clinical",
+    "patient",
+    "patients",
+    "diagnosis",
+    "symptom",
+    "symptoms",
+    "nutrition",
+    "therapy",
+    "therapist",
+    "wellness",
+    "pharma",
+    "pharmaceutical",
+    "nurse",
+    "physician",
+    "fitness",
+    "mental health",
+    "triage",
+  ],
+  trivia: [
+    "trivia",
+    "quiz",
+    "quizzes",
+    "quizmaster",
+    "general knowledge",
+    "flashcard",
+    "flashcards",
+    "pub quiz",
+    "recall",
+  ],
+  academia: [
+    "academic",
+    "academia",
+    "thesis",
+    "dissertation",
+    "literature review",
+    "citation",
+    "citations",
+    "peer review",
+    "scholarly",
+    "university",
+    "professor",
+    "tutoring",
+    "tutor",
+    "curriculum",
+    "coursework",
+    "lecture",
+    "essay",
+    "essays",
+    "bibliography",
+    "footnotes",
+  ],
+};
+
+/**
+ * Text as a run of space-separated words, padded at both ends.
+ *
+ * Padding is what makes a whole-word match a substring test: " law " finds the
+ * word and not "lawn", "flawed" or "outlaw". Punctuation becomes a space rather
+ * than nothing, so "contracts, compliance" is two words and "e-commerce" is
+ * two rather than one nobody would match either way.
+ */
+function words(text: string): string {
+  return ` ${text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()} `;
+}
+
+/** How much one field says about one use case. Each word counts once. */
+function score(field: string, weight: number, vocabulary: string[]): number {
+  let total = 0;
+  for (const word of vocabulary) {
+    if (field.includes(` ${word} `)) total += weight;
+  }
+  return total;
+}
+
+/**
+ * What this agent reads as, if it reads as anything.
+ *
+ * `undefined` for the ordinary case: an agent whose work OpenRouter has no
+ * category for. Also `undefined` for a tie, which is evidence pointing two ways
+ * rather than a coin to toss — an agent described as both legal and finance
+ * genuinely has no single best model, and saying so by staying quiet is better
+ * than picking whichever list happens to be declared first.
+ */
+export function roleFor(evidence: Evidence): Role | undefined {
+  const name = words(evidence.name);
+  const skills = words(evidence.skills.join(" "));
+  const instructions = words(evidence.instructions);
+
+  let best: Role | undefined;
+  let top = 0;
+  let runnerUp = 0;
+
+  for (const role of ROLES) {
+    const vocabulary = WORDS[role.id] ?? [];
+    const total =
+      score(name, WEIGHT.name, vocabulary) +
+      score(skills, WEIGHT.skills, vocabulary) +
+      score(instructions, WEIGHT.instructions, vocabulary);
+
+    if (total > top) {
+      runnerUp = top;
+      top = total;
+      best = role;
+    } else if (total > runnerUp) {
+      runnerUp = total;
+    }
+  }
+
+  if (top < FLOOR || top === runnerUp) return undefined;
+  return best;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -423,6 +423,27 @@ export interface GuardLimits {
  */
 export type Provider = "compatible" | "chatgpt";
 
+/**
+ * One model OpenRouter ranks for a kind of work, as a suggestion beside a model
+ * field.
+ *
+ * Ranked by capability inside the pool of models that use case actually gets
+ * sent, which is not the order the endpoint returns by default: `catalogue.rs`
+ * has the argument. The price is here because that ranking ignores it, and the
+ * most capable model in a pool is regularly the dearest thing in it.
+ */
+export interface RankedModel {
+  /** The slug, which is what the model field holds. */
+  id: string;
+  /** How the vendor writes it for a person. */
+  name: string;
+  contextLength: number;
+  /** Dollars per million prompt tokens. `null` when none was quoted, which is
+   *  not the same as free. */
+  promptPerMillion: number | null;
+  completionPerMillion: number | null;
+}
+
 export interface Settings {
   /** What agents call you. Empty means they say "the operator". */
   operatorName: string;


### PR DESCRIPTION
An agent's model field is a blank text box with no way to find out what to put in it, so it now offers three models underneath, derived from a keyword scan over the agent's name, skills and instructions, and only when OpenRouter is what pays for that agent's turns.

The order is deliberately not OpenRouter's default category order: that one ranks by tokens routed, which is bulk traffic, and puts the same cheap model at the top of eleven of the twelve use cases. So the use case picks the pool and capability orders it, and every row carries its price because capability ordering ignores price and the top of a pool is regularly the dearest thing in it.

Saying nothing is the common answer rather than a failure, since most agents are none of the twelve and a tie is not a winner. Reasoning is in `docs/WORKSPACE.md` and `llm/catalogue.rs`; `ipc.contract.test.ts` holds the twelve in step across Rust and TypeScript, and an `#[ignore]`d test asks the live service whether it still ranks all of them, which is the failure no offline suite can see.