### PR TITLE
feat: a group chooses which of the account's Googles its crew uses

### DIFF
--- a/docs/ACCOUNT.md
+++ b/docs/ACCOUNT.md
@@ -176,6 +176,25 @@ a live Google credential on a laptop for an hour at a time, and the rule from
 model.** Keeping the token at the origin that holds the refresh token is the
 stronger position, and the app gets tools instead.
 
+## One account, several identities
+
+Signing in to `guaca.bot` is one identity: the address a code reached. What that
+account *holds* is not. A person can authorize a work Google and a personal one,
+and those are two grants — Better Auth keys them on `(issuer, accountId)`, and
+two Google accounts are two subjects.
+
+The first version of this got that wrong by one word. It said "one grant per
+provider" and read the first row matching one, so a second account could be
+authorized and never seen again, and a crew had no way to name one. Two things
+were needed to fix it and only one of them was in the app:
+
+- `prompt=select_account` on Google's consent. `consent` alone forces the screen
+  and still silently reuses whichever Google the browser is signed into, so an
+  operator could not create the second grant in the first place.
+- A connection id on the plugin row, so a group can say which it means.
+
+`docs/PLUGINS.md`, *A crew chooses which identity it uses*, has the app half.
+
 ## What is not built yet
 
 Cloud-run agents and managed provider keys, both of which were named as reasons

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -222,6 +222,25 @@ account rotates its own token, so a copy on the row would be a second thing to
 keep fresh, a second thing to be stale, and a renewal path racing the account's.
 `Runtime::account_token` reads a live one per call.
 
+**A crew chooses which identity it uses.** A person can authorize the same
+provider twice — a work Google and a personal one — and those are two grants at
+`guaca.bot` with two ids. `plugins.connection` holds the one this crew means,
+and it is part of the address: `/mcp/<id>` rather than `/mcp`. Two groups can
+therefore hold two Google accounts at once, which is the case the single-grant
+model could not express at all.
+
+Empty means unnamed, and that is not a missing value. It is the account's
+default, it is what every plugin connected before this column existed keeps
+sending, and bare `/mcp` still answers with every connection's tools. An upgrade
+that invented an id would silently repoint a working crew at a different
+mailbox.
+
+Changing it is `set_plugin_connection` rather than Disconnect and Connect,
+because those are different acts: reconnecting replaces the row and loses the
+per-tool switches the operator set. The tool list is re-read either way, because
+two identities do not publish the same tools — a grant that can read mail and
+not send it offers fewer.
+
 **What the tools are is decided at `guaca.bot`, not here.** The server offers a
 tool only when every scope it needs came back from Google, so a grant that can
 read mail and not send it offers `gmail_search` and not `gmail_send`. A crew

--- a/src-tauri/src/account.rs
+++ b/src-tauri/src/account.rs
@@ -228,11 +228,32 @@ pub struct Provider {
 /// when the operator authorizes something in a browser rather than when this
 /// app does anything, and a stale local copy would be a list of capabilities an
 /// agent is told it has and does not.
+/// One identity the operator has authorized at a provider.
+///
+/// A person can authorize the same provider twice — a work Google and a
+/// personal one — and each is a separate grant with its own id. A group binds
+/// to one of these, which is what lets two crews use two mailboxes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountConnection {
+    pub id: String,
+    pub provider: String,
+    /// The provider's own name for it, which is how an operator tells two
+    /// apart. An email where the provider says, its subject where it does not.
+    pub label: String,
+    pub capabilities: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Connectors {
     pub email: String,
     pub providers: Vec<Provider>,
+    /// Every authorized identity, newest last. Empty on a service that has none
+    /// and on one too old to report them, which reads the same to a caller:
+    /// there is nothing to choose between.
+    #[serde(default)]
+    pub connections: Vec<AccountConnection>,
 }
 
 /// A signed-in Guaca account, and the file it lives in.
@@ -514,6 +535,8 @@ impl Account {
         struct Body {
             user: User,
             providers: Vec<Provider>,
+            #[serde(default)]
+            connections: Vec<AccountConnection>,
         }
         #[derive(Deserialize)]
         struct User {
@@ -542,7 +565,11 @@ impl Account {
             origin: self.origin.clone(),
             detail: format!("its answer did not parse: {err}"),
         })?;
-        Ok(Connectors { email: parsed.user.email, providers: parsed.providers })
+        Ok(Connectors {
+            email: parsed.user.email,
+            providers: parsed.providers,
+            connections: parsed.connections,
+        })
     }
 
     fn store(&self, stored: Stored) -> Result<Status, AccountError> {

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -467,6 +467,7 @@ pub fn run() {
             commands::sign_in_account,
             commands::account_connectors,
             commands::sign_out_account,
+            commands::set_plugin_connection,
             commands::subscription_status,
             commands::begin_subscription_signin,
             commands::complete_subscription_signin,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -492,18 +492,35 @@ pub async fn connect_plugin(
     state: State<'_, AppState>,
     group_id: GroupId,
     kind: PluginKind,
+    // Which of the account's authorized identities this crew should use.
+    // Absent is the account's default, which is the right answer for an account
+    // with one Google and what every already-connected plugin keeps doing.
+    // Naming one is how two crews use two different mailboxes.
+    connection: Option<String>,
 ) -> Reply<Plugin> {
     // Read here rather than inside the flow, so a machine that is not signed in
     // is told so before a browser opens. An account-backed plugin has no
     // sign-in of its own: see `PluginKind::account_backed`.
-    let account = if kind.account_backed() { state.account.access().await.ok() } else { None };
+    let token = if kind.account_backed() { state.account.access().await.ok() } else { None };
+    let connection = connection.unwrap_or_default();
+    let account =
+        token.as_deref().map(|token| crate::plugins::AccountUse { token, connection: &connection });
+
+    // An account-backed plugin's server is the operator's own account, and
+    // which identity it means is part of the address. The other kinds ignore
+    // both and dial the vendor.
+    let endpoint = if kind.account_backed() {
+        crate::plugins::AccountUse::endpoint(state.account.origin(), &connection)
+    } else {
+        state.runtime.plugin_endpoint(kind).to_string()
+    };
 
     let plugin = crate::plugins::connect(
         state.runtime.store(),
         group_id,
         kind,
-        state.runtime.plugin_endpoint(kind),
-        account.as_deref(),
+        &endpoint,
+        account,
         move |url| {
             // The one line in this feature that knows the app is a Tauri app. The
             // flow itself takes a callback so that `oauth.rs` does not have to.
@@ -516,6 +533,32 @@ pub async fn connect_plugin(
     // on its next turn and what the roster says they can reach.
     state.runtime.emit(UiEvent::AgentsChanged);
     Ok(plugin)
+}
+
+/// Points a crew's plugin at a different authorized identity.
+///
+/// Kept apart from connecting, because it is not the same act: connecting reads
+/// the server's tool list and replaces the row, and this moves an existing row
+/// to another mailbox. Doing it through Connect would mean an operator who
+/// wanted the other Google lost the per-tool switches they had set on this one.
+///
+/// The tool list is re-read, because two identities do not offer the same
+/// tools: a grant that can read mail and not send it publishes fewer, and a row
+/// left holding the old list would offer a model a tool that is no longer there.
+#[tauri::command]
+pub async fn set_plugin_connection(
+    state: State<'_, AppState>,
+    group_id: GroupId,
+    kind: PluginKind,
+    connection: String,
+) -> Reply<Plugin> {
+    if !kind.account_backed() {
+        return Err(CommandError::new(
+            "validation",
+            format!("{} signs in per group and has no account identity to choose", kind.label()),
+        ));
+    }
+    connect_plugin(state, group_id, kind, Some(connection)).await
 }
 
 /// Chooses which of a crew's agents may call one plugin.

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -822,6 +822,29 @@ CREATE TABLE plugin_denied_tools (
 );
 "#,
     ),
+    (
+        30,
+        r#"
+-- Which authorized identity a plugin uses, for the one kind whose sign-in is
+-- the operator's Guaca account rather than its own.
+--
+-- A person can authorize the same provider twice: a work Google and a personal
+-- one are two grants at guaca.bot, with two ids, and revoking one says nothing
+-- about the other. Until now a group had no way to say which it meant, so both
+-- of an operator's crews reached whichever row came back first and the second
+-- account was unreachable.
+--
+-- Empty means unnamed, which is the account's default connection and is what
+-- every plugin connected before this column existed keeps doing. That matters:
+-- an upgrade must not silently repoint a working crew at a different mailbox.
+-- The endpoint is derived from it, so a value here is the difference between
+-- `/mcp` and `/mcp/<id>`.
+--
+-- Only meaningful for an account-backed kind. The other five sign in per group
+-- and their grant already names the identity it was issued to.
+ALTER TABLE plugins ADD COLUMN connection TEXT NOT NULL DEFAULT '';
+"#,
+    ),
 ];
 
 /// The group every agent starts in, and the one the UI keeps out of the way

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -1517,6 +1517,7 @@ impl Store {
     /// decision about the crew, and a reconnection that quietly handed Stripe
     /// back to everybody would undo one silently, at the moment the operator
     /// was fixing something else.
+    #[allow(clippy::too_many_arguments)]
     pub fn save_plugin(
         &self,
         group: GroupId,
@@ -1524,6 +1525,10 @@ impl Store {
         account: &str,
         tools: &[PluginTool],
         grant: Option<&crate::oauth::Grant>,
+        // Which authorized identity at the account this crew is using, for an
+        // account-backed kind. Empty is the account's default, which is what a
+        // row written before connections existed keeps meaning.
+        connection: &str,
     ) -> Result<Plugin, StoreError> {
         let conn = self.conn()?;
         let id = PluginId::new();
@@ -1533,10 +1538,11 @@ impl Store {
         conn.execute(
             "INSERT INTO plugins
                 (id,group_id,kind,account,tools,client_id,client_secret,token_endpoint,
-                 access_token,refresh_token,expires_at,connected_at)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)
+                 access_token,refresh_token,expires_at,connected_at,connection)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13)
              ON CONFLICT(group_id,kind) DO UPDATE SET
                 account=excluded.account,
+                connection=excluded.connection,
                 tools=excluded.tools,
                 client_id=excluded.client_id,
                 client_secret=excluded.client_secret,
@@ -1558,6 +1564,7 @@ impl Store {
                 grant.and_then(|g| g.refresh_token.as_deref()).unwrap_or_default(),
                 grant.and_then(|g| g.expires_at),
                 now_ms(),
+                connection,
             ],
         )?;
 
@@ -2726,7 +2733,7 @@ pub enum PluginReach {
 }
 
 const PLUGIN_COLUMNS: &str =
-    "SELECT id,group_id,kind,account,tools,access_token,connected_at,access FROM plugins";
+    "SELECT id,group_id,kind,account,tools,access_token,connected_at,access,connection FROM plugins";
 
 /// The one rule that decides whether an agent is offered a plugin's tools and
 /// whether a call it makes may spend the grant.
@@ -2776,6 +2783,7 @@ fn row_to_plugin(
     let tools_raw: String = row.get(4)?;
     let access: String = row.get(5)?;
     let reach: String = row.get(7)?;
+    let connection: String = row.get(8)?;
 
     Ok((|| {
         let Some(kind) = PluginKind::from_slug(&kind_raw) else { return Ok(None) };
@@ -2801,6 +2809,7 @@ fn row_to_plugin(
                 })
                 .collect(),
             access: PluginAccess::from_row(&reach, chosen.get(&id).cloned().unwrap_or_default()),
+            connection,
             signed_in: !access.is_empty(),
             connected_at: row.get(6)?,
         }))
@@ -5013,7 +5022,7 @@ mod tests {
             .store
             .create_group(&CleanGroup { name: "Crew".into(), ..Default::default() })
             .unwrap();
-        f.store.save_plugin(group.id, PluginKind::Neon, "", &[], None).unwrap();
+        f.store.save_plugin(group.id, PluginKind::Neon, "", &[], None, "").unwrap();
 
         f.store.delete_group(group.id).unwrap();
         assert!(f.store.group_plugins(group.id).unwrap().is_empty());
@@ -5031,7 +5040,7 @@ mod tests {
         // carry `Bearer `. The kind is incidental: the column is what decides.
         let f = fixture();
         let group = default_group_id();
-        f.store.save_plugin(group, PluginKind::Neon, "", &[], None).unwrap();
+        f.store.save_plugin(group, PluginKind::Neon, "", &[], None, "").unwrap();
 
         let agent = f.store.create_agent(&draft("Manager")).unwrap();
         let PluginReach::Granted { grant, .. } =
@@ -5051,7 +5060,7 @@ mod tests {
         let f = fixture();
         let group = default_group_id();
         let manager = f.store.create_agent(&draft("Manager")).unwrap();
-        f.store.save_plugin(group, PluginKind::Neon, "", &[tool("run_sql")], None).unwrap();
+        f.store.save_plugin(group, PluginKind::Neon, "", &[tool("run_sql")], None, "").unwrap();
 
         assert_eq!(f.store.group_plugins(group).unwrap()[0].access, PluginAccess::Everyone);
         assert_eq!(f.store.plugin_tools(group, manager.id).unwrap().len(), 1);
@@ -5068,8 +5077,10 @@ mod tests {
         let group = default_group_id();
         let revenue = f.store.create_agent(&draft("Revenue")).unwrap();
         let scribe = f.store.create_agent(&draft("Scribe")).unwrap();
-        let plugin =
-            f.store.save_plugin(group, PluginKind::Stripe, "", &[tool("refund")], None).unwrap();
+        let plugin = f
+            .store
+            .save_plugin(group, PluginKind::Stripe, "", &[tool("refund")], None, "")
+            .unwrap();
 
         let saved = f
             .store
@@ -5100,8 +5111,10 @@ mod tests {
         let f = fixture();
         let group = default_group_id();
         let manager = f.store.create_agent(&draft("Manager")).unwrap();
-        let plugin =
-            f.store.save_plugin(group, PluginKind::Stripe, "", &[tool("refund")], None).unwrap();
+        let plugin = f
+            .store
+            .save_plugin(group, PluginKind::Stripe, "", &[tool("refund")], None, "")
+            .unwrap();
 
         f.store.set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![] }).unwrap();
 
@@ -5119,7 +5132,7 @@ mod tests {
         let f = fixture();
         let group = default_group_id();
         let revenue = f.store.create_agent(&draft("Revenue")).unwrap();
-        let plugin = f.store.save_plugin(group, PluginKind::Stripe, "", &[], None).unwrap();
+        let plugin = f.store.save_plugin(group, PluginKind::Stripe, "", &[], None, "").unwrap();
 
         f.store
             .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![revenue.id] })
@@ -5151,7 +5164,7 @@ mod tests {
             .create_agent(&CleanDraft { group_id: Some(other.id), ..draft("Outsider") })
             .unwrap();
         let plugin =
-            f.store.save_plugin(default_group_id(), PluginKind::Stripe, "", &[], None).unwrap();
+            f.store.save_plugin(default_group_id(), PluginKind::Stripe, "", &[], None, "").unwrap();
 
         let refused = f
             .store
@@ -5170,14 +5183,18 @@ mod tests {
         let group = default_group_id();
         let revenue = f.store.create_agent(&draft("Revenue")).unwrap();
         let scribe = f.store.create_agent(&draft("Scribe")).unwrap();
-        let plugin =
-            f.store.save_plugin(group, PluginKind::Stripe, "", &[tool("refund")], None).unwrap();
+        let plugin = f
+            .store
+            .save_plugin(group, PluginKind::Stripe, "", &[tool("refund")], None, "")
+            .unwrap();
         f.store
             .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![revenue.id] })
             .unwrap();
 
-        let again =
-            f.store.save_plugin(group, PluginKind::Stripe, "", &[tool("refund")], None).unwrap();
+        let again = f
+            .store
+            .save_plugin(group, PluginKind::Stripe, "", &[tool("refund")], None, "")
+            .unwrap();
 
         assert_eq!(again.access, PluginAccess::Chosen { agents: vec![revenue.id] });
         assert!(f.store.plugin_tools(group, scribe.id).unwrap().is_empty());
@@ -5188,7 +5205,7 @@ mod tests {
         let f = fixture();
         let group = default_group_id();
         let revenue = f.store.create_agent(&draft("Revenue")).unwrap();
-        let plugin = f.store.save_plugin(group, PluginKind::Stripe, "", &[], None).unwrap();
+        let plugin = f.store.save_plugin(group, PluginKind::Stripe, "", &[], None, "").unwrap();
         f.store
             .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![revenue.id] })
             .unwrap();
@@ -5208,7 +5225,7 @@ mod tests {
         let f = fixture();
         let group = default_group_id();
         let revenue = f.store.create_agent(&draft("Revenue")).unwrap();
-        let plugin = f.store.save_plugin(group, PluginKind::Stripe, "", &[], None).unwrap();
+        let plugin = f.store.save_plugin(group, PluginKind::Stripe, "", &[], None, "").unwrap();
         f.store
             .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![revenue.id] })
             .unwrap();
@@ -5238,6 +5255,7 @@ mod tests {
                 "",
                 &[tool("run_sql"), tool("drop_project")],
                 None,
+                "",
             )
             .unwrap();
 
@@ -5266,6 +5284,7 @@ mod tests {
                 "",
                 &[tool("run_sql"), tool("drop_project")],
                 None,
+                "",
             )
             .unwrap();
 
@@ -5308,7 +5327,14 @@ mod tests {
         let scribe = f.store.create_agent(&draft("Scribe")).unwrap();
         let plugin = f
             .store
-            .save_plugin(group, PluginKind::Stripe, "", &[tool("charges"), tool("refund")], None)
+            .save_plugin(
+                group,
+                PluginKind::Stripe,
+                "",
+                &[tool("charges"), tool("refund")],
+                None,
+                "",
+            )
             .unwrap();
 
         f.store
@@ -5339,7 +5365,7 @@ mod tests {
         let group = default_group_id();
         let manager = f.store.create_agent(&draft("Manager")).unwrap();
         let plugin =
-            f.store.save_plugin(group, PluginKind::Neon, "", &[tool("run_sql")], None).unwrap();
+            f.store.save_plugin(group, PluginKind::Neon, "", &[tool("run_sql")], None, "").unwrap();
 
         f.store.set_plugin_tool(plugin.id, "run_sql", false).unwrap();
         let back = f.store.set_plugin_tool(plugin.id, "run_sql", true).unwrap();
@@ -5363,7 +5389,7 @@ mod tests {
         let f = fixture();
         let plugin = f
             .store
-            .save_plugin(default_group_id(), PluginKind::Neon, "", &[tool("run_sql")], None)
+            .save_plugin(default_group_id(), PluginKind::Neon, "", &[tool("run_sql")], None, "")
             .unwrap();
 
         let refused = f.store.set_plugin_tool(plugin.id, "drop_project", false).unwrap_err();
@@ -5385,7 +5411,8 @@ mod tests {
         let group = default_group_id();
         let manager = f.store.create_agent(&draft("Manager")).unwrap();
         let published = [tool("run_sql"), tool("drop_project")];
-        let plugin = f.store.save_plugin(group, PluginKind::Neon, "", &published, None).unwrap();
+        let plugin =
+            f.store.save_plugin(group, PluginKind::Neon, "", &published, None, "").unwrap();
         f.store.set_plugin_tool(plugin.id, "drop_project", false).unwrap();
 
         // And a tool the vendor started publishing since arrives switched on,
@@ -5400,6 +5427,7 @@ mod tests {
                 "",
                 &[tool("run_sql"), tool("drop_project"), tool("list_branches")],
                 None,
+                "",
             )
             .unwrap();
 
@@ -5420,7 +5448,7 @@ mod tests {
         let f = fixture();
         let group = default_group_id();
         let plugin =
-            f.store.save_plugin(group, PluginKind::Neon, "", &[tool("run_sql")], None).unwrap();
+            f.store.save_plugin(group, PluginKind::Neon, "", &[tool("run_sql")], None, "").unwrap();
         f.store.set_plugin_tool(plugin.id, "run_sql", false).unwrap();
 
         assert!(f.store.delete_plugin(plugin.id).unwrap());
@@ -5440,8 +5468,10 @@ mod tests {
             .store
             .create_group(&CleanGroup { name: "Crew".into(), ..Default::default() })
             .unwrap();
-        let plugin =
-            f.store.save_plugin(group.id, PluginKind::Neon, "", &[tool("run_sql")], None).unwrap();
+        let plugin = f
+            .store
+            .save_plugin(group.id, PluginKind::Neon, "", &[tool("run_sql")], None, "")
+            .unwrap();
         f.store.set_plugin_tool(plugin.id, "run_sql", false).unwrap();
 
         f.store.delete_group(group.id).unwrap();
@@ -5463,7 +5493,7 @@ mod tests {
         let group = default_group_id();
         let manager = f.store.create_agent(&draft("Manager")).unwrap();
         let plugin =
-            f.store.save_plugin(group, PluginKind::Neon, "", &[tool("run_sql")], None).unwrap();
+            f.store.save_plugin(group, PluginKind::Neon, "", &[tool("run_sql")], None, "").unwrap();
         f.store
             .conn()
             .unwrap()

--- a/src-tauri/src/domain/plugin.rs
+++ b/src-tauri/src/domain/plugin.rs
@@ -363,6 +363,13 @@ pub struct Plugin {
     /// group's either way: this decides who is allowed to spend it, not who
     /// holds it.
     pub access: PluginAccess,
+    /// Which authorized identity at the operator's Guaca account this crew uses.
+    ///
+    /// Only meaningful for an account-backed kind, and empty is the account's
+    /// default. A person can authorize the same provider twice — a work Google
+    /// and a personal one — and those are two grants with two ids; this is how
+    /// one group says which of them it means while another says the other.
+    pub connection: String,
     /// False for a server that authorised nothing because it asked for nothing.
     /// Every server on the list today asks, so this is true in practice; it is
     /// read off whether a grant was actually issued rather than off the fact

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -91,11 +91,11 @@ pub async fn connect(
     // and there is no other seam wide enough to put one behind. Production
     // passes `kind.endpoint()` and nothing else ever should.
     endpoint: &str,
-    // The machine's Guaca account token, for a plugin whose credential is that
+    // The machine's Guaca account, for a plugin whose credential is that
     // account rather than a grant of its own. `None` for every other kind, and
     // for an account-backed one it is the caller saying the operator is signed
     // in: see [`PluginKind::account_backed`].
-    account: Option<&str>,
+    account: Option<AccountUse<'_>>,
     open: impl FnOnce(&str) -> Result<(), String>,
 ) -> Result<Plugin, PluginError> {
     // An account-backed plugin never runs the browser dance. Its server is the
@@ -103,11 +103,18 @@ pub async fn connect(
     // grant: the token rotates on the account's clock, so a copy here would be
     // a second thing to keep fresh and a second thing to be stale.
     if kind.account_backed() {
-        let token = account.ok_or(PluginError::NoAccount { label: kind.label() })?;
-        let session = mcp::open(endpoint, Some(token)).await?;
+        let used = account.ok_or(PluginError::NoAccount { label: kind.label() })?;
+        let session = mcp::open(endpoint, Some(used.token)).await?;
         let tools = read_tools(&session).await?;
         let account_label = account_label(&session, kind);
-        return Ok(store.save_plugin(group, kind, &account_label, &tools, None)?);
+        return Ok(store.save_plugin(
+            group,
+            kind,
+            &account_label,
+            &tools,
+            None,
+            used.connection,
+        )?);
     }
 
     let (session, grant) = match mcp::open(endpoint, None).await {
@@ -127,7 +134,9 @@ pub async fn connect(
     let tools = read_tools(&session).await?;
     let account_label = account_label(&session, kind);
 
-    Ok(store.save_plugin(group, kind, &account_label, &tools, grant.as_ref())?)
+    // Only an account-backed kind carries one; the others sign in per group and
+    // their grant already names the identity it was issued to.
+    Ok(store.save_plugin(group, kind, &account_label, &tools, grant.as_ref(), "")?)
 }
 
 async fn read_tools(session: &mcp::Session) -> Result<Vec<PluginTool>, PluginError> {
@@ -172,6 +181,37 @@ fn account_label(session: &mcp::Session, kind: PluginKind) -> String {
 /// server rejects it anyway: a token can be revoked at the vendor between one
 /// turn and the next, and a clock that is a little wrong makes "close to
 /// expiring" a guess rather than a fact.
+/// The machine's Guaca account, as a plugin credential.
+///
+/// The token and the identity travel together and mean nothing apart: the token
+/// says which account, and the connection says which of the identities that
+/// account has authorized. A caller holding one and guessing the other is the
+/// bug this type exists to prevent, which is a crew reaching the wrong mailbox.
+#[derive(Debug, Clone, Copy)]
+pub struct AccountUse<'a> {
+    pub token: &'a str,
+    /// Which authorized identity, or empty for the account's default. Empty is
+    /// what a plugin connected before connections existed keeps sending, and it
+    /// is right for an account with one identity, which is most of them.
+    pub connection: &'a str,
+}
+
+impl AccountUse<'_> {
+    /// Where this connection's server is, given the account's own origin.
+    ///
+    /// Unnamed stays on the bare path rather than inventing one, because that
+    /// is the address an already-connected plugin is dialling and an upgrade
+    /// must not quietly repoint a working crew.
+    pub fn endpoint(origin: &str, connection: &str) -> String {
+        let origin = origin.trim_end_matches('/');
+        if connection.is_empty() {
+            format!("{origin}/mcp")
+        } else {
+            format!("{origin}/mcp/{connection}")
+        }
+    }
+}
+
 /// Which plugin a call is for, and on whose behalf.
 ///
 /// Grouped rather than passed loose because the five travel together and mean
@@ -184,8 +224,8 @@ pub struct Target<'a> {
     pub kind: PluginKind,
     /// See `connect`: production passes `kind.endpoint()`.
     pub endpoint: &'a str,
-    /// See `connect`: the machine's account token, for an account-backed kind.
-    pub account: Option<&'a str>,
+    /// See `connect`: the machine's account, for an account-backed kind.
+    pub account: Option<AccountUse<'a>>,
 }
 
 pub async fn call(
@@ -212,8 +252,8 @@ pub async fn call(
     // account that has been signed out reads as no token at all, which says so
     // rather than failing on the wire.
     if kind.account_backed() {
-        let token = account.ok_or(PluginError::NoAccount { label: kind.label() })?;
-        let session = mcp::open(endpoint, Some(token)).await?;
+        let used = account.ok_or(PluginError::NoAccount { label: kind.label() })?;
+        let session = mcp::open(endpoint, Some(used.token)).await?;
         return Ok(mcp::call_tool(&session, tool, arguments).await?);
     }
 
@@ -265,6 +305,32 @@ async fn renew(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn an_unnamed_connection_stays_on_the_bare_path() {
+        // The address an already-connected plugin is dialling. An upgrade that
+        // invented an id here would silently repoint a working crew at a
+        // different mailbox, which is the one failure this column exists to
+        // prevent rather than cause.
+        assert_eq!(AccountUse::endpoint("https://guaca.bot", ""), "https://guaca.bot/mcp");
+        assert_eq!(AccountUse::endpoint("https://guaca.bot/", ""), "https://guaca.bot/mcp");
+    }
+
+    #[test]
+    fn a_named_connection_is_part_of_the_address() {
+        // Which identity a crew uses is in the path, because that is how the
+        // server scopes a session and there is nowhere else in MCP to put it.
+        assert_eq!(
+            AccountUse::endpoint("https://guaca.bot", "acct_1"),
+            "https://guaca.bot/mcp/acct_1"
+        );
+        // Development points the account somewhere else, and the plugin has to
+        // follow it or a crew signs in to one origin and calls another.
+        assert_eq!(
+            AccountUse::endpoint("http://localhost:8787", "acct_1"),
+            "http://localhost:8787/mcp/acct_1"
+        );
+    }
 
     #[test]
     fn a_plugin_that_is_not_connected_says_who_can_connect_it() {

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -554,6 +554,15 @@ impl Runtime {
         let _ = self.inner.account.set(account);
     }
 
+    /// Where the machine's account lives, for building a plugin endpoint.
+    pub fn account_origin(&self) -> &str {
+        self.inner
+            .account
+            .get()
+            .map(|account| account.origin())
+            .unwrap_or(crate::account::DEFAULT_ORIGIN)
+    }
+
     /// A token for the machine's account, or nothing.
     ///
     /// Nothing means either no account was handed over or the operator is not
@@ -2730,14 +2739,34 @@ impl Runtime {
                 // token, and a copy taken when the turn started is one that can
                 // be stale by the time the tool is reached.
                 let account = if kind.account_backed() { self.account_token().await } else { None };
+                // Which identity this crew chose, and therefore which address.
+                // Read off the stored row rather than remembered, because the
+                // operator can move a group between accounts between turns.
+                let connection = if kind.account_backed() {
+                    self.store()
+                        .group_plugins(card.group_id)
+                        .ok()
+                        .and_then(|all| all.into_iter().find(|held| held.kind == kind))
+                        .map(|held| held.connection)
+                        .unwrap_or_default()
+                } else {
+                    String::new()
+                };
+                let endpoint = if kind.account_backed() {
+                    plugins::AccountUse::endpoint(self.account_origin(), &connection)
+                } else {
+                    self.plugin_endpoint(kind).to_string()
+                };
                 let called = plugins::call(
                     self.store(),
                     plugins::Target {
                         group: card.group_id,
                         agent: card.id,
                         kind,
-                        endpoint: self.plugin_endpoint(kind),
-                        account: account.as_deref(),
+                        endpoint: &endpoint,
+                        account: account
+                            .as_deref()
+                            .map(|token| plugins::AccountUse { token, connection: &connection }),
                     },
                     &tool,
                     &sent,

--- a/src-tauri/tests/plugins.rs
+++ b/src-tauri/tests/plugins.rs
@@ -610,7 +610,7 @@ mod account_backed {
             group,
             PluginKind::Google,
             &format!("{}/mcp", server.base()),
-            Some(ACCOUNT),
+            Some(plugins::AccountUse { token: ACCOUNT, connection: "" }),
             |_| panic!("an account-backed plugin must not send anyone to a browser"),
         )
         .await
@@ -636,9 +636,16 @@ mod account_backed {
         let (_dir, store, group, agent) = workspace();
         let endpoint = format!("{}/mcp", server.base());
 
-        plugins::connect(&store, group, PluginKind::Google, &endpoint, Some(ACCOUNT), |_| Ok(()))
-            .await
-            .unwrap();
+        plugins::connect(
+            &store,
+            group,
+            PluginKind::Google,
+            &endpoint,
+            Some(plugins::AccountUse { token: ACCOUNT, connection: "" }),
+            |_| Ok(()),
+        )
+        .await
+        .unwrap();
 
         match store.plugin_reach(group, agent, PluginKind::Google, "gmail_search").unwrap() {
             guac_lib::db::store::PluginReach::Granted { grant, .. } => {
@@ -676,9 +683,16 @@ mod account_backed {
         let (_dir, store, group, agent) = workspace();
         let endpoint = format!("{}/mcp", server.base());
 
-        plugins::connect(&store, group, PluginKind::Google, &endpoint, Some(ACCOUNT), |_| Ok(()))
-            .await
-            .unwrap();
+        plugins::connect(
+            &store,
+            group,
+            PluginKind::Google,
+            &endpoint,
+            Some(plugins::AccountUse { token: ACCOUNT, connection: "" }),
+            |_| Ok(()),
+        )
+        .await
+        .unwrap();
 
         let answer = plugins::call(
             &store,
@@ -687,7 +701,7 @@ mod account_backed {
                 agent,
                 kind: PluginKind::Google,
                 endpoint: &endpoint,
-                account: Some(ACCOUNT),
+                account: Some(plugins::AccountUse { token: ACCOUNT, connection: "" }),
             },
             "run_sql",
             &serde_json::json!({ "sql": "select 1" }),
@@ -707,9 +721,16 @@ mod account_backed {
         let (_dir, store, group, agent) = workspace();
         let endpoint = format!("{}/mcp", server.base());
 
-        plugins::connect(&store, group, PluginKind::Google, &endpoint, Some(ACCOUNT), |_| Ok(()))
-            .await
-            .unwrap();
+        plugins::connect(
+            &store,
+            group,
+            PluginKind::Google,
+            &endpoint,
+            Some(plugins::AccountUse { token: ACCOUNT, connection: "" }),
+            |_| Ok(()),
+        )
+        .await
+        .unwrap();
 
         let failed = plugins::call(
             &store,
@@ -738,12 +759,16 @@ mod account_backed {
         let (_dir, store, group, agent) = workspace();
         let endpoint = format!("{}/mcp", server.base());
 
-        let plugin =
-            plugins::connect(&store, group, PluginKind::Google, &endpoint, Some(ACCOUNT), |_| {
-                Ok(())
-            })
-            .await
-            .unwrap();
+        let plugin = plugins::connect(
+            &store,
+            group,
+            PluginKind::Google,
+            &endpoint,
+            Some(plugins::AccountUse { token: ACCOUNT, connection: "" }),
+            |_| Ok(()),
+        )
+        .await
+        .unwrap();
 
         // Chosen, and this agent is not among them.
         store
@@ -760,7 +785,7 @@ mod account_backed {
                 agent,
                 kind: PluginKind::Google,
                 endpoint: &endpoint,
-                account: Some(ACCOUNT),
+                account: Some(plugins::AccountUse { token: ACCOUNT, connection: "" }),
             },
             "run_sql",
             &serde_json::json!({}),
@@ -806,12 +831,16 @@ async fn the_real_account_server_still_speaks_what_this_client_sends() {
 
     let (_dir, store, group, agent) = workspace();
 
-    let plugin =
-        plugins::connect(&store, group, PluginKind::Google, &endpoint, Some(&token), |_| {
-            panic!("an account-backed plugin must not open a browser")
-        })
-        .await
-        .expect("the account token should connect");
+    let plugin = plugins::connect(
+        &store,
+        group,
+        PluginKind::Google,
+        &endpoint,
+        Some(plugins::AccountUse { token: &token, connection: "" }),
+        |_| panic!("an account-backed plugin must not open a browser"),
+    )
+    .await
+    .expect("the account token should connect");
 
     // A grant with nothing authorised offers nothing, which is a real state and
     // not a failure: it means the operator has not authorised Google yet.
@@ -828,7 +857,7 @@ async fn the_real_account_server_still_speaks_what_this_client_sends() {
                 agent,
                 kind: PluginKind::Google,
                 endpoint: &endpoint,
-                account: Some(&token),
+                account: Some(plugins::AccountUse { token: &token, connection: "" }),
             },
             tool,
             &serde_json::json!({}),

--- a/src/components/PluginList.test.tsx
+++ b/src/components/PluginList.test.tsx
@@ -1,12 +1,20 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { AgentCard, Plugin, PluginAccess, PluginOffer, PluginToolCard } from "../lib/types";
+import type {
+  AccountConnectors,
+  AgentCard,
+  Plugin,
+  PluginAccess,
+  PluginOffer,
+  PluginToolCard,
+} from "../lib/types";
 import { PluginList } from "./PluginList";
 
 const pluginCatalogue = vi.fn<() => Promise<PluginOffer[]>>();
 const groupPlugins = vi.fn<() => Promise<Plugin[]>>();
-const connectPlugin = vi.fn<(groupId: string, kind: string) => Promise<Plugin>>();
+const connectPlugin =
+  vi.fn<(groupId: string, kind: string, connection?: string) => Promise<Plugin>>();
 const disconnectPlugin = vi.fn();
 const setPluginAccess = vi.fn<(id: string, access: PluginAccess) => Promise<Plugin>>();
 const setPluginTool = vi.fn<(id: string, tool: string, allowed: boolean) => Promise<Plugin>>();
@@ -16,13 +24,31 @@ vi.mock("../lib/ipc", () => ({
   api: {
     pluginCatalogue: () => pluginCatalogue(),
     groupPlugins: () => groupPlugins(),
-    connectPlugin: (groupId: string, kind: string) => connectPlugin(groupId, kind),
+    accountConnectors: () => accountConnectors(),
+    connectPlugin: (groupId: string, kind: string, connection?: string) =>
+      connectPlugin(groupId, kind, connection),
+    setPluginConnection: (groupId: string, kind: string, connection: string) =>
+      setPluginConnection(groupId, kind, connection),
     disconnectPlugin: (id: string) => disconnectPlugin(id),
     setPluginAccess: (id: string, access: PluginAccess) => setPluginAccess(id, access),
     setPluginTool: (id: string, tool: string, allowed: boolean) => setPluginTool(id, tool, allowed),
   },
   openExternal: (url: string) => openExternal(url),
 }));
+
+/**
+ * The account's authorized identities.
+ *
+ * Rejecting by default, which is what an install with no Guaca account does.
+ * The panel has to draw anyway: the account is optional and a plugin list that
+ * waited on it would be blank for everybody who never signed in.
+ */
+const accountConnectors = vi.fn<() => Promise<AccountConnectors>>(async () => {
+  throw new Error("not signed in");
+});
+const setPluginConnection = vi.fn<
+  (groupId: string, kind: string, connection: string) => Promise<Plugin>
+>(async () => plugin());
 
 const GROUP = "00000000-0000-4000-8000-000000000001";
 
@@ -57,6 +83,7 @@ function plugin(over: Partial<Plugin> = {}): Plugin {
     account: "",
     tools: [tool("run_sql"), tool("create_branch")],
     access: { mode: "everyone" },
+    connection: "",
     signedIn: true,
     connectedAt: 0,
     ...over,
@@ -124,7 +151,9 @@ describe("PluginList", () => {
     render(<PluginList groupId={GROUP} crew={CREW} />);
     fireEvent.click((await screen.findAllByText("Connect"))[0]!);
 
-    await waitFor(() => expect(connectPlugin).toHaveBeenCalledWith(GROUP, "neon"));
+    // No identity named: Neon signs in per group, and an account with none
+    // connects against the account's default.
+    await waitFor(() => expect(connectPlugin).toHaveBeenCalledWith(GROUP, "neon", undefined));
     expect(screen.getByText("Waiting for your browser…")).toBeTruthy();
 
     groupPlugins.mockResolvedValue([plugin()]);
@@ -327,5 +356,96 @@ describe("PluginList", () => {
     fireEvent.click((await screen.findAllByText("Connect"))[0]!);
     expect(await screen.findByText(/access_denied/)).toBeTruthy();
     expect(screen.getAllByText("Connect").length).toBe(2);
+  });
+});
+
+/**
+ * Two Google accounts on one Guaca account.
+ *
+ * The case this whole column exists for: a work Google and a personal one are
+ * two grants, and two crews have to be able to use one each. Before this, both
+ * reached whichever the service returned first.
+ */
+describe("choosing which account a crew uses", () => {
+  const GOOGLE_OFFER: PluginOffer = {
+    kind: "google",
+    name: "Google",
+    blurb: "Your Gmail, Calendar and Drive.",
+    docs: "https://guaca.bot/app",
+    endpoint: "https://guaca.bot/mcp",
+  };
+
+  const two: AccountConnectors = {
+    email: "robert@example.com",
+    providers: [],
+    connections: [
+      { id: "acct_work", provider: "google", label: "work@example.com", capabilities: ["gmail"] },
+      { id: "acct_home", provider: "google", label: "home@example.com", capabilities: ["drive"] },
+    ],
+  };
+
+  const one: AccountConnectors = { ...two, connections: [two.connections[0]!] };
+
+  beforeEach(() => {
+    pluginCatalogue.mockResolvedValue([GOOGLE_OFFER]);
+  });
+
+  it("offers no picker when there is only one account to pick", async () => {
+    // A select with a single option is a control that cannot do anything.
+    accountConnectors.mockResolvedValue(one);
+    groupPlugins.mockResolvedValue([plugin({ kind: "google", connection: "acct_work" })]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    await waitFor(() => expect(screen.getByText("Google")).toBeTruthy());
+    expect(screen.queryByLabelText(/^Account/)).toBeNull();
+  });
+
+  it("offers a picker showing every authorized identity", async () => {
+    accountConnectors.mockResolvedValue(two);
+    groupPlugins.mockResolvedValue([plugin({ kind: "google", connection: "acct_work" })]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    const picker = (await screen.findByLabelText(/^Account/)) as HTMLSelectElement;
+    expect([...picker.options].map((option) => option.textContent)).toEqual([
+      "work@example.com",
+      "home@example.com",
+    ]);
+    expect(picker.value).toBe("acct_work");
+  });
+
+  it("moves the crew to the other account without disconnecting", async () => {
+    // Reconnecting would replace the row and lose the per-tool switches the
+    // operator set, which is why this is its own command.
+    accountConnectors.mockResolvedValue(two);
+    groupPlugins.mockResolvedValue([plugin({ kind: "google", connection: "acct_work" })]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    const picker = await screen.findByLabelText(/^Account/);
+    fireEvent.change(picker, { target: { value: "acct_home" } });
+
+    await waitFor(() =>
+      expect(setPluginConnection).toHaveBeenCalledWith(GROUP, "google", "acct_home"),
+    );
+    expect(disconnectPlugin).not.toHaveBeenCalled();
+  });
+
+  it("connects a fresh crew against the first identity", async () => {
+    accountConnectors.mockResolvedValue(two);
+    groupPlugins.mockResolvedValue([]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    fireEvent.click(await screen.findByText("Connect"));
+    await waitFor(() => expect(connectPlugin).toHaveBeenCalledWith(GROUP, "google", "acct_work"));
+  });
+
+  it("draws the plugin list even when the account cannot be reached", async () => {
+    // The account is optional. A panel that waited on guaca.bot would be blank
+    // for everybody who never signed in.
+    accountConnectors.mockRejectedValue(new Error("not signed in"));
+    groupPlugins.mockResolvedValue([]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    expect(await screen.findByText("Google")).toBeTruthy();
+    expect(screen.queryByLabelText(/^Account/)).toBeNull();
   });
 });

--- a/src/components/PluginList.tsx
+++ b/src/components/PluginList.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import { api, openExternal } from "../lib/ipc";
 import { BRANDS, hostOf } from "../lib/plugins";
 import {
+  type AccountConnection,
   type AgentCard,
   type AgentId,
   errorMessage,
@@ -103,6 +104,11 @@ export function PluginList({ groupId, crew }: Props) {
   // between the operator and the button they came here for, and the counts on
   // the line above are what says whether opening one is worth it.
   const [opened, setOpened] = useState<string[]>([]);
+  // Which identities the operator has authorized at their Guaca account. Only
+  // an account-backed plugin has any, and an install with no account has none,
+  // which is why a failure here is swallowed rather than surfaced: it means
+  // there is nothing to choose between, not that the panel is broken.
+  const [connections, setConnections] = useState<AccountConnection[]>([]);
 
   const load = useCallback(async () => {
     try {
@@ -113,6 +119,13 @@ export function PluginList({ groupId, crew }: Props) {
       setOffers(catalogue);
       setConnected(held);
       setError(null);
+      // Separately, and deliberately not awaited with the two above: this one
+      // goes over the network to guaca.bot, and a slow or absent service must
+      // not keep the plugin list from drawing.
+      void api
+        .accountConnectors()
+        .then((account) => setConnections(account.connections))
+        .catch(() => setConnections([]));
     } catch (caught) {
       setError(errorMessage(caught));
       setOffers([]);
@@ -146,6 +159,8 @@ export function PluginList({ groupId, crew }: Props) {
         const brand = BRANDS[offer.kind];
         const working = busy === offer.kind;
         const chosen = held?.access.mode === "chosen" ? held.access.agents : [];
+        // Two Google accounts are two grants, and a crew uses one of them.
+        const mine = connections.filter((connection) => connection.provider === offer.kind);
 
         return (
           <div className="access__item" key={offer.kind}>
@@ -179,7 +194,15 @@ export function PluginList({ groupId, crew }: Props) {
                   type="button"
                   className="btn btn--small btn--primary"
                   disabled={busy !== null}
-                  onClick={() => void run(offer.kind, () => api.connectPlugin(groupId, offer.kind))}
+                  onClick={() =>
+                    void run(offer.kind, () =>
+                      // The first identity when there is one, so the common
+                      // case is still one click. With none, this connects
+                      // against the account's default and the refusal from Rust
+                      // is what says an account is needed.
+                      api.connectPlugin(groupId, offer.kind, mine[0]?.id),
+                    )
+                  }
                 >
                   {working ? "Waiting for your browser…" : "Connect"}
                 </button>
@@ -194,6 +217,36 @@ export function PluginList({ groupId, crew }: Props) {
                   {!held.signedIn &&
                     " This server asked for no sign-in, so nothing was authorised."}
                 </p>
+
+                {/* Which of the account's identities this crew uses.
+                    Shown only when there is a choice to make: one authorized
+                    Google is not a decision, and a select with a single option
+                    is a control that cannot do anything. */}
+                {mine.length > 1 && (
+                  <label className="field">
+                    <span className="field__label">Account</span>
+                    <select
+                      className="input"
+                      value={held.connection || mine[0]?.id || ""}
+                      disabled={busy !== null}
+                      onChange={(event) =>
+                        void run(offer.kind, () =>
+                          api.setPluginConnection(groupId, offer.kind, event.target.value),
+                        )
+                      }
+                    >
+                      {mine.map((connection) => (
+                        <option key={connection.id} value={connection.id}>
+                          {connection.label}
+                        </option>
+                      ))}
+                    </select>
+                    <span className="field__hint">
+                      Which {offer.name} account this crew acts as. Its tools are re-read when you
+                      change it, because two accounts do not always authorize the same things.
+                    </span>
+                  </label>
+                )}
 
                 {/* Two buttons rather than a list with an "all" entry at the
                     top: every agent is a standing answer that covers whoever

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -113,6 +113,9 @@ function linked(over: Partial<AccountStatus> = {}): AccountStatus {
 function held(granted = true): AccountConnectors {
   return {
     email: "robert@example.com",
+    connections: [
+      { id: "acct_1", provider: "google", label: "robert@example.com", capabilities: ["gmail"] },
+    ],
     providers: [
       {
         id: "google",

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -138,8 +138,8 @@ export const api = {
    * one. Resolves only once they have finished there, which can be minutes, so
    * whatever calls this has to show that it is waiting on a person.
    */
-  connectPlugin: (groupId: GroupId, kind: PluginKind) =>
-    invoke<Plugin>("connect_plugin", { groupId, kind }),
+  connectPlugin: (groupId: GroupId, kind: PluginKind, connection?: string) =>
+    invoke<Plugin>("connect_plugin", { groupId, kind, connection: connection ?? null }),
 
   /**
    * Narrows a plugin to named agents, or opens it back up to the crew.
@@ -425,6 +425,16 @@ export const api = {
 
   /** Forgets the sign-in on this machine. */
   signOutAccount: () => invoke<AccountStatus>("sign_out_account"),
+
+  /**
+   * Points a crew's plugin at a different authorized identity.
+   *
+   * Separate from connecting because it is a different act: this moves an
+   * existing row to another mailbox and keeps the per-tool switches, where
+   * reconnecting would replace the row and lose them.
+   */
+  setPluginConnection: (groupId: GroupId, kind: PluginKind, connection: string) =>
+    invoke<Plugin>("set_plugin_connection", { groupId, kind, connection }),
 };
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -307,6 +307,8 @@ export interface Plugin {
   tools: PluginToolCard[];
   /** Which of the crew is offered them. `everyone` until somebody says else. */
   access: PluginAccess;
+  /** Which authorized identity at the Guaca account this crew uses, if any. */
+  connection: string;
   signedIn: boolean;
   connectedAt: number;
 }
@@ -568,9 +570,25 @@ export interface AccountProvider {
  * Read rather than kept. It changes when the operator authorizes something in
  * a browser rather than when this app does anything.
  */
+/**
+ * One identity the operator has authorized at a provider.
+ *
+ * A person can authorize the same provider twice — a work Google and a personal
+ * one — and each is its own grant. A group binds to one of these, which is what
+ * lets two crews use two mailboxes.
+ */
+export interface AccountConnection {
+  id: string;
+  provider: string;
+  /** The provider's own name for it, which is how two are told apart. */
+  label: string;
+  capabilities: string[];
+}
+
 export interface AccountConnectors {
   email: string;
   providers: AccountProvider[];
+  connections: AccountConnection[];
 }
 
 /** What the operator carries to a browser to finish signing in. */


### PR DESCRIPTION
Two crews, one Guaca account, and each needs a different Google. Connecting the
second one reached the first, because a plugin row named a provider and the
service answered with whichever grant came back first.

A plugin row now names an identity. `plugins.connection` holds the guaca.bot
connection a crew is bound to, and it is part of the address the runtime dials:
`/mcp/<id>` rather than `/mcp`. Two groups can hold two Google accounts at once,
which the single-grant model could not express at all.

Empty is not a missing value. It is the account's default, it is what every
plugin connected before this column existed keeps sending, and bare `/mcp` still
answers with every connection's tools. An upgrade that invented an id here would
silently repoint a working crew at a different mailbox, which is the failure
this change exists to prevent rather than cause.

Changing it is `set_plugin_connection` rather than Disconnect and Connect.
Those are different acts: reconnecting replaces the row and loses the per-tool
switches the operator set. The tool list is re-read either way, because two
identities do not publish the same tools — a grant that can read mail and not
send it offers fewer, and a row holding the old list would offer a model a tool
that is no longer there.

The picker appears only when there is a choice to make. One authorized Google is
not a decision, and a select with a single option is a control that cannot do
anything. It is loaded separately from the plugin list and its failure is
swallowed: the account is optional, and a panel that waited on guaca.bot would
be blank for everybody who never signed in.

`AccountUse` pairs the token with the connection because they mean nothing
apart — a caller holding one and guessing the other is a crew reaching the wrong
mailbox.