### PR TITLE
feat: a reply can be a chart or a page, and both are fences in the text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@ src/                  React + TypeScript. A view over the runtime, nothing more.
   lib/orb.ts          How a crew stands inside its circle, and when it counts.
   lib/search.ts       One ranking over hits from SQLite and from the store.
   lib/trail.ts        A turn's own tool calls: what folds into one chip.
+  lib/figure.ts       A fenced block the transcript draws instead of printing.
+  lib/chart.ts        A chart spec, and where every mark goes. No DOM.
+  lib/palette.ts      Eight hues in one order, and why that order and not another.
   lib/diff.ts         Two versions of a page, as the lines between them.
   lib/reasoning.ts    A turn's own thinking: how much is held, what is drawn.
   lib/cafeteria.ts    Preset agents, waiting to be hired. Content, not runtime.
@@ -52,6 +55,8 @@ src-tauri/src/
   db/                 SQLite. Plain SQL, numbered migrations.
   e2b.rs              Computers: the machines agents look at and point at.
   proxy.rs            Loopback viewer for those machines.
+  artifact.rs         The other loopback origin: where a page an agent wrote
+                      is allowed to run, and everything it may not reach.
   sessions.py         Reports what a machine's Chrome is signed in to.
   kernel.rs           Browsers: a hosted Chrome, which is where the web belongs.
   cdp.rs              The DevTools protocol. Asks a page instead of looking.
@@ -100,6 +105,9 @@ repo: the frontend renders state and forwards intent.
 | Which of a plugin's tools which agents may call | *And which of its tools, for which of them, which is a third decision* in `docs/PLUGINS.md`, then `Store::set_plugin_tool` and both readers of `plugin_tool_access` |
 | The guaca.bot account: signing in, what it is for, why it is optional | `docs/ACCOUNT.md`, then `account.rs` |
 | Channels, the rail, search: what the operator sees | `docs/WORKSPACE.md`, then `src/lib/transcript.ts` |
+| Charts, tables, a page an agent wrote: what a reply can be drawn as | *A reply can be a figure* in `docs/WORKSPACE.md`, then `src/lib/figure.ts` and `src/lib/chart.ts` |
+| A chart's colours, or how many series one may carry | *A chart's colours are the output of a check* in `docs/WORKSPACE.md`, then `src/lib/palette.ts` and the test beside it, which is the gate |
+| Running a model's own HTML, or anything about that origin | *A page an agent wrote runs somewhere else* in `docs/WORKSPACE.md`, then `src-tauri/src/artifact.rs` |
 | A turn's tool calls in a channel: what folds, what a chip says, what opens | *A turn's own work is chips* in `docs/WORKSPACE.md`, then `src/lib/trail.ts` |
 | What an agent changed about its own memory, and where the version before it came from | *A memory rewrite opens as a diff* in `docs/WORKSPACE.md`, then `Workspace::write` and `src/lib/diff.ts` |
 | Anything announced to a screen reader, or a live region | *A transcript is a log, and says one thing out loud* in `docs/WORKSPACE.md` |
@@ -215,6 +223,65 @@ the model takes a screenshot to see what `browse` did.
   draws as a page that is all new. A truthiness check collapses the first two
   and loses the only write where the whole page is the news. `Part::ToolCall`
   in `domain/envelope.rs`, then `trailStep`.
+- **A figure is a fence in the reply, not a tool call and not a new part.** An
+  agent has the numbers in hand at the moment it writes the sentence about them,
+  so a chart behind a tool call is a round trip spent sending back something it
+  had already finished computing. A fence also needs no runtime change at all:
+  `as_plain_text` returns the text of a message, so the record, the prompt, the
+  dedup fingerprint, search and a peer's copy keep working untouched, and the
+  agent can read back what it drew. `Part::Json` is still unused and is still
+  not this.
+- **A chart spec that has not finished arriving is neither drawn nor refused.**
+  A reply lands a token at a time, so a chart spends most of its life on screen
+  as half a JSON object, and calling that an error puts a red box under every
+  figure for a second, which teaches an operator the feature is broken.
+  `looksComplete` counts braces outside strings, since a category legitimately
+  named `}` must not end the document early, and until they balance the figure
+  says it is still drawing. Once they balance, a spec that still will not parse is
+  wrong rather than late, and says so.
+- **A refused chart is drawn as its own source with the reason under it.** Both
+  halves are load-bearing. The operator needs to see what their agent thought it
+  was showing them, and the agent needs a sentence it can act on next turn,
+  which is why every refusal in `readChart` names the field and the fix. "Invalid
+  chart" costs a whole turn and teaches nothing.
+- **The eight series colours are the output of a check, and the *order* is the
+  check.** Neighbouring slots are what touch in a stack and cross in a line
+  chart, so neighbours are the pairs that decide whether a chart is readable to a
+  colourblind operator, and nobody can verify that by looking. The order came out
+  of enumerating all 40,320 and keeping the 160 that pass on this app's own two
+  surfaces. `palette.test.ts` recomputes every figure in `palette.ts`'s comment
+  from the hexes themselves, so a hex nudged because a screenshot looked slightly
+  off fails the suite. A ninth hue is refused rather than generated: a generated
+  one is indistinguishable from one of the eight under colourblindness.
+- **Nothing inside a chart's drawing is focusable, and the Figures table is
+  why.** The `svg` is one `role="img"` with a sentence on it, which makes its
+  subtree invisible to a screen reader by definition, so a label on a band
+  would be announced to nobody, and tab stops would put twelve invisible
+  rectangles between one message and the next for a readout the table already
+  holds in a form somebody can read. The table is also the relief that lets
+  three light-mode hues sit under 3:1 against the surface, and
+  `palette.test.ts` asserts that debt so it cannot be dropped quietly.
+- **A page an agent wrote is framed from `artifact.rs`, never from `srcdoc`.**
+  A frame pointed at `srcdoc:`, `blob:` or `about:blank` inherits the framing
+  document's content policy, and this app's forbids script. The page would draw
+  and its script would silently never run: an empty rectangle that passes every
+  test, which is the same failure `FileCard` has a note about. So it gets an
+  origin of its own, and the round trip through `frame_artifact` is what buys it.
+- **`allow-scripts` and `allow-same-origin` must never appear together.** On the
+  frame or in `ARTIFACT_CSP`. Together they let the page remove its own sandbox
+  attribute and reload out of the box, which is the whole lock. `default-src
+  'none'` is the other half and is not decoration: `<img src="https://…/?data=">`
+  is the cheapest exfiltration there is, and a model's page is content written by
+  something that may have read a hostile web page earlier in the same turn.
+- **The height reporter is prepended to a model's page, not appended.** A
+  model's page is exactly where an unclosed tag lives, and an unclosed tag
+  swallows everything after it. Ahead of the doctype it is still parsed and run.
+  The parent trusts the message by the window that sent it and by nothing else:
+  an opaque origin reports itself as `"null"`, so an origin check would either
+  reject every real message or accept every forged one.
+- **A peer is not told any of this.** The figure section is in the prompt for
+  every reply mode but `ToPeer`. A peer is a model and wants the numbers, so a
+  chart spec on that path is tokens spent drawing something nobody will look at.
 - **`emit_reply` delivers a reply that carries a file and no text.** Handing over
   a document with nothing typed is normal, and judging the reply empty by its
   text alone drops the thing the turn was spent producing.

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -133,6 +133,139 @@ back the flicker the sentence rule in `lib/reasoning.ts` takes out. What the
 line is for is the wait an operator notices, so a call has to become one before
 it earns the line.
 
+## A reply can be a figure, and a figure is a fenced block
+
+An operator asking for last quarter by region gets four numbers, and four
+numbers written as `Enterprise: $810K` lines is a shape they have to hold in
+their head. What they wanted was to see which one was biggest, which is a
+picture. So a reply can carry one.
+
+**A fence, not a tool call.** An agent has the numbers in hand at the moment it
+writes the sentence about them, so a chart it asks for through a tool call is a
+round trip spent sending back something it had already finished computing. A
+fence costs nothing, streams in with the rest of the reply, and needs no change
+to the runtime at all: `as_plain_text` already returns the text of a message, so
+the record, the prompt, the dedup fingerprint, search and a peer's copy all keep
+working exactly as they did. It also means the agent can read back what it drew,
+and an agent that cannot see its own last chart draws it again.
+
+Three tags are figures (`chart`, `graph`, `plot` for the first, `html` or
+`artifact` for the second) and every other fence is source, which is the rule
+that keeps ```python from turning into something nobody asked for.
+
+**Guaca draws the chart, from a spec.** `lib/chart.ts` reads a model's JSON into
+a value that cannot be wrong (a pie with two series is not a thing that file can
+produce) and turns it into coordinates; `components/Chart.tsx` turns those into
+elements. Neither half touches the DOM, which is the point: jsdom performs no
+layout, so a chart that worked out its own geometry from a measured element
+would be exercised by no test in this repo and checked by nobody but the
+operator. Every geometry decision this app makes is a pure function with a test
+on it.
+
+The spec is deliberately the shape every plotting library uses: `type`, `labels`,
+`series: [{ name, data }]`. That is not a lack of imagination. A model has seen
+it ten thousand times and writes it right first try; a novel schema of our own
+would be a thing every agent has to be taught in a prompt it is already
+skimming.
+
+**A figure that will not draw shows what was asked for and why.** Not instead of
+it. The operator needs to see the request to know what their agent thought it
+was showing them, and the agent needs a sentence it can act on next turn: every
+refusal in `readChart` names the field and the fix, because "invalid chart"
+costs a whole turn and teaches nothing. And a spec that has not finished
+arriving is neither drawn nor refused. A reply lands a token at a time, so a
+chart spends most of its life on screen as half an object, and called an error
+that is a red box under every figure for a second, which teaches an operator the
+feature is broken. `looksComplete` counts braces outside strings; until they
+balance, the figure says it is still drawing.
+
+## A chart's colours are the output of a check, not a decision
+
+Every other colour in `styles.css` is a judgement somebody can revise. The eight
+series hues are not. What makes a chart readable to a red-green colourblind
+operator is that *neighbouring* slots stay far apart, because neighbours are
+what touch in a stack, sit side by side in a group and cross in a line chart,
+and no one can check that by looking.
+
+So the order was not chosen by looking. The eight hexes are a documented set;
+what this app chose is the order, by enumerating all 40,320 of them and keeping
+the 160 that clear every gate on this app's own two surfaces. Guaca opens on
+green because Guaca is green, and it cost nothing: of the orders that pass, this
+is one of the best, and it beats the set's own default on the gate that scatter
+needs.
+
+`palette.test.ts` recomputes all of it from the hexes themselves: sRGB to
+linear, Machado-Oliveira-Fernandes at full severity, distance in OKLab. The
+figures in `palette.ts`'s comment cannot drift from the values they describe,
+and a hex nudged because a screenshot looked slightly off fails the suite. That
+is the intended experience.
+
+**Nine hues is not an option.** A generated ninth is indistinguishable from one
+of the eight under colourblindness, so a ninth series is refused with the fix in
+the sentence: fold the tail into an "Other". A pie past six wedges folds itself,
+because past six nobody is comparing them, they are reading the big ones and the
+remainder.
+
+**Every chart carries its own numbers, and that is not a fallback.** The Figures
+table beside the source control is how a value is read by a screen reader, by an
+operator who cannot separate two of the hues, and by anybody who wants the
+figure rather than the shape. Three light-mode hues sit under 3:1 against the
+surface, which is allowed only because the table and the direct labels are
+there; a change that drops either has to change the palette too, and
+`palette.test.ts` asserts the debt so it cannot be dropped quietly.
+
+The drawing itself is one `role="img"` with one sentence on it, and nothing
+inside it is focusable. That is deliberate: a `role="img"` subtree is invisible
+to a screen reader by definition, so labels on the bands would be announced to
+nobody, and tab stops would put twelve invisible rectangles between the message
+above and the message below for a readout the table already holds in a form
+somebody can actually read. The readout enhances; it never gates.
+
+## A page an agent wrote runs somewhere else entirely
+
+A chart is drawn by Guaca and needs nowhere to run. A page is different: asked
+for a diagram, a layout or a small thing to click, an agent writes markup and
+script, and the only honest way to show that is to run it.
+
+Not in this document. The webview's policy is `script-src 'self'` and it stays
+that way. A frame pointed at `srcdoc:`, `blob:` or `about:blank` inherits the
+policy of whoever framed it, so the page would draw and its script would
+silently never run: an empty rectangle that passes every test, which is the
+worst thing this app could ship and is the same failure `FileCard` already has
+a note about.
+
+So a page gets an origin of its own: `artifact.rs`, a loopback server serving
+one document by the SHA-256 of its own bytes, on a port already in the app's
+`frame-src` because the computer viewer needed one first. It is deliberately not
+part of `proxy.rs`, whose request parser is where the token that reaches a
+running machine gets decided; a second unrelated route in front of that is a
+branch nobody wants to reason about at three in the morning.
+
+**What the page may do is the whole argument.** It is the least trustworthy
+content in the app: written by a model that may have read a hostile web page
+earlier in the same turn. It may compute and it may draw, and it may not talk to
+anybody. `default-src 'none'` closes every fetch, socket, remote font and remote
+image, and `<img src="https://…/?data=">` is the cheapest exfiltration there is.
+`script-src 'unsafe-inline'` lets its own script run and nothing loaded from
+elsewhere. `sandbox allow-scripts` on the header and on the frame gives it an
+opaque origin with no same-origin access, and the two values must never gain
+`allow-same-origin` beside `allow-scripts`: together they let a page take its own
+sandbox off and reload out of it.
+
+Nothing is persisted. The message that carried the document is the record; the
+server holds a copy of the last two dozen while a transcript is drawing them,
+and a restart re-registers whatever is on screen.
+
+**The page reports its own height, because nothing outside it can measure it.**
+A cross-origin frame cannot be read, so `artifact.rs` prepends a reporter that
+posts its height on every change. Prepended rather than appended: a model's page
+is exactly where an unclosed tag lives, and an unclosed tag swallows everything
+after it. The parent trusts the message by the window that sent it and by
+nothing else, because an opaque origin reports itself as `"null"` and checking
+the origin would either reject every real message or accept every forged one. It
+clamps what it is told, too: a page claiming a height of a hundred thousand has
+made itself the whole channel.
+
 ## A transcript is a log, and says one thing out loud
 
 Waiting for a reply is the shape of using this app, and a reader who cannot see

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -5,12 +5,14 @@
 //! the cascade tests can drive the real runtime without a window.
 
 use std::path::PathBuf;
+use std::sync::atomic::AtomicU16;
 use std::sync::{Arc, OnceLock};
 
 use tauri::http::{Request, Response};
 use tauri::{Emitter, Manager, UriSchemeContext};
 
 use crate::account::Account;
+use crate::artifact::{self, Artifacts};
 use crate::commands::{self, AppState};
 use crate::config;
 use crate::db::Store;
@@ -320,6 +322,16 @@ pub fn run() {
                 .map_err(|e| format!("could not start the computer viewer: {e}"))?;
             runtime.set_viewer_port(viewer_port);
 
+            // And the origin a page an agent wrote is allowed to run on, which
+            // is separate from the app's for exactly one reason: the app's
+            // content policy forbids script and must keep forbidding it.
+            // `artifact.rs` says what that origin does and does not permit.
+            let artifacts = Artifacts::new();
+            let artifact_port = Arc::new(AtomicU16::new(
+                tauri::async_runtime::block_on(artifact::start(artifacts.clone()))
+                    .map_err(|e| format!("could not start the artifact viewer: {e}"))?,
+            ));
+
             // Anything this app left running that no agent still refers to is
             // released, since a forgotten sandbox bills exactly like a used one.
             {
@@ -390,6 +402,8 @@ pub fn run() {
                 subscription,
                 account,
                 catalogue: Arc::new(Catalogue::new()),
+                artifacts,
+                artifact_port,
             });
             Ok(())
         })
@@ -446,6 +460,7 @@ pub fn run() {
             commands::stage_files,
             commands::save_file,
             commands::send_message,
+            commands::frame_artifact,
             commands::retry_turn,
             commands::stop_run,
             commands::clear_channel,

--- a/src-tauri/src/artifact.rs
+++ b/src-tauri/src/artifact.rs
@@ -1,0 +1,459 @@
+//! Where a page an agent wrote is allowed to run.
+//!
+//! A chart spec is drawn by Guaca and needs nowhere to run. A page is
+//! different: an agent asked for a diagram, a mock-up or a small thing to
+//! click has written markup and script, and the only honest way to show it is
+//! to run it. That cannot happen in the app's own document. The webview's
+//! content policy is `script-src 'self'` and it must stay that way, and a
+//! frame pointed at `srcdoc:`, `blob:` or `about:blank` inherits that policy
+//! from whoever framed it, so the page would draw and its script would
+//! silently never run. An empty rectangle that passes every test is the worst
+//! failure this app can ship.
+//!
+//! So a page gets an origin of its own. This is a loopback HTTP server, bound
+//! on a port the OS picks, that serves exactly one kind of thing: a document
+//! the renderer registered a moment earlier, by the SHA-256 of its own bytes.
+//! `http://127.0.0.1:{port}` is already in the app's `frame-src`, because the
+//! computer viewer needed it first.
+//!
+//! It is deliberately not part of `proxy.rs`. That relay carries the tokens
+//! that reach a running machine, and its request parser is where the sandbox
+//! those tokens belong to is decided. Putting a second, unrelated route in
+//! front of that is a branch nobody wants to reason about at three in the
+//! morning. Two small servers with one job each is the cheaper arrangement.
+//!
+//! # What the page can and cannot do
+//!
+//! Everything served here carries [`ARTIFACT_CSP`], and it is the whole
+//! argument for allowing this at all. A model's page is the least trustworthy
+//! content in the app: it was written by something that may have read a hostile
+//! web page earlier in the same turn. It may compute and it may draw, and it
+//! may not talk to anybody:
+//!
+//! - `default-src 'none'`: no fetch, no XHR, no websocket, no font, no
+//!   stylesheet and no image from anywhere. An `<img src="https://…/?data=">`
+//!   is the cheapest exfiltration there is and it is the first thing this
+//!   closes.
+//! - `script-src 'unsafe-inline'`: its own inline script runs, and nothing
+//!   loaded from anywhere else does.
+//! - `img-src data:` and `font-src data:`: it can draw a picture it generated
+//!   itself, which is what a chart library written inline does.
+//! - `form-action 'none'`, `frame-ancestors 'self'` and `sandbox`: it cannot
+//!   post anywhere, cannot be framed by anything but this app, and gets an
+//!   opaque origin with no same-origin access, so it cannot read the document
+//!   that framed it.
+//!
+//! `allow-scripts` without `allow-same-origin` is what makes the last one true,
+//! and the two must never be granted together: that combination lets the page
+//! remove its own sandbox attribute and reload itself out of the box.
+//!
+//! Nothing here is persisted. The document itself already lives in the message
+//! that carried it, which is the record; this holds a copy only while a
+//! transcript is drawing one, and a restart re-registers whatever is on screen.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// What a registered page is served under.
+///
+/// Every directive matters; the module comment says why each one is there.
+/// `sandbox` is repeated in the header as well as on the frame because the
+/// frame's attribute is set by the renderer and this is not: a page reached
+/// directly, by an operator who copied the address, gets the same treatment.
+pub const ARTIFACT_CSP: &str = "default-src 'none'; \
+     script-src 'unsafe-inline'; \
+     style-src 'unsafe-inline'; \
+     img-src data:; \
+     font-src data:; \
+     form-action 'none'; \
+     base-uri 'none'; \
+     frame-ancestors 'self'; \
+     sandbox allow-scripts";
+
+/// How many documents are kept at once.
+///
+/// A transcript scrolls past a lot of pages and each one is held whole. This is
+/// comfortably more than fit on a screen and far less than a long channel's
+/// worth, and the oldest is dropped rather than the store being allowed to
+/// grow: the renderer registers again when it draws again, so an eviction
+/// costs one IPC call and nothing else.
+const KEPT: usize = 24;
+
+/// A document that is too big to be a figure is too big to be worth framing.
+///
+/// Also the ceiling on what one of these can cost in memory: `KEPT` times this.
+const MOST_BYTES: usize = 512 * 1024;
+
+/// Request head must arrive within this. A connection that opens and says
+/// nothing is a probe or a mistake, and should not hold a task forever.
+const HEAD_LIMIT: usize = 8 * 1024;
+
+/// The pages the renderer currently has on screen.
+#[derive(Clone, Default)]
+pub struct Artifacts {
+    inner: Arc<Mutex<Kept>>,
+}
+
+#[derive(Default)]
+struct Kept {
+    pages: HashMap<String, String>,
+    /// Oldest first, so eviction is a pop from the front.
+    order: Vec<String>,
+}
+
+/// Why a page was not taken.
+#[derive(Debug, PartialEq)]
+pub enum ArtifactError {
+    Empty,
+    TooBig { bytes: usize },
+}
+
+impl std::fmt::Display for ArtifactError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ArtifactError::Empty => write!(f, "there is no document here to show"),
+            ArtifactError::TooBig { bytes } => write!(
+                f,
+                "this page is {}KB, and {}KB is the most Guaca will frame. Attach it as a file \
+                 instead.",
+                bytes / 1024,
+                MOST_BYTES / 1024
+            ),
+        }
+    }
+}
+
+impl Artifacts {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Takes a page and hands back the id it is served under.
+    ///
+    /// Addressed by the digest of its own bytes, so registering the same
+    /// document twice is the same id and a transcript redrawn is not a leak.
+    pub fn keep(&self, html: &str) -> Result<String, ArtifactError> {
+        if html.trim().is_empty() {
+            return Err(ArtifactError::Empty);
+        }
+        if html.len() > MOST_BYTES {
+            return Err(ArtifactError::TooBig { bytes: html.len() });
+        }
+
+        let id = format!("{:x}", Sha256::digest(html.as_bytes()));
+        let mut kept = self.inner.lock().expect("artifact store poisoned");
+
+        // Moved to the back rather than left where it was: a page still being
+        // looked at should not be evicted because it was registered first.
+        kept.order.retain(|held| held != &id);
+        kept.order.push(id.clone());
+        kept.pages.insert(id.clone(), html.to_string());
+
+        while kept.order.len() > KEPT {
+            let oldest = kept.order.remove(0);
+            kept.pages.remove(&oldest);
+        }
+
+        Ok(id)
+    }
+
+    fn get(&self, id: &str) -> Option<String> {
+        self.inner.lock().expect("artifact store poisoned").pages.get(id).cloned()
+    }
+}
+
+/// Starts the server and answers with the port it landed on.
+///
+/// Loopback, like the computer viewer, and for a plainer reason: nothing
+/// outside this machine has any business reading what an agent drew.
+pub async fn start(artifacts: Artifacts) -> std::io::Result<u16> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let port = listener.local_addr()?.port();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((client, _)) = listener.accept().await else {
+                continue;
+            };
+            let artifacts = artifacts.clone();
+            tokio::spawn(async move {
+                if let Err(err) = serve(client, artifacts).await {
+                    tracing::debug!(%err, "artifact connection ended");
+                }
+            });
+        }
+    });
+
+    tracing::info!(port, "artifact viewer listening");
+    Ok(port)
+}
+
+async fn serve(mut client: TcpStream, artifacts: Artifacts) -> std::io::Result<()> {
+    let head = read_head(&mut client).await?;
+    let Some(id) = requested(&head) else {
+        return answer(&mut client, "400 Bad Request", "text/plain", "Not an artifact address.")
+            .await;
+    };
+    let Some(page) = artifacts.get(&id) else {
+        // Said rather than dropped. A frame given nothing draws a blank
+        // rectangle, which reads exactly like a page that rendered nothing.
+        return answer(
+            &mut client,
+            "404 Not Found",
+            "text/plain",
+            "This page is no longer held. Scroll back to it to draw it again.",
+        )
+        .await;
+    };
+    answer(&mut client, "200 OK", "text/html; charset=utf-8", &wrap(&page)).await
+}
+
+/// The id a request line asks for, if it asks for one at all.
+///
+/// Only `GET /{hex}` counts. A path with anything else in it is not something
+/// this serves, and the id is checked for shape here rather than trusted,
+/// because it goes on to be a map key and a map key built from a request is
+/// exactly the sort of thing that turns out to be a path later.
+fn requested(head: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(head);
+    let mut start = text.split("\r\n").next()?.split(' ');
+    if start.next()? != "GET" {
+        return None;
+    }
+    let path = start.next()?.split('?').next()?;
+    let id = path.strip_prefix('/')?;
+    let ok = id.len() == 64 && id.bytes().all(|byte| byte.is_ascii_hexdigit());
+    ok.then(|| id.to_ascii_lowercase())
+}
+
+/// The document, plus the one thing Guaca adds to it.
+///
+/// A frame on another origin cannot be measured from outside, so a page that
+/// says nothing about its own size is drawn at whatever height was guessed,
+/// which for a one-line diagram is a tall grey box and for a long one is a
+/// nested scrollbar. So the page is asked, and it answers on the only channel
+/// an opaque origin has.
+///
+/// Prepended, not appended: a document with an unclosed tag swallows anything
+/// after it, and a model's page is exactly where an unclosed tag lives. Ahead
+/// of `<!doctype>` it is still parsed and run, because the parser treats a
+/// stray script before the doctype as content and starts the document anyway.
+fn wrap(page: &str) -> String {
+    format!("{HEIGHT_REPORTER}{page}")
+}
+
+/// Tells whoever framed this how tall it turned out to be.
+///
+/// Reported on every change rather than once on load: a page that draws after
+/// a timer, or grows when something in it is clicked, has a different answer a
+/// second later. `postMessage` to `"*"` because the parent's origin is not
+/// something this document is allowed to know, and it does not need to: the
+/// parent identifies this frame by the window that sent the message, which is
+/// the check that actually holds.
+const HEIGHT_REPORTER: &str = r#"<script>
+(function () {
+  var last = 0;
+  function tell() {
+    var height = Math.max(
+      document.documentElement ? document.documentElement.scrollHeight : 0,
+      document.body ? document.body.scrollHeight : 0
+    );
+    if (height && height !== last) {
+      last = height;
+      parent.postMessage({ guaca: "artifact-height", height: height }, "*");
+    }
+  }
+  addEventListener("load", tell);
+  addEventListener("resize", tell);
+  if (window.ResizeObserver) {
+    addEventListener("DOMContentLoaded", function () {
+      new ResizeObserver(tell).observe(document.documentElement);
+    });
+  }
+})();
+</script>
+"#;
+
+async fn read_head(client: &mut TcpStream) -> std::io::Result<Vec<u8>> {
+    let mut head = Vec::new();
+    let mut byte = [0u8; 1];
+    while !head.ends_with(b"\r\n\r\n") {
+        if head.len() > HEAD_LIMIT {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "request head too long",
+            ));
+        }
+        if client.read(&mut byte).await? == 0 {
+            break;
+        }
+        head.push(byte[0]);
+    }
+    Ok(head)
+}
+
+async fn answer(
+    client: &mut TcpStream,
+    status: &str,
+    content_type: &str,
+    body: &str,
+) -> std::io::Result<()> {
+    // The policy rides on every answer, refusals included. A page served
+    // without it is a page with the app's own policy inherited or none at all,
+    // depending on how it was reached, and neither is the one that was argued
+    // for above.
+    let head = format!(
+        "HTTP/1.1 {status}\r\n\
+         content-type: {content_type}\r\n\
+         content-security-policy: {ARTIFACT_CSP}\r\n\
+         x-content-type-options: nosniff\r\n\
+         referrer-policy: no-referrer\r\n\
+         cache-control: no-store\r\n\
+         content-length: {}\r\n\
+         connection: close\r\n\r\n",
+        body.len()
+    );
+    client.write_all(head.as_bytes()).await?;
+    client.write_all(body.as_bytes()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PAGE: &str = "<!doctype html><p>hello</p>";
+
+    #[test]
+    fn addresses_a_page_by_its_own_bytes() {
+        let artifacts = Artifacts::new();
+        let once = artifacts.keep(PAGE).unwrap();
+        let again = artifacts.keep(PAGE).unwrap();
+        assert_eq!(once, again, "a transcript redrawn must not grow the store");
+        assert_ne!(once, artifacts.keep("<!doctype html><p>other</p>").unwrap());
+    }
+
+    #[test]
+    fn hands_back_what_it_was_given() {
+        let artifacts = Artifacts::new();
+        let id = artifacts.keep(PAGE).unwrap();
+        assert_eq!(artifacts.get(&id).as_deref(), Some(PAGE));
+        assert_eq!(artifacts.get("nope"), None);
+    }
+
+    #[test]
+    fn drops_the_oldest_and_keeps_what_is_being_looked_at() {
+        let artifacts = Artifacts::new();
+        let first = artifacts.keep("<p>0</p>").unwrap();
+        for at in 1..KEPT {
+            artifacts.keep(&format!("<p>{at}</p>")).unwrap();
+        }
+        // Touched again, so it is no longer the oldest thing here.
+        artifacts.keep("<p>0</p>").unwrap();
+        let second = artifacts.keep("<p>new</p>").unwrap();
+
+        assert!(artifacts.get(&first).is_some(), "a page still on screen was evicted");
+        assert!(artifacts.get(&second).is_some());
+        assert_eq!(artifacts.inner.lock().unwrap().pages.len(), KEPT);
+    }
+
+    #[test]
+    fn refuses_a_document_too_big_to_be_a_figure() {
+        let artifacts = Artifacts::new();
+        let huge = "x".repeat(MOST_BYTES + 1);
+        let Err(err) = artifacts.keep(&huge) else {
+            panic!("expected a refusal");
+        };
+        // Every error the operator can hit says what to do about it.
+        assert!(err.to_string().contains("Attach it as a file"), "{err}");
+        assert_eq!(artifacts.keep("   "), Err(ArtifactError::Empty));
+    }
+
+    #[test]
+    fn serves_only_a_digest_shaped_path() {
+        let id = "a".repeat(64);
+        assert_eq!(requested(format!("GET /{id} HTTP/1.1\r\n\r\n").as_bytes()), Some(id.clone()));
+        assert_eq!(
+            requested(format!("GET /{} HTTP/1.1\r\n\r\n", id.to_uppercase()).as_bytes()),
+            Some(id.clone())
+        );
+        // The id becomes a map key, so its shape is checked rather than trusted.
+        assert_eq!(requested(b"GET /../../etc/passwd HTTP/1.1\r\n\r\n"), None);
+        assert_eq!(requested(b"GET / HTTP/1.1\r\n\r\n"), None);
+        assert_eq!(requested(b"GET /short HTTP/1.1\r\n\r\n"), None);
+        assert_eq!(requested(format!("POST /{id} HTTP/1.1\r\n\r\n").as_bytes()), None);
+    }
+
+    #[test]
+    fn never_lets_a_page_reach_anything() {
+        // The whole argument for running a model's page at all. A page written
+        // by something that may have read a hostile web page an hour ago may
+        // compute and may draw, and may not talk to anybody.
+        assert!(ARTIFACT_CSP.contains("default-src 'none'"));
+        assert!(ARTIFACT_CSP.contains("img-src data:"), "no remote image, which is the cheap leak");
+        assert!(ARTIFACT_CSP.contains("form-action 'none'"));
+        assert!(ARTIFACT_CSP.contains("sandbox allow-scripts"));
+        // These two together let a page take its own sandbox off and reload
+        // out of it, which is the one combination that must never appear.
+        assert!(!ARTIFACT_CSP.contains("allow-same-origin"));
+        // It has to be able to run, or none of the above bought anything.
+        assert!(ARTIFACT_CSP.contains("script-src 'unsafe-inline'"));
+    }
+
+    /// One request, start to finish, over a real socket.
+    ///
+    /// The unit tests above check what this module believes; this checks what
+    /// actually goes out on the wire, which is where a policy assembled into a
+    /// header string can quietly stop being sent.
+    async fn ask(port: u16, path: &str) -> String {
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        client
+            .write_all(format!("GET {path} HTTP/1.1\r\nhost: localhost\r\n\r\n").as_bytes())
+            .await
+            .unwrap();
+        let mut said = Vec::new();
+        client.read_to_end(&mut said).await.unwrap();
+        String::from_utf8_lossy(&said).into_owned()
+    }
+
+    #[tokio::test]
+    async fn serves_a_kept_page_under_the_policy() {
+        let artifacts = Artifacts::new();
+        let id = artifacts.keep(PAGE).unwrap();
+        let port = start(artifacts).await.unwrap();
+
+        let said = ask(port, &format!("/{id}")).await;
+        assert!(said.starts_with("HTTP/1.1 200 OK"), "{said}");
+        assert!(said.contains(&format!("content-security-policy: {ARTIFACT_CSP}")), "{said}");
+        assert!(said.contains("<p>hello</p>"), "{said}");
+        // The page has to be able to report its own height, or a frame on
+        // another origin is drawn at whatever was guessed.
+        assert!(said.contains("artifact-height"), "{said}");
+    }
+
+    #[tokio::test]
+    async fn answers_an_id_it_is_not_holding_rather_than_dropping_the_connection() {
+        let port = start(Artifacts::new()).await.unwrap();
+        let said = ask(port, &format!("/{}", "b".repeat(64))).await;
+
+        // A frame given nothing draws a blank rectangle, which reads exactly
+        // like a page that rendered nothing.
+        assert!(said.starts_with("HTTP/1.1 404"), "{said}");
+        assert!(said.contains("Scroll back to it"), "{said}");
+        // The refusal carries the policy too: it is reachable in a frame.
+        assert!(said.contains("content-security-policy:"), "{said}");
+    }
+
+    #[test]
+    fn puts_the_height_reporter_where_an_unclosed_tag_cannot_eat_it() {
+        // A model's page is exactly where an unclosed tag lives, and anything
+        // after one is swallowed by it.
+        let wrapped = wrap("<!doctype html><p>hi");
+        assert!(wrapped.starts_with("<script>"), "{wrapped}");
+        assert!(wrapped.contains("artifact-height"));
+        assert!(wrapped.ends_with("<!doctype html><p>hi"));
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::account::{Account, AccountError, Connectors};
+use crate::artifact::Artifacts;
 use crate::config::{self, AppConfig, RedactedConfig};
 use crate::domain::agent::{copy_name, hire_names, AgentCard, AgentDraft, Lifecycle};
 use crate::domain::approval::{Approval, ApprovalState, Decision, ProtectedAction};
@@ -54,6 +55,12 @@ pub struct AppState {
     /// at no other time. No turn, prompt, tool or guard reads it, and an install
     /// that never opens that dialog never asks for it.
     pub catalogue: Arc<Catalogue>,
+    /// The pages a transcript currently has framed. Not a store: see
+    /// `frame_artifact`.
+    pub artifacts: Artifacts,
+    /// Where those are served from. Set once, at startup, after the OS has
+    /// picked the port.
+    pub artifact_port: Arc<std::sync::atomic::AtomicU16>,
 }
 
 /// A structured error the UI can render as more than a toast.
@@ -1227,6 +1234,35 @@ pub fn save_file(state: State<'_, AppState>, digest: String, name: String) -> Re
         .save_copy(&digest, &name, &state.downloads)
         .map_err(|err| CommandError::new("file", err.to_string()))?;
     Ok(saved.display().to_string())
+}
+
+/// Where a page an agent wrote can be framed.
+///
+/// The renderer hands over the document and gets back an address on the
+/// artifact server, which is a loopback origin of its own. It has to be a round
+/// trip rather than a `srcdoc`: a frame given its markup inline inherits the
+/// app's own content policy, and the app's policy forbids script, so the page
+/// would draw and quietly do nothing. What the page is then allowed to do is
+/// `artifact.rs`'s argument, and none of it is negotiable from here.
+///
+/// The document is not persisted and this is not a store. The message that
+/// carried it is the record; this is a copy held while a transcript is drawing
+/// one, and an id that has been evicted is registered again by the next draw.
+#[tauri::command]
+pub fn frame_artifact(state: State<'_, AppState>, html: String) -> Reply<ArtifactAddress> {
+    let id = state
+        .artifacts
+        .keep(&html)
+        .map_err(|err| CommandError::new("artifact", err.to_string()))?;
+    Ok(ArtifactAddress { port: state.artifact_port.load(std::sync::atomic::Ordering::SeqCst), id })
+}
+
+/// Where the renderer should point a frame.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactAddress {
+    pub port: u16,
+    pub id: String,
 }
 
 /// Sends a failed turn's message again, as a new run.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod account;
 pub mod app;
+pub mod artifact;
 pub mod cdp;
 pub mod commands;
 pub mod config;

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -544,6 +544,50 @@ pub fn system_prompt(
          `files` of a `send_message`.\n",
     );
 
+    // Said only where the reply is read by a person. A peer is a model and
+    // wants the numbers, so a chart spec on that path is tokens spent drawing
+    // something nobody will look at.
+    //
+    // Stated as a capability rather than as an instruction, and with the case
+    // against it in the same paragraph: an agent told it can draw charts draws
+    // one for three numbers, which is worse than the sentence it replaced.
+    if mode != ReplyMode::ToPeer {
+        out.push_str(
+            "\n## What your reply can show\n\
+             Your reply is drawn, not printed. Markdown works, and a table is usually the right \
+             shape for anything with rows and columns: write one rather than a run of \
+             \"Name: value\" lines.\n\n\
+             Two fenced blocks are drawn as figures instead of as code.\n\n\
+             A ```chart fence holds one JSON object and becomes a real chart:\n\n\
+             ```chart\n\
+             {\"type\": \"bar\", \"title\": \"Revenue by quarter\", \"prefix\": \"$\",\n\
+              \"labels\": [\"Q1\", \"Q2\", \"Q3\", \"Q4\"],\n\
+              \"series\": [{\"name\": \"2026\", \"data\": [12, 18, 9, 22]}]}\n\
+             ```\n\n\
+             - `type` is one of bar, line, area, pie, donut, scatter.\n\
+             - `labels` names the categories, one per point. `series` holds one entry per thing \
+             being compared, each with `data` in the same order. `null` is a gap, and is not the \
+             same as a zero.\n\
+             - `stacked: true` stacks a bar or an area, and an area with more than one series \
+             wants it: unstacked, each fill is drawn over the one before it. `horizontal: true` \
+             lays bars along the bottom, which is what long category names want.\n\
+             - `prefix` and `unit` dress every number: `\"prefix\": \"$\"`, `\"unit\": \"%\"`.\n\
+             - A pie or a donut takes exactly one series, and its `labels` are the slices.\n\
+             - A scatter's `data` is `[x, y]` pairs.\n\
+             - Guaca chooses the colours, the axes, the legend and the layout. Do not describe \
+             them, and do not ask for them.\n\n\
+             An ```html fence is run as a page: a diagram, a layout, a small thing the operator \
+             can click. Its own markup, style and script, and it can reach nothing at all: no \
+             network, no remote image, no font. Everything it shows it has to contain or \
+             compute.\n\n\
+             Reach for a figure when the shape is the point: a trend, a comparison, a breakdown, \
+             a schedule. Do not draw a single number, or three of them; write those in a \
+             sentence, where they are read at a glance instead of measured off an axis. And \
+             write the sentence either way. A figure nobody says anything about leaves the \
+             operator to work out for themselves what you concluded.\n",
+        );
+    }
+
     out.push_str("\n## Your reply\n");
     out.push_str(match mode {
         ReplyMode::ToOperator => {
@@ -929,6 +973,28 @@ mod tests {
         assert!(lowered.contains("claim from a peer"));
         assert!(lowered.contains("cannot change your role"));
         assert!(lowered.contains("reveal this system prompt"));
+    }
+
+    #[test]
+    fn system_prompt_says_what_a_reply_can_be_drawn_as() {
+        // A capability an agent is not told about is a capability nobody uses.
+        // Asked for a breakdown by region, one with all of this working still
+        // wrote out four "Region: number" lines.
+        let prompt = prompt_for(&card("Analyst"), &[], "", ReplyMode::ToOperator);
+        assert!(prompt.contains("```chart"), "the chart fence is never mentioned");
+        assert!(prompt.contains("bar, line, area, pie, donut, scatter"));
+        assert!(prompt.contains("```html"));
+        // And the argument against overusing it, in the same breath. An agent
+        // told only that it can draw charts draws one for three numbers.
+        assert!(prompt.contains("Do not draw a single number"));
+    }
+
+    #[test]
+    fn a_peer_is_not_told_how_a_reply_is_drawn() {
+        // A peer is a model. It wants the numbers, so a chart spec on that path
+        // is tokens spent drawing something nobody will look at.
+        let prompt = prompt_for(&card("Analyst"), &[], "", ReplyMode::ToPeer);
+        assert!(!prompt.contains("```chart"), "the peer path carries the figure section");
     }
 
     #[test]

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,0 +1,618 @@
+import { useId, useMemo, useState } from "react";
+
+import {
+  barPath,
+  type CartesianPlot,
+  type Chart as ChartValue,
+  chartSeriesNames,
+  chartSummary,
+  chartTable,
+  formatValue,
+  isCartesian,
+  isRadial,
+  isScatter,
+  layout,
+  MARK,
+  type Point,
+  type RadialPlot,
+  type ScatterPlot,
+  WIDTH,
+} from "../lib/chart";
+import { seriesColor, seriesMark } from "../lib/palette";
+
+/**
+ * A chart, drawn.
+ *
+ * All the arithmetic happened in `lib/chart.ts`; this file turns coordinates
+ * into elements and handles the two things a coordinate cannot: what the
+ * pointer is on, and what the legend has switched off.
+ *
+ * Drawn at a fixed width and scaled by CSS rather than measured. jsdom does no
+ * layout, so a chart that sized itself from a real element would be exercised
+ * by no test in this repo; and a chart that waits to be measured is a jump on
+ * every first paint. The trade is that type grows a little when a figure is
+ * opened large, which is the behaviour a figure should have anyway.
+ *
+ * Three things carry every value, and that is deliberate. The marks carry the
+ * shape, the direct labels and the readout carry the number, and the table
+ * underneath carries all of them. A tooltip may never be the only way to find
+ * out what something is worth: it is unreachable by touch, unreachable by a
+ * screen reader, and gone from a screenshot.
+ */
+export function Chart({ chart }: { chart: ChartValue }) {
+  const plot = useMemo(() => layout(chart), [chart]);
+  const names = useMemo(() => chartSeriesNames(chart), [chart]);
+  const [hidden, setHidden] = useState<ReadonlySet<number>>(() => new Set());
+  const [at, setAt] = useState<number | null>(null);
+  const titleId = useId();
+
+  // A legend that could switch everything off is a legend that can empty the
+  // chart, and an empty frame reads as a chart that broke.
+  const toggle = (index: number) =>
+    setHidden((was) => {
+      const next = new Set(was);
+      if (next.has(index)) next.delete(index);
+      else if (next.size < names.length - 1) next.add(index);
+      return next;
+    });
+
+  return (
+    <div className="chart">
+      {chart.title && (
+        <h4 className="chart__title" id={titleId}>
+          {chart.title}
+        </h4>
+      )}
+      <div className="chart__frame">
+        <svg
+          className="chart__svg"
+          viewBox={`0 0 ${WIDTH} ${plot.height}`}
+          role="img"
+          aria-label={chartSummary(chart)}
+          onPointerLeave={() => setAt(null)}
+        >
+          <title>{chartSummary(chart)}</title>
+          {plot.family === "cartesian" && (
+            <Cartesian chart={chart} plot={plot} hidden={hidden} at={at} onAt={setAt} />
+          )}
+          {plot.family === "radial" && <Radial chart={chart} plot={plot} at={at} onAt={setAt} />}
+          {plot.family === "scatter" && (
+            <Scatter chart={chart} plot={plot} hidden={hidden} at={at} onAt={setAt} />
+          )}
+        </svg>
+        <Readout chart={chart} plot={plot} hidden={hidden} at={at} names={names} />
+      </div>
+      {/* One series needs no legend: there is one colour, and the title above
+          already says what is plotted. A box with a single swatch in it
+          restates the title and costs a line. */}
+      {names.length > 1 && (
+        <Legend
+          chart={chart}
+          names={names}
+          hidden={hidden}
+          // A pie's legend is a key and nothing more. Its slices are shares of
+          // one whole, so switching one off would leave the others claiming
+          // percentages of a total that has not changed.
+          onToggle={isRadial(chart) ? null : toggle}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Bars, lines and areas, which share an axis and a set of category bands. */
+function Cartesian({
+  chart,
+  plot,
+  hidden,
+  at,
+  onAt,
+}: {
+  chart: ChartValue;
+  plot: CartesianPlot;
+  hidden: ReadonlySet<number>;
+  at: number | null;
+  onAt: (band: number | null) => void;
+}) {
+  const { frame, horizontal } = plot;
+  const filled = chart.kind === "area";
+
+  return (
+    <>
+      {/* Gridlines are solid hairlines a step off the surface. Dashed reads as
+          a threshold or a projection when it is only a grid. */}
+      {plot.ticks.map((tick) => (
+        <line
+          key={tick.value}
+          className={tick.value === 0 ? "chart__axis" : "chart__grid"}
+          x1={horizontal ? tick.at : frame.left}
+          x2={horizontal ? tick.at : frame.left + frame.width}
+          y1={horizontal ? frame.top : tick.at}
+          y2={horizontal ? frame.top + frame.height : tick.at}
+        />
+      ))}
+
+      {plot.ticks.map((tick) => (
+        <text
+          key={tick.value}
+          className="chart__tick"
+          x={horizontal ? tick.at : frame.left - 8}
+          y={horizontal ? frame.top + frame.height + 16 : tick.at + 4}
+          textAnchor={horizontal ? "middle" : "end"}
+        >
+          {tick.text}
+        </text>
+      ))}
+
+      {plot.shown.map((index) => {
+        const band = plot.bands[index];
+        if (!band) return null;
+        return (
+          <text
+            key={band.center}
+            className="chart__name"
+            x={horizontal ? frame.left - 8 : band.center}
+            y={horizontal ? band.center + 4 : frame.top + frame.height + 16}
+            textAnchor={horizontal ? "end" : "middle"}
+          >
+            {band.label}
+          </text>
+        );
+      })}
+
+      {plot.strokes.map((stroke) =>
+        hidden.has(stroke.series) ? null : (
+          <g key={`${stroke.series}:${stroke.line}`}>
+            {filled && (
+              <path
+                d={stroke.fill}
+                fill={seriesColor(stroke.series)}
+                fillOpacity={0.1}
+                stroke="none"
+              />
+            )}
+            <path
+              className="chart__line"
+              d={stroke.line}
+              stroke={seriesColor(stroke.series)}
+              strokeWidth={MARK.lineWidth}
+              fill="none"
+            />
+          </g>
+        ),
+      )}
+
+      {plot.bars.map((bar) =>
+        hidden.has(bar.series) ? null : (
+          <path
+            key={`${bar.series}:${bar.band}`}
+            className="chart__bar"
+            d={barPath(bar)}
+            fill={seriesColor(bar.series)}
+            data-lit={at === bar.band ? "" : undefined}
+          />
+        ),
+      )}
+
+      {/* Only where the pointer is. A dot on every point of a twelve-month line
+          is a bead necklace, and the line already says where the readings are. */}
+      {plot.dots.map((dot) =>
+        hidden.has(dot.series) || at !== dot.band ? null : (
+          <circle
+            key={`${dot.series}:${dot.band}`}
+            className="chart__dot"
+            cx={dot.x}
+            cy={dot.y}
+            r={MARK.dotRadius}
+            fill={seriesColor(dot.series)}
+          />
+        ),
+      )}
+
+      {plot.labels.map((label) => (
+        <text
+          key={`${label.x}:${label.y}:${label.text}`}
+          className="chart__value"
+          x={label.x}
+          y={label.y}
+          textAnchor={label.anchor}
+        >
+          {label.text}
+        </text>
+      ))}
+
+      {/* The hit target is the whole band, not the marks in it: a reader aims
+          at a month, never at a two-pixel line.
+
+          Not focusable, and carrying no label. The `svg` above is `role="img"`
+          with a sentence describing itself, which makes everything inside it
+          invisible to a screen reader by definition, so a label here would be
+          announced to nobody. Tab stops would be worse than useless: twelve
+          invisible rectangles between the message above and the message below,
+          for a readout the Figures table already holds in full and in a form
+          somebody can actually read. The readout enhances; it never gates. */}
+      {plot.bands.map((band) => (
+        <rect
+          key={band.center}
+          className="chart__band"
+          x={horizontal ? frame.left : band.from}
+          y={horizontal ? band.from : frame.top}
+          width={horizontal ? frame.width : band.size}
+          height={horizontal ? band.size : frame.height}
+          onPointerEnter={() => onAt(band.index)}
+          onPointerMove={() => onAt(band.index)}
+        />
+      ))}
+    </>
+  );
+}
+
+/** Pies and donuts. */
+function Radial({
+  chart,
+  plot,
+  at,
+  onAt,
+}: {
+  chart: ChartValue;
+  plot: RadialPlot;
+  at: number | null;
+  onAt: (slice: number | null) => void;
+}) {
+  if (!isRadial(chart)) return null;
+  return (
+    <>
+      {plot.wedges.map((wedge) => (
+        <path
+          key={wedge.slice}
+          className="chart__wedge"
+          d={wedge.path}
+          fill={seriesColor(wedge.slice)}
+          data-lit={at === wedge.slice ? "" : undefined}
+          onPointerEnter={() => onAt(wedge.slice)}
+        />
+      ))}
+      {plot.wedges.map(({ slice, label }) =>
+        label === null ? null : (
+          <text
+            key={slice}
+            className="chart__value"
+            x={label.x}
+            y={label.y}
+            textAnchor={label.anchor}
+          >
+            {label.text}
+          </text>
+        ),
+      )}
+    </>
+  );
+}
+
+/**
+ * Clouds of points.
+ *
+ * Every series wears a shape as well as a colour. That is not decoration: in a
+ * scatter any dot can end up beside any other, so the guarantee that holds for
+ * neighbouring colours elsewhere does not hold here at all, and shape is the
+ * channel that survives colourblindness, grey print and a screenshot.
+ */
+function Scatter({
+  chart,
+  plot,
+  hidden,
+  at,
+  onAt,
+}: {
+  chart: ChartValue;
+  plot: ScatterPlot;
+  hidden: ReadonlySet<number>;
+  at: number | null;
+  onAt: (dot: number | null) => void;
+}) {
+  if (!isScatter(chart)) return null;
+  const { frame } = plot;
+
+  return (
+    <>
+      {plot.ticks.map((tick) => (
+        <line
+          key={`y${tick.value}`}
+          className="chart__grid"
+          x1={frame.left}
+          x2={frame.left + frame.width}
+          y1={tick.at}
+          y2={tick.at}
+        />
+      ))}
+      {plot.ticks.map((tick) => (
+        <text
+          key={`yt${tick.value}`}
+          className="chart__tick"
+          x={frame.left - 8}
+          y={tick.at + 4}
+          textAnchor="end"
+        >
+          {tick.text}
+        </text>
+      ))}
+      {plot.across.map((tick) => (
+        <text
+          key={`xt${tick.value}`}
+          className="chart__tick"
+          x={tick.at}
+          y={frame.top + frame.height + 16}
+          textAnchor="middle"
+        >
+          {tick.text}
+        </text>
+      ))}
+
+      {plot.dots.map((dot, index) =>
+        hidden.has(dot.series) ? null : (
+          <Mark
+            key={`${dot.series}:${dot.band}`}
+            dot={dot}
+            lit={at === index}
+            onEnter={() => onAt(index)}
+          />
+        ),
+      )}
+    </>
+  );
+}
+
+/**
+ * One point, with a target far bigger than itself.
+ *
+ * A nine-pixel dot is a pinpoint nobody hits, so the transparent circle over it
+ * is what the pointer is actually aiming at. The ring in the surface colour is
+ * what keeps two overlapping points readable as two.
+ */
+function Mark({ dot, lit, onEnter }: { dot: Point; lit: boolean; onEnter: () => void }) {
+  const color = seriesColor(dot.series);
+  const shape = seriesMark(dot.series);
+  const r = MARK.dotRadius + 1;
+
+  return (
+    <g className="chart__mark" data-lit={lit ? "" : undefined} onPointerEnter={onEnter}>
+      {shape === "circle" && <circle cx={dot.x} cy={dot.y} r={r} fill={color} />}
+      {shape === "square" && (
+        <rect x={dot.x - r} y={dot.y - r} width={r * 2} height={r * 2} fill={color} />
+      )}
+      {shape === "triangle" && (
+        <path
+          d={`M${dot.x} ${dot.y - r * 1.2}L${dot.x + r * 1.1} ${dot.y + r * 0.8}L${dot.x - r * 1.1} ${dot.y + r * 0.8}Z`}
+          fill={color}
+        />
+      )}
+      {shape === "diamond" && (
+        <path
+          d={`M${dot.x} ${dot.y - r * 1.3}L${dot.x + r * 1.3} ${dot.y}L${dot.x} ${dot.y + r * 1.3}L${dot.x - r * 1.3} ${dot.y}Z`}
+          fill={color}
+        />
+      )}
+      <circle className="chart__hit" cx={dot.x} cy={dot.y} r={MARK.hitRadius} />
+    </g>
+  );
+}
+
+/**
+ * What is under the pointer, as words.
+ *
+ * Every series at that category, not just the one the pointer landed on: a
+ * reader comparing two lines should not have to hit each of them in turn. The
+ * value leads and the name follows, which is the legend's hierarchy inverted,
+ * because by the time somebody is hovering they know which series they want
+ * and are after the number.
+ *
+ * Positioned as a percentage of the drawing rather than in its coordinates,
+ * since the drawing is scaled by CSS and this is not inside it.
+ */
+function Readout({
+  chart,
+  plot,
+  hidden,
+  at,
+  names,
+}: {
+  chart: ChartValue;
+  plot: ReturnType<typeof layout>;
+  hidden: ReadonlySet<number>;
+  at: number | null;
+  names: string[];
+}) {
+  if (at === null) return null;
+
+  if (plot.family === "radial") {
+    if (!isRadial(chart)) return null;
+    const slice = chart.slices[at];
+    const wedge = plot.wedges[at];
+    if (!slice || !wedge) return null;
+    return (
+      <div className="chart__readout" style={{ left: "50%", top: "8%" }} aria-hidden="true">
+        <p className="chart__readout-head">{slice.label}</p>
+        <p className="chart__readout-row">
+          <span className="chart__readout-value">{formatValue(chart, slice.value, false)}</span>
+          <span className="chart__readout-name">{Math.round(wedge.share * 100)}%</span>
+        </p>
+      </div>
+    );
+  }
+
+  if (plot.family === "scatter") {
+    if (!isScatter(chart)) return null;
+    const dot = plot.dots[at];
+    if (!dot) return null;
+    const point = chart.series[dot.series]?.points[dot.band];
+    return (
+      <div
+        className="chart__readout"
+        style={{ left: `${(dot.x / WIDTH) * 100}%`, top: `${(dot.y / plot.height) * 100}%` }}
+        aria-hidden="true"
+      >
+        <p className="chart__readout-head">{names[dot.series]}</p>
+        <p className="chart__readout-row">
+          <span className="chart__readout-value">
+            {formatValue(chart, point?.x ?? 0, false)}, {formatValue(chart, dot.value, false)}
+          </span>
+        </p>
+      </div>
+    );
+  }
+
+  if (!isCartesian(chart) || plot.family !== "cartesian") return null;
+  const band = plot.bands[at];
+  if (!band) return null;
+
+  return (
+    <div
+      className="chart__readout"
+      style={
+        plot.horizontal
+          ? { left: "50%", top: `${(band.center / plot.height) * 100}%` }
+          : { left: `${(band.center / WIDTH) * 100}%`, top: "6%" }
+      }
+      aria-hidden="true"
+    >
+      <p className="chart__readout-head">{band.label}</p>
+      {chart.series.map((series, index) =>
+        hidden.has(index) ? null : (
+          <p className="chart__readout-row" key={series.name}>
+            {/* A short stroke of the series colour, not a filled box: at this
+                density a box is data-weight ink doing a label's job. */}
+            <span className="chart__key" style={{ background: seriesColor(index) }} />
+            <span className="chart__readout-value">
+              {series.values[at] === null || series.values[at] === undefined
+                ? "no reading"
+                : formatValue(chart, series.values[at] as number, false)}
+            </span>
+            <span className="chart__readout-name">{series.name}</span>
+          </p>
+        ),
+      )}
+    </div>
+  );
+}
+
+/**
+ * Which series is which, and which are switched off.
+ *
+ * Always present past one series, because colour-matching alone is not an
+ * identity channel a reader can rely on. Toggling never repaints what is left:
+ * a colour belongs to a series, not to its position in what is currently shown,
+ * and an operator who has learned that revenue is green is misled by a chart
+ * that reassigns it when something else is hidden.
+ */
+function Legend({
+  chart,
+  names,
+  hidden,
+  onToggle,
+}: {
+  chart: ChartValue;
+  names: string[];
+  hidden: ReadonlySet<number>;
+  /** `null` where switching a series off would misstate the rest. */
+  onToggle: ((index: number) => void) | null;
+}) {
+  const line = chart.kind === "line" || chart.kind === "area";
+  return (
+    <ul className="chart__legend">
+      {names.map((name, index) => (
+        <li key={name}>
+          <Entry
+            className="chart__legend-item"
+            pressed={onToggle ? !hidden.has(index) : undefined}
+            onClick={onToggle ? () => onToggle(index) : undefined}
+          >
+            {/* The legend mirrors the mark: a rule for a line, a swatch for
+                anything filled, a shape for a scatter. */}
+            <span
+              className={line ? "chart__key" : "chart__swatch"}
+              data-mark={isScatter(chart) ? seriesMark(index) : undefined}
+              // Both, because a triangle is drawn out of a border and a border
+              // reads `currentColor`. One or the other leaves one shape grey.
+              style={{ background: seriesColor(index), color: seriesColor(index) }}
+            />
+            {name}
+          </Entry>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * One legend row: a switch where there is something to switch, otherwise a key.
+ *
+ * A button that does nothing when pressed is worse than a label, so a legend
+ * that cannot hide anything is not made of buttons.
+ */
+function Entry({
+  className,
+  pressed,
+  onClick,
+  children,
+}: {
+  className: string;
+  pressed?: boolean;
+  onClick?: () => void;
+  children: React.ReactNode;
+}) {
+  if (!onClick) {
+    return (
+      <span className={className} data-static="">
+        {children}
+      </span>
+    );
+  }
+  return (
+    <button type="button" className={className} aria-pressed={pressed} onClick={onClick}>
+      {children}
+    </button>
+  );
+}
+
+/**
+ * The chart as its own numbers.
+ *
+ * Not a fallback. It is how a value is read by a screen reader, by an operator
+ * who cannot separate two of the hues, and by anybody who wants the figure
+ * rather than the shape. Folded away because a transcript is a conversation and
+ * a table under every chart doubles its height; one press from open, because a
+ * value behind a hover is a value some readers can never get to.
+ */
+export function ChartFigures({ chart }: { chart: ChartValue }) {
+  const table = useMemo(() => chartTable(chart), [chart]);
+  return (
+    <details className="chart__table">
+      <summary>Figures</summary>
+      <div className="md__scroll">
+        <table>
+          <thead>
+            <tr>
+              {table.head.map((cell, at) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: two series can honestly carry the same name, and this grid is derived whole from an immutable chart rather than reordered
+                <th key={at} scope="col">
+                  {cell}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {table.rows.map((row, down) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: as above
+              <tr key={down}>
+                {row.map((cell, across) => (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: as above
+                  <td key={across}>{cell}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  );
+}

--- a/src/components/Figure.test.tsx
+++ b/src/components/Figure.test.tsx
@@ -1,0 +1,196 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const frameArtifact = vi.fn(async () => ({ port: 9999, id: "a".repeat(64) }));
+vi.mock("../lib/ipc", () => ({
+  api: { frameArtifact: () => frameArtifact() },
+  openExternal: vi.fn(),
+}));
+
+const { Markdown } = await import("./Markdown");
+
+const fence = (language: string, body: unknown) =>
+  `\`\`\`${language}\n${typeof body === "string" ? body : JSON.stringify(body)}\n\`\`\``;
+
+const BARS = JSON.stringify({
+  type: "bar",
+  title: "Revenue by quarter",
+  prefix: "$",
+  labels: ["Q1", "Q2"],
+  series: [{ name: "2026", data: [12, 18] }],
+});
+
+describe("a chart in a message", () => {
+  it("draws instead of printing the JSON", () => {
+    const { container } = render(<Markdown>{fence("chart", BARS)}</Markdown>);
+    expect(container.querySelector("svg.chart__svg")).toBeTruthy();
+    expect(container.querySelector(".chart__bar")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Revenue by quarter" })).toBeTruthy();
+  });
+
+  it("says what it is, for anyone who cannot see it", () => {
+    // The drawing itself is one image with one sentence on it. The numbers are
+    // in the table underneath, which is where a reader is sent rather than
+    // being read a hundred coordinates.
+    render(<Markdown>{fence("chart", BARS)}</Markdown>);
+    const drawing = screen.getByRole("img");
+    expect(drawing.getAttribute("aria-label")).toContain("Revenue by quarter");
+    expect(drawing.getAttribute("aria-label")).toContain("table below");
+  });
+
+  it("carries every value as text as well as as a shape", () => {
+    // A value behind a hover is a value some readers can never reach. This is
+    // the channel that makes the drawing an enhancement rather than the only
+    // way to find out what the numbers were.
+    const { container } = render(<Markdown>{fence("chart", BARS)}</Markdown>);
+    const table = container.querySelector(".chart__table table");
+    if (!table) throw new Error("a chart shipped without its figures");
+    expect(within(table as HTMLElement).getByText("$12")).toBeTruthy();
+    expect(within(table as HTMLElement).getByText("$18")).toBeTruthy();
+  });
+
+  it("writes the values on a single series, where they are the point", () => {
+    const { container } = render(<Markdown>{fence("chart", BARS)}</Markdown>);
+    const labels = [...container.querySelectorAll(".chart__value")].map((at) => at.textContent);
+    expect(labels).toEqual(["$12", "$18"]);
+  });
+
+  it("offers a legend past one series and none at one", () => {
+    // One colour, and the title above already says what is plotted. A box with
+    // a single swatch in it restates the title and costs a line.
+    const { container } = render(<Markdown>{fence("chart", BARS)}</Markdown>);
+    expect(container.querySelector(".chart__legend")).toBeNull();
+
+    const two = render(
+      <Markdown>
+        {fence(
+          "chart",
+          JSON.stringify({
+            type: "bar",
+            labels: ["Q1"],
+            series: [
+              { name: "2025", data: [1] },
+              { name: "2026", data: [2] },
+            ],
+          }),
+        )}
+      </Markdown>,
+    );
+    expect(two.container.querySelector(".chart__legend")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "2025", pressed: true })).toBeTruthy();
+  });
+
+  it("makes a pie's legend a key rather than a set of switches", () => {
+    // Its slices are shares of one whole, so switching one off would leave the
+    // others claiming percentages of a total that has not changed. A button
+    // that does nothing when pressed is worse than a label.
+    const { container } = render(
+      <Markdown>
+        {fence("chart", {
+          type: "pie",
+          labels: ["a", "b"],
+          series: [{ data: [3, 1] }],
+        } as never)}
+      </Markdown>,
+    );
+    expect(container.querySelector(".chart__legend")).toBeTruthy();
+    expect(container.querySelector(".chart__legend button")).toBeNull();
+    expect(container.querySelectorAll(".chart__legend-item[data-static]")).toHaveLength(2);
+  });
+
+  it("keeps the source one press away", () => {
+    // A figure drawn from a model's own JSON is a claim about numbers, and an
+    // operator checking the chart against what was written has nowhere else to
+    // look. It is also the only thing that can be copied out.
+    render(<Markdown>{fence("chart", BARS)}</Markdown>);
+    expect(screen.getByRole("button", { name: "Source" })).toBeTruthy();
+  });
+});
+
+describe("a chart that will not draw", () => {
+  it("shows what was asked for and why it was refused", () => {
+    const { container } = render(
+      <Markdown>{fence("chart", '{"type": "sunburst", "series": [{"data": [1]}]}')}</Markdown>,
+    );
+    expect(container.querySelector(".figure__fault")?.textContent).toContain("not a chart type");
+    // The spec itself stays on screen: the operator needs to see the request,
+    // and the agent needs to be told what to change.
+    expect(container.querySelector(".figure__source")?.textContent).toContain("sunburst");
+  });
+
+  it("waits quietly while one is still arriving", () => {
+    // Mid-stream a chart is half an object. Called an error, that is a red box
+    // under every figure for a second, which teaches an operator that the
+    // feature is broken.
+    const { container } = render(<Markdown>{'```chart\n{"type": "ba'}</Markdown>);
+    expect(container.querySelector(".figure--waiting")).toBeTruthy();
+    expect(container.querySelector(".figure__fault")).toBeNull();
+  });
+});
+
+describe("a page in a message", () => {
+  const PAGE =
+    "<!doctype html><html><body><h1>Plan</h1><p>Something worth framing.</p></body></html>";
+
+  it("mounts exactly one frame, however many places it could go", async () => {
+    // The same element written into both the inline card and the full view is
+    // two of them: React draws it once per position in the tree, so a second
+    // renderer would start loading the same page and the height message would
+    // arrive from the wrong window.
+    const { container } = render(<Markdown>{fence("html", PAGE)}</Markdown>);
+    await waitFor(() => expect(container.querySelector("iframe")).toBeTruthy());
+    expect(container.querySelectorAll("iframe")).toHaveLength(1);
+  });
+
+  it("is framed on an origin of its own, with scripts and nothing else", async () => {
+    // Never `allow-same-origin` beside `allow-scripts`: together they let the
+    // page take its own sandbox off and reload without one.
+    const { container } = render(<Markdown>{fence("html", PAGE)}</Markdown>);
+    await waitFor(() => {
+      const frame = container.querySelector("iframe");
+      if (!frame) throw new Error("no frame yet");
+      expect(frame.getAttribute("sandbox")).toBe("allow-scripts");
+      expect(frame.getAttribute("src")).toBe(`http://127.0.0.1:9999/${"a".repeat(64)}`);
+    });
+  });
+
+  it("never becomes part of this document", async () => {
+    // The markup goes over IPC and comes back as an address. Nothing in the
+    // fence is ever parsed into the app's own tree.
+    const { container } = render(<Markdown>{fence("html", PAGE)}</Markdown>);
+    await waitFor(() => expect(container.querySelector("iframe")).toBeTruthy());
+    expect(container.querySelector("h1")).toBeNull();
+  });
+
+  it("leaves markup in the prose alone, as it always did", () => {
+    const { container } = render(
+      <Markdown>{'<img src=x onerror="alert(1)"><script>alert(2)</script>**safe**'}</Markdown>,
+    );
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.querySelector("iframe")).toBeNull();
+    expect(container.querySelector("strong")?.textContent).toBe("safe");
+  });
+
+  it("leaves a snippet as a code block", () => {
+    // Framing `<div>hi</div>` on its own origin is a renderer and a round trip
+    // spent on what a code block already showed.
+    const { container } = render(<Markdown>{fence("html", "<div>hi</div>")}</Markdown>);
+    expect(container.querySelector(".md__pre")).toBeTruthy();
+    expect(container.querySelector("iframe")).toBeNull();
+  });
+});
+
+describe("every other fence", () => {
+  it("stays source", () => {
+    const { container } = render(<Markdown>{fence("python", "print(1)")}</Markdown>);
+    expect(container.querySelector(".md__pre code")?.textContent).toContain("print(1)");
+    expect(container.querySelector(".figure")).toBeNull();
+  });
+
+  it("including one holding JSON that happens to be a chart spec", () => {
+    // A model showing an operator what a spec looks like is showing them text.
+    const { container } = render(<Markdown>{fence("json", BARS)}</Markdown>);
+    expect(container.querySelector("svg.chart__svg")).toBeNull();
+    expect(container.querySelector(".md__pre")).toBeTruthy();
+  });
+});

--- a/src/components/Figure.tsx
+++ b/src/components/Figure.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+
+import { isFault } from "../lib/chart";
+import type { Figure as FigureValue } from "../lib/figure";
+import { Chart, ChartFigures } from "./Chart";
+import { HtmlArtifact } from "./HtmlArtifact";
+
+/**
+ * A fenced block that turned out to be worth drawing.
+ *
+ * One card whatever is inside it, so a chart and a page an agent wrote sit in
+ * a transcript the same way a file does: a bounded thing with a hairline round
+ * it, not a wall of markup in the middle of a sentence.
+ *
+ * The source is always one press away, and that is not a debugging affordance.
+ * A figure drawn from a model's own JSON is a claim about numbers, and an
+ * operator who wants to check the chart against what was actually written has
+ * nowhere else to look. It is also the only thing that can be copied out.
+ */
+export function Figure({ figure, source }: { figure: FigureValue; source: string }) {
+  const [showing, setShowing] = useState(false);
+
+  if (figure.kind === "pending") {
+    // Still arriving. Named as such rather than left blank, because a gap that
+    // appears mid-reply and then fills in reads as the message having broken.
+    return (
+      <div className="figure figure--waiting">
+        <p className="hint">Drawing…</p>
+      </div>
+    );
+  }
+
+  const fault = figure.kind === "chart" && isFault(figure.read) ? figure.read.why : null;
+  const drawn = figure.kind === "chart" && !isFault(figure.read) ? figure.read.chart : null;
+
+  return (
+    <div className="figure">
+      <div className="figure__body">
+        {drawn && <Chart chart={drawn} />}
+        {figure.kind === "html" && <HtmlArtifact html={figure.html} title="Page" />}
+        {/* A refused chart shows what was asked for. The operator needs to see
+            the request, and the agent that wrote it needs to be told what to
+            change; a box saying "invalid chart" is neither of those. */}
+        {(fault || showing) && <pre className="md__pre figure__source">{source}</pre>}
+      </div>
+      <div className="figure__foot">
+        {fault ? (
+          <p className="figure__fault">{fault}</p>
+        ) : (
+          <>
+            {/* The chart's own numbers and the spec that drew them, side by
+                side: they are the two ways of checking a figure and they belong
+                in the same strip rather than as two stray rows under it. */}
+            {drawn && <ChartFigures chart={drawn} />}
+            <button
+              type="button"
+              className="btn btn--ghost btn--small"
+              aria-expanded={showing}
+              onClick={() => setShowing((was) => !was)}
+            >
+              {showing ? "Hide source" : "Source"}
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/HtmlArtifact.tsx
+++ b/src/components/HtmlArtifact.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef, useState } from "react";
+
+import { api } from "../lib/ipc";
+import { errorMessage } from "../lib/types";
+
+/**
+ * A page an agent wrote, running.
+ *
+ * The frame points at a loopback origin of Guaca's own rather than carrying
+ * the markup inline, because a frame given `srcdoc` inherits this document's
+ * content policy and this document forbids script. A page framed that way
+ * draws and then quietly does nothing, which is the worst thing this could
+ * ship: it passes every test and shows the operator a blank rectangle.
+ *
+ * What the page may do once it is running is argued in `artifact.rs`, and none
+ * of it is decided here. The short version is that it may compute and it may
+ * draw, and it may not reach anything: no fetch, no remote image, no form. The
+ * `sandbox` attribute below is the second half of the same lock and its two
+ * values must never gain `allow-same-origin`, which would let the page take the
+ * sandbox off and reload out of it.
+ */
+export function HtmlArtifact({ html, title }: { html: string; title: string }) {
+  const frame = useRef<HTMLIFrameElement>(null);
+  const [src, setSrc] = useState<string | null>(null);
+  const [failed, setFailed] = useState<string | null>(null);
+  const [height, setHeight] = useState(MIN_HEIGHT);
+  const [full, setFull] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    setFailed(null);
+    api
+      .frameArtifact(html)
+      .then((at) => live && setSrc(`http://127.0.0.1:${at.port}/${at.id}`))
+      .catch((error) => live && setFailed(errorMessage(error)));
+    return () => {
+      live = false;
+    };
+  }, [html]);
+
+  // A frame on another origin cannot be measured from outside, so the page is
+  // asked. The message is trusted by the window it came from and by nothing
+  // else: an opaque origin reports itself as "null", so checking the origin
+  // would either reject every real message or accept every forged one.
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      if (event.source !== frame.current?.contentWindow) return;
+      const said: unknown = event.data;
+      if (typeof said !== "object" || said === null) return;
+      const { guaca, height: reported } = said as { guaca?: unknown; height?: unknown };
+      if (guaca !== "artifact-height" || typeof reported !== "number") return;
+      // Clamped rather than obeyed. A page that reports a height of a hundred
+      // thousand has made itself the whole channel, and one that reports zero
+      // has made itself invisible.
+      setHeight(Math.max(MIN_HEIGHT, Math.min(MAX_HEIGHT, Math.ceil(reported))));
+    };
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, []);
+
+  useEffect(() => {
+    if (!full) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setFull(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [full]);
+
+  if (failed) {
+    return (
+      <p className="hint">
+        Could not show this page: {failed}. The source is above, and saving it to a file and opening
+        it in a browser will always work.
+      </p>
+    );
+  }
+
+  // One frame, in one of two places. The same element written into both would
+  // be two of them: React draws it once per position in the tree, so opening
+  // the full view would start a second renderer loading the same page, and the
+  // ref would end up on whichever mounted last.
+  const page = (
+    <iframe
+      ref={frame}
+      className="artifact__frame"
+      // Scripts, and deliberately nothing else. Never `allow-same-origin`
+      // beside `allow-scripts`: together they let the page remove its own
+      // sandbox and reload without one.
+      sandbox="allow-scripts"
+      referrerPolicy="no-referrer"
+      src={src ?? undefined}
+      title={title}
+      style={full ? undefined : { height }}
+    />
+  );
+
+  if (full) {
+    return (
+      <div className="scrim">
+        <button
+          type="button"
+          className="scrim__close"
+          aria-label="Close dialog"
+          onClick={() => setFull(false)}
+        />
+        <div className="dialog dialog--file" role="dialog" aria-modal="true" aria-label={title}>
+          <div className="file-view__head">
+            <h2 className="dialog__title">{title}</h2>
+            <div className="file-view__actions">
+              <button
+                type="button"
+                className="file-view__close"
+                aria-label="Close"
+                title="Close"
+                onClick={() => setFull(false)}
+              >
+                ×
+              </button>
+            </div>
+          </div>
+          <div className="file-view__body artifact__full">
+            <div className="artifact">{page}</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="artifact">
+      {src ? page : <p className="hint">Opening…</p>}
+      {/* A transcript is a conversation, so a page in one is bounded however
+          tall it says it is. The full view is where the reading happens, the
+          same way a document works. */}
+      <button
+        type="button"
+        className="btn btn--ghost btn--small artifact__open"
+        onClick={() => setFull(true)}
+      >
+        Open
+      </button>
+    </div>
+  );
+}
+
+/** Tall enough that a page still drawing does not read as a broken frame. */
+const MIN_HEIGHT = 120;
+/** And short enough that one cannot make itself the whole channel. */
+const MAX_HEIGHT = 640;

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,7 +1,10 @@
+import type { ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+import { fenceLanguage, fenceText, readFigure } from "../lib/figure";
 import { openExternal } from "../lib/ipc";
+import { Figure } from "./Figure";
 
 /**
  * Renders message bodies as Markdown.
@@ -9,10 +12,13 @@ import { openExternal } from "../lib/ipc";
  * Models write Markdown whether or not you ask them to, so plain text means
  * reading raw `**bold**` and unformatted lists all day.
  *
- * Raw HTML is deliberately not enabled. Message bodies come from a model, and
- * on the peer path from *another agent's* model, which is the least trustworthy
- * input in the app. `react-markdown` ignores embedded HTML unless `rehype-raw`
- * is added, and it is not.
+ * Raw HTML is deliberately not enabled, and a fenced `html` block is not a
+ * hole in that. Message bodies come from a model, and on the peer path from
+ * *another agent's* model, which is the least trustworthy input in the app, so
+ * markup in the prose is ignored: `react-markdown` drops embedded HTML unless
+ * `rehype-raw` is added, and it is not. A fence tagged as a page is a different
+ * thing entirely. It never becomes part of this document, and is run on an
+ * origin of its own that can reach nothing. `artifact.rs` is the argument.
  */
 export function Markdown({ children }: { children: string }) {
   return (
@@ -46,7 +52,20 @@ export function Markdown({ children }: { children: string }) {
               {alt || "image"}
             </a>
           ),
-          pre: ({ children }) => <pre className="md__pre">{children}</pre>,
+          // Intercepted at the `pre` rather than at the `code` inside it: a
+          // figure is a block, and a block returned from the `code` slot lands
+          // inside a `<pre>` that react-markdown has already opened, which is
+          // markup no browser agrees on how to lay out.
+          pre: ({ children }) => {
+            const fenced = asFence(children);
+            if (fenced) {
+              const figure = readFigure(fenced.language, fenced.source);
+              if (figure.kind !== "source") {
+                return <Figure figure={figure} source={fenced.source} />;
+              }
+            }
+            return <pre className="md__pre">{children}</pre>;
+          },
           table: ({ children }) => (
             <div className="md__scroll">
               <table>{children}</table>
@@ -58,4 +77,22 @@ export function Markdown({ children }: { children: string }) {
       </ReactMarkdown>
     </div>
   );
+}
+
+/**
+ * The language and text of a fenced block, given the node `pre` was handed.
+ *
+ * A `pre` holds exactly one `code` element when it came from a fence, and
+ * something else entirely when it came from an indented block. Only the first
+ * is a figure: an indented block carries no language, so there is nothing to
+ * decide from and nothing to draw.
+ */
+function asFence(children: ReactNode): { language: string; source: string } | null {
+  const only = Array.isArray(children) ? children[0] : children;
+  if (!only || typeof only !== "object" || !("props" in only)) return null;
+  const props = (only as { props?: { className?: unknown; children?: unknown } }).props;
+  if (!props) return null;
+  const language = fenceLanguage(props.className);
+  if (!language) return null;
+  return { language, source: fenceText(props.children) };
 }

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -179,10 +179,13 @@ export const MessageItem = memo(function MessageItem({
  * `send_message` and then carried on typing. That text has no recipient, so it
  * is drawn as an aside rather than as anything addressed to the operator.
  *
- * A `json` part is the one kind that reaches here and draws nothing. Nothing in
- * the runtime emits one yet; it is the seam a model-authored artifact would
- * arrive through, and a renderer for it before there is a producer is surface
- * with no caller.
+ * A `json` part is the one kind that reaches here and draws nothing, and it is
+ * still the case that nothing in the runtime emits one. It used to be described
+ * here as the seam a model-authored artifact would arrive through; artifacts
+ * arrived, and they came through the text instead. A chart or a page is a
+ * fenced block in the reply, which costs no round trip and needs no new part:
+ * `lib/figure.ts`. A renderer for `json` before there is a producer is still
+ * surface with no caller.
  */
 function ActivityRecord({ message }: { message: Envelope }) {
   const rows: React.ReactNode[] = [];

--- a/src/lib/chart.test.ts
+++ b/src/lib/chart.test.ts
@@ -1,0 +1,474 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  barPath,
+  type CartesianPlot,
+  type Chart,
+  chartTable,
+  formatValue,
+  isFault,
+  layout,
+  MARK,
+  niceTicks,
+  type RadialPlot,
+  readChart,
+} from "./chart";
+
+/** Reads a spec that is expected to be good, and hands back the chart. */
+function good(value: unknown): Chart {
+  const read = readChart(value);
+  if (isFault(read)) throw new Error(`expected a chart, got: ${read.why}`);
+  return read.chart;
+}
+
+/** Reads one that is expected to be refused, and hands back the sentence. */
+function refused(value: unknown): string {
+  const read = readChart(value);
+  if (!isFault(read)) throw new Error("expected a refusal");
+  return read.why;
+}
+
+const bars = {
+  type: "bar",
+  title: "Revenue",
+  labels: ["Q1", "Q2", "Q3"],
+  series: [{ name: "2026", data: [10, 20, 15] }],
+};
+
+describe("reading a spec", () => {
+  it("reads the shape every plotting library uses", () => {
+    const chart = good(bars);
+    expect(chart.kind).toBe("bar");
+    expect(chart.title).toBe("Revenue");
+    if (chart.kind === "bar") {
+      expect(chart.labels).toEqual(["Q1", "Q2", "Q3"]);
+      expect(chart.series[0]?.values).toEqual([10, 20, 15]);
+    }
+  });
+
+  it("names the field and the fix in every refusal", () => {
+    // These are read by the agent that wrote the spec, on a turn where it can
+    // still put it right. "Invalid chart" costs a whole turn and teaches it
+    // nothing, so every one of these has to say what to do.
+    expect(refused({ type: "sunburst", series: [{ data: [1] }] })).toContain("bar, line");
+    expect(refused({ type: "bar" })).toContain('"series" is required');
+    expect(refused({ type: "bar", series: [{ name: "a" }] })).toContain('needs "data"');
+    expect(refused("nope")).toContain("JSON object");
+  });
+
+  it("keeps a gap a gap rather than calling it zero", () => {
+    // A month with no reading is not a month that sold nothing, and a chart
+    // that draws the second when it was told the first is inventing data.
+    const chart = good({ type: "line", labels: ["a", "b", "c"], series: [{ data: [1, null, 3] }] });
+    if (chart.kind !== "line") throw new Error("wrong kind");
+    expect(chart.series[0]?.values).toEqual([1, null, 3]);
+  });
+
+  it("refuses more series than a reader can tell apart, and says what to do", () => {
+    const many = Array.from({ length: 9 }, (_, at) => ({ name: `s${at}`, data: [1] }));
+    expect(refused({ type: "bar", labels: ["a"], series: many })).toContain("Other");
+  });
+
+  it("refuses labels that do not line up with the data", () => {
+    // Silently padding would slide every point one category to the left, which
+    // is a chart that is confidently wrong rather than absent.
+    expect(refused({ type: "bar", labels: ["a", "b"], series: [{ data: [1, 2, 3] }] })).toContain(
+      "one label per point",
+    );
+  });
+
+  it("numbers the categories when nobody named them", () => {
+    const chart = good({ type: "bar", series: [{ data: [1, 2] }] });
+    if (chart.kind !== "bar") throw new Error("wrong kind");
+    expect(chart.labels).toEqual(["1", "2"]);
+  });
+
+  it("pads a short series rather than losing the whole figure", () => {
+    const chart = good({
+      type: "bar",
+      labels: ["a", "b", "c"],
+      series: [{ data: [1, 2, 3] }, { data: [4, 5] }],
+    });
+    if (chart.kind !== "bar") throw new Error("wrong kind");
+    expect(chart.series[1]?.values).toEqual([4, 5, null]);
+  });
+});
+
+describe("reading a pie", () => {
+  it("takes one series and turns it into slices", () => {
+    const chart = good({ type: "pie", labels: ["a", "b"], series: [{ data: [3, 1] }] });
+    if (chart.kind !== "pie") throw new Error("wrong kind");
+    expect(chart.slices).toEqual([
+      { label: "a", value: 3 },
+      { label: "b", value: 1 },
+    ]);
+  });
+
+  it("sends several series to a stacked bar instead", () => {
+    expect(refused({ type: "pie", series: [{ data: [1] }, { data: [2] }] })).toContain(
+      "stacked bar",
+    );
+  });
+
+  it("refuses a negative share, which a circle cannot show", () => {
+    expect(refused({ type: "pie", series: [{ data: [1, -1] }] })).toContain("negative");
+  });
+
+  it("folds a long tail into Other rather than refusing", () => {
+    // Past six wedges nobody is comparing them: they are reading the big ones
+    // and the remainder. Folding gives them exactly that; refusing gives them
+    // nothing.
+    const chart = good({
+      type: "pie",
+      labels: ["a", "b", "c", "d", "e", "f", "g", "h"],
+      series: [{ data: [10, 9, 8, 7, 6, 5, 4, 3] }],
+    });
+    if (chart.kind !== "pie") throw new Error("wrong kind");
+    expect(chart.slices).toHaveLength(6);
+    expect(chart.slices[5]).toEqual({ label: "Other", value: 5 + 4 + 3 });
+  });
+
+  it("drops slices worth nothing", () => {
+    const chart = good({ type: "pie", labels: ["a", "b"], series: [{ data: [1, 0] }] });
+    if (chart.kind !== "pie") throw new Error("wrong kind");
+    expect(chart.slices).toHaveLength(1);
+  });
+});
+
+describe("reading a scatter", () => {
+  it("takes pairs", () => {
+    const chart = good({
+      type: "scatter",
+      series: [
+        {
+          name: "runs",
+          data: [
+            [1, 2],
+            [3, 4],
+          ],
+        },
+      ],
+    });
+    if (chart.kind !== "scatter") throw new Error("wrong kind");
+    expect(chart.series[0]?.points).toEqual([
+      { x: 1, y: 2 },
+      { x: 3, y: 4 },
+    ]);
+  });
+
+  it("says what a pair looks like when it was given something else", () => {
+    expect(refused({ type: "scatter", series: [{ data: [1, 2, 3] }] })).toContain("[1, 4.5]");
+  });
+});
+
+describe("ticks", () => {
+  it("steps by numbers a reader can do arithmetic with", () => {
+    expect(niceTicks(0, 100)).toEqual([0, 20, 40, 60, 80, 100]);
+    expect(niceTicks(0, 10)).toEqual([0, 2, 4, 6, 8, 10]);
+  });
+
+  it("reaches past the data rather than stopping under it", () => {
+    // An axis whose top gridline is below the tallest bar leaves that bar
+    // sticking out of its own frame, which reads as a chart that did not
+    // finish drawing.
+    for (const [low, high] of [
+      [0, 1_240_000],
+      [0, 97],
+      [0, 3],
+      [-40, 110],
+    ] as const) {
+      const ticks = niceTicks(low, high);
+      expect(ticks[ticks.length - 1], `${low}..${high}`).toBeGreaterThanOrEqual(high);
+      expect(ticks[0], `${low}..${high}`).toBeLessThanOrEqual(low);
+    }
+  });
+
+  it("offers a quarter step, so a wide range is not three gridlines", () => {
+    // Without 2.5 in the set, 1.24M steps by 500K and the whole chart gets
+    // three lines to read against.
+    expect(niceTicks(0, 1_240_000)).toEqual([0, 250_000, 500_000, 750_000, 1_000_000, 1_250_000]);
+  });
+
+  it("does not produce 0.30000000000000004", () => {
+    // Floating point turns a tenth into seventeen digits, and an axis that
+    // says so is an axis nobody trusts.
+    for (const tick of niceTicks(0, 0.5)) {
+      expect(String(tick).length).toBeLessThan(6);
+    }
+  });
+
+  it("survives a series that never changes", () => {
+    expect(() => niceTicks(5, 5)).not.toThrow();
+  });
+});
+
+describe("formatting a value", () => {
+  it("compacts what would otherwise eat the chart", () => {
+    expect(
+      formatValue({ prefix: "", unit: "", title: "", captionX: "", captionY: "" }, 1_250_000),
+    ).toBe("1.25M");
+    expect(
+      formatValue({ prefix: "", unit: "", title: "", captionX: "", captionY: "" }, 12_500),
+    ).toBe("12.5K");
+  });
+
+  it("does not write 4 as 4.00", () => {
+    const plain = { prefix: "", unit: "", title: "", captionX: "", captionY: "" };
+    expect(formatValue(plain, 4)).toBe("4");
+    expect(formatValue(plain, 1234)).toBe("1,234");
+  });
+
+  it("wears the unit it was given", () => {
+    expect(formatValue({ prefix: "$", unit: "", title: "", captionX: "", captionY: "" }, 12)).toBe(
+      "$12",
+    );
+    expect(formatValue({ prefix: "", unit: "%", title: "", captionX: "", captionY: "" }, 12)).toBe(
+      "12%",
+    );
+  });
+
+  it("keeps the full number in the table, where the room is", () => {
+    const chart = good({ type: "bar", labels: ["a"], series: [{ data: [1_250_000] }] });
+    expect(chartTable(chart).rows[0]?.[1]).toBe("1,250,000");
+  });
+});
+
+describe("laying a bar chart out", () => {
+  const plot = layout(good(bars)) as CartesianPlot;
+
+  it("anchors bars to zero, because their length is the quantity", () => {
+    // A bar chart from 90 to 100 makes a two percent difference look like
+    // everything there is.
+    const tall = layout(good({ ...bars, series: [{ data: [90, 95, 100] }] })) as CartesianPlot;
+    expect(tall.ticks[0]?.value).toBe(0);
+  });
+
+  it("lets a line float, because a line encodes change", () => {
+    const line = layout(
+      good({ type: "line", labels: ["a", "b"], series: [{ data: [90, 100] }] }),
+    ) as CartesianPlot;
+    expect(line.ticks[0]?.value).toBeGreaterThan(0);
+  });
+
+  it("never lets a bar fill its band", () => {
+    // The air left over is what separates one category from the next, and it
+    // does that job better than a stroke around each bar would.
+    const band = plot.bands[0]?.size ?? 0;
+    for (const bar of plot.bars) expect(bar.width).toBeLessThan(band);
+  });
+
+  it("caps how thick a bar gets however few there are", () => {
+    const two = layout(good({ type: "bar", labels: ["a"], series: [{ data: [1] }] }));
+    const [only] = (two as CartesianPlot).bars;
+    expect(only?.width).toBeLessThanOrEqual(MARK.maxBarThickness);
+  });
+
+  it("puts surface between the segments of a stack", () => {
+    const stack = layout(
+      good({
+        type: "bar",
+        stacked: true,
+        labels: ["a"],
+        series: [{ data: [50] }, { data: [50] }],
+      }),
+    ) as CartesianPlot;
+    const [lower, upper] = stack.bars;
+    if (!lower || !upper) throw new Error("expected two segments");
+    // The upper one ends short of where the lower one starts.
+    expect(lower.y - (upper.y + upper.height)).toBeGreaterThanOrEqual(MARK.gap - 0.001);
+  });
+
+  it("writes the value on every bar of a single series and on none of a group", () => {
+    // On one series the numbers are the point, and they are also what makes a
+    // pale fill readable. On a group they are a wall of digits nobody reads.
+    expect(plot.labels).toHaveLength(3);
+    const grouped = layout(
+      good({ ...bars, series: [{ data: [1, 2, 3] }, { data: [4, 5, 6] }] }),
+    ) as CartesianPlot;
+    expect(grouped.labels).toEqual([]);
+  });
+
+  it("drops whole category names rather than overlapping them", () => {
+    // A label is never shrunk, rotated or clipped to fit: rotated axis text is
+    // unreadable and a clipped one loses what told two categories apart.
+    const many = layout(
+      good({
+        type: "bar",
+        labels: Array.from({ length: 40 }, (_, at) => `week ${at + 1}`),
+        series: [{ data: Array.from({ length: 40 }, () => 1) }],
+      }),
+    ) as CartesianPlot;
+    expect(many.shown.length).toBeLessThan(40);
+    expect(many.shown.length).toBeGreaterThan(0);
+  });
+
+  it("stops a stacked fill at the series under it, not at the axis", () => {
+    // Every band drawn down to zero is every band drawn over the one before
+    // it, which at a tenth opacity makes a stack whose colours are all
+    // mixtures of each other.
+    const stack = layout(
+      good({
+        type: "area",
+        stacked: true,
+        labels: ["a", "b"],
+        series: [
+          { name: "lower", data: [10, 10] },
+          { name: "upper", data: [10, 10] },
+        ],
+      }),
+    ) as CartesianPlot;
+    const [lower, upper] = stack.strokes;
+    if (!lower || !upper) throw new Error("expected two fills");
+
+    // The lower one closes on the baseline. The upper one closes on the line
+    // the lower one drew, and never reaches the axis at all.
+    const floor = (stroke: { line: string; fill: string }) =>
+      [...stroke.fill.slice(stroke.line.length).matchAll(/L[\d.]+ ([\d.]+)/g)].map((at) =>
+        Number(at[1]),
+      );
+    const lowerLine = Number(lower.line.match(/M[\d.]+ ([\d.]+)/)?.[1]);
+
+    expect(new Set(floor(lower))).toEqual(new Set([stack.baseline]));
+    expect(new Set(floor(upper))).toEqual(new Set([lowerLine]));
+  });
+
+  it("labels a stacked series with its own value, not the running total", () => {
+    // The readout and the table both say what this series was worth, and a
+    // label saying something else is the chart contradicting itself two inches
+    // lower down.
+    const stack = layout(
+      good({
+        type: "area",
+        stacked: true,
+        labels: ["a"],
+        series: [
+          { name: "lower", data: [30] },
+          { name: "upper", data: [12] },
+        ],
+      }),
+    ) as CartesianPlot;
+    expect(stack.labels.map((label) => label.text)).toEqual(["30", "12"]);
+  });
+
+  it("breaks a line at a gap instead of drawing through it", () => {
+    const gapped = layout(
+      good({ type: "line", labels: ["a", "b", "c"], series: [{ data: [1, null, 3] }] }),
+    ) as CartesianPlot;
+    expect(gapped.strokes).toHaveLength(2);
+  });
+
+  it("gives every category a pointer target the size of the whole band", () => {
+    // A reader aims at a month, never at a two-pixel line.
+    for (const band of plot.bands) expect(band.size).toBeGreaterThan(MARK.hitRadius);
+  });
+});
+
+describe("laying a pie out", () => {
+  it("says nothing beside a wedge too thin to hold a label", () => {
+    // Two one-percent slivers put two labels in the same place, and the shot of
+    // that reads "Partne Other 1%". The legend and the table already name them.
+    const plot = layout(
+      good({
+        type: "pie",
+        labels: ["big", "sliver"],
+        series: [{ data: [990, 10] }],
+      }),
+    ) as RadialPlot;
+    expect(plot.wedges[0]?.label).not.toBeNull();
+    expect(plot.wedges[1]?.label).toBeNull();
+  });
+
+  it("puts surface between the wedges and a share on each", () => {
+    const plot = layout(
+      good({ type: "pie", labels: ["a", "b"], series: [{ data: [3, 1] }] }),
+    ) as RadialPlot;
+    expect(plot.wedges).toHaveLength(2);
+    expect(plot.wedges[0]?.label?.text).toBe("a 75%");
+    expect(plot.wedges[0]?.path).toMatch(/^M[\d.-]/);
+  });
+
+  it("draws a single slice as a whole circle rather than nothing", () => {
+    // One wedge sweeping the full turn starts and ends on the same point, so
+    // the arc collapses and a pie of one category draws an empty frame.
+    const plot = layout(
+      good({ type: "pie", labels: ["all"], series: [{ data: [5] }] }),
+    ) as RadialPlot;
+    const [only] = plot.wedges;
+    expect(only?.path).toContain("A");
+    expect(only?.label?.text).toBe("all 100%");
+  });
+
+  it("hollows a donut and leaves a pie solid", () => {
+    const donut = layout(
+      good({ type: "donut", labels: ["a", "b"], series: [{ data: [1, 1] }] }),
+    ) as RadialPlot;
+    const pie = layout(
+      good({ type: "pie", labels: ["a", "b"], series: [{ data: [1, 1] }] }),
+    ) as RadialPlot;
+    // A solid wedge is drawn from the centre out; a hollow one never goes there.
+    expect(pie.wedges[0]?.path.startsWith(`M${pie.center.x} ${pie.center.y}`)).toBe(true);
+    expect(donut.wedges[0]?.path.startsWith(`M${donut.center.x} ${donut.center.y}`)).toBe(false);
+  });
+});
+
+describe("a bar's outline", () => {
+  it("is rounded where the data ends and square at the baseline", () => {
+    // Rounded at both ends a bar floats, and every bar in the chart looks as
+    // though it starts above the axis it is measured from.
+    const path = barPath({
+      series: 0,
+      band: 0,
+      x: 0,
+      y: 0,
+      width: 20,
+      height: 100,
+      round: "top",
+      value: 1,
+    });
+    // Two corner arcs at the top, none at the bottom.
+    expect(path.match(/A/g)).toHaveLength(2);
+    expect(path).toContain("V100");
+  });
+
+  it("gives up the corners rather than turning a short bar into a lozenge", () => {
+    const path = barPath({
+      series: 0,
+      band: 0,
+      x: 0,
+      y: 0,
+      width: 20,
+      height: 0.4,
+      round: "top",
+      value: 1,
+    });
+    expect(path).not.toContain("A");
+  });
+});
+
+describe("the table every chart carries", () => {
+  it("holds one row per category and one column per series", () => {
+    const table = chartTable(
+      good({ type: "bar", labels: ["a", "b"], series: [{ name: "x", data: [1, 2] }] }),
+    );
+    expect(table.head).toEqual(["", "x"]);
+    expect(table.rows).toEqual([
+      ["a", "1"],
+      ["b", "2"],
+    ]);
+  });
+
+  it("says a gap is a gap", () => {
+    const table = chartTable(
+      good({ type: "line", labels: ["a", "b"], series: [{ data: [1, null] }] }),
+    );
+    expect(table.rows[1]?.[1]).toBe("no reading");
+  });
+
+  it("refuses a series with nothing in it at all", () => {
+    // Distinct from a gap: a series of nothing but gaps has no reading
+    // anywhere, so it puts a name in the legend that points at no mark.
+    expect(refused({ type: "line", labels: ["a"], series: [{ data: [null] }] })).toContain(
+      "nothing to draw",
+    );
+  });
+});

--- a/src/lib/chart.ts
+++ b/src/lib/chart.ts
@@ -1,0 +1,1087 @@
+/**
+ * A chart, from what a model wrote to where every mark goes.
+ *
+ * Two halves, and the split is the point. {@link readChart} turns a model's
+ * JSON into a value that cannot be wrong: the shapes are discriminated by
+ * chart type, so a pie with two series or a scatter with categories is not a
+ * thing this file can produce. {@link layout} then turns that into
+ * coordinates. Neither half touches the DOM, which is what makes a chart
+ * testable in a suite where nothing has a size: jsdom performs no layout, so a
+ * chart that worked out its own geometry from a measured element would be
+ * exercised by no test in this repo and checked by nobody but the operator.
+ *
+ * The spec deliberately looks like the one every plotting library uses:
+ * `type`, `labels`, `series: [{ name, data }]`. That is not a lack of
+ * imagination. A model has seen that shape ten thousand times and writes it
+ * correctly first try, and a novel schema of our own would be a thing every
+ * agent has to be taught in a prompt it is already skimming.
+ *
+ * Coordinates are worked out against a fixed {@link WIDTH}, and the drawing is
+ * scaled by CSS to whatever room it has. So a "pixel" here is roughly a real
+ * one in a transcript and rather more than one in the full view, which is the
+ * behaviour a figure should have: opened larger, it is larger.
+ */
+
+import { MAX_SERIES } from "./palette";
+
+export type ChartKind = "bar" | "line" | "area" | "pie" | "donut" | "scatter";
+
+const KINDS: ChartKind[] = ["bar", "line", "area", "pie", "donut", "scatter"];
+
+/** Everything a chart carries whatever shape it is. */
+interface Common {
+  title: string;
+  /** Written before every number: a currency, usually. */
+  prefix: string;
+  /** Written after every number: a unit, usually. */
+  unit: string;
+  /** What the two axes are of. Empty is common and draws nothing. */
+  captionX: string;
+  captionY: string;
+}
+
+/** One line, one area, or one run of bars. */
+export interface Series {
+  name: string;
+  /** One per category. `null` is a gap, which is not the same as a zero. */
+  values: (number | null)[];
+}
+
+/** One wedge. */
+export interface Slice {
+  label: string;
+  value: number;
+}
+
+/** One cloud of points. */
+export interface Cloud {
+  name: string;
+  points: { x: number; y: number }[];
+}
+
+/**
+ * A chart that has been checked.
+ *
+ * Discriminated on `kind` all the way down, so the renderer never asks whether
+ * a pie has categories. The alternative, one wide record with everything
+ * optional, puts that question at every use site and gets it wrong at one.
+ */
+export type Chart = CartesianChart | RadialChart | ScatterChart;
+
+/** Anything with categories along one axis and a value scale up the other. */
+export type CartesianChart = Common & {
+  kind: "bar" | "line" | "area";
+  labels: string[];
+  series: Series[];
+  stacked: boolean;
+  /** Bars along the x axis instead of up it. What long names want. */
+  horizontal: boolean;
+};
+
+/** One series against its own total. */
+export type RadialChart = Common & { kind: "pie" | "donut"; slices: Slice[] };
+
+/** Points with no categories at all. */
+export type ScatterChart = Common & { kind: "scatter"; series: Cloud[] };
+
+/**
+ * Why a chart was refused, in a sentence the model can act on.
+ *
+ * Shown under the spec rather than instead of it: an operator looking at a
+ * figure that did not draw needs to see what was asked for, and the agent that
+ * wrote it needs to be told what to change. A red box saying "invalid chart" is
+ * neither.
+ */
+export interface ChartFault {
+  why: string;
+}
+
+export type ChartRead = { chart: Chart } | ChartFault;
+
+export function isFault(read: ChartRead): read is ChartFault {
+  return "why" in read;
+}
+
+/**
+ * Which of the three families a chart belongs to.
+ *
+ * Predicates rather than comparisons at each use site, and not only for
+ * tidiness: TypeScript will not narrow an intersection whose discriminant is
+ * itself two literals, so `kind !== "pie" && kind !== "donut"` leaves the pie
+ * arm in the type and every read of `series` after it is an error. These say
+ * the same thing in a form the compiler acts on.
+ */
+export function isCartesian(chart: Chart): chart is CartesianChart {
+  return chart.kind === "bar" || chart.kind === "line" || chart.kind === "area";
+}
+
+export function isRadial(chart: Chart): chart is RadialChart {
+  return chart.kind === "pie" || chart.kind === "donut";
+}
+
+export function isScatter(chart: Chart): chart is ScatterChart {
+  return chart.kind === "scatter";
+}
+
+/**
+ * What a table says where a series has no value for a category.
+ *
+ * Words rather than a dash. In a column of numbers a dash reads as a minus
+ * sign, and a screen reader announces it as punctuation or as nothing at all,
+ * which is the one cell in the table where saying nothing is wrong: a gap and a
+ * zero are different facts and this column is where the difference is read.
+ */
+const NO_READING = "no reading";
+
+/** Part-to-whole stops being readable well before it stops being drawable. */
+const MAX_SLICES = 6;
+
+/** Under this share, a wedge is too thin to write beside without collisions. */
+const LABELLED_SHARE = 0.04;
+
+/** The width every coordinate below is worked out against. */
+export const WIDTH = 640;
+
+// ---------------------------------------------------------------------------
+// Reading
+// ---------------------------------------------------------------------------
+
+function str(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * A number, or `null` for a gap.
+ *
+ * `null` and `0` are different facts and a chart that confuses them lies: a
+ * month with no reading yet is not a month that sold nothing. Anything that is
+ * neither is a gap too, because a model that emits `"12"` or `NaN` for one
+ * point should still get the other eleven drawn.
+ */
+function num(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return null;
+}
+
+/**
+ * Turns a model's JSON into a chart, or says why it will not.
+ *
+ * Every refusal names the field and what to do about it. These are read by the
+ * agent that wrote the spec, on a turn where it can still fix it, so "invalid
+ * spec" costs a whole turn and teaches nothing.
+ */
+export function readChart(value: unknown): ChartRead {
+  if (!isRecord(value)) {
+    return { why: 'A chart must be a JSON object, like {"type": "bar", …}.' };
+  }
+
+  const kind = str(value.type).toLowerCase() as ChartKind;
+  if (!KINDS.includes(kind)) {
+    return {
+      why: `"${str(value.type) || "(missing)"}" is not a chart type. Use one of: ${KINDS.join(", ")}.`,
+    };
+  }
+
+  const common: Common = {
+    title: str(value.title),
+    prefix: str(value.prefix),
+    unit: str(value.unit),
+    captionX: str(value.x),
+    captionY: str(value.y),
+  };
+
+  const raw = Array.isArray(value.series) ? value.series : [];
+  if (raw.length === 0) {
+    return { why: '"series" is required and must hold at least one series.' };
+  }
+  if (raw.length > MAX_SERIES && kind !== "pie" && kind !== "donut") {
+    return {
+      why: `${raw.length} series is more than a reader can tell apart. Keep the largest ${MAX_SERIES} and fold the rest into one called "Other".`,
+    };
+  }
+
+  const labels = Array.isArray(value.labels) ? value.labels.map((label) => str(label)) : [];
+
+  if (kind === "scatter") return readScatter(common, raw);
+  if (kind === "pie" || kind === "donut") return readRadial(common, kind, labels, raw);
+  return readCartesian(common, kind, labels, raw, value);
+}
+
+function readCartesian(
+  common: Common,
+  kind: "bar" | "line" | "area",
+  labels: string[],
+  raw: unknown[],
+  value: Record<string, unknown>,
+): ChartRead {
+  const series: Series[] = [];
+  for (const [at, entry] of raw.entries()) {
+    if (!isRecord(entry)) return { why: `Series ${at + 1} must be an object with "data".` };
+    const data = entry.data;
+    if (!Array.isArray(data) || data.length === 0) {
+      return { why: `Series ${at + 1} needs "data": an array of numbers, one per label.` };
+    }
+    series.push({ name: str(entry.name) || `Series ${at + 1}`, values: data.map(num) });
+  }
+
+  const width = Math.max(...series.map((one) => one.values.length));
+  if (series.some((one) => one.values.every((point) => point === null))) {
+    return { why: "A series whose values are all missing has nothing to draw." };
+  }
+
+  // Named rather than numbered where the model said nothing, because an axis
+  // reading 1..12 under a chart of months is worse than one reading nothing.
+  const named =
+    labels.length === 0
+      ? Array.from({ length: width }, (_, at) => String(at + 1))
+      : labels.length === width
+        ? labels
+        : null;
+  if (named === null) {
+    return {
+      why: `"labels" has ${labels.length} entries but the longest series has ${width}. They have to match: one label per point.`,
+    };
+  }
+
+  // Ragged series are padded rather than refused. A model writing four
+  // quarters of one year and three of the next has said something true, and a
+  // refusal there loses the whole figure over the part it got right.
+  for (const one of series) {
+    while (one.values.length < width) one.values.push(null);
+  }
+
+  return {
+    chart: {
+      ...common,
+      kind,
+      labels: named,
+      series,
+      stacked: value.stacked === true,
+      horizontal: value.horizontal === true,
+    },
+  };
+}
+
+function readRadial(
+  common: Common,
+  kind: "pie" | "donut",
+  labels: string[],
+  raw: unknown[],
+): ChartRead {
+  const first = raw[0];
+  if (!isRecord(first) || !Array.isArray(first.data)) {
+    return { why: `A ${kind} needs one series whose "data" holds one number per slice.` };
+  }
+  if (raw.length > 1) {
+    return {
+      why: `A ${kind} shows one series against its own total. For several series, use a stacked bar.`,
+    };
+  }
+
+  const values = first.data.map(num);
+  if (values.some((one) => one !== null && one < 0)) {
+    return { why: `A ${kind} cannot show a negative share. Use a bar chart.` };
+  }
+
+  const named = values.map((_, at) => labels[at] ?? `Slice ${at + 1}`);
+  let slices: Slice[] = values
+    .map((one, at) => ({ label: named[at] as string, value: one ?? 0 }))
+    .filter((slice) => slice.value > 0);
+
+  if (slices.length === 0) return { why: `A ${kind} needs at least one slice above zero.` };
+
+  // Folded rather than refused, which is the documented answer to too many
+  // classes and is what the operator wanted anyway: past six wedges nobody is
+  // comparing them, they are reading the big ones and the remainder.
+  if (slices.length > MAX_SLICES) {
+    const ranked = [...slices].sort((a, b) => b.value - a.value);
+    const kept = ranked.slice(0, MAX_SLICES - 1);
+    const rest = ranked.slice(MAX_SLICES - 1).reduce((sum, slice) => sum + slice.value, 0);
+    slices = [...kept, { label: "Other", value: rest }];
+  }
+
+  return { chart: { ...common, kind, slices } };
+}
+
+function readScatter(common: Common, raw: unknown[]): ChartRead {
+  const series: Cloud[] = [];
+  for (const [at, entry] of raw.entries()) {
+    if (!isRecord(entry) || !Array.isArray(entry.data)) {
+      return { why: `Series ${at + 1} needs "data": an array of [x, y] pairs.` };
+    }
+    const points = entry.data
+      .map((pair) => {
+        if (!Array.isArray(pair)) return null;
+        const x = num(pair[0]);
+        const y = num(pair[1]);
+        return x === null || y === null ? null : { x, y };
+      })
+      .filter((point): point is { x: number; y: number } => point !== null);
+    if (points.length === 0) {
+      return { why: `Series ${at + 1} has no usable points. Each one is a pair, like [1, 4.5].` };
+    }
+    series.push({ name: str(entry.name) || `Series ${at + 1}`, points });
+  }
+  return { chart: { ...common, kind: "scatter", series } };
+}
+
+// ---------------------------------------------------------------------------
+// Numbers, as people read them
+// ---------------------------------------------------------------------------
+
+/**
+ * A value, short enough to sit on a mark.
+ *
+ * Compacted above ten thousand, because an axis of `1,250,000` steals the
+ * width the chart was drawn in, and rounded to the precision the number
+ * actually has rather than to two decimals always: `4` should not draw as
+ * `4.00`.
+ */
+export function formatValue(chart: Common, value: number, compact = true): string {
+  const magnitude = Math.abs(value);
+  let text: string;
+  if (compact && magnitude >= 1_000_000) text = `${trim(value / 1_000_000)}M`;
+  else if (compact && magnitude >= 10_000) text = `${trim(value / 1000)}K`;
+  else text = trim(value).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return `${chart.prefix}${text}${chart.unit}`;
+}
+
+function trim(value: number): string {
+  const magnitude = Math.abs(value);
+  const places = magnitude >= 100 ? 0 : magnitude >= 10 ? 1 : magnitude >= 1 ? 2 : 3;
+  return String(Number(value.toFixed(places)));
+}
+
+/**
+ * Round numbers a reader can do arithmetic with, spanning the data.
+ *
+ * The 1-2-5 rule, which is the only tick algorithm anybody recognises: an axis
+ * that steps by 37 is technically a fit and practically unreadable.
+ */
+export function niceTicks(low: number, high: number, wanted = 5): number[] {
+  if (!(Number.isFinite(low) && Number.isFinite(high)) || high === low) {
+    return [low || 0];
+  }
+  const rough = (high - low) / Math.max(1, wanted);
+  const power = 10 ** Math.floor(Math.log10(rough));
+  // 2.5 is in there because without it a range of 1.24M steps by 500K, which is
+  // three gridlines for the whole chart. The classic set, and the reason every
+  // axis you have ever read steps by one of these five.
+  const step =
+    [1, 2, 2.5, 5, 10].map((factor) => factor * power).find((size) => size >= rough) ?? power;
+  const first = Math.floor(low / step) * step;
+  const ticks: number[] = [];
+  // Carried past the data rather than stopping under it. An axis whose top
+  // gridline is below the tallest bar leaves that bar sticking out of its own
+  // frame, which reads as a chart that did not finish drawing.
+  //
+  // Nudged at the comparison, because floating point turns three tenths into
+  // 0.30000000000000004 and an axis that says so is an axis nobody trusts.
+  for (let at = first; ; at += step) {
+    ticks.push(Number(at.toFixed(10)));
+    if (at >= high - step / 1000) break;
+  }
+  return ticks;
+}
+
+// ---------------------------------------------------------------------------
+// Geometry
+// ---------------------------------------------------------------------------
+
+/** The mark specs, which are fixed for every chart this app draws. */
+export const MARK = {
+  /** A bar never fills its band: the leftover is what separates two of them. */
+  maxBarThickness: 24,
+  /** The surface showing through is what separates touching marks. */
+  gap: 2,
+  /** Rounded at the end the data reaches, square where it leaves the baseline. */
+  barRadius: 4,
+  lineWidth: 2,
+  dotRadius: 4.5,
+  /** Big enough that a pointer aimed near a dot counts as aimed at it. */
+  hitRadius: 16,
+} as const;
+
+export interface Frame {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface Tick {
+  /** Along the value axis, in drawing coordinates. */
+  at: number;
+  text: string;
+  value: number;
+}
+
+/** One category's slot, and the whole-height target that reads it out. */
+export interface Band {
+  /** Its own position, carried so a band is a value rather than a position. */
+  index: number;
+  label: string;
+  /** Where the label and the crosshair sit. */
+  center: number;
+  /** The pointer target, which is the whole band and not the marks in it. */
+  from: number;
+  size: number;
+}
+
+export interface Bar {
+  series: number;
+  band: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  /** Which corners are rounded: the data end only. */
+  round: "top" | "bottom" | "left" | "right";
+  value: number;
+}
+
+export interface Point {
+  series: number;
+  band: number;
+  x: number;
+  y: number;
+  value: number;
+}
+
+/** A run of points with no gap in it. `null` breaks a line rather than bridging it. */
+export interface Stroke {
+  series: number;
+  line: string;
+  /** The same run closed down to the baseline, for an area fill. */
+  fill: string;
+}
+
+export interface DirectLabel {
+  x: number;
+  y: number;
+  text: string;
+  anchor: "start" | "middle" | "end";
+  /** Set where the label sits on top of a filled mark and must not be ink. */
+  onMark?: boolean;
+}
+
+export interface CartesianPlot {
+  family: "cartesian";
+  height: number;
+  frame: Frame;
+  horizontal: boolean;
+  ticks: Tick[];
+  /** Where zero sits, which is where every bar leaves from. */
+  baseline: number;
+  bands: Band[];
+  bars: Bar[];
+  strokes: Stroke[];
+  dots: Point[];
+  labels: DirectLabel[];
+  /** Bands whose label is drawn. The rest are dropped rather than overlapped. */
+  shown: number[];
+}
+
+export interface Wedge {
+  slice: number;
+  path: string;
+  /** Written beside the wedge, or `null` where there is no room for one. */
+  label: DirectLabel | null;
+  share: number;
+}
+
+export interface RadialPlot {
+  family: "radial";
+  height: number;
+  center: { x: number; y: number };
+  radius: number;
+  wedges: Wedge[];
+  total: number;
+}
+
+export interface ScatterPlot {
+  family: "scatter";
+  height: number;
+  frame: Frame;
+  ticks: Tick[];
+  across: Tick[];
+  dots: Point[];
+}
+
+export type Plot = CartesianPlot | RadialPlot | ScatterPlot;
+
+/** Room for the numbers down the side, the names along the bottom, and air. */
+const PAD = { top: 16, right: 20, bottom: 34, left: 52 };
+
+/**
+ * More of it where a line writes its last value in the margin.
+ *
+ * The alternative is a number half off the edge of the card, which is the one
+ * label a reader was most likely looking for.
+ */
+const END_LABEL_ROOM = 46;
+const PLOT_HEIGHT = 250;
+
+export function layout(chart: Chart): Plot {
+  if (isRadial(chart)) return radial(chart);
+  if (isScatter(chart)) return scatter(chart);
+  return cartesian(chart);
+}
+
+/**
+ * What the value axis has to span.
+ *
+ * Bars and areas are anchored to zero because their length is the quantity:
+ * a bar chart from 90 to 100 makes a 2% difference look like everything. A
+ * line is not, because a line encodes change and a temperature series forced
+ * down to zero is a flat line across the top of the frame.
+ */
+function span(chart: CartesianChart): [number, number] {
+  const stacks = stacked(chart);
+  let low = Math.min(...stacks.flat());
+  let high = Math.max(...stacks.flat());
+  if (chart.kind !== "line") {
+    low = Math.min(0, low);
+    high = Math.max(0, high);
+  }
+  if (low === high) {
+    // A flat series still needs a frame to sit in.
+    const room = Math.abs(high) || 1;
+    return [low - room / 2, high + room / 2];
+  }
+  return [low, high];
+}
+
+/** Every value the axis has to reach, which for a stack is the running total. */
+function stacked(chart: CartesianChart): number[][] {
+  if (!chart.stacked) {
+    return chart.series.map((one) => one.values.filter((v): v is number => v !== null));
+  }
+  return chart.labels.map((_, band) => {
+    let up = 0;
+    let down = 0;
+    for (const one of chart.series) {
+      const value = one.values[band] ?? 0;
+      if (value >= 0) up += value;
+      else down += value;
+    }
+    return [up, down];
+  });
+}
+
+function cartesian(chart: CartesianChart): CartesianPlot {
+  const flip = chart.horizontal && chart.kind === "bar";
+  const [low, high] = span(chart);
+  const values = niceTicks(low, high);
+  const min = Math.min(low, values[0] as number);
+  const max = Math.max(high, values[values.length - 1] as number);
+
+  // Horizontal bars give the names the left margin instead of the numbers, and
+  // widen it: a category axis holds words, and the numbers axis holds numbers.
+  const left = flip ? 92 : PAD.left;
+  const right = chart.kind === "bar" ? PAD.right : END_LABEL_ROOM;
+  const frame: Frame = {
+    left,
+    top: PAD.top,
+    width: WIDTH - left - right,
+    height: PLOT_HEIGHT,
+  };
+
+  /** A value, as a coordinate along whichever axis carries values. */
+  const place = (value: number) => {
+    const ratio = (value - min) / (max - min || 1);
+    return flip ? frame.left + ratio * frame.width : frame.top + (1 - ratio) * frame.height;
+  };
+
+  const ticks: Tick[] = values.map((value) => ({
+    at: place(value),
+    text: formatValue(chart, value),
+    value,
+  }));
+  const baseline = place(Math.min(Math.max(0, min), max));
+
+  const count = chart.labels.length;
+  const size = (flip ? frame.height : frame.width) / Math.max(1, count);
+  const origin = flip ? frame.top : frame.left;
+  const bands: Band[] = chart.labels.map((label, at) => ({
+    index: at,
+    label,
+    center: origin + size * (at + 0.5),
+    from: origin + size * at,
+    size,
+  }));
+
+  const bars: Bar[] = [];
+  const dots: Point[] = [];
+  const strokes: Stroke[] = [];
+  const labels: DirectLabel[] = [];
+
+  if (chart.kind === "bar") {
+    bars.push(...barMarks(chart, bands, place, flip));
+    labels.push(...barLabels(chart, bars, flip));
+  } else {
+    for (const [at, one] of chart.series.entries()) {
+      // Stacked, a series is drawn at the height of everything up to and
+      // including it, but it still *reports* its own value: the readout and the
+      // table both say what this series was worth, and a label saying something
+      // else is the chart contradicting itself two inches lower down.
+      const running = chart.stacked ? runningTotals(chart, at) : one.values;
+      const points = running.map((value, band) =>
+        value === null
+          ? null
+          : {
+              x: bands[band]?.center ?? 0,
+              y: place(value),
+              value: one.values[band] ?? value,
+              band,
+            },
+      );
+
+      // And its fill stops at the series underneath rather than at zero. Every
+      // band drawn down to the axis is every band drawn over the one before it,
+      // which at a tenth opacity is a stack whose colours are all mixtures.
+      const under = chart.stacked && at > 0 ? runningTotals(chart, at - 1) : null;
+      const floorAt = (band: number) => {
+        const below = under?.[band];
+        return below === null || below === undefined ? baseline : place(below);
+      };
+
+      strokes.push(...strokeRuns(at, points, floorAt));
+      for (const point of points) {
+        if (point) {
+          dots.push({ series: at, band: point.band, x: point.x, y: point.y, value: point.value });
+        }
+      }
+      labels.push(...endLabel(chart, points));
+    }
+  }
+
+  return {
+    family: "cartesian",
+    height: frame.top + frame.height + PAD.bottom,
+    frame,
+    horizontal: flip,
+    ticks,
+    baseline,
+    bands,
+    bars,
+    strokes,
+    dots,
+    labels,
+    shown: showable(bands, flip),
+  };
+}
+
+/** A stacked series sits on top of the ones before it. */
+function runningTotals(chart: CartesianChart, upTo: number): (number | null)[] {
+  return chart.labels.map((_, band) => {
+    let sum = 0;
+    let seen = false;
+    for (let at = 0; at <= upTo; at++) {
+      const value = chart.series[at]?.values[band];
+      if (value === null || value === undefined) continue;
+      seen = true;
+      sum += value;
+    }
+    return seen ? sum : null;
+  });
+}
+
+function barMarks(
+  chart: CartesianChart,
+  bands: Band[],
+  place: (value: number) => number,
+  flip: boolean,
+): Bar[] {
+  const bars: Bar[] = [];
+  const lanes = chart.stacked ? 1 : chart.series.length;
+  const band = bands[0]?.size ?? 0;
+  // Never the whole band: the air left over is what separates one category
+  // from the next, and it is doing that job better than a stroke would.
+  const room = band * 0.72;
+  const thickness = Math.max(
+    1,
+    Math.min(MARK.maxBarThickness, (room - MARK.gap * (lanes - 1)) / lanes),
+  );
+  const runWidth = thickness * lanes + MARK.gap * (lanes - 1);
+
+  // Categories outside, series inside, because a stack's running total belongs
+  // to the category. Written the other way round each series starts again from
+  // the baseline, and a stacked chart draws every series on top of the axis
+  // rather than on top of the one before it.
+  for (const [at, slot] of bands.entries()) {
+    let up = 0;
+    let down = 0;
+    for (const [index, one] of chart.series.entries()) {
+      const value = one.values[at];
+      if (value === null || value === undefined) continue;
+
+      const lane = chart.stacked ? 0 : index;
+      const offset = slot.center - runWidth / 2 + lane * (thickness + MARK.gap);
+      const from = chart.stacked ? (value >= 0 ? up : down) : 0;
+      const to = from + value;
+      if (chart.stacked) {
+        if (value >= 0) up = to;
+        else down = to;
+      }
+
+      const a = place(from);
+      const b = place(to);
+      const near = Math.min(a, b);
+      const length = Math.abs(a - b);
+      // Trimmed by the surface gap so touching segments never share an edge, and
+      // trimmed off the end nearest the baseline so the far end stays where the
+      // value says it is. A stroke around each segment would add ink that is not
+      // data; this removes some instead. Skipped on a segment too short to lose
+      // it, which would otherwise vanish entirely.
+      const trim = chart.stacked && length > MARK.gap * 2 ? MARK.gap : 0;
+      const rising = value >= 0;
+
+      bars.push(
+        flip
+          ? {
+              series: index,
+              band: at,
+              x: near + (rising ? trim : 0),
+              y: offset,
+              width: Math.max(1, length - trim),
+              height: thickness,
+              round: rising ? "right" : "left",
+              value,
+            }
+          : {
+              series: index,
+              band: at,
+              x: offset,
+              y: near + (rising ? 0 : trim),
+              width: thickness,
+              height: Math.max(1, length - trim),
+              round: rising ? "top" : "bottom",
+              value,
+            },
+      );
+    }
+  }
+  return bars;
+}
+
+/**
+ * The values written on the marks.
+ *
+ * One series only, and only while they fit. A number on every bar of a grouped
+ * chart is a wall of digits nobody reads, and the tooltip and the table below
+ * already hold every value. On a single series it is the opposite: the numbers
+ * are the point, and they are also what makes a pale fill legible on paper.
+ */
+function barLabels(chart: CartesianChart, bars: Bar[], flip: boolean): DirectLabel[] {
+  if (chart.series.length !== 1 || bars.length > 14) return [];
+  return bars.map((bar) => {
+    const text = formatValue(chart, bar.value);
+    if (flip) {
+      const outside = bar.round === "right";
+      return {
+        x: outside ? bar.x + bar.width + 5 : bar.x - 5,
+        y: bar.y + bar.height / 2 + 4,
+        text,
+        anchor: outside ? "start" : "end",
+      };
+    }
+    const above = bar.round === "top";
+    return {
+      x: bar.x + bar.width / 2,
+      y: above ? bar.y - 6 : bar.y + bar.height + 13,
+      text,
+      anchor: "middle",
+    };
+  });
+}
+
+/** The value at the end of a line, which is the one a reader looks for. */
+function endLabel(
+  chart: CartesianChart,
+  points: ({ x: number; y: number; value: number } | null)[],
+): DirectLabel[] {
+  if (chart.series.length > 4) return [];
+  const last = [...points].reverse().find((point) => point !== null);
+  if (!last) return [];
+  return [
+    {
+      x: last.x + 7,
+      y: last.y + 4,
+      text: formatValue(chart, last.value),
+      anchor: "start",
+    },
+  ];
+}
+
+/**
+ * A line, broken wherever the data is.
+ *
+ * One path per run of present values rather than one per series, because a
+ * missing month drawn as a straight line between the months either side of it
+ * is the chart inventing a reading.
+ */
+function strokeRuns(
+  series: number,
+  points: ({ x: number; y: number; band: number } | null)[],
+  floorAt: (band: number) => number,
+): Stroke[] {
+  const strokes: Stroke[] = [];
+  let run: { x: number; y: number; band: number }[] = [];
+  const close = () => {
+    if (run.length === 0) return;
+    const line = run.map((point, at) => `${at === 0 ? "M" : "L"}${point.x} ${point.y}`).join("");
+    // Back along the floor rather than straight across it, so a fill follows
+    // the shape of whatever it is sitting on.
+    const floor = [...run]
+      .reverse()
+      .map((point) => `L${point.x} ${floorAt(point.band)}`)
+      .join("");
+    strokes.push({ series, line, fill: `${line}${floor}Z` });
+    run = [];
+  };
+  for (const point of points) {
+    if (point) run.push(point);
+    else close();
+  }
+  close();
+  return strokes;
+}
+
+/**
+ * Which category names are drawn.
+ *
+ * Every one that fits, and then every other one, and so on. A label is never
+ * shrunk, rotated or clipped to make it fit: rotated axis text is unreadable
+ * and a clipped one drops the characters that told them apart. Dropping whole
+ * labels at an even interval keeps the axis honest about what it is showing.
+ */
+function showable(bands: Band[], flip: boolean): number[] {
+  if (bands.length === 0) return [];
+  const size = bands[0]?.size ?? 0;
+  const widest = Math.max(...bands.map((band) => band.label.length));
+  // Roughly, for the axis type size. Measuring properly needs a laid-out
+  // document, which the suite does not have and a first paint does not either.
+  const needed = flip ? 14 : widest * 5.6 + 8;
+  const every = Math.max(1, Math.ceil(needed / Math.max(1, size)));
+  return bands.map((_, at) => at).filter((at) => at % every === 0);
+}
+
+function radial(chart: RadialChart): RadialPlot {
+  const total = chart.slices.reduce((sum, slice) => sum + slice.value, 0);
+  const height = 260;
+  const center = { x: WIDTH / 2, y: height / 2 };
+  const radius = 96;
+  const inner = chart.kind === "donut" ? radius * 0.58 : 0;
+
+  // Two pixels of surface between wedges, expressed as the angle that subtends
+  // at the rim. The same separator every other mark in this file uses.
+  const pad = Math.min(0.06, MARK.gap / radius);
+
+  let angle = -Math.PI / 2;
+  const wedges: Wedge[] = chart.slices.map((slice, at) => {
+    const share = total > 0 ? slice.value / total : 0;
+    const sweep = share * Math.PI * 2;
+    const from = angle + pad / 2;
+    const to = angle + sweep - pad / 2;
+    angle += sweep;
+    const middle = (from + to) / 2;
+    const out = radius + 16;
+    const right = Math.cos(middle) >= 0;
+    return {
+      slice: at,
+      path: arc(center, radius, inner, from, Math.max(from, to)),
+      share,
+      // A one percent wedge is a sliver, and two of them side by side put two
+      // labels in the same place: the shot of that reads "Partne Other 1%".
+      // Under the threshold the legend and the table carry the name, which they
+      // were already doing, and nothing is written on top of anything.
+      label:
+        share < LABELLED_SHARE
+          ? null
+          : {
+              x: center.x + Math.cos(middle) * out,
+              y: center.y + Math.sin(middle) * out + 4,
+              text: `${slice.label} ${Math.round(share * 100)}%`,
+              anchor: right ? "start" : "end",
+            },
+    };
+  });
+
+  return { family: "radial", height, center, radius, wedges, total };
+}
+
+function arc(
+  center: { x: number; y: number },
+  outer: number,
+  inner: number,
+  from: number,
+  to: number,
+): string {
+  const point = (radius: number, angle: number) => ({
+    x: center.x + Math.cos(angle) * radius,
+    y: center.y + Math.sin(angle) * radius,
+  });
+  const big = to - from > Math.PI ? 1 : 0;
+  const a = point(outer, from);
+  const b = point(outer, to);
+  // A full circle has no arc to draw: start and end land on the same point and
+  // the path collapses to nothing. Two half arcs is the standard way round it.
+  if (to - from >= Math.PI * 2 - 1e-6) {
+    const half = point(outer, from + Math.PI);
+    const ring = `M${a.x} ${a.y}A${outer} ${outer} 0 1 1 ${half.x} ${half.y}A${outer} ${outer} 0 1 1 ${a.x} ${a.y}Z`;
+    if (inner <= 0) return ring;
+    const c = point(inner, from);
+    const d = point(inner, from + Math.PI);
+    return `${ring}M${c.x} ${c.y}A${inner} ${inner} 0 1 0 ${d.x} ${d.y}A${inner} ${inner} 0 1 0 ${c.x} ${c.y}Z`;
+  }
+  if (inner <= 0) {
+    return `M${center.x} ${center.y}L${a.x} ${a.y}A${outer} ${outer} 0 ${big} 1 ${b.x} ${b.y}Z`;
+  }
+  const c = point(inner, to);
+  const d = point(inner, from);
+  return `M${a.x} ${a.y}A${outer} ${outer} 0 ${big} 1 ${b.x} ${b.y}L${c.x} ${c.y}A${inner} ${inner} 0 ${big} 0 ${d.x} ${d.y}Z`;
+}
+
+function scatter(chart: ScatterChart): ScatterPlot {
+  const all = chart.series.flatMap((one) => one.points);
+  const xs = all.map((point) => point.x);
+  const ys = all.map((point) => point.y);
+  const acrossTicks = niceTicks(Math.min(...xs), Math.max(...xs), 6);
+  const upTicks = niceTicks(Math.min(...ys), Math.max(...ys));
+
+  const frame: Frame = {
+    left: PAD.left,
+    top: PAD.top,
+    width: WIDTH - PAD.left - PAD.right,
+    height: PLOT_HEIGHT,
+  };
+  const range = (ticks: number[], values: number[]) => {
+    const low = Math.min(ticks[0] as number, ...values);
+    const high = Math.max(ticks[ticks.length - 1] as number, ...values);
+    return [low, high - low || 1] as const;
+  };
+  const [xLow, xSpan] = range(acrossTicks, xs);
+  const [yLow, ySpan] = range(upTicks, ys);
+  const toX = (value: number) => frame.left + ((value - xLow) / xSpan) * frame.width;
+  const toY = (value: number) => frame.top + (1 - (value - yLow) / ySpan) * frame.height;
+
+  const dots: Point[] = chart.series.flatMap((one, series) =>
+    one.points.map((point, band) => ({
+      series,
+      band,
+      x: toX(point.x),
+      y: toY(point.y),
+      value: point.y,
+    })),
+  );
+
+  return {
+    family: "scatter",
+    height: frame.top + frame.height + PAD.bottom,
+    frame,
+    ticks: upTicks.map((value) => ({ at: toY(value), text: formatValue(chart, value), value })),
+    across: acrossTicks.map((value) => ({
+      at: toX(value),
+      text: formatValue(chart, value),
+      value,
+    })),
+    dots,
+  };
+}
+
+/**
+ * A bar's outline, rounded only where the data ends.
+ *
+ * Square at the baseline on purpose: a bar rounded at both ends floats, and
+ * every bar in the chart appears to start slightly above the axis it is
+ * measured from.
+ */
+export function barPath(bar: Bar): string {
+  const { x, y, width: w, height: h } = bar;
+  const r = Math.min(MARK.barRadius, w / 2, h / 2);
+  if (r <= 0.5) return `M${x} ${y}h${w}v${h}h${-w}Z`;
+  switch (bar.round) {
+    case "top":
+      return `M${x} ${y + h}V${y + r}A${r} ${r} 0 0 1 ${x + r} ${y}H${x + w - r}A${r} ${r} 0 0 1 ${x + w} ${y + r}V${y + h}Z`;
+    case "bottom":
+      return `M${x} ${y}V${y + h - r}A${r} ${r} 0 0 0 ${x + r} ${y + h}H${x + w - r}A${r} ${r} 0 0 0 ${x + w} ${y + h - r}V${y}Z`;
+    case "right":
+      return `M${x} ${y}H${x + w - r}A${r} ${r} 0 0 1 ${x + w} ${y + r}V${y + h - r}A${r} ${r} 0 0 1 ${x + w - r} ${y + h}H${x}Z`;
+    default:
+      return `M${x + w} ${y}H${x + r}A${r} ${r} 0 0 0 ${x} ${y + r}V${y + h - r}A${r} ${r} 0 0 0 ${x + r} ${y + h}H${x + w}Z`;
+  }
+}
+
+/**
+ * The chart as its own numbers.
+ *
+ * Every figure has one, and it is not a fallback. It is how a value is read by
+ * a screen reader, by an operator who cannot separate two of the hues, and by
+ * anybody who wants the number rather than the shape. A tooltip may never be
+ * the only way to find out what a mark is worth.
+ */
+export function chartTable(chart: Chart): { head: string[]; rows: string[][] } {
+  if (isRadial(chart)) {
+    const total = chart.slices.reduce((sum, slice) => sum + slice.value, 0) || 1;
+    return {
+      head: [chart.captionX || "Slice", chart.captionY || "Value", "Share"],
+      rows: chart.slices.map((slice) => [
+        slice.label,
+        formatValue(chart, slice.value, false),
+        `${Math.round((slice.value / total) * 100)}%`,
+      ]),
+    };
+  }
+  if (isScatter(chart)) {
+    return {
+      head: ["Series", chart.captionX || "x", chart.captionY || "y"],
+      rows: chart.series.flatMap((one) =>
+        one.points.map((point) => [
+          one.name,
+          formatValue(chart, point.x, false),
+          formatValue(chart, point.y, false),
+        ]),
+      ),
+    };
+  }
+  return {
+    head: [chart.captionX || "", ...chart.series.map((one) => one.name)],
+    rows: chart.labels.map((label, at) => [
+      label,
+      ...chart.series.map((one) => {
+        const value = one.values[at];
+        return value === null || value === undefined
+          ? NO_READING
+          : formatValue(chart, value, false);
+      }),
+    ]),
+  };
+}
+
+/** What the series are called, for a legend and for a readout. */
+export function chartSeriesNames(chart: Chart): string[] {
+  if (isRadial(chart)) return chart.slices.map((slice) => slice.label);
+  return chart.series.map((one) => one.name);
+}
+
+/**
+ * What a chart is, said in one sentence.
+ *
+ * The whole of what a screen reader gets from the drawing itself, which is why
+ * it says what is plotted rather than "chart": the numbers are in the table
+ * underneath, and repeating them here would be a hundred announcements nobody
+ * asked for.
+ */
+export function chartSummary(chart: Chart): string {
+  const names = chartSeriesNames(chart);
+  const what = chart.title || `${chart.kind} chart`;
+  const of = isRadial(chart)
+    ? `${names.length} slices`
+    : `${names.length} series: ${names.join(", ")}`;
+  return `${what}. A ${chart.kind} chart of ${of}. The figures are in the table below.`;
+}

--- a/src/lib/figure.test.ts
+++ b/src/lib/figure.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { isFault } from "./chart";
+import { fenceLanguage, fenceText, looksComplete, readFigure } from "./figure";
+
+const SPEC = '{"type":"bar","labels":["a"],"series":[{"data":[1]}]}';
+
+describe("what a fence turns out to be", () => {
+  it("draws the three tags that mean a figure", () => {
+    for (const tag of ["chart", "graph", "plot"]) {
+      expect(readFigure(tag, SPEC).kind).toBe("chart");
+    }
+  });
+
+  it("leaves every other language as source", () => {
+    // The rule that keeps ```python from turning into something nobody asked
+    // for. A fence is text unless it was tagged as one of the few that are not.
+    for (const tag of ["", "python", "rust", "json", "sql", "ts"]) {
+      expect(readFigure(tag, SPEC).kind).toBe("source");
+    }
+  });
+
+  it("waits for a spec that is still arriving instead of failing it", () => {
+    // A reply lands a token at a time, so a chart spends most of its life on
+    // screen as half an object. Called an error, that is a red box under every
+    // figure for a second, which teaches an operator the feature is broken.
+    expect(readFigure("chart", '{"type":"ba').kind).toBe("pending");
+    expect(readFigure("chart", '{"type":"bar","series":[{"data":[1,2').kind).toBe("pending");
+  });
+
+  it("does call it wrong once every brace has closed", () => {
+    const figure = readFigure("chart", "{ nope: }");
+    if (figure.kind !== "chart") throw new Error("expected a chart");
+    expect(isFault(figure.read)).toBe(true);
+  });
+
+  it("keeps the source beside a refusal", () => {
+    // An operator looking at a figure that did not draw needs to see what was
+    // asked for, and the agent needs to be told what to change. A box saying
+    // "invalid chart" is neither of those.
+    const figure = readFigure("chart", '{"type":"sunburst","series":[{"data":[1]}]}');
+    if (figure.kind !== "chart") throw new Error("expected a chart");
+    expect(figure.source).toContain("sunburst");
+    expect(isFault(figure.read) && figure.read.why).toContain("bar, line");
+  });
+});
+
+describe("an html fence", () => {
+  const page = `<!doctype html><html><body><h1>Hello</h1><p>Some content here.</p></body></html>`;
+
+  it("is a page when it is long enough to be worth a frame", () => {
+    expect(readFigure("html", page).kind).toBe("html");
+    expect(readFigure("artifact", page).kind).toBe("html");
+  });
+
+  it("is source when it is a snippet somebody wants to read", () => {
+    // Framing `<div>hi</div>` on its own origin is a whole renderer and a
+    // network round trip spent on what a code block already showed.
+    expect(readFigure("html", "<div>hi</div>").kind).toBe("source");
+  });
+
+  it("is source when it has no markup in it at all", () => {
+    expect(readFigure("html", "just some prose, mistagged, and reasonably long").kind).toBe(
+      "source",
+    );
+  });
+});
+
+describe("telling a finished document from one still arriving", () => {
+  it("counts braces and brackets", () => {
+    expect(looksComplete("{}")).toBe(true);
+    expect(looksComplete("{ ")).toBe(false);
+    expect(looksComplete('{"a":[1,2]}')).toBe(true);
+    expect(looksComplete('{"a":[1,2]')).toBe(false);
+  });
+
+  it("does not count a brace inside a string", () => {
+    // A label of "}" is a perfectly ordinary category name, and reading it as
+    // structure ends the document early and draws half a chart.
+    expect(looksComplete('{"label":"}"')).toBe(false);
+    expect(looksComplete('{"label":"}"}')).toBe(true);
+  });
+
+  it("does not let an escaped quote end a string", () => {
+    expect(looksComplete('{"label":"\\""}')).toBe(true);
+    expect(looksComplete('{"label":"\\"')).toBe(false);
+  });
+
+  it("does not call an empty string finished", () => {
+    expect(looksComplete("")).toBe(false);
+    expect(looksComplete("   ")).toBe(false);
+  });
+});
+
+describe("getting at a fence", () => {
+  it("finds the language react-markdown leaves on the class", () => {
+    expect(fenceLanguage("language-chart")).toBe("chart");
+    expect(fenceLanguage("hljs language-html other")).toBe("html");
+    expect(fenceLanguage(undefined)).toBe("");
+    expect(fenceLanguage("no-language-here")).toBe("");
+  });
+
+  it("flattens the nodes a fence's text arrives as", () => {
+    expect(fenceText(["a", ["b", "c"]])).toBe("abc");
+    expect(fenceText(null)).toBe("");
+  });
+});

--- a/src/lib/figure.ts
+++ b/src/lib/figure.ts
@@ -1,0 +1,155 @@
+/**
+ * A fenced block the transcript draws instead of printing.
+ *
+ * An agent asked for last quarter by region has the numbers in hand at the
+ * moment it writes the sentence about them, so the cheapest possible way to
+ * get a chart out of it is to let it write one where it is already writing.
+ * A fence costs no extra model call, streams in with the rest of the reply,
+ * and needs nothing new in the runtime: `as_plain_text` already returns the
+ * text of a message, so the record, the prompt, the dedup fingerprint, search,
+ * and a peer's copy of the reply all keep working with no change at all. A
+ * tool call for the same thing would be a round trip to send back data the
+ * model had already finished computing.
+ *
+ * It also means the agent can read back what it drew. A figure that lived
+ * outside the text would be invisible to the turn after it, and an agent that
+ * cannot see its own last chart draws it again.
+ *
+ * Three languages are figures and everything else is source, which is the rule
+ * that keeps ```python from turning into something nobody asked for.
+ */
+
+import { type ChartRead, readChart } from "./chart";
+
+/**
+ * What a fence turns out to be.
+ *
+ * `pending` is the shape that matters most and is the least obvious. A reply
+ * arrives a token at a time, so a chart spends most of its life on screen as
+ * half a JSON object. Drawn as an error, that is a red box that appears under
+ * every figure for a second and then goes away, which teaches an operator that
+ * the feature is broken. Drawn as `pending`, it is a figure that has not
+ * finished arriving, which is what it is.
+ */
+export type Figure =
+  | { kind: "chart"; read: ChartRead; source: string }
+  | { kind: "html"; html: string }
+  | { kind: "pending" }
+  | { kind: "source" };
+
+/** The languages that mean something other than "show me this text". */
+const CHART = new Set(["chart", "graph", "plot"]);
+const PAGE = new Set(["html", "artifact"]);
+
+/**
+ * An HTML document has to be worth the frame it costs.
+ *
+ * A one-line fence is a snippet an operator wants to read, not a page they
+ * want to look at, and framing `<div>hi</div>` on its own origin is a renderer
+ * and a network round trip spent on something a code block already showed.
+ */
+const LEAST_PAGE = 40;
+
+/**
+ * Whether a JSON document has finished arriving.
+ *
+ * Cheaper and more honest than trying to parse: a spec that is still streaming
+ * has an unclosed brace, and one that has closed every brace is as complete as
+ * it is ever going to be, whether or not it parses. Quoted braces do not count,
+ * and a backslash inside a string escapes the character after it, so neither
+ * `{"label": "}"}` nor `{"label": "\""}` is read as finished early.
+ */
+export function looksComplete(source: string): boolean {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let opened = false;
+
+  for (const character of source) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (inString) {
+      if (character === "\\") escaped = true;
+      else if (character === '"') inString = false;
+      continue;
+    }
+    if (character === '"') inString = true;
+    else if (character === "{" || character === "[") {
+      depth++;
+      opened = true;
+    } else if (character === "}" || character === "]") depth--;
+  }
+
+  return opened && depth === 0 && !inString;
+}
+
+/**
+ * Reads a fence, given the language it was tagged with.
+ *
+ * Undecidable cases come back as `source`, never as an error. A model that
+ * writes a chart the app cannot draw has still written something the operator
+ * can read, and showing them the text is strictly better than showing them a
+ * refusal where the text used to be. What a *valid* refusal looks like is the
+ * chart's own business: {@link readChart} returns the sentence, and the figure
+ * draws it under the source so the agent can be told what to change.
+ */
+export function readFigure(language: string, source: string): Figure {
+  const tag = language.trim().toLowerCase();
+  const body = source.trim();
+  if (body.length === 0) return { kind: "source" };
+
+  if (CHART.has(tag)) {
+    if (!looksComplete(body)) return { kind: "pending" };
+    let value: unknown;
+    try {
+      value = JSON.parse(body);
+    } catch {
+      // Every brace closed and it still will not parse, so this is not a chart
+      // that is on its way: it is one that was written wrongly.
+      return {
+        kind: "chart",
+        read: { why: "This is not valid JSON, so there is nothing to draw yet." },
+        source: body,
+      };
+    }
+    return { kind: "chart", read: readChart(value), source: body };
+  }
+
+  if (PAGE.has(tag) && body.length >= LEAST_PAGE && /<[a-z!]/i.test(body)) {
+    return { kind: "html", html: body };
+  }
+
+  return { kind: "source" };
+}
+
+/**
+ * The language a fenced block was tagged with, as react-markdown reports it.
+ *
+ * `language-json` on the `code` element, which is the only place the tag
+ * survives: by the time it is a React node the info string is gone.
+ */
+export function fenceLanguage(className: unknown): string {
+  if (typeof className !== "string") return "";
+  return (
+    className
+      .split(/\s+/)
+      .find((name) => name.startsWith("language-"))
+      ?.slice(9) ?? ""
+  );
+}
+
+/**
+ * The text inside a fenced block.
+ *
+ * React children rather than a string, because the block has already been
+ * turned into nodes. Anything that is not a string is skipped instead of
+ * stringified: a fence holds text, and a node in there means the markdown was
+ * something other than what this is looking for.
+ */
+export function fenceText(children: unknown): string {
+  if (typeof children === "string") return children;
+  if (Array.isArray(children)) return children.map(fenceText).join("");
+  return "";
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -315,6 +315,15 @@ export const api = {
   saveFile: (digest: string, name: string) => invoke<string>("save_file", { digest, name }),
 
   /**
+   * Puts a page an agent wrote somewhere it can be framed, and says where.
+   *
+   * A round trip rather than a `srcdoc`, because a frame given its markup
+   * inline inherits this document's content policy, and this document forbids
+   * script. What the returned origin permits is `artifact.rs`'s argument.
+   */
+  frameArtifact: (html: string) => invoke<{ port: number; id: string }>("frame_artifact", { html }),
+
+  /**
    * Sends what the operator typed, with the files they attached.
    *
    * Only the digest and the name go over: the runtime resolves both against

--- a/src/lib/palette.test.ts
+++ b/src/lib/palette.test.ts
@@ -1,0 +1,226 @@
+/**
+ * The chart palette's gates, recomputed rather than remembered.
+ *
+ * Every number in `palette.ts`'s doc comment is worked out here from the hexes
+ * themselves, so the comment cannot drift away from the values it describes and
+ * a hex changed by eye fails the suite. That is the whole point of this file:
+ * colourblind separation is not something anybody can check by looking, and a
+ * palette is exactly the kind of thing somebody adjusts because a screenshot
+ * looked slightly off.
+ *
+ * The maths is the standard one for this: sRGB to linear, Machado, Oliveira &
+ * Fernandes (2009) at full severity for the two red-green colourblindnesses,
+ * then Euclidean distance in OKLab ×100. The simulation model is part of the
+ * standard rather than an implementation detail, because the thresholds below
+ * are calibrated against it and a different model moves every borderline pair.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { MAX_SCATTER_HUES, SCATTER_MARKS, SLOTS, seriesColor, seriesMark } from "./palette";
+
+/** The surface a figure card is drawn on, which is `--raised` in both. */
+const SURFACE = { paper: "#ffffff", ink: "#222622" };
+
+/** Neighbours must clear this under simulated colourblindness. */
+const CVD_TARGET = 8;
+/** And this under ordinary colour vision, which is a separate failure. */
+const NORMAL_FLOOR = 15;
+/** OKLCH lightness a hue has to sit inside, per surface. */
+const BAND: Record<"paper" | "ink", readonly [number, number]> = {
+  paper: [0.43, 0.77],
+  ink: [0.48, 0.67],
+};
+/** Below this a hue reads as grey and stops telling series apart at all. */
+const CHROMA_FLOOR = 0.1;
+
+const MACHADO = {
+  protan: [
+    [0.152286, 1.052583, -0.204868],
+    [0.114503, 0.786281, 0.099216],
+    [-0.003882, -0.048116, 1.051998],
+  ],
+  deutan: [
+    [0.367322, 0.860646, -0.227968],
+    [0.280085, 0.672501, 0.047413],
+    [-0.01182, 0.04294, 0.968881],
+  ],
+} as const;
+
+type Vision = keyof typeof MACHADO;
+
+function linear(hex: string): [number, number, number] {
+  const channels = [0, 2, 4].map((at) => Number.parseInt(hex.slice(at + 1, at + 3), 16) / 255);
+  return channels.map((c) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4)) as [
+    number,
+    number,
+    number,
+  ];
+}
+
+function oklab([r, g, b]: [number, number, number]): [number, number, number] {
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+  return [
+    0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+    1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+    0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+  ];
+}
+
+function simulate(hex: string, vision: Vision): [number, number, number] {
+  const [r, g, b] = linear(hex);
+  const m = MACHADO[vision];
+  const clamp = (c: number) => Math.max(0, Math.min(1, c));
+  return [
+    clamp(m[0][0] * r + m[0][1] * g + m[0][2] * b),
+    clamp(m[1][0] * r + m[1][1] * g + m[1][2] * b),
+    clamp(m[2][0] * r + m[2][1] * g + m[2][2] * b),
+  ];
+}
+
+/** Perceived distance between two colours, optionally through one vision. */
+function distance(one: string, other: string, vision?: Vision): number {
+  const a = oklab(vision ? simulate(one, vision) : linear(one));
+  const b = oklab(vision ? simulate(other, vision) : linear(other));
+  return 100 * Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+function chroma(hex: string): number {
+  const [, a, b] = oklab(linear(hex));
+  return Math.hypot(a, b);
+}
+
+function lightness(hex: string): number {
+  return oklab(linear(hex))[0];
+}
+
+function contrast(one: string, other: string): number {
+  const luminance = (hex: string) => {
+    const [r, g, b] = linear(hex);
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  };
+  const [high, low] = [luminance(one), luminance(other)].sort((a, b) => b - a) as [number, number];
+  return (high + 0.05) / (low + 0.05);
+}
+
+/** Every pair of slots that can touch in a stack, a group or a line chart. */
+function neighbours(colors: string[]): [string, string][] {
+  return colors.slice(0, -1).map((color, at) => [color, colors[at + 1] as string]);
+}
+
+/** Every pair, full stop, which is what a scatter has. */
+function everyPair(colors: string[]): [string, string][] {
+  return colors.flatMap((color, at) => colors.slice(at + 1).map((other) => [color, other])) as [
+    string,
+    string,
+  ][];
+}
+
+const surfaces = [
+  ["paper", SLOTS.map((slot) => slot.paper), SURFACE.paper, BAND.paper],
+  ["ink", SLOTS.map((slot) => slot.ink), SURFACE.ink, BAND.ink],
+] as const;
+
+describe.each(surfaces)("the chart palette on %s", (_surface, colors, ground, band) => {
+  it("keeps neighbouring slots apart for a red-green colourblind reader", () => {
+    // The gate the order exists to pass. Neighbours are what touch in a stack
+    // and cross in a line chart, so this is the pair list that decides whether
+    // a chart is readable rather than merely colourful.
+    for (const vision of ["protan", "deutan"] as const) {
+      for (const [one, other] of neighbours([...colors])) {
+        expect(
+          distance(one, other, vision),
+          `${one} and ${other} collapse under ${vision}`,
+        ).toBeGreaterThanOrEqual(CVD_TARGET);
+      }
+    }
+  });
+
+  it("keeps them apart for everybody else too", () => {
+    // A separate failure from the one above, and not excused by it: a pair can
+    // be safe under simulation and still be two colours an ordinary reader has
+    // to squint at.
+    for (const [one, other] of neighbours([...colors])) {
+      expect(
+        distance(one, other),
+        `${one} and ${other} are hard to tell apart in full colour`,
+      ).toBeGreaterThanOrEqual(NORMAL_FLOOR);
+    }
+  });
+
+  it("keeps a scatter's first three apart from each other, in every pairing", () => {
+    // Scatter has no neighbours: any dot can land beside any other, so the
+    // adjacent test above says nothing about it. This is the harder gate, and
+    // it is why `MAX_SCATTER_HUES` is three.
+    const three = [...colors].slice(0, MAX_SCATTER_HUES);
+    for (const vision of ["protan", "deutan"] as const) {
+      for (const [one, other] of everyPair(three)) {
+        expect(distance(one, other, vision)).toBeGreaterThanOrEqual(CVD_TARGET);
+      }
+    }
+    for (const [one, other] of everyPair(three)) {
+      expect(distance(one, other)).toBeGreaterThanOrEqual(NORMAL_FLOOR);
+    }
+  });
+
+  it("sits inside the lightness band this surface has room for", () => {
+    const [floor, ceiling] = band;
+    for (const color of colors) {
+      expect(lightness(color), `${color} is off ${_surface}'s band`).toBeGreaterThanOrEqual(floor);
+      expect(lightness(color), `${color} is off ${_surface}'s band`).toBeLessThanOrEqual(ceiling);
+    }
+  });
+
+  it("stays colourful enough to carry identity", () => {
+    for (const color of colors) {
+      expect(chroma(color), `${color} reads as grey`).toBeGreaterThanOrEqual(CHROMA_FLOOR);
+    }
+  });
+
+  it("says which hues need the numbers written next to them", () => {
+    // Contrast under 3:1 is allowed here and is not a licence to ship a chart
+    // that cannot be read: every figure carries direct labels and a table of
+    // its own numbers, which is what makes a pale fill legible. This asserts
+    // the relief is owed, so removing the table twin is not a silent change.
+    const pale = colors.filter((color) => contrast(color, ground) < 3);
+    if (_surface === "ink") expect(pale).toEqual([]);
+    else expect(pale.length, "paper leans on labels and the table twin").toBeLessThanOrEqual(3);
+  });
+});
+
+describe("handing colours out", () => {
+  it("gives a series the same colour wherever its neighbours went", () => {
+    // Colour follows the series, never its rank. An operator who has learned
+    // that revenue is green is misled by a legend that repaints what is left
+    // when something is switched off.
+    expect(seriesColor(0)).toBe("var(--series-0)");
+    expect(seriesColor(3)).toBe("var(--series-3)");
+  });
+
+  it("wraps rather than inventing a ninth hue", () => {
+    // A generated ninth is indistinguishable from one of the eight under
+    // colourblindness. Wrapping is at least honest about repeating.
+    expect(seriesColor(SLOTS.length)).toBe(seriesColor(0));
+  });
+
+  it("gives a scatter a shape as well as a hue", () => {
+    // The second channel, and the reason a scatter is not capped at three
+    // series. Shape survives every colourblindness, grayscale print and a
+    // screenshot; hue survives none of them.
+    expect(seriesMark(0)).toBe(SCATTER_MARKS[0]);
+    expect(seriesMark(MAX_SCATTER_HUES)).not.toBe(seriesMark(0));
+  });
+});
+
+describe("the palette itself", () => {
+  it("opens on green, because the app does", () => {
+    expect(SLOTS[0]?.hue).toBe("green");
+  });
+
+  it("has eight, which is the ceiling and not a coincidence", () => {
+    expect(SLOTS).toHaveLength(8);
+    expect(new Set(SLOTS.map((slot) => slot.hue)).size).toBe(8);
+  });
+});

--- a/src/lib/palette.ts
+++ b/src/lib/palette.ts
@@ -1,0 +1,107 @@
+/**
+ * The colours a chart is allowed to use.
+ *
+ * Eight hues in one fixed order, assigned to series by position and never
+ * cycled. The order is the accessibility mechanism, not a preference: what
+ * makes a chart readable to a red-green colourblind operator is that
+ * *neighbouring* slots stay far apart, because neighbouring slots are the ones
+ * that touch in a stack, sit side by side in a group, and cross in a line
+ * chart. A palette picked by eye fails that test roughly always.
+ *
+ * So this one was not picked by eye. The eight hexes are a documented set with
+ * published separation figures; what this file chose is the order, by
+ * enumerating all 40,320 of them and keeping only the 160 that clear every
+ * gate in both surfaces. Guaca opens on green because Guaca is green, and that
+ * choice cost nothing: of the orders that pass, this is one of the best.
+ *
+ * Measured on this app's own chart surface (`--raised`: `#ffffff` on paper,
+ * `#222622` on ink), simulating protanopia and deuteranopia at full severity,
+ * as OKLab distance ×100:
+ *
+ * | gate                        | target | paper | ink  |
+ * |-----------------------------|--------|-------|------|
+ * | neighbours, colourblind     | ≥ 8    | 9.1   | 8.4  |
+ * | neighbours, full colour     | ≥ 15   | 19.6  | 19.3 |
+ * | first three, every pair     | ≥ 8    | 13.0  | 13.0 |
+ *
+ * The last row is the one scatter needs, where any two dots can end up
+ * touching and "neighbours" means nothing. Nine hues is not an option: a
+ * generated ninth is indistinguishable from one of these eight under
+ * colourblindness, so a ninth series folds into an "Other" instead.
+ *
+ * `palette.test.ts` recomputes every figure above from these hexes. It is the
+ * gate, not a note about one: a hex edited here fails the suite.
+ *
+ * Ink is not paper flipped. It is the same eight hues re-stepped for a dark
+ * ground, chosen and measured as its own set, which is why green is the one
+ * value that repeats: it already sat in both bands.
+ */
+
+/** One hue, in each of the two surfaces the reading column has. */
+export interface Slot {
+  /** Named for the doc comment above and for a failure message, never drawn. */
+  hue: string;
+  paper: string;
+  ink: string;
+}
+
+/**
+ * The eight, in the order they are handed out.
+ *
+ * Read by index, so a series keeps its colour when its neighbours are switched
+ * off in the legend. Colour follows the series, never its rank: an operator who
+ * has learned that revenue is green is misled by a chart that repaints the
+ * survivors when something is hidden.
+ */
+export const SLOTS: readonly Slot[] = [
+  { hue: "green", paper: "#008300", ink: "#008300" },
+  { hue: "blue", paper: "#2a78d6", ink: "#3987e5" },
+  { hue: "magenta", paper: "#e87ba4", ink: "#d55181" },
+  { hue: "yellow", paper: "#eda100", ink: "#c98500" },
+  { hue: "aqua", paper: "#1baf7a", ink: "#199e70" },
+  { hue: "orange", paper: "#eb6834", ink: "#d95926" },
+  { hue: "violet", paper: "#4a3aa7", ink: "#9085e9" },
+  { hue: "red", paper: "#e34948", ink: "#e66767" },
+];
+
+/** How many series a chart may carry before the tail has to be folded up. */
+export const MAX_SERIES = SLOTS.length;
+
+/**
+ * How many of them a form where any two marks can touch may carry.
+ *
+ * Scatter and bubble have no neighbours: every dot is potentially beside every
+ * other, so the gate is every pair rather than adjacent pairs, and that is a
+ * strictly harder test no ordering of eight hues can pass. Three is what does
+ * pass. Past three, a scatter leans on the shape of its marks as well as their
+ * colour, which is the documented answer to running out of hues.
+ */
+export const MAX_SCATTER_HUES = 3;
+
+/**
+ * The marks a scatter draws its series with.
+ *
+ * A second channel beside the hue, and it is why a scatter here is not capped
+ * at three series. Shape survives every kind of colourblindness, print, and a
+ * screenshot pasted into a document, none of which hue does.
+ */
+export const SCATTER_MARKS = ["circle", "square", "triangle", "diamond"] as const;
+
+export type ScatterMark = (typeof SCATTER_MARKS)[number];
+
+/**
+ * The colour for a series, as a CSS custom property reference.
+ *
+ * A property rather than a hex, so the surface decides which of the two values
+ * it resolves to and nothing here has to know which one is current. The
+ * alternative is reading `data-surface` in every chart and re-rendering all of
+ * them when it changes, which is a subscription to a value CSS already has.
+ */
+export function seriesColor(index: number): string {
+  return `var(--series-${index % SLOTS.length})`;
+}
+
+/** The mark a scatter series is drawn with, by the same rule. */
+export function seriesMark(index: number): ScatterMark {
+  return SCATTER_MARKS[index % SCATTER_MARKS.length] as ScatterMark;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1460,6 +1460,375 @@ button {
 }
 
 /* ==========================================================================
+   Figures
+
+   A fenced block the transcript draws instead of printing: a chart, or a page
+   an agent wrote. One card either way, so a figure sits in a conversation the
+   way a file does rather than as a wall of markup mid-sentence.
+
+   The series colours are the one block of literal hex left in this file, and
+   they are literal on purpose. Every other colour here is a decision somebody
+   can revise; these eight are the output of a check (neighbouring slots must
+   stay apart for a red-green colourblind reader on this exact surface) and
+   `palette.test.ts` recomputes that check from these values. Editing one by eye
+   fails the suite, which is the intended experience.
+   ========================================================================== */
+
+.figure {
+  margin: 0.65rem 0;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  background: var(--raised);
+  overflow: hidden;
+
+  --series-0: #008300;
+  --series-1: #2a78d6;
+  --series-2: #e87ba4;
+  --series-3: #eda100;
+  --series-4: #1baf7a;
+  --series-5: #eb6834;
+  --series-6: #4a3aa7;
+  --series-7: #e34948;
+
+  /* What separates two touching marks: the surface showing through, never a
+     stroke around each one. A stroke is ink that is not data. */
+  --chart-surface: var(--raised);
+}
+
+/* Not paper flipped. The same eight hues re-stepped for a dark ground and
+   measured as their own set, which is why green is the one value that repeats:
+   it already sat in both bands. */
+:root[data-surface="dark"] .figure {
+  --series-1: #3987e5;
+  --series-2: #d55181;
+  --series-3: #c98500;
+  --series-4: #199e70;
+  --series-5: #d95926;
+  --series-6: #9085e9;
+  --series-7: #e66767;
+}
+
+.figure--waiting {
+  padding: 1.1rem 0.9rem;
+}
+
+.figure__body {
+  padding: 0.7rem 0.8rem 0.2rem;
+}
+
+.figure__foot {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.3rem 0.55rem 0.5rem;
+}
+
+/* Takes the row when it is open, so the table lands under both controls rather
+   than shoving the button off to one side of it. */
+.figure__foot .chart__table {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.figure__fault {
+  margin: 0;
+  padding: 0 0.25rem;
+  font-size: 0.8rem;
+  color: var(--alarm);
+}
+
+.figure__source {
+  margin-top: 0.55rem;
+}
+
+/* --- the chart itself --------------------------------------------------- */
+
+.chart__title {
+  font-family: var(--font-display);
+  font-size: 0.92rem;
+  font-weight: 600;
+  margin: 0 0 0.4rem;
+  color: var(--text);
+}
+
+/* The readout is positioned against this, and it is the drawing's own box
+   rather than the card's: the percentages it is placed by are of the viewBox. */
+.chart__frame {
+  position: relative;
+}
+
+.chart__svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+/* Recessive, hairline and solid. Dashed reads as a threshold or a projection
+   when it is only a grid. */
+.chart__grid {
+  stroke: var(--edge);
+  stroke-width: 1;
+}
+
+/* Zero is not a gridline: every bar is measured from it. */
+.chart__axis {
+  stroke: var(--faint);
+  stroke-width: 1;
+}
+
+.chart__tick,
+.chart__name {
+  font-family: var(--font-ui);
+  font-size: 10.5px;
+  fill: var(--faint);
+  /* Ticks are a column of numbers, which is the one place equal-width digits
+     are worth having. */
+  font-variant-numeric: tabular-nums;
+}
+
+.chart__name {
+  font-variant-numeric: normal;
+}
+
+/* Text never wears the data colour. A pale hue is illegible as type on the
+   surface, and identity comes from the coloured mark beside the words. */
+.chart__value {
+  font-family: var(--font-ui);
+  font-size: 10.5px;
+  font-weight: 600;
+  fill: var(--muted);
+}
+
+.chart__line {
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.chart__bar,
+.chart__wedge {
+  transition: opacity 120ms ease;
+}
+
+/* The mark under the pointer lifts, so the reader can see it respond. The
+   others recede rather than the hovered one brightening: brightening a fill
+   changes the colour a series is identified by. */
+.chart__frame:hover .chart__bar:not([data-lit]),
+.chart__frame:hover .chart__wedge:not([data-lit]) {
+  opacity: 0.55;
+}
+
+.chart__dot {
+  stroke: var(--chart-surface);
+  stroke-width: 2;
+}
+
+/* The ring keeps two overlapping points readable as two, and the transparent
+   circle over each is what the pointer is actually aiming at: a nine-pixel dot
+   is a pinpoint nobody hits. */
+.chart__mark > :first-child {
+  stroke: var(--chart-surface);
+  stroke-width: 2;
+}
+
+.chart__mark[data-lit] > :first-child {
+  stroke: var(--text);
+}
+
+.chart__hit,
+.chart__band {
+  fill: transparent;
+}
+
+.chart__band:hover,
+.chart__mark:hover {
+  cursor: default;
+}
+
+.chart__band:focus-visible,
+.chart__mark:focus-visible,
+.chart__wedge:focus-visible {
+  outline: 2px solid var(--flesh);
+  outline-offset: 1px;
+}
+
+/* --- what is under the pointer ------------------------------------------ */
+
+.chart__readout {
+  position: absolute;
+  transform: translate(-50%, 0);
+  pointer-events: none;
+  min-width: 6rem;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  background: var(--raised);
+  box-shadow: var(--shadow-pop);
+  font-size: 0.76rem;
+  z-index: 2;
+}
+
+.chart__readout-head {
+  margin: 0 0 0.2rem;
+  color: var(--muted);
+  font-size: 0.7rem;
+}
+
+.chart__readout-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  margin: 0.1rem 0 0;
+}
+
+/* The value leads and the name follows, which is the legend's hierarchy
+   inverted: by the time somebody is hovering they know which series they want
+   and are after the number. */
+.chart__readout-value {
+  font-weight: 600;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.chart__readout-name {
+  color: var(--muted);
+}
+
+/* A short stroke rather than a filled box. At this density a box is
+   data-weight ink doing a label's job. */
+.chart__key {
+  display: inline-block;
+  width: 0.7rem;
+  height: 2px;
+  border-radius: 1px;
+  flex: none;
+  align-self: center;
+}
+
+.chart__swatch {
+  display: inline-block;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 2px;
+  flex: none;
+}
+
+/* The legend mirrors the mark, which for a scatter means the shape as well. */
+.chart__swatch[data-mark="circle"] { border-radius: 50%; }
+.chart__swatch[data-mark="diamond"] { border-radius: 1px; transform: rotate(45deg); }
+.chart__swatch[data-mark="triangle"] {
+  background: none;
+  width: 0;
+  height: 0;
+  border-left: 0.3rem solid transparent;
+  border-right: 0.3rem solid transparent;
+  border-bottom: 0.52rem solid currentColor;
+}
+
+/* --- legend and figures ------------------------------------------------- */
+
+.md .chart__legend,
+.chart__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.7rem;
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+}
+
+.chart__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 0;
+  background: none;
+  padding: 0.1rem 0;
+  font-size: 0.78rem;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+/* Switched off, said twice: struck through as well as faded, because faded
+   alone is a state somebody reads as "this one is less important". */
+.chart__legend-item[aria-pressed="false"] {
+  opacity: 0.5;
+  text-decoration: line-through;
+}
+
+/* A key rather than a switch. Nothing to press, so nothing that looks pressable. */
+.chart__legend-item[data-static] {
+  cursor: default;
+}
+
+.chart__table {
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+/* Sized and spaced like the ghost button beside it, because they are two
+   controls doing the same kind of job and a summary that reads as body text
+   next to a button reads as a mistake. */
+.chart__table > summary {
+  cursor: pointer;
+  color: var(--muted);
+  font-size: 0.78rem;
+  padding: 0.2rem 0.4rem;
+  border-radius: var(--radius-sm);
+  list-style-position: inside;
+}
+
+.chart__table > summary:hover {
+  background: var(--sunken);
+  color: var(--text);
+}
+
+.chart__table[open] > summary {
+  margin-bottom: 0.35rem;
+}
+
+.chart__table td {
+  font-variant-numeric: tabular-nums;
+}
+
+/* --- a page an agent wrote ---------------------------------------------- */
+
+.artifact {
+  position: relative;
+}
+
+.artifact__frame {
+  display: block;
+  width: 100%;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: #ffffff;
+}
+
+/* Revealed by the pointer. A transcript is a conversation, and a control on
+   every figure in it is a column of buttons down the side of the reading. */
+.artifact__open {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+  opacity: 0;
+  background: var(--raised);
+}
+
+.artifact:hover .artifact__open,
+.artifact__open:focus-visible {
+  opacity: 1;
+}
+
+/* The full view is the one thing in the dialog that has room, so the frame
+   takes all of it. Nothing here may clip: the body is what scrolls. */
+.artifact__full .artifact,
+.artifact__full .artifact__frame {
+  height: 100%;
+  min-height: 60vh;
+}
+
+/* ==========================================================================
    Chips, controls, dialogs
    ========================================================================== */
 


### PR DESCRIPTION
A fenced block in a reply is now drawn rather than printed: `chart`, `graph` or `plot` becomes a real chart (bar, line, area, pie, donut, scatter, with stacking, horizontal bars, units and gaps that are not zeros), `html` or `artifact` becomes a page that actually runs, and every other fence stays source as it was.

A fence rather than a tool call, because an agent has the numbers in hand as it writes the sentence about them, and because nothing in the runtime has to change: `as_plain_text` already returns a message's text, so the record, the prompt, the dedup fingerprint, search and a peer's copy all keep working untouched, and an agent can read back what it drew.

Charts are drawn by Guaca from a spec deliberately shaped like the one every plotting library uses, with the geometry as pure functions in `lib/chart.ts` and the drawing in `Chart.tsx`; the eight series colours are not a design decision but the output of a colourblind-separation check, picked by enumerating all 40,320 orderings and keeping one of the 160 that clear every gate on this app's own two surfaces, and `palette.test.ts` recomputes every one of those figures from the hexes so a nudged colour fails the build.

Pages get a loopback origin of their own in `artifact.rs`, served under `default-src 'none'; script-src 'unsafe-inline'; sandbox allow-scripts`, because a `srcdoc` frame inherits this app's content policy and would draw a page whose script silently never runs, and because a model's page is the least trustworthy content in the app and may compute and draw but not talk to anybody.

The prompt says all of this for every reply mode except `ToPeer`, along with the case against overusing it; 90 new tests, and `./scripts/ci.sh` is green.
