### PR TITLE
fix: an agent's machine and browser are read from its row, not from its turn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,6 +366,20 @@ the model takes a screenshot to see what `browse` did.
   dispatcher as well, and that is not a duplicate: it is what turns a model
   calling a tool it was never offered into a refusal it can act on rather than
   an error that reads like a broken machine.
+- **What an agent is *given* comes from the turn's card; what it *holds* comes
+  from the row.** `run_turn` reads one `AgentCard` and passes it through every
+  round, so a machine or a browser provisioned by the first tool call is on the
+  row and not on that snapshot. Read from the snapshot, the second call of a
+  turn provisions again: a duplicate sandbox that bills until the sweep finds
+  it, and a second browser Kernel refuses by name, which is a `browse` tool that
+  fails for the rest of the turn after the first page loads. `Runtime::held` is
+  the read, and the card stays the authority on `has_computer` and `has_browser`.
+- **A 409 from Kernel's create is an orphan to adopt, not a failure to
+  report.** The name is one per agent, so a conflict is this agent's own
+  browser, alive and unrecorded: a crash between creating one and writing it
+  down. It is found by its `guac-agent` tag rather than by the name the conflict
+  was about, and asked for by id, because a list row is not documented to carry
+  a socket and a session without one names a browser nothing can talk to.
 - **Taking a computer back leaves `sandbox_id` where it is.** The machine sleeps
   and its disk stays, because that disk is where the operator's sign-ins live.
   A revoke that destroyed it would make giving the computer back mean signing
@@ -564,6 +578,17 @@ build expects, which is the failure no offline test can see. It reaches the inte
 
 ```sh
 ./scripts/plugins.sh
+```
+
+A sixth, `tests/machines.rs`, is the same shape for the two providers: scripted
+control planes for Kernel and E2B, and the real `Runtime` provisioning against
+them. It is entirely offline and costs nothing. Nothing else in the build
+reaches a provider, so without it every suite passes with a turn renting a
+machine on every tool call. Run it after touching `ensure_computer`,
+`ensure_browser` or either client.
+
+```sh
+cargo test --manifest-path src-tauri/Cargo.toml --test machines
 ```
 
 The model suggestions beside an agent's model field have the same shape again,

--- a/docs/BROWSERS.md
+++ b/docs/BROWSERS.md
@@ -85,6 +85,33 @@ The profile is deleted with the agent. A name is free to reuse the moment an
 agent is deleted, and the profile is named from the agent, so leaving it behind
 would hand the next agent of that name somebody else's sessions.
 
+## What an agent holds is read from its row, not from its turn
+
+A turn carries one `AgentCard`, read once in `run_turn` and passed through every
+round. That is right for everything the operator decides and wrong for the one
+thing a turn changes about itself: the browser made by the first `browse` is
+written to the row and not to that snapshot. Read from the snapshot, the second
+`browse` of a turn sees an agent holding nothing and asks for another browser,
+under a name only one live browser may have. Kernel answers 409, and it answers
+it to every page the agent tries to open for the rest of the turn.
+
+So `ensure_browser` reads `browser_id` from the store. `Runtime::held` is the
+whole of it, and `ensure_computer` reads the sandbox the same way for the same
+reason, where the provider does not refuse the second one and simply bills for
+it.
+
+A conflict is still possible without that mistake, because the row can be lost
+while the browser is up: a crash between creating one and writing it down leaves
+a browser running, holding the agent's name, with nothing in the app pointing at
+it. `KernelClient::create` treats the 409 as the answer it wanted and adopts
+that browser, found by its `guac-agent` tag rather than by the name the conflict
+was about, and asked for by id so the reply carries a socket. The alternative is
+a `browse` tool that refuses every call until the orphan times out.
+
+`tests/machines.rs` drives both of these against a scripted control plane: a
+provider that refuses a duplicate name is the only thing that can tell one
+browser per agent from two.
+
 ## The element numbering lives on the page
 
 `read` returns the page's text and a numbered list of what can be used, and

--- a/src-tauri/src/e2b.rs
+++ b/src-tauri/src/e2b.rs
@@ -87,6 +87,18 @@ const ENVD_PORT: u16 = 49983;
 
 const API_BASE: &str = "https://api.e2b.app";
 
+/// The control plane this build talks to.
+///
+/// [`API_BASE`] everywhere except under `GUAC_E2B_API_BASE`, which is the seam
+/// `tests/machines.rs` points at a scripted one. Only the control plane moves:
+/// a sandbox's own envd is at an address the control plane hands out.
+fn api_base() -> String {
+    match std::env::var("GUAC_E2B_API_BASE") {
+        Ok(base) if !base.trim().is_empty() => base.trim().trim_end_matches('/').to_string(),
+        _ => API_BASE.to_string(),
+    }
+}
+
 /// Everything Guaca puts on a machine. Spelled absolutely rather than as `~`,
 /// because a command daemon that runs as a different user resolves `~`
 /// somewhere else, and the failure that produces is not an error: it is a
@@ -290,6 +302,7 @@ pub struct E2bClient {
     /// process environment of the command that needs it and goes when the
     /// command does.
     env: std::collections::BTreeMap<String, String>,
+    base: String,
 }
 
 impl E2bClient {
@@ -301,7 +314,7 @@ impl E2bClient {
             return None;
         }
         let http = reqwest::Client::builder().timeout(RUN_TIMEOUT).build().ok()?;
-        Some(Self { http, api_key: api_key.to_string(), env: Default::default() })
+        Some(Self { http, api_key: api_key.to_string(), env: Default::default(), base: api_base() })
     }
 
     /// Hands this client the credentials its agent's group holds.
@@ -355,7 +368,7 @@ impl E2bClient {
         let row: SandboxRow = self
             .control(
                 self.http
-                    .post(format!("{API_BASE}/sandboxes"))
+                    .post(format!("{}/sandboxes", self.base))
                     .json(&create_body(agent, idle_seconds)),
             )
             .await?;
@@ -374,7 +387,7 @@ impl E2bClient {
     pub async fn state(&self, sandbox: &str) -> Result<SandboxState, E2bError> {
         let response = self
             .http
-            .get(format!("{API_BASE}/sandboxes/{sandbox}"))
+            .get(format!("{}/sandboxes/{sandbox}", self.base))
             .header("X-API-Key", &self.api_key)
             .send()
             .await
@@ -407,7 +420,7 @@ impl E2bClient {
     pub async fn pause(&self, sandbox: &str) -> Result<(), E2bError> {
         let response = self
             .http
-            .post(format!("{API_BASE}/sandboxes/{sandbox}/pause"))
+            .post(format!("{}/sandboxes/{sandbox}/pause", self.base))
             .header("X-API-Key", &self.api_key)
             .json(&serde_json::json!({ "memory": false }))
             .send()
@@ -431,7 +444,7 @@ impl E2bClient {
         let row: SandboxRow = self
             .control(
                 self.http
-                    .post(format!("{API_BASE}/sandboxes/{sandbox}/resume"))
+                    .post(format!("{}/sandboxes/{sandbox}/resume", self.base))
                     .json(&serde_json::json!({ "timeout": idle_seconds })),
             )
             .await?;
@@ -450,7 +463,7 @@ impl E2bClient {
     pub async fn keep_awake(&self, sandbox: &str, idle_seconds: u32) {
         let _ = self
             .http
-            .post(format!("{API_BASE}/sandboxes/{sandbox}/timeout"))
+            .post(format!("{}/sandboxes/{sandbox}/timeout", self.base))
             .header("X-API-Key", &self.api_key)
             .json(&serde_json::json!({ "timeout": idle_seconds }))
             .send()
@@ -467,7 +480,7 @@ impl E2bClient {
     /// billing quietly forever.
     pub async fn list_ours(&self) -> Result<Vec<String>, E2bError> {
         let rows: Vec<SandboxRow> =
-            self.control(self.http.get(format!("{API_BASE}/v2/sandboxes"))).await?;
+            self.control(self.http.get(format!("{}/v2/sandboxes", self.base))).await?;
         Ok(rows
             .into_iter()
             .filter(|r| r.metadata.get("guac").map(String::as_str) == Some("true"))
@@ -478,7 +491,7 @@ impl E2bClient {
     pub async fn kill(&self, sandbox: &str) -> Result<(), E2bError> {
         let response = self
             .http
-            .delete(format!("{API_BASE}/sandboxes/{sandbox}"))
+            .delete(format!("{}/sandboxes/{sandbox}", self.base))
             .header("X-API-Key", &self.api_key)
             .send()
             .await

--- a/src-tauri/src/kernel.rs
+++ b/src-tauri/src/kernel.rs
@@ -53,6 +53,20 @@ use crate::domain::signin::BrowserState;
 
 const API_BASE: &str = "https://api.onkernel.com";
 
+/// The control plane this build talks to.
+///
+/// [`API_BASE`] everywhere except under `GUAC_KERNEL_API_BASE`, which is the
+/// seam `tests/machines.rs` points at a scripted one. The same shape
+/// `GUACA_ACCOUNT_ORIGIN` has and here for the same reason: the rule this
+/// module keeps is that an agent holds one browser, and the only way to prove
+/// it is against a provider that refuses the second.
+fn api_base() -> String {
+    match std::env::var("GUAC_KERNEL_API_BASE") {
+        Ok(base) if !base.trim().is_empty() => base.trim().trim_end_matches('/').to_string(),
+        _ => API_BASE.to_string(),
+    }
+}
+
 /// The hosts a live view is served from, and the port it is served on.
 ///
 /// Two hosts because the provider moved: a browser created today answers on
@@ -94,6 +108,10 @@ const SETTLE_SCROLL_MS: u32 = 600;
 /// Marks every browser this app made, so the sweep can tell them from the ones
 /// somebody else's project put on the same account.
 const TAG: &str = "guac";
+
+/// Marks a browser with the agent it was made for, which is how one is found
+/// again when nothing in this app is holding its id.
+const AGENT_TAG: &str = "guac-agent";
 
 #[derive(Debug, thiserror::Error)]
 pub enum KernelError {
@@ -241,6 +259,7 @@ struct ProfileRow {
 pub struct KernelClient {
     http: reqwest::Client,
     api_key: String,
+    base: String,
 }
 
 impl KernelClient {
@@ -252,7 +271,7 @@ impl KernelClient {
             return None;
         }
         let http = reqwest::Client::builder().timeout(REQUEST_TIMEOUT).build().ok()?;
-        Some(Self { http, api_key: api_key.to_string() })
+        Some(Self { http, api_key: api_key.to_string(), base: api_base() })
     }
 
     async fn call<T: for<'de> Deserialize<'de>>(
@@ -295,7 +314,7 @@ impl KernelClient {
         let name = profile_name(agent);
         match self
             .call::<ProfileRow>(
-                self.http.post(format!("{API_BASE}/profiles")).json(&json!({ "name": name })),
+                self.http.post(format!("{}/profiles", self.base)).json(&json!({ "name": name })),
             )
             .await
         {
@@ -319,15 +338,53 @@ impl KernelClient {
         stealth: bool,
     ) -> Result<Session, KernelError> {
         let profile = self.ensure_profile(agent).await?;
-        let row: BrowserRow = self
-            .call(self.http.post(format!("{API_BASE}/browsers")).json(&create_body(
-                agent,
-                &profile,
-                idle_seconds,
-                stealth,
-            )))
+        let made = self
+            .call::<BrowserRow>(
+                self.http.post(format!("{}/browsers", self.base)).json(&create_body(
+                    agent,
+                    &profile,
+                    idle_seconds,
+                    stealth,
+                )),
+            )
+            .await;
+
+        match made {
+            Ok(row) => Ok(row.into()),
+            // The name is one per agent, so a conflict is this agent's own
+            // browser, alive and unrecorded: a crash between creating one and
+            // writing it down, or a row cleared while the browser was up. That
+            // browser is what the caller asked for, and the alternative to
+            // taking it is a `browse` tool that refuses every call until the
+            // orphan times out.
+            Err(KernelError::Api { status: 409, message }) => match self.held_by(agent).await? {
+                Some(live) => Ok(live),
+                None => Err(KernelError::Api { status: 409, message }),
+            },
+            Err(err) => Err(err),
+        }
+    }
+
+    /// The browser this agent already has, whatever recorded it.
+    ///
+    /// Found by the tag rather than by the name, because the name is the thing
+    /// the conflict was about and the tag is what says whose browser it is. The
+    /// socket comes from asking for the session itself: a list row is not
+    /// documented to carry one, and a `Session` without its socket names a
+    /// browser nothing can talk to.
+    async fn held_by(&self, agent: &str) -> Result<Option<Session>, KernelError> {
+        let rows: Vec<BrowserRow> = self
+            .call(self.http.get(format!("{}/browsers", self.base)).query(&[
+                ("status", "active"),
+                (&format!("tags[{TAG}]"), "true"),
+                (&format!("tags[{AGENT_TAG}]"), agent),
+                ("limit", "10"),
+            ]))
             .await?;
-        Ok(row.into())
+        match rows.first() {
+            Some(row) => self.get(&row.session_id).await,
+            None => Ok(None),
+        }
     }
 
     /// The browser with this id, or `None` if it has gone.
@@ -337,7 +394,7 @@ impl KernelClient {
     /// caller that had to distinguish a 404 from a real failure would get it
     /// wrong somewhere.
     pub async fn get(&self, id: &str) -> Result<Option<Session>, KernelError> {
-        match self.call::<BrowserRow>(self.http.get(format!("{API_BASE}/browsers/{id}"))).await {
+        match self.call::<BrowserRow>(self.http.get(format!("{}/browsers/{id}", self.base))).await {
             Ok(row) => Ok(Some(row.into())),
             Err(KernelError::Api { status: 404, .. }) => Ok(None),
             Err(err) => Err(err),
@@ -350,7 +407,7 @@ impl KernelClient {
     /// and on the provider's clock, so this is also how an operator's sign-in
     /// is made durable now rather than in an hour.
     pub async fn delete(&self, id: &str) -> Result<(), KernelError> {
-        match self.call::<Value>(self.http.delete(format!("{API_BASE}/browsers/{id}"))).await {
+        match self.call::<Value>(self.http.delete(format!("{}/browsers/{id}", self.base))).await {
             Ok(_) => Ok(()),
             // Already gone is the outcome that was asked for.
             Err(KernelError::Api { status: 404, .. }) => Ok(()),
@@ -367,7 +424,7 @@ impl KernelClient {
     /// would hand the next agent of that name somebody else's sessions.
     pub async fn delete_profile(&self, agent: &str) -> Result<(), KernelError> {
         let name = profile_name(agent);
-        match self.call::<Value>(self.http.delete(format!("{API_BASE}/profiles/{name}"))).await {
+        match self.call::<Value>(self.http.delete(format!("{}/profiles/{name}", self.base))).await {
             Ok(_) => Ok(()),
             Err(KernelError::Api { status: 404, .. }) => Ok(()),
             Err(err) => Err(err),
@@ -381,7 +438,7 @@ impl KernelClient {
     /// created just before a crash has a name nothing recorded.
     pub async fn list_ours(&self) -> Result<Vec<String>, KernelError> {
         let rows: Vec<BrowserRow> = self
-            .call(self.http.get(format!("{API_BASE}/browsers")).query(&[
+            .call(self.http.get(format!("{}/browsers", self.base)).query(&[
                 ("status", "active"),
                 (&format!("tags[{TAG}]"), "true"),
                 ("limit", "100"),
@@ -602,7 +659,7 @@ fn create_body(agent: &str, profile: &str, idle_seconds: u32, stealth: bool) -> 
         "stealth": stealth,
         // The tag is what the sweep matches on; the name is what an operator
         // sees in Kernel's own dashboard when they go looking.
-        "tags": { TAG: "true", "guac-agent": agent },
+        "tags": { TAG: "true", AGENT_TAG: agent },
         "name": format!("guac-{agent}"),
     })
 }

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -3582,6 +3582,7 @@ impl Runtime {
         if !card.has_computer {
             return Err(E2bError::NotGiven);
         }
+        let held = self.held(card);
         let config = self.config();
         // The one place a sandbox is provisioned is the one place that knows
         // which agent it is for, so it is where the group's credentials are
@@ -3594,7 +3595,7 @@ impl Runtime {
 
         // A sandbox recorded without its tokens predates them and cannot be
         // reached, so it counts as absent rather than as something to retry.
-        let known = match (&card.sandbox_id, &card.sandbox_envd_token) {
+        let known = match (&held.sandbox_id, &held.sandbox_envd_token) {
             (Some(id), Some(envd)) => Some((id.clone(), envd.clone())),
             _ => None,
         };
@@ -3610,7 +3611,7 @@ impl Runtime {
                         Sandbox {
                             id,
                             envd_token: envd,
-                            traffic_token: card.sandbox_traffic_token.clone().unwrap_or_default(),
+                            traffic_token: held.sandbox_traffic_token.clone().unwrap_or_default(),
                         },
                     ));
                 }
@@ -3681,6 +3682,26 @@ impl Runtime {
         self.configured().given_to(card)
     }
 
+    /// What this agent is holding *now*, rather than when its turn started.
+    ///
+    /// A turn carries one `AgentCard`, read once in `run_turn` and passed
+    /// through every round. That is right for everything the operator decides
+    /// and wrong for the two things a turn changes about itself: a machine or a
+    /// browser provisioned by one tool call is written to the row and not to
+    /// that snapshot, so the next call sees an agent holding nothing and
+    /// provisions again. It cost a duplicate sandbox, billing until the sweep
+    /// found it, and a second browser Kernel refused by name, which left an
+    /// agent's `browse` failing for the rest of a turn after its first page
+    /// had loaded.
+    ///
+    /// The card stays the authority on what an agent was *given*. This is only
+    /// what it now holds, and a row that cannot be read falls back to the card
+    /// rather than to nothing: provisioning again is the expensive answer,
+    /// refusing a turn its machine because the store hiccupped is the wrong one.
+    fn held(&self, card: &AgentCard) -> AgentCard {
+        self.inner.store.get_agent(card.id).ok().flatten().unwrap_or_else(|| card.clone())
+    }
+
     /// The agent's browser, made or replaced if there is not a live one.
     ///
     /// The single place a browser is provisioned, for the same reason the
@@ -3710,7 +3731,7 @@ impl Runtime {
         let client = KernelClient::new(&config.kernel.api_key).ok_or(KernelError::NoKey)?;
         let idle = config.kernel.idle_minutes.max(1) * 60;
 
-        if let Some(id) = card.browser_id.clone() {
+        if let Some(id) = self.held(card).browser_id {
             // Asked rather than assumed, and the socket is taken from the
             // answer. A stored socket outlives the browser it addressed, and
             // connecting to one is a hang rather than an error.

--- a/src-tauri/tests/machines.rs
+++ b/src-tauri/tests/machines.rs
@@ -1,0 +1,382 @@
+//! The two places an agent can be given, against scripted control planes.
+//!
+//! A sixth suite, and it is here for the reason `plugins.rs` is here: nothing
+//! else in the build reaches a provider, so every other test passes with a turn
+//! renting a machine on every tool call. What that costs is not visible from
+//! inside the app. E2B charges for the second sandbox and says nothing; Kernel
+//! refuses the second browser by name, which arrives in a transcript as
+//! `Kernel rejected the request (409)` on every page an agent tries to open
+//! after its first.
+//!
+//! What is scripted is the far side, and only the control plane: creating,
+//! looking up, listing and deleting. Driving a browser is CDP on a socket the
+//! control plane hands out, and a machine is worked through envd at an address
+//! it hands out; neither is what these tests are about. Everything above the
+//! wire is the real `Runtime`, the real store and the real clients.
+
+mod harness;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use parking_lot::Mutex;
+use serde_json::{json, Value};
+use std::sync::OnceLock;
+
+use guac_lib::runtime::guard::GuardLimits;
+
+use harness::*;
+
+// ---- scripted Kernel -----------------------------------------------------
+
+/// One browser the scripted provider is holding.
+#[derive(Debug, Clone)]
+struct Browser {
+    id: String,
+    name: String,
+    agent: String,
+}
+
+/// What the scripted Kernel has been asked to do, and what it did.
+///
+/// Counted per agent rather than in total, because one of these servers is
+/// shared by every test in the binary and a total is whatever order they
+/// happened to run in.
+#[derive(Debug, Default)]
+struct KernelBooks {
+    profiles: Vec<String>,
+    /// Live browsers only. A deleted one frees its name, which is what the
+    /// real service does: an expired session's name is free to reuse and a
+    /// live one's is not.
+    live: Vec<Browser>,
+    /// Every browser it ever made, oldest first, kept after a delete.
+    made: Vec<Browser>,
+    /// The agent behind every conflict it answered.
+    refused: Vec<String>,
+}
+
+impl KernelBooks {
+    fn made_for(&self, agent: &str) -> usize {
+        self.made.iter().filter(|browser| browser.agent == agent).count()
+    }
+
+    fn refused_for(&self, agent: &str) -> usize {
+        self.refused.iter().filter(|refused| *refused == agent).count()
+    }
+}
+
+fn browser_row(browser: &Browser) -> Value {
+    json!({
+        "session_id": browser.id,
+        "name": browser.name,
+        "cdp_ws_url": format!("ws://127.0.0.1:9222/devtools/browser/{}", browser.id),
+        "browser_live_view_url": format!("https://{}.kernel.sh:8443/view", browser.id),
+        "tags": { "guac": "true", "guac-agent": browser.agent },
+    })
+}
+
+fn refused(code: &str, message: &str) -> Response {
+    let status = match code {
+        "conflict" => StatusCode::CONFLICT,
+        _ => StatusCode::NOT_FOUND,
+    };
+    (status, Json(json!({ "code": code, "message": message }))).into_response()
+}
+
+async fn kernel_profile(
+    State(books): State<Arc<Mutex<KernelBooks>>>,
+    Json(body): Json<Value>,
+) -> Response {
+    let name = body["name"].as_str().unwrap_or_default().to_string();
+    let mut books = books.lock();
+    if books.profiles.contains(&name) {
+        // What the real service answers, and what `ensure_profile` reads as
+        // the profile already being there.
+        return refused("conflict", "profile name already exists in project");
+    }
+    books.profiles.push(name.clone());
+    Json(json!({ "name": name })).into_response()
+}
+
+async fn kernel_create(
+    State(books): State<Arc<Mutex<KernelBooks>>>,
+    Json(body): Json<Value>,
+) -> Response {
+    let name = body["name"].as_str().unwrap_or_default().to_string();
+    let agent = body["tags"]["guac-agent"].as_str().unwrap_or_default().to_string();
+    let mut books = books.lock();
+    if books.live.iter().any(|held| held.name == name) {
+        books.refused.push(agent);
+        return refused("conflict", "browser session name already exists in project");
+    }
+    let browser = Browser { id: format!("bx{}", books.made.len() + 1), name, agent };
+    books.live.push(browser.clone());
+    books.made.push(browser.clone());
+    Json(browser_row(&browser)).into_response()
+}
+
+async fn kernel_get(
+    State(books): State<Arc<Mutex<KernelBooks>>>,
+    Path(id): Path<String>,
+) -> Response {
+    match books.lock().live.iter().find(|held| held.id == id) {
+        Some(browser) => Json(browser_row(browser)).into_response(),
+        None => refused("not_found", &format!("browser session '{id}' not found")),
+    }
+}
+
+async fn kernel_list(
+    State(books): State<Arc<Mutex<KernelBooks>>>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    let agent = query.get("tags[guac-agent]").cloned();
+    let rows: Vec<Value> = books
+        .lock()
+        .live
+        .iter()
+        .filter(|held| agent.as_deref().is_none_or(|wanted| held.agent == wanted))
+        .map(browser_row)
+        .collect();
+    Json(rows).into_response()
+}
+
+async fn kernel_delete(
+    State(books): State<Arc<Mutex<KernelBooks>>>,
+    Path(id): Path<String>,
+) -> StatusCode {
+    let mut books = books.lock();
+    let before = books.live.len();
+    books.live.retain(|held| held.id != id);
+    if books.live.len() == before {
+        StatusCode::NOT_FOUND
+    } else {
+        StatusCode::NO_CONTENT
+    }
+}
+
+// ---- scripted E2B --------------------------------------------------------
+
+#[derive(Debug, Default)]
+struct E2bBooks {
+    /// Every sandbox it ever made, as `(id, agent)`.
+    made: Vec<(String, String)>,
+}
+
+impl E2bBooks {
+    fn made_for(&self, agent: &str) -> usize {
+        self.made.iter().filter(|(_, made_for)| made_for == agent).count()
+    }
+
+    fn holds(&self, id: &str) -> bool {
+        self.made.iter().any(|(made, _)| made == id)
+    }
+}
+
+async fn e2b_create(
+    State(books): State<Arc<Mutex<E2bBooks>>>,
+    Json(body): Json<Value>,
+) -> Response {
+    let agent = body["metadata"]["guac-agent"].as_str().unwrap_or_default().to_string();
+    let mut books = books.lock();
+    let id = format!("sbx{}", books.made.len() + 1);
+    books.made.push((id.clone(), agent));
+    // Both tokens, because a sandbox created secure and with public traffic
+    // restricted answers with both, and a client that lost them holds a
+    // machine it cannot reach.
+    Json(json!({
+        "sandboxID": id,
+        "envdAccessToken": format!("envd-{id}"),
+        "trafficAccessToken": format!("traffic-{id}"),
+    }))
+    .into_response()
+}
+
+async fn e2b_state(State(books): State<Arc<Mutex<E2bBooks>>>, Path(id): Path<String>) -> Response {
+    if books.lock().holds(&id) {
+        Json(json!({ "state": "running" })).into_response()
+    } else {
+        (StatusCode::NOT_FOUND, Json(json!({ "message": "sandbox not found" }))).into_response()
+    }
+}
+
+async fn e2b_timeout() -> StatusCode {
+    StatusCode::NO_CONTENT
+}
+
+// ---- the fleet -----------------------------------------------------------
+
+struct Fleet {
+    kernel: Arc<Mutex<KernelBooks>>,
+    e2b: Arc<Mutex<E2bBooks>>,
+}
+
+/// Started once for the whole binary, on a runtime of its own.
+///
+/// Once, because the seam is an environment variable and a process has one
+/// environment: a server per test would leave the tests racing over where the
+/// providers are. Sharing costs nothing, because each test builds its own
+/// workspace and the ids and names everything here is keyed on come from a
+/// fresh store.
+///
+/// On its own runtime because `#[tokio::test]` builds a current-thread one per
+/// test and drops it at the end: a listener spawned on the first test's runtime
+/// stops accepting the moment that test returns, and the tests still running
+/// see a connection refused rather than a provider. This thread outlives all of
+/// them and drives nothing else.
+static FLEET: OnceLock<Fleet> = OnceLock::new();
+
+fn fleet() -> &'static Fleet {
+    FLEET.get_or_init(|| {
+        let (ready, started) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("a runtime for the scripted providers");
+            runtime.block_on(async move {
+                ready.send(start().await).expect("the test thread is waiting on this");
+                // Nothing else to do, and returning would drop the servers.
+                std::future::pending::<()>().await;
+            });
+        });
+        started.recv().expect("the scripted providers started")
+    })
+}
+
+async fn start() -> Fleet {
+    let kernel = Arc::new(Mutex::new(KernelBooks::default()));
+    let e2b = Arc::new(Mutex::new(E2bBooks::default()));
+
+    let kernel_app = Router::new()
+        .route("/profiles", post(kernel_profile))
+        .route("/browsers", post(kernel_create).get(kernel_list))
+        .route("/browsers/:id", get(kernel_get).delete(kernel_delete))
+        .with_state(kernel.clone());
+
+    let e2b_app = Router::new()
+        .route("/sandboxes", post(e2b_create))
+        .route("/sandboxes/:id", get(e2b_state))
+        .route("/sandboxes/:id/timeout", post(e2b_timeout))
+        .with_state(e2b.clone());
+
+    std::env::set_var("GUAC_KERNEL_API_BASE", listen(kernel_app).await);
+    std::env::set_var("GUAC_E2B_API_BASE", listen(e2b_app).await);
+
+    Fleet { kernel, e2b }
+}
+
+async fn listen(app: Router) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+/// A workspace whose model is never called: every test here drives the
+/// provisioning path directly, which is the path a tool call reaches and the
+/// one no scripted model can exercise.
+async fn quiet() -> Stub {
+    serve(|_| Script::Say("nothing to say".into())).await
+}
+
+// ---- browsers ------------------------------------------------------------
+
+#[tokio::test]
+async fn a_second_browse_in_one_turn_uses_the_browser_the_first_made() {
+    let fleet = fleet();
+    let stub = quiet().await;
+    let h = harness_with_browser(&stub, &["Scout"], GuardLimits::default());
+
+    // The turn's own snapshot: read once, before anything is provisioned,
+    // exactly as `run_turn` reads it and holds it for every round after.
+    let card = h.agent_named("Scout").unwrap();
+    assert!(card.browser_id.is_none(), "a fresh agent is holding nothing");
+
+    let (_, first) = h.runtime.ensure_browser(&card).await.expect("the first browse");
+    let (_, second) = h.runtime.ensure_browser(&card).await.expect("the second browse");
+
+    assert_eq!(
+        first.id, second.id,
+        "the second call made a different browser: a turn that opens two pages was signing in \
+         twice and overwriting its own cookies"
+    );
+    let books = fleet.kernel.lock();
+    let agent = card.id.to_string();
+    assert_eq!(
+        (books.made_for(&agent), books.refused_for(&agent)),
+        (1, 0),
+        "one browser, and nothing refused"
+    );
+    drop(books);
+    assert_eq!(
+        h.agent_named("Scout").unwrap().browser_id.as_deref(),
+        Some(first.id.as_str()),
+        "the row names the browser the agent is on"
+    );
+}
+
+#[tokio::test]
+async fn a_live_browser_no_row_points_at_is_adopted_rather_than_refused() {
+    let fleet = fleet();
+    let stub = quiet().await;
+    let h = harness_with_browser(&stub, &["Stray"], GuardLimits::default());
+    let card = h.agent_named("Stray").unwrap();
+
+    let (_, orphan) = h.runtime.ensure_browser(&card).await.expect("the first browse");
+    // A crash between creating a browser and writing it down, or a row cleared
+    // while the browser was up: the browser is running, it is holding this
+    // agent's name, and nothing in the app can see it.
+    h.runtime.store().set_agent_browser(card.id, None).unwrap();
+
+    let (_, adopted) = h.runtime.ensure_browser(&card).await.expect("the browse after the crash");
+
+    assert_eq!(adopted.id, orphan.id, "the orphan is what the agent is put back on");
+    assert!(
+        !adopted.cdp_ws_url.is_empty(),
+        "an adopted browser without its socket is one nothing can drive"
+    );
+    assert_eq!(
+        fleet.kernel.lock().refused_for(&card.id.to_string()),
+        1,
+        "the conflict is what the adoption is a recovery from"
+    );
+    assert_eq!(
+        h.agent_named("Stray").unwrap().browser_id.as_deref(),
+        Some(orphan.id.as_str()),
+        "and the row is written back, so the next turn does not have to find it again"
+    );
+}
+
+// ---- computers -----------------------------------------------------------
+
+#[tokio::test]
+async fn a_second_command_in_one_turn_runs_on_the_machine_the_first_rented() {
+    let fleet = fleet();
+    let stub = quiet().await;
+    let h = harness_with_computer(&stub, &["Hand"], GuardLimits::default());
+
+    let card = h.agent_named("Hand").unwrap();
+    assert!(card.sandbox_id.is_none(), "a fresh agent is holding nothing");
+
+    let (_, first) = h.runtime.ensure_computer(&card).await.expect("the first command");
+    let (_, second) = h.runtime.ensure_computer(&card).await.expect("the second command");
+
+    assert_eq!(
+        first.id, second.id,
+        "the second call rented another machine: the provider allows it, charges for it, and the \
+         first one keeps billing until the sweep finds it"
+    );
+    assert_eq!(fleet.e2b.lock().made_for(&card.name), 1, "one machine");
+    assert_eq!(
+        second.envd_token,
+        format!("envd-{}", first.id),
+        "and the token that reaches it is the one that machine was issued"
+    );
+}


### PR DESCRIPTION
`run_turn` reads one `AgentCard` and passes it through every round, so a browser or a sandbox provisioned by the first tool call was invisible to the second, which asked for another one: Kernel refuses the duplicate name with a 409, and E2B quietly rents and bills a second machine. `Runtime::held` reads what an agent is holding from its row instead, and `KernelClient::create` now adopts the browser a 409 is telling it about, found by its `guac-agent` tag, which also covers the browser a crash between creating one and recording it leaves running under that name. `tests/machines.rs` is a new offline suite that drives the real runtime against scripted Kernel and E2B control planes, and each of its three tests fails without its half of this change; the two control-plane base URLs moved off constants onto the clients so it can point at them. `./scripts/ci.sh` passes in full.