### PR TITLE
fix: the account picker appears before Connect, not only after it

### DIFF
--- a/src-tauri/src/domain/plugin.rs
+++ b/src-tauri/src/domain/plugin.rs
@@ -198,6 +198,14 @@ pub struct PluginOffer {
     /// The host the sign-in and every later call goes to, so an operator can
     /// see where their account is being handed to before they click.
     pub endpoint: &'static str,
+    /// Whether this one's credential is the operator's Guaca account, and
+    /// therefore whether there is an identity to choose before connecting.
+    ///
+    /// Reported rather than inferred from the kind in the webview, for the
+    /// reason the rest of this struct is: the runtime is what decides, and a
+    /// second copy of that decision in the front end is a second place for it
+    /// to be wrong.
+    pub account_backed: bool,
 }
 
 pub fn catalogue() -> Vec<PluginOffer> {
@@ -209,6 +217,7 @@ pub fn catalogue() -> Vec<PluginOffer> {
             blurb: kind.blurb(),
             docs: kind.docs(),
             endpoint: kind.endpoint(),
+            account_backed: kind.account_backed(),
         })
         .collect()
 }

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -113,15 +113,13 @@ pub async fn connect(
         let used = account.ok_or(PluginError::NoAccount { label: kind.label() })?;
         let session = mcp::open(endpoint, Some(used.token)).await?;
         let tools = read_tools(&session).await?;
-        let account_label = account_label(&session, kind);
-        return Ok(store.save_plugin(
-            group,
-            kind,
-            &account_label,
-            &tools,
-            None,
-            used.connection,
-        )?);
+        // No account label. An MCP server's own name is not an account, and for
+        // this one it is "Guaca Connectors", which on a card reading "Signed in
+        // as ..." looks exactly like an answer to whose mailbox this is and is
+        // not. Which identity this row uses is `connection`, and the operator's
+        // own name for it lives at the account, where it can change without
+        // this row going stale.
+        return Ok(store.save_plugin(group, kind, "", &tools, None, used.connection)?);
     }
 
     let (session, grant) = match mcp::open(endpoint, None).await {

--- a/src/components/PluginList.test.tsx
+++ b/src/components/PluginList.test.tsx
@@ -60,6 +60,7 @@ const OFFERS: PluginOffer[] = [
     blurb: "Postgres databases.",
     docs: "https://neon.com/docs/ai/neon-mcp-server",
     endpoint: "https://mcp.neon.tech/mcp",
+    accountBacked: false,
   },
   {
     kind: "stripe",
@@ -68,6 +69,7 @@ const OFFERS: PluginOffer[] = [
     docs: "https://docs.stripe.com/mcp",
     // Stripe's has no path, which is what the host line has to survive.
     endpoint: "https://mcp.stripe.com",
+    accountBacked: false,
   },
 ];
 
@@ -473,6 +475,7 @@ describe("choosing which account a crew uses", () => {
     blurb: "Your Gmail, Calendar and Drive.",
     docs: "https://guaca.bot/app",
     endpoint: "https://guaca.bot/mcp",
+    accountBacked: true,
   };
 
   const two: AccountConnectors = {
@@ -490,14 +493,53 @@ describe("choosing which account a crew uses", () => {
     pluginCatalogue.mockResolvedValue([GOOGLE_OFFER]);
   });
 
-  it("offers no picker when there is only one account to pick", async () => {
-    // A select with a single option is a control that cannot do anything.
+  it("says which account it acts as, without an inert picker, when there is one", async () => {
+    // A select with a single option cannot do anything, but a crew acting as
+    // somebody's mail must never leave them guessing whose.
     accountConnectors.mockResolvedValue(one);
     groupPlugins.mockResolvedValue([plugin({ kind: "google", connection: "acct_work" })]);
     render(<PluginList groupId={GROUP} crew={CREW} />);
 
-    await waitFor(() => expect(screen.getByText("Google")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/Acting as work@example.com/)).toBeTruthy());
     expect(screen.queryByLabelText(/^Account/)).toBeNull();
+  });
+
+  it("offers the picker before connecting, not only after", async () => {
+    // The whole complaint: Connect took the first account silently, so a crew
+    // could end up on the wrong mailbox with nothing on screen saying so.
+    accountConnectors.mockResolvedValue(two);
+    groupPlugins.mockResolvedValue([]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    const picker = (await screen.findByLabelText(/^Account/)) as HTMLSelectElement;
+    expect([...picker.options].map((option) => option.value)).toEqual(["acct_work", "acct_home"]);
+  });
+
+  it("connects against the identity picked before the click", async () => {
+    accountConnectors.mockResolvedValue(two);
+    groupPlugins.mockResolvedValue([]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    fireEvent.change(await screen.findByLabelText(/^Account/), {
+      target: { value: "acct_home" },
+    });
+    // Nothing is written until Connect: there is no row to write to yet.
+    expect(setPluginConnection).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Connect"));
+    await waitFor(() => expect(connectPlugin).toHaveBeenCalledWith(GROUP, "google", "acct_home"));
+  });
+
+  it("says so when the account has authorized nothing at that provider", async () => {
+    // A hidden picker is indistinguishable from a broken feature.
+    accountConnectors.mockResolvedValue({ ...two, connections: [] });
+    groupPlugins.mockResolvedValue([]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    expect(
+      await screen.findByText(/No Google account is authorized on your Guaca account yet/),
+    ).toBeTruthy();
+    expect(screen.getByText("Authorize a Google account")).toBeTruthy();
   });
 
   it("offers a picker showing every authorized identity", async () => {

--- a/src/components/PluginList.tsx
+++ b/src/components/PluginList.tsx
@@ -173,6 +173,10 @@ export function PluginList({ groupId, crew }: Props) {
   // which is why a failure here is swallowed rather than surfaced: it means
   // there is nothing to choose between, not that the panel is broken.
   const [connections, setConnections] = useState<AccountConnection[]>([]);
+  // Which identity the operator picked for a plugin that is not connected yet,
+  // keyed by kind. Only ever holds a pre-connect choice: once connected, the
+  // stored row is what the picker reads, because that is what a turn will use.
+  const [picked, setPicked] = useState<Record<string, string>>({});
 
   const load = useCallback(async () => {
     try {
@@ -225,6 +229,11 @@ export function PluginList({ groupId, crew }: Props) {
         const chosen = held?.access.mode === "chosen" ? held.access.agents : [];
         // Two Google accounts are two grants, and a crew uses one of them.
         const mine = connections.filter((connection) => connection.provider === offer.kind);
+        // What this row is bound to, or about to be. A connected plugin reads
+        // its stored row, because that is what a turn actually uses; one that
+        // is not connected reads whatever the operator picked, defaulting to
+        // the first.
+        const using = held ? held.connection || mine[0]?.id : (picked[offer.kind] ?? mine[0]?.id);
 
         return (
           <div className="access__item" key={offer.kind}>
@@ -260,11 +269,11 @@ export function PluginList({ groupId, crew }: Props) {
                   disabled={busy !== null}
                   onClick={() =>
                     void run(offer.kind, () =>
-                      // The first identity when there is one, so the common
-                      // case is still one click. With none, this connects
-                      // against the account's default and the refusal from Rust
-                      // is what says an account is needed.
-                      api.connectPlugin(groupId, offer.kind, mine[0]?.id),
+                      // What the picker above says, which defaults to the first
+                      // identity. With none, this connects against the account's
+                      // default and the refusal from Rust is what says an
+                      // account is needed.
+                      api.connectPlugin(groupId, offer.kind, using),
                     )
                   }
                 >
@@ -273,44 +282,84 @@ export function PluginList({ groupId, crew }: Props) {
               )}
             </div>
 
+            {/* Which of the account's identities this row uses.
+                Shown whether or not the plugin is connected, because choosing
+                is part of connecting: taking the first silently is how a crew
+                ends up on the wrong mailbox with nothing on screen saying so.
+                Only for a plugin whose credential is the account; the others
+                sign in per group and their grant names its own identity. */}
+            {offer.accountBacked &&
+              (mine.length === 0 ? (
+                <div className="access__empty">
+                  <p className="field__hint">
+                    No {offer.name} account is authorized on your Guaca account yet. Authorize one,
+                    then connect it here.
+                  </p>
+                  <button
+                    type="button"
+                    className="btn btn--ghost btn--small"
+                    onClick={() => void openExternal("https://guaca.bot/app")}
+                  >
+                    Authorize a {offer.name} account
+                  </button>
+                </div>
+              ) : mine.length === 1 ? (
+                // One authorized account is not a decision, so this says which
+                // it is rather than offering a control that cannot do anything.
+                // It is still said out loud: a crew acting as somebody's mail
+                // should never leave you guessing whose.
+                <p className="field__hint">
+                  Acting as{" "}
+                  {mine.find((connection) => connection.id === using)?.label ?? mine[0]?.label}.
+                </p>
+              ) : (
+                <label className="field">
+                  <span className="field__label">Account</span>
+                  <select
+                    className="input"
+                    value={using ?? ""}
+                    disabled={busy !== null}
+                    onChange={(event) => {
+                      const chosen = event.target.value;
+                      if (!held) {
+                        // Nothing to write yet: remembered until Connect.
+                        setPicked((was) => ({ ...was, [offer.kind]: chosen }));
+                        return;
+                      }
+                      // Connected, so this moves the crew. Its own command
+                      // rather than a reconnect, which would replace the row
+                      // and lose the per-tool switches.
+                      void run(offer.kind, () =>
+                        api.setPluginConnection(groupId, offer.kind, chosen),
+                      );
+                    }}
+                  >
+                    {mine.map((connection) => (
+                      <option key={connection.id} value={connection.id}>
+                        {connection.label}
+                      </option>
+                    ))}
+                  </select>
+                  <span className="field__hint">
+                    Which {offer.name} account this crew acts as.{" "}
+                    {held
+                      ? "Its tools are re-read when you change it, because two accounts do not always authorize the same things."
+                      : "Pick before connecting; you can change it afterwards."}
+                  </span>
+                </label>
+              ))}
+
             {held ? (
               <>
                 <p className="field__hint">
                   {offering(held.tools)}, {offeredTo(held.access, crew)}.
+                  {/* Blank for an account-backed plugin: whose account it is
+                      is the Account line above, and a server's own name is not
+                      an account. */}
                   {held.account && ` Signed in as ${held.account}.`}
                   {!held.signedIn &&
                     " This server asked for no sign-in, so nothing was authorised."}
                 </p>
-
-                {/* Which of the account's identities this crew uses.
-                    Shown only when there is a choice to make: one authorized
-                    Google is not a decision, and a select with a single option
-                    is a control that cannot do anything. */}
-                {mine.length > 1 && (
-                  <label className="field">
-                    <span className="field__label">Account</span>
-                    <select
-                      className="input"
-                      value={held.connection || mine[0]?.id || ""}
-                      disabled={busy !== null}
-                      onChange={(event) =>
-                        void run(offer.kind, () =>
-                          api.setPluginConnection(groupId, offer.kind, event.target.value),
-                        )
-                      }
-                    >
-                      {mine.map((connection) => (
-                        <option key={connection.id} value={connection.id}>
-                          {connection.label}
-                        </option>
-                      ))}
-                    </select>
-                    <span className="field__hint">
-                      Which {offer.name} account this crew acts as. Its tools are re-read when you
-                      change it, because two accounts do not always authorize the same things.
-                    </span>
-                  </label>
-                )}
 
                 {/* Two buttons rather than a list with an "all" entry at the
                     top: every agent is a standing answer that covers whoever

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -258,6 +258,11 @@ export interface PluginOffer {
   docs: string;
   /** Where the sign-in and every later call goes, shown before it is clicked. */
   endpoint: string;
+  /**
+   * Whether this one's credential is the operator's Guaca account, and so
+   * whether there is an identity to choose before connecting.
+   */
+  accountBacked: boolean;
 }
 
 /**

--- a/src/styles.css
+++ b/src/styles.css
@@ -4854,6 +4854,17 @@ button {
    edited here. A list rather than the field rows above it, because none of it
    is a control: the ticking happens on guaca.bot, where the consent screens
    are. */
+/* The state where a crew has a plugin available and the account behind it has
+   nothing authorized. Said out loud rather than left as a hidden picker: an
+   empty control that quietly does not appear is indistinguishable from a
+   feature that is broken. */
+.access__empty {
+  display: grid;
+  gap: 0.5rem;
+  justify-items: start;
+  margin-top: 0.6rem;
+}
+
 .settings__list {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
Connecting Google took the first authorized account silently. The picker only
appeared once a plugin was already connected, so an operator with two Google
accounts clicked Connect, got one of them with nothing on screen saying which,
and had no way to tell it was a choice at all.

That was not the design that was agreed; it was half of it. The picker now
appears whether or not the plugin is connected. Before connecting it is a
choice held in the component and spent by Connect; after connecting it reads the
stored row, because that is the identity a turn will actually use.

Three states rather than one, because the honest answer differs:

- No account authorized at that provider: say so, and offer the way to fix it.
  A picker that quietly does not render is indistinguishable from a feature that
  is broken, which is how this was reported.
- One: name it in a line of prose. A select with a single option is a control
  that cannot do anything, but a crew acting as somebody's mail must never leave
  them guessing whose.
- Several: the picker.

`PluginOffer` gains `accountBacked` so the front end can tell which plugins have
an identity to choose without a second copy of that decision.

Also fixes a label this surfaced. An account-backed plugin stored the MCP
server's own name as its account, so a connected Google read "Signed in as Guaca
Connectors" — which looks exactly like an answer to whose mailbox this is and is
not. It stores nothing there now; which identity a row uses is `connection`, and
the operator's own name for it lives at the account where it can change without
this row going stale.