### PR TITLE
fix: a transcript is at the end when it says it is

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,7 +262,11 @@ the model takes a screenshot to see what `browse` did.
   it wrote and checks the box is still there before writing again, which is why
   one pixel is enough and no threshold is. Its listener is bound by a ref
   callback for the same reason: the node is replaced whenever the pane shows a
-  pair thread or the activity board, and an effect cannot re-bind on that.
+  pair thread or the activity board, and an effect cannot re-bind on that. The
+  size observer beside it is bound there for that reason too, and it is not
+  decoration: everything under a transcript takes height from it without
+  anything arriving or scrolling, so a composer growing a line or the working
+  panel opening put the newest message under the fold and left it there.
 - **What a plugin's sign-in asks for is the resource's list, not its
   authorisation server's.** They are two documents and two lists: RFC 9728 names
   the scopes for *that resource*, RFC 8414 names everything the server can issue

--- a/src/lib/follow.test.ts
+++ b/src/lib/follow.test.ts
@@ -29,6 +29,7 @@ import { useFollowBottom } from "./follow";
 function box(content: number, view: number, late = false) {
   const el = document.createElement("div");
   let height = content;
+  let viewport = view;
   let top = 0;
   let writes = 0;
   let owed = 0;
@@ -37,13 +38,13 @@ function box(content: number, view: number, late = false) {
     else el.dispatchEvent(new Event("scroll"));
   };
   Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => height });
-  Object.defineProperty(el, "clientHeight", { configurable: true, get: () => view });
+  Object.defineProperty(el, "clientHeight", { configurable: true, get: () => viewport });
   Object.defineProperty(el, "scrollTop", {
     configurable: true,
     get: () => top,
     set: (next: number) => {
       writes += 1;
-      const landed = Math.max(0, Math.min(next, height - view));
+      const landed = Math.max(0, Math.min(next, height - viewport));
       if (landed === top) return;
       top = landed;
       announce();
@@ -63,10 +64,29 @@ function box(content: number, view: number, late = false) {
       height -= by;
       // The browser clamps an offset that no longer exists, and that is a
       // scroll event nobody asked for.
-      if (top > height - view) {
-        top = Math.max(0, height - view);
+      if (top > height - viewport) {
+        top = Math.max(0, height - viewport);
         announce();
       }
+    },
+    /**
+     * The box itself getting smaller, which is what everything under a
+     * transcript does to it: the composer growing a line, a trail of chips
+     * landing, the working panel opening, the window being dragged shorter.
+     * Nothing scrolls, so nothing is announced, and the end of the
+     * conversation is simply somewhere else now.
+     */
+    narrow: (by: number) => {
+      viewport -= by;
+      resized(el);
+    },
+    widen: (by: number) => {
+      viewport += by;
+      if (top > height - viewport) {
+        top = Math.max(0, height - viewport);
+        announce();
+      }
+      resized(el);
     },
     /** What the browser gets round to telling us, whenever it does. */
     deliver: () => {
@@ -74,7 +94,7 @@ function box(content: number, view: number, late = false) {
     },
     top: () => top,
     /** How far the newest line sits below the bottom edge. */
-    behind: () => height - top - view,
+    behind: () => height - top - viewport,
     /** How many times anything has moved the box. */
     writes: () => writes,
   };
@@ -89,6 +109,36 @@ function flushFrames() {
   for (const run of due) run(0);
 }
 
+/**
+ * Who is watching which box for a change of size.
+ *
+ * The stub in `test-setup` reports nothing, which is right for a component that
+ * only has to mount. This one is driven: `narrow` and `widen` are the box
+ * changing size, and the browser telling whoever asked is the point.
+ */
+const watchers = new Map<Element, Set<ResizeObserverCallback>>();
+
+function resized(el: Element) {
+  for (const notify of watchers.get(el) ?? []) {
+    notify([{ target: el } as ResizeObserverEntry], null as unknown as ResizeObserver);
+  }
+}
+
+class WatchedResizeObserver {
+  constructor(private readonly notify: ResizeObserverCallback) {}
+  observe(target: Element) {
+    const held = watchers.get(target) ?? new Set();
+    held.add(this.notify);
+    watchers.set(target, held);
+  }
+  unobserve(target: Element) {
+    watchers.get(target)?.delete(this.notify);
+  }
+  disconnect() {
+    for (const held of watchers.values()) held.delete(this.notify);
+  }
+}
+
 function attach(content = 1000, view = 200, late = false) {
   const { result } = renderHook(() => useFollowBottom());
   const scroller = box(content, view, late);
@@ -98,11 +148,14 @@ function attach(content = 1000, view = 200, late = false) {
 
 beforeEach(() => {
   frames = [];
+  watchers.clear();
   vi.spyOn(window, "requestAnimationFrame").mockImplementation((run) => frames.push(run));
+  vi.stubGlobal("ResizeObserver", WatchedResizeObserver);
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("following the newest line", () => {
@@ -206,6 +259,69 @@ describe("following the newest line", () => {
     view.grow(400);
     view.hook.follow();
     expect(view.behind()).toBe(0);
+  });
+
+  it("holds the end when the box shrinks under a follower", () => {
+    // Everything below a transcript takes its height from the transcript: the
+    // composer growing a line as a message is typed, a turn's chips landing,
+    // the working panel opening, the window dragged shorter. Nothing scrolls
+    // and no content arrives, so neither of the other two routes here fires,
+    // and the newest line goes quietly under the fold and stays there until
+    // the next token happens to land.
+    const view = attach();
+    view.hook.pin();
+    expect(view.behind()).toBe(0);
+
+    view.narrow(160);
+    expect(view.behind()).toBe(0);
+  });
+
+  it("holds the end when the box grows back", () => {
+    // Sending is the round trip: the composer grew while the message was
+    // typed, and collapses to one line the moment it goes. The browser clamps
+    // the offset on the way back, which leaves the operator at the end, and
+    // this has to agree rather than call it somebody moving the box.
+    const view = attach();
+    view.hook.pin();
+    view.narrow(160);
+    expect(view.behind()).toBe(0);
+
+    view.widen(160);
+    expect(view.behind()).toBe(0);
+
+    view.grow(400);
+    view.hook.follow();
+    expect(view.behind()).toBe(0);
+  });
+
+  it("leaves a reader alone when the box shrinks under them", () => {
+    // The same event, and the reason it cannot simply write the end: somebody
+    // who scrolled up and then typed a long message is still reading.
+    const view = attach();
+    view.hook.pin();
+    view.scroll(-400);
+
+    view.narrow(160);
+    expect(view.top()).toBe(400);
+  });
+
+  it("does not move a reader who scrolled up after touching the end", () => {
+    // Down to the newest line, then straight back up to keep reading. The
+    // return is what puts this hook back in charge, and until it writes an
+    // offset of its own there is nothing for the next scroll to be measured
+    // against: every one of them read as its own, and the next message threw
+    // the operator back to the floor.
+    const view = attach();
+    view.hook.pin();
+    view.scroll(-400);
+    view.scroll(400);
+    view.scroll(-300);
+
+    view.grow(400);
+    view.hook.follow();
+    flushFrames();
+
+    expect(view.top()).toBe(500);
   });
 
   it("goes back to the end when the operator asks for it", () => {

--- a/src/lib/follow.ts
+++ b/src/lib/follow.ts
@@ -29,6 +29,16 @@ import { type RefCallback, useCallback, useRef } from "react";
  * about. Stopping a few pixels short of the end while scrolling down is
  * arriving at the end, and a transcript that then refuses to follow reads as
  * broken in the other direction.
+ *
+ * **The end also moves when nothing arrives.** Everything under a transcript
+ * takes its height from the transcript: the composer growing a line as a
+ * message is typed, a turn's chips landing, the working panel opening, the
+ * window dragged shorter. Nothing scrolls and no content arrives, so neither
+ * of the routes above fires, and the newest line goes under the fold and stays
+ * there until the next token happens to land. So the box is watched for a
+ * change of its own size, and that is the third and last thing that writes
+ * here. It answers to the same question as the other two, which is whether the
+ * operator is at the end.
  */
 
 /** Coming down the page: this close to the end is arriving at it. */
@@ -118,16 +128,32 @@ export function useFollowBottom(): FollowBottom {
         }
         if (down && box.scrollHeight - top - box.clientHeight <= NEAR_END_PX) {
           following.current = true;
-          written.current = null;
+          // Where they stopped, rather than nothing. An offset of null means
+          // this hook has not written one, and reads as "wherever the box is,
+          // it is where I left it", so until something committed and wrote a
+          // real one every scroll up from here counted as this hook's own: the
+          // operator could not leave the end again, and the next message threw
+          // them back to it from wherever they had climbed to.
+          written.current = top;
         }
       };
       box.addEventListener("scroll", onScroll, { passive: true });
+
+      // The box changing size is the third way the end moves, and the only one
+      // nothing else can see: no content arrived and nobody scrolled, so there
+      // is no render to hang a layout effect on and no event to listen for.
+      // `toEnd` asks the same question it always does, so a reader who scrolled
+      // up and then typed a long message is left where they are.
+      const watch = new ResizeObserver(() => toEnd());
+      watch.observe(box);
+
       return () => {
         node.current = null;
         box.removeEventListener("scroll", onScroll);
+        watch.disconnect();
       };
     },
-    [ours, release],
+    [ours, release, toEnd],
   );
 
   // Written now and again at the end of the frame. Now, because a frame drawn


### PR DESCRIPTION
Two defects in `src/lib/follow.ts`, both reproduced in a real rendering browser with before/after numbers. The transcript followed content arriving but not the box shrinking, and everything under a transcript takes height from it without anything arriving or anybody scrolling, so typing a three-line message buried 160px of conversation and opening the working panel buried 43 more, each staying buried until the next token happened to land; the box is now watched for a change of its own size, bound in the same ref callback as the scroll listener and for the same reason. Separately, coming back to the end cleared the offset the hook remembers, so from the moment the operator touched the bottom every scroll up counted as the hook's own move and the next message threw them back to the floor from wherever they had climbed to.

Three new tests fail without the change, and a fourth covers the half that has to keep doing nothing: a reader who scrolled up and then typed a long message is not moved. `./scripts/ci.sh` passes.