### PR TITLE
test: a crew of eight is run more than once, and what varies is written down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ src-tauri/gen/
 
 # Generated from scripts/make-icon.py
 scripts/icon-source.png
+
+# What ./scripts/crew.sh records: a live crew's events, messages and numbers.
+# Kept out of the build directory because `cargo clean` should not take a run
+# recording with it, and out of git because it is a log of one afternoon.
+/runs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ repo: the frontend renders state and forwards intent.
 | The group editor: what a crew overrides and what it inherits | *A group's settings are the app's, with the crew's answer on top* in `docs/WORKSPACE.md`, then `src/components/GroupEditor.tsx` |
 | What model an agent is offered, and how its job is guessed at | *The model field suggests three, and is still a text box* in `docs/WORKSPACE.md`, then `src/lib/roles.ts` and `llm/catalogue.rs`, whose twelve use cases have to agree |
 | A prompt, or anything that changes how much a crew talks | *Three test suites, asking different questions*, then run the live evals |
+| What a real crew of eight does with one directive, and what is different when you ask twice | *A crew is watched rather than asserted*, then `src-tauri/tests/crew.rs` |
 
 Unqualified section names are headings in `docs/ARCHITECTURE.md`.
 
@@ -532,7 +533,24 @@ failing the next. *Three test suites, asking different questions* in
 cargo test --manifest-path src-tauri/Cargo.toml --test trajectory
 ```
 
-A fourth, narrower one exists for the subscription. `tests/subscription.rs` runs
+None of the three can be pointed at a whole team, because a real model given a
+real instruction does something slightly different every time and one run of it
+proves nothing either way. `tests/crew.rs` is that question: eight roles, one
+directive to the Chief of Staff, run as many times as you ask for, and the
+answer is a recording rather than an assertion. Every run writes its events, its
+messages, a readable transcript and its numbers to `runs/<timestamp>/`, and the
+comparison beside them says what was different between runs that were given
+identical instructions. It asserts only what is not a matter of taste: every run
+settled, no run left the machinery in a state `trajectory.rs` calls broken, and
+somebody answered the operator. Run it after anything that changes how a crew
+divides work, and read the transcripts rather than the exit code.
+
+```sh
+./scripts/crew.sh                 # one run, a few cents
+GUACA_RUNS=5 ./scripts/crew.sh    # five, to see what varies
+```
+
+A narrower one exists for the subscription. `tests/subscription.rs` runs
 the real runtime against a scripted *Responses* server, which is a protocol the
 other three never touch, and it holds one `#[ignore]`d live test. Run that after
 changing `llm/codex.rs`, or when a sign-in that worked stops working: everything
@@ -556,7 +574,7 @@ machine instead. It authorizes nothing and stores nothing.
 cargo test --manifest-path src-tauri/Cargo.toml --test account -- --ignored
 ```
 
-A fifth, `tests/plugins.rs`, does the same job for MCP: a scripted server that
+Another, `tests/plugins.rs`, does the same job for MCP: a scripted server that
 publishes the four metadata documents an OAuth sign-in needs, and one runtime
 turn that calls a plugin tool end to end. Its live half runs `oauth::discover`
 against every vendor on the list and asks whether each still publishes what this

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -944,6 +944,41 @@ offline is a stub agreeing with what this app believes the protocol is; the live
 one is the only thing that notices when that belief goes stale, which it will,
 because the protocol belongs to somebody else.
 
+## A crew is watched rather than asserted
+
+All three suites above decide something. The fourth question cannot be decided,
+and pretending otherwise is how a suite ends up asserting the model's taste: put
+a team of eight in front of one real instruction and a real model divides the
+work differently every time. Once it sends four messages and once it sends six.
+Once the coordinator reports when the last answer lands, and once it reports
+before, then again after, and the operator reads two packages an hour apart with
+no way to tell which is current. Every one of those runs passes the cascade
+suite, because each individual message was correct.
+
+`tests/crew.rs` puts the question the only way it can be put: run the same
+directive several times and write down what happened. Eight roles an operator
+would recognise, one of them carrying the standing instruction and the other
+seven described by their skills alone; a directive with four asks, three of the
+crew with no part in it, and two pairs whose skills overlap so that choosing is
+a judgement rather than a lookup. Each run leaves its whole event stream,
+timestamped as it arrived, its envelopes, a transcript a person can read, and
+its numbers. Beside them is the comparison, which is the actual product: for
+each thing worth comparing, the distinct answers and which runs gave them. A
+dimension with one answer was stable. A dimension with five is where to start
+reading.
+
+It asserts three things and no more, because only three of them are not a
+matter of taste: every run settled, no run left the machinery in a state
+`trajectory.rs` calls broken, and somebody answered the operator. A crew that
+chose oddly is a finding to read; a placeholder left open is a defect. Anything
+promoted from a finding to a rule belongs in `eval.rs`, where it is decidable
+and every suite gets it.
+
+```sh
+./scripts/crew.sh                 # one run, a few cents
+GUACA_RUNS=5 ./scripts/crew.sh    # five, to see what varies
+```
+
 ## Known limitations
 
 Stated plainly rather than discovered later.

--- a/scripts/crew.sh
+++ b/scripts/crew.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# One directive, a crew of eight, and a real model deciding what to do with it.
+#
+# The evals ask whether a crew communicates sensibly and assert the answer. This
+# asks what a whole team actually does, and a real model does something slightly
+# different every time, so the answer is a recording rather than an assertion:
+# every run writes its events, its messages, its transcript and its numbers to
+# runs/<timestamp>/, and a run more than once writes down what was different.
+#
+#   ./scripts/crew.sh                             one run
+#   GUACA_RUNS=5 ./scripts/crew.sh                five, to see what varies
+#   GUACA_MODEL=anthropic/claude-sonnet-5 ./scripts/crew.sh
+#
+# Everything it reads from the environment, and where the defaults live:
+#
+#   GUACA_RUNS         how many times to send the same directive   (crew.rs)
+#   GUACA_MODEL        what every agent runs on                    (crew.rs)
+#   GUACA_STEPS        model calls one run may spend               (crew.rs)
+#   GUACA_SETTLE_SECS  how long a run has to go quiet              (crew.rs)
+#   GUACA_DIRECTIVE    what the Chief of Staff is asked            (crew.rs)
+#
+# The defaults are in the test rather than here so there is one of each; the run
+# prints what it resolved them to before it spends anything.
+#
+# The endpoint, the key and the guard's limits come from the app's own settings,
+# so what this measures is the workspace the operator is actually running. The
+# one exception is the step budget, which is capped here: a crew of eight that
+# will not converge is a bill rather than a finding.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+CONFIG="$HOME/Library/Application Support/com.madebywelch.guac/config.json"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "no settings at $CONFIG; open Guaca and set an endpoint and key first" >&2
+  exit 1
+fi
+
+printf '\033[1m==> A live crew, against your own key\033[0m\n'
+echo "These make real model calls and cost real money. Ctrl-C now if that is a surprise."
+echo
+
+# --nocapture so the runs print as they happen: a five-run comparison takes
+# minutes and a person watching it wants the first run's numbers before the
+# fifth one starts. One thread, because two crews thinking at once against the
+# same endpoint makes the timings meaningless and interleaves the output.
+cargo test --manifest-path src-tauri/Cargo.toml --test crew \
+  -- --ignored --nocapture --test-threads=1

--- a/src-tauri/tests/crew.rs
+++ b/src-tauri/tests/crew.rs
@@ -1,0 +1,688 @@
+//! One directive, eight agents, a real model, and a record of what happened.
+//!
+//! The other three suites each ask a question with one right answer. The
+//! cascade tests ask whether the runtime did as it was told; the evals ask
+//! whether a crew communicated like something worth watching; the trajectory
+//! suite asks whether the machinery behaved. All three can be asserted because
+//! all three are decidable.
+//!
+//! This one is not, and that is the point of it. A real model given a real
+//! instruction and a team of eight makes a different set of decisions every
+//! time, and the interesting failures live in the spread rather than in any one
+//! run: the delegation that goes to five agents on the third attempt and one on
+//! the first two, the fan-in that reports twice when a reply lands late, the
+//! turn that only hangs when two answers arrive in the same batch. A suite that
+//! runs once and asserts cannot see any of that. So this runs the same
+//! directive as many times as it is asked to, writes down everything each run
+//! did, and says what was different.
+//!
+//! What it does assert is the part that is not a matter of taste: every run
+//! settled, no run left the machinery in a state `trajectory.rs` calls broken,
+//! and somebody answered the operator. A crew that chose oddly is a finding to
+//! read. A placeholder left open is a defect.
+//!
+//! ```sh
+//! ./scripts/crew.sh          # one run, on the default model
+//! GUACA_RUNS=5 ./scripts/crew.sh
+//! ```
+
+mod harness;
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+
+use guac_lib::config::AppConfig;
+use guac_lib::domain::envelope::{Envelope, Part, Participant};
+use guac_lib::domain::ids::AgentId;
+use guac_lib::eval::{analyse, faults, Fault};
+use guac_lib::runtime::events::{EventSink, UiEvent};
+
+use harness::live::*;
+use harness::*;
+
+/// The agent the operator talks to. Everything else is reached through it.
+const CHIEF: &str = "Chief of Staff";
+
+/// Cheap, fast, and a competent tool caller, which is what eight agents making
+/// several calls each needs to be. Every run records the model it used, so a
+/// comparison between two of them is two runs and a diff rather than a rebuild:
+/// `GUACA_MODEL=anthropic/claude-sonnet-5 ./scripts/crew.sh`.
+const DEFAULT_MODEL: &str = "openai/gpt-5.6-luna";
+
+/// What an operator types when they have one person they talk to.
+///
+/// Close to the `ONLY_DELEGATES` instruction the evals use, because the failure
+/// it produces is the same one and the two are worth comparing: an agent told
+/// not to do the work either answers from its own head, asks everybody, or
+/// takes the instruction as a reason to do nothing. The addition is the fan-in,
+/// which a crew of two cannot be asked about: four answers have to become one
+/// package, and the operator is waiting for the package rather than for the
+/// pieces.
+const STANDING_INSTRUCTION: &str =
+    "You are the Chief of Staff. Work the operator brings you is yours to place: decide who on \
+     the team each piece belongs to, send it to them, and answer the operator yourself once you \
+     have what you need. You do not do the team's work yourself.";
+
+/// The eight, and the ambiguity is deliberate.
+///
+/// Four of the directive's asks have an obvious owner and three of the crew
+/// have no part in it at all, which is the arrangement that separates a
+/// coordinator that chooses from one that hands everybody a piece. The
+/// Market Researcher overlaps the Content Marketer on positioning and the Data
+/// Analyst on sizing, so there is a real judgement to make rather than a lookup.
+/// The Executive Assistant is bait: the directive mentions a meeting on Monday
+/// and never asks for anything to be done about it.
+///
+/// Only the Chief of Staff carries instructions. The other seven are described
+/// by their skills and nothing else, because that is how most agents are
+/// created, and a crew whose specialists each carry a hand-written brief is a
+/// test of the briefs.
+fn crew() -> Vec<LiveAgent> {
+    vec![
+        LiveAgent::told(CHIEF, &["coordination", "prioritisation"], STANDING_INSTRUCTION),
+        LiveAgent::skilled(
+            "Executive Assistant",
+            &["calendar", "inbox", "travel booking", "meeting logistics"],
+        ),
+        LiveAgent::skilled(
+            "Sales Development Rep",
+            &["outbound prospecting", "lead qualification", "cold email"],
+        ),
+        LiveAgent::skilled("Content Marketer", &["blog posts", "positioning copy", "editing"]),
+        LiveAgent::skilled("Paralegal", &["contract review", "compliance", "filings"]),
+        LiveAgent::skilled(
+            "Product Manager",
+            &["product requirements", "roadmap", "release scoping"],
+        ),
+        LiveAgent::skilled(
+            "Market Researcher",
+            &["competitor analysis", "market sizing", "customer interviews"],
+        ),
+        LiveAgent::skilled("Data Analyst", &["SQL", "metrics", "forecasting"]),
+    ]
+}
+
+/// Four asks with four owners, in the sentence an operator would type.
+///
+/// Deliberately not a numbered list: a list is a delegation plan already
+/// written, and what is being watched is whether one gets written at all.
+const DIRECTIVE: &str = "We're launching the Pro tier on the 15th of next month and I want to \
+                         walk into Monday's leadership meeting with one package. I need a \
+                         one-page positioning brief, a read on whether our current terms of \
+                         service cover usage-based billing, the fifty accounts we should \
+                         approach first and the reasoning for those fifty, and what the launch \
+                         does to next quarter's numbers. Bring it back to me together.";
+
+// ---- the run -------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "live: costs money, needs a configured key"]
+async fn a_directive_to_the_chief_of_staff() {
+    let Some(mut config) = configured() else {
+        eprintln!("no configured model; skipping");
+        return;
+    };
+
+    let model = setting("GUACA_MODEL").unwrap_or_else(|| DEFAULT_MODEL.to_string());
+    let runs = number("GUACA_RUNS", 1);
+    let steps = number("GUACA_STEPS", 120);
+    let secs = number("GUACA_SETTLE_SECS", 420) as u64;
+    let directive = setting("GUACA_DIRECTIVE").unwrap_or_else(|| DIRECTIVE.to_string());
+
+    config.inference.default_model = model.clone();
+    // The operator's own limits otherwise, because the guard is part of what is
+    // being watched: a fan-out ceiling low enough to refuse a broadcast would
+    // answer the question this suite is asking. The step budget is the
+    // exception, and it is the only real spend control: a crew of eight that
+    // will not converge is a bill, not a finding.
+    config.limits.max_steps_per_run = steps as u32;
+
+    let crew = crew();
+    let names: Vec<&str> = crew.iter().map(|agent| agent.name).collect();
+
+    let dir = recordings().join(stamp());
+    std::fs::create_dir_all(&dir).unwrap();
+    // Printed several times and pasted into a shell at least once, so it is
+    // worth being a path rather than a route to one.
+    let dir = dir.canonicalize().unwrap_or(dir);
+    write(&dir.join("directive.txt"), &format!("to: {CHIEF}\n\n{directive}\n"));
+    write(
+        &dir.join("setup.json"),
+        &serde_json::to_string_pretty(&serde_json::json!({
+            "model": model,
+            "runs": runs,
+            "settleSecs": secs,
+            "limits": config.limits,
+            "crew": crew.iter().map(|agent| serde_json::json!({
+                "name": agent.name,
+                "skills": agent.skills,
+                "prompt": agent.system_prompt(),
+            })).collect::<Vec<_>>(),
+        }))
+        .unwrap(),
+    );
+
+    println!("\n==> {runs} run(s) of one directive on {model}");
+    println!("    at most {steps} model call(s) per run, {secs}s to settle in");
+    println!("    recording to {}", dir.display());
+
+    let mut reports = Vec::new();
+    for run in 1..=runs {
+        let report =
+            one_run(&config, &crew, &names, &directive, secs, run, &dir.join(format!("run-{run}")))
+                .await;
+        println!("{}", report.line());
+        reports.push(report);
+    }
+
+    let across = compare(&reports, &model);
+    write(&dir.join("across-runs.md"), &across);
+    println!("\n{across}\nrecorded in {}\n", dir.display());
+
+    // Only the three that are not a matter of taste. Everything else about a
+    // run is in the comparison above, which is what the suite is for.
+    let unsettled = which(&reports, |report| !report.settled);
+    assert!(
+        unsettled.is_empty(),
+        "run(s) {unsettled:?} never settled inside {secs}s. Either the crew did not converge or \
+         the runtime lost a turn; the events in {} say which",
+        dir.display()
+    );
+    let broken = which(&reports, |report| !report.anomalies.is_empty());
+    assert!(
+        broken.is_empty(),
+        "run(s) {broken:?} left the machinery in a state trajectory.rs calls broken. This is a \
+         defect in Guaca rather than a decision a model made:\n{}",
+        reports
+            .iter()
+            .filter(|report| !report.anomalies.is_empty())
+            .flat_map(|report| report
+                .anomalies
+                .iter()
+                .map(|anomaly| format!("  run {}: {anomaly}", report.run)))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+    let silent = which(&reports, |report| report.silent);
+    assert!(
+        silent.is_empty(),
+        "in run(s) {silent:?} the operator asked for something and was never told anything by \
+         anybody, which is the one outcome worse than a bad answer"
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn one_run(
+    config: &AppConfig,
+    crew: &[LiveAgent],
+    names: &[&str],
+    directive: &str,
+    secs: u64,
+    number: usize,
+    dir: &Path,
+) -> RunReport {
+    std::fs::create_dir_all(dir).unwrap();
+
+    // Opened before the crew exists, so a run that never comes back still
+    // leaves everything up to the moment it stopped. `tail -f` works on it.
+    let recorder = Recorder::open(&dir.join("events.jsonl"));
+    let before = machines_now(config).await;
+    let h = live_crew_watched(config.clone(), crew, recorder);
+    let (answering, asked) = answer_permission_requests(&h);
+
+    // Written before the first message rather than with the rest, because the
+    // events name agents by id and a run that hangs is one whose record has to
+    // be readable without it having finished. Per run, since every run builds
+    // its crew in a fresh store and none of the ids survive.
+    let lookup: HashMap<AgentId, String> =
+        names.iter().map(|name| (h.id(name), (*name).to_string())).collect();
+    write(
+        &dir.join("agents.json"),
+        &serde_json::to_string_pretty(
+            &lookup.iter().map(|(id, name)| (id.to_string(), name)).collect::<BTreeMap<_, _>>(),
+        )
+        .unwrap(),
+    );
+
+    println!("--> run {number}: {} agents, asking {CHIEF}", crew.len());
+    let started = Instant::now();
+    let run = h.runtime.send_from_human(h.id(CHIEF), directive).unwrap();
+    let settled = h.settled_within(run, secs).await;
+    let seconds = started.elapsed().as_secs();
+    answering.abort();
+    // Before anything that can fail, exactly as the evals do it: a run that
+    // overruns is a run whose agents are all still working, and those are the
+    // ones that leave the most behind.
+    release_machines(config, before).await;
+
+    let messages = h.envelopes(names);
+    let name_of = |id: AgentId| lookup.get(&id).cloned().unwrap_or_else(|| "?".into());
+    let convo = analyse(&messages, &name_of);
+    let found = faults(&messages, &name_of);
+    let trajectory = h.trajectory(run);
+
+    let mut tools: BTreeMap<String, usize> = BTreeMap::new();
+    for tool in trajectory.tools() {
+        *tools.entry(tool.to_string()).or_default() += 1;
+    }
+
+    let (prompt_tokens, completion_tokens) = trajectory.tokens();
+    let report = RunReport {
+        run: number,
+        settled,
+        seconds,
+        calls: trajectory.calls(),
+        steps: trajectory.steps(),
+        prompt_tokens,
+        completion_tokens,
+        cost: spend(&h),
+        peak_concurrency: trajectory.peak_concurrency(),
+        peer_messages: convo.between_agents,
+        max_hop: convo.max_hop,
+        told_operator: convo
+            .to_operator
+            .iter()
+            .map(|(who, text)| (who.clone(), text.clone()))
+            .collect(),
+        delegated: h.messaged_by(CHIEF),
+        turns: names
+            .iter()
+            .map(|name| ((*name).to_string(), trajectory.turns(h.id(name))))
+            .collect(),
+        chased: chases(&messages, &name_of),
+        tools,
+        refusals: trajectory.refusals(),
+        silent: found.contains(&Fault::Silent),
+        faults: found.iter().map(Fault::explain).collect(),
+        anomalies: trajectory.anomalies().iter().map(|a| a.explain()).collect(),
+        approvals: asked.lock().clone(),
+    };
+
+    write(&dir.join("transcript.md"), &render(&messages, &lookup, &report));
+    write(&dir.join("messages.json"), &serde_json::to_string_pretty(&messages).unwrap());
+    write(&dir.join("summary.json"), &serde_json::to_string_pretty(&report).unwrap());
+    write(&dir.join("ledger.txt"), &trajectory.ledger);
+    report
+}
+
+// ---- what one run did ----------------------------------------------------
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RunReport {
+    run: usize,
+    settled: bool,
+    seconds: u64,
+    /// Model calls, which is the unit the budget and the bill are both in.
+    calls: usize,
+    steps: Option<u32>,
+    prompt_tokens: u64,
+    completion_tokens: u64,
+    /// Dollars, when the provider prices a call. Absent rather than zero: a
+    /// local endpoint charges nothing and reports nothing, and the two must not
+    /// add up the same.
+    cost: Option<f64>,
+    peak_concurrency: usize,
+    peer_messages: usize,
+    max_hop: u16,
+    told_operator: Vec<(String, String)>,
+    /// Who the Chief of Staff sent something to, with a count each. The
+    /// decision the whole scenario exists to watch.
+    delegated: Vec<(String, usize)>,
+    turns: Vec<(String, usize)>,
+    /// Work sent to a peer that had not answered the last thing yet, by pair.
+    ///
+    /// The prompt asks for this in so many words: a send returns once the
+    /// message is queued, a reply arrives later on its own, and calling
+    /// `send_message` again to check for one is named as the thing not to do.
+    /// It is not one of `eval.rs`'s faults, so nothing else counts it, and a
+    /// coordinator waiting on four answers is exactly where it happens.
+    chased: Vec<String>,
+    tools: BTreeMap<String, usize>,
+    refusals: Vec<String>,
+    silent: bool,
+    faults: Vec<String>,
+    anomalies: Vec<String>,
+    /// Permission requests, all of which were declined.
+    approvals: Vec<String>,
+}
+
+impl RunReport {
+    fn line(&self) -> String {
+        format!(
+            "    run {}: {} in {}s, {} call(s){}, {} peer message(s), told the operator {} \
+             time(s), {} fault(s), {} anomal{}",
+            self.run,
+            if self.settled { "settled" } else { "DID NOT SETTLE" },
+            self.seconds,
+            self.calls,
+            match self.cost {
+                Some(cost) => format!(" (${cost:.4})"),
+                None => String::new(),
+            },
+            self.peer_messages,
+            self.told_operator.len(),
+            self.faults.len(),
+            self.anomalies.len(),
+            if self.anomalies.len() == 1 { "y" } else { "ies" },
+        )
+    }
+
+    /// Who was given work, as one comparable string.
+    fn chose(&self) -> String {
+        if self.delegated.is_empty() {
+            return "nobody".to_string();
+        }
+        self.delegated.iter().map(|(name, _)| name.as_str()).collect::<Vec<_>>().join(", ")
+    }
+}
+
+/// What every model call this run reported costing.
+///
+/// Read from the events rather than from the trajectory, which keeps the token
+/// counts and drops the price: a comparison between two models is a comparison
+/// of what they charged, and tokens alone cannot make it.
+fn spend(h: &Harness) -> Option<f64> {
+    let mut total = None;
+    for event in h.sink.snapshot() {
+        let Ok(value) = serde_json::to_value(&event) else { continue };
+        if value["type"] != "tokensUsed" {
+            continue;
+        }
+        if let Some(cost) = value["cost"].as_f64() {
+            total = Some(total.unwrap_or(0.0) + cost);
+        }
+    }
+    total
+}
+
+/// Work sent to a peer that had not answered the last one yet.
+///
+/// Decidable from the envelopes and nothing else: a pair is waiting from the
+/// moment work is sent until anything comes back the other way, and a second
+/// piece of work inside that window is a chase. Counted here rather than in
+/// `eval.rs` because it has not yet been seen often enough to be a fault: a
+/// crew is allowed to send a peer a second, different thing to do, and telling
+/// that apart from nagging needs more than one run of evidence.
+fn chases(messages: &[Envelope], name_of: &dyn Fn(AgentId) -> String) -> Vec<String> {
+    let mut waiting: BTreeSet<(AgentId, AgentId)> = BTreeSet::new();
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+
+    for envelope in messages {
+        let (Participant::Agent { id: from }, Participant::Agent { id: to }) =
+            (envelope.from, envelope.to)
+        else {
+            continue;
+        };
+        // Anything back the other way ends the wait, whatever it says: an
+        // agent that has spoken is an agent that is no longer silent.
+        waiting.remove(&(to, from));
+        if envelope.intent.is_work() && !waiting.insert((from, to)) {
+            *counts.entry(format!("{} chased {}", name_of(from), name_of(to))).or_default() += 1;
+        }
+    }
+
+    counts.into_iter().map(|(pair, times)| format!("{pair} {times} time(s)")).collect()
+}
+
+// ---- what was different --------------------------------------------------
+
+/// The whole reason this suite runs more than once.
+///
+/// One table of numbers and then, for each thing worth comparing, the distinct
+/// answers and which runs gave them. A dimension with one answer was stable; a
+/// dimension with five is where to start reading the transcripts.
+fn compare(reports: &[RunReport], model: &str) -> String {
+    let mut out = format!("# {} run(s) of one directive on `{model}`\n\n", reports.len());
+
+    out.push_str(
+        "| run | settled | secs | calls | prompt | completion | cost | peer msgs | hop | told \
+         operator | peak |\n|---|---|---|---|---|---|---|---|---|---|---|\n",
+    );
+    for report in reports {
+        out.push_str(&format!(
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n",
+            report.run,
+            if report.settled { "yes" } else { "**no**" },
+            report.seconds,
+            report.calls,
+            report.prompt_tokens,
+            report.completion_tokens,
+            match report.cost {
+                Some(cost) => format!("${cost:.4}"),
+                None => "-".to_string(),
+            },
+            report.peer_messages,
+            report.max_hop,
+            report.told_operator.len(),
+            report.peak_concurrency,
+        ));
+    }
+
+    out.push_str("\n## What varied\n\n");
+    out.push_str(&varied("who the Chief of Staff sent work to", reports, RunReport::chose));
+    out.push_str(&varied("peer messages", reports, |r| r.peer_messages.to_string()));
+    out.push_str(&varied("model calls", reports, |r| r.calls.to_string()));
+    out.push_str(&varied("times the operator was told", reports, |r| {
+        r.told_operator.len().to_string()
+    }));
+    // The two halves of that number, because they are different complaints. A
+    // coordinator that answers four times is the one the operator notices; a
+    // specialist writing one line in its own channel is the workspace working.
+    out.push_str(&varied("times the Chief of Staff answered", reports, |r| {
+        r.told_operator.iter().filter(|(who, _)| who == CHIEF).count().to_string()
+    }));
+    out.push_str(&varied("who answered the operator", reports, |r| {
+        set(r.told_operator.iter().map(|(who, _)| who.clone()))
+    }));
+    out.push_str(&varied("chased for an answer", reports, |r| set(r.chased.iter().cloned())));
+    out.push_str(&varied("deepest hop", reports, |r| r.max_hop.to_string()));
+    out.push_str(&varied("tools used", reports, |r| set(r.tools.keys().cloned())));
+    out.push_str(&varied("guard refusals", reports, |r| set(r.refusals.iter().cloned())));
+    out.push_str(&varied("faults", reports, |r| set(r.faults.iter().cloned())));
+    out.push_str(&varied("anomalies", reports, |r| set(r.anomalies.iter().cloned())));
+    out.push_str(&varied("permission requests", reports, |r| r.approvals.len().to_string()));
+
+    out.push_str("\n## What the operator was told\n");
+    for report in reports {
+        out.push_str(&format!("\n### run {}\n", report.run));
+        if report.told_operator.is_empty() {
+            out.push_str("\nNothing.\n");
+        }
+        for (who, text) in &report.told_operator {
+            out.push_str(&format!("\n**{who}**\n\n{text}\n"));
+        }
+    }
+    out
+}
+
+/// One dimension, and which runs gave which answer.
+fn varied(label: &str, reports: &[RunReport], of: impl Fn(&RunReport) -> String) -> String {
+    let mut answers: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    for report in reports {
+        answers.entry(of(report)).or_default().push(report.run);
+    }
+    if answers.len() == 1 {
+        let (answer, _) = answers.into_iter().next().expect("one answer");
+        return format!("- {label}: {answer}, in every run\n");
+    }
+    let mut out = format!("- **{label}: {} different answers**\n", answers.len());
+    for (answer, runs) in answers {
+        let runs: Vec<String> = runs.iter().map(usize::to_string).collect();
+        out.push_str(&format!("  - {answer} (run {})\n", runs.join(", ")));
+    }
+    out
+}
+
+/// A set of strings, ordered and joined, so two runs that produced the same
+/// things in a different order compare equal.
+fn set(values: impl Iterator<Item = String>) -> String {
+    let ordered: BTreeSet<String> = values.collect();
+    if ordered.is_empty() {
+        return "none".to_string();
+    }
+    ordered.into_iter().collect::<Vec<_>>().join("; ")
+}
+
+fn which(reports: &[RunReport], fits: impl Fn(&RunReport) -> bool) -> Vec<usize> {
+    reports.iter().filter(|report| fits(report)).map(|report| report.run).collect()
+}
+
+// ---- the recording -------------------------------------------------------
+
+/// Every event the runtime emitted, timestamped, written as it happened.
+///
+/// The same stream the webview is drawn from and the same one `trajectory.rs`
+/// reads, so a question about what the operator would have seen is answerable
+/// from the file rather than from a rerun. Timestamps are here and nowhere near
+/// an assertion: a wall clock in a test is a flake, and a wall clock in a
+/// recording is how you find the turn that sat for four minutes.
+struct Recorder {
+    file: parking_lot::Mutex<std::fs::File>,
+    started: Instant,
+}
+
+impl Recorder {
+    fn open(path: &Path) -> Arc<Self> {
+        Arc::new(Recorder {
+            file: parking_lot::Mutex::new(std::fs::File::create(path).unwrap()),
+            started: Instant::now(),
+        })
+    }
+}
+
+impl EventSink for Recorder {
+    fn emit(&self, event: UiEvent) {
+        let line = serde_json::json!({
+            "atMs": self.started.elapsed().as_millis() as u64,
+            "event": event,
+        });
+        let mut file = self.file.lock();
+        if let Err(err) = writeln!(file, "{line}") {
+            eprintln!("could not record an event: {err}");
+        }
+    }
+}
+
+/// The conversation, as a person would read it.
+///
+/// `messages.json` beside it is the same thing without a decision taken about
+/// what matters, and this is the one that gets read: every envelope in the
+/// order it was filed, named rather than numbered, carrying the two fields that
+/// decide whether a cascade terminates.
+fn render(messages: &[Envelope], names: &HashMap<AgentId, String>, report: &RunReport) -> String {
+    let who = |participant: Participant| match participant {
+        Participant::Human => "OPERATOR".to_string(),
+        Participant::System => "Guaca".to_string(),
+        Participant::Agent { id } => {
+            names.get(&id).cloned().unwrap_or_else(|| format!("agent {}", id.short()))
+        }
+    };
+
+    let mut out = format!("# run {}\n\n{}\n\n", report.run, report.line().trim());
+    let first = messages.first().map(|envelope| envelope.created_at).unwrap_or_default();
+    let at = |envelope: &Envelope| (envelope.created_at - first) as f64 / 1000.0;
+
+    // One line per message before the messages themselves, because a cascade
+    // is a shape and a shape cannot be read at the pace of full paragraphs.
+    // Everything a runaway is recognised by is in it: work going out to five
+    // peers at once, a hop count climbing past where the operator's message
+    // started, a specialist answering the operator while its coordinator is
+    // still consolidating.
+    out.push_str("## The shape\n\n| at | hop | intent | reply | from → to | chars | tools |\n");
+    out.push_str("|---|---|---|---|---|---:|---|\n");
+    for envelope in messages {
+        let tools: Vec<&str> = envelope
+            .parts
+            .iter()
+            .filter_map(|part| match part {
+                Part::ToolCall { name, .. } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        out.push_str(&format!(
+            "| +{:.1}s | {} | {} | {} | {} → {} | {} | {} |\n",
+            at(envelope),
+            envelope.hop,
+            envelope.intent.as_str(),
+            if envelope.expects_reply { "yes" } else { "" },
+            who(envelope.from),
+            who(envelope.to),
+            envelope.plain_text().chars().count(),
+            tools.join(", "),
+        ));
+    }
+
+    out.push_str("\n## The messages\n");
+    for envelope in messages {
+        out.push_str(&format!(
+            "\n### +{:.1}s  {} → {}  (hop {}, {}{})\n",
+            at(envelope),
+            who(envelope.from),
+            who(envelope.to),
+            envelope.hop,
+            envelope.intent.as_str(),
+            if envelope.expects_reply { ", reply expected" } else { "" },
+        ));
+        for part in &envelope.parts {
+            out.push_str(&match part {
+                Part::Text { text } => format!("\n{text}\n"),
+                Part::Notice { kind, text } => format!("\n> [{kind:?}] {text}\n"),
+                Part::ToolCall { name, arguments, outcome, .. } => {
+                    format!("\n`{name}` → {outcome:?}\n\n```json\n{}\n```\n", clip(arguments))
+                }
+                Part::File(file) => format!("\n[file: {}]\n", file.name),
+                Part::Approval { summary, .. } => format!("\n[asks the operator: {summary}]\n"),
+                Part::Routine { name, what, .. } => format!("\n[routine {name:?}] {what}\n"),
+                Part::Json { name, value } => format!("\n[{name}]\n\n```json\n{value}\n```\n"),
+            });
+        }
+    }
+    out
+}
+
+/// Tool arguments, shortened. A `send_message` carries the whole message it
+/// sent, and the transcript is already the place that message is read.
+fn clip(arguments: &serde_json::Value) -> String {
+    let rendered = arguments.to_string();
+    match rendered.char_indices().nth(400) {
+        Some((at, _)) => format!("{}…", &rendered[..at]),
+        None => rendered,
+    }
+}
+
+// ---- plumbing ------------------------------------------------------------
+
+fn setting(name: &str) -> Option<String> {
+    std::env::var(name).ok().map(|value| value.trim().to_string()).filter(|v| !v.is_empty())
+}
+
+/// A number from the environment, or the default. A value that is not a number
+/// is a typo in a command line, and taking the default silently is how a five
+/// hundred step budget gets spent on a run somebody thought was bounded.
+fn number(name: &str, fallback: usize) -> usize {
+    match setting(name) {
+        Some(raw) => raw.parse().unwrap_or_else(|_| panic!("{name} must be a number, got {raw:?}")),
+        None => fallback,
+    }
+}
+
+/// Where recordings go: beside the repo, never inside the build directory.
+///
+/// `cargo clean` is something people run without thinking about it, and the
+/// runs are the product of this suite rather than a build artifact of it.
+fn recordings() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../runs")
+}
+
+fn stamp() -> String {
+    chrono::Local::now().format("%Y-%m-%d-%H%M%S").to_string()
+}
+
+fn write(path: &Path, contents: &str) {
+    std::fs::write(path, contents)
+        .unwrap_or_else(|err| panic!("could not write {}: {err}", path.display()));
+}

--- a/src-tauri/tests/evals.rs
+++ b/src-tauri/tests/evals.rs
@@ -24,14 +24,12 @@ mod harness;
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
 
-use guac_lib::domain::agent::CleanDraft;
-use guac_lib::domain::approval::Decision;
-use guac_lib::domain::envelope::Envelope;
 use guac_lib::domain::ids::{AgentId, RunId};
 use guac_lib::eval::{analyse, faults, Conversation, Fault};
 use guac_lib::runtime::guard::GuardLimits;
 use guac_lib::trajectory::Trajectory;
 
+use harness::live::*;
 use harness::*;
 
 /// One instruction, run end to end, read for what it did to the operator.
@@ -123,20 +121,7 @@ fn read(h: &Harness, run: RunId, names: &[&str]) -> Eval {
         names.iter().map(|n| (h.id(n), (*n).to_string())).collect();
     let name_of = move |id: AgentId| lookup.get(&id).cloned().unwrap_or_else(|| "?".into());
 
-    // Every channel, not `conversation_flow`: that one is built for the
-    // activity view and excludes the system channel, which is where refusals
-    // are recorded. An eval that cannot see a refusal cannot tell a guard doing
-    // its job from a message that silently went nowhere.
-    let mut messages: Vec<Envelope> = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    for name in names {
-        for envelope in h.runtime.store().channel_messages(h.id(name), 400).unwrap() {
-            if seen.insert(envelope.id) {
-                messages.push(envelope);
-            }
-        }
-    }
-    messages.sort_by_key(|e| (e.created_at, e.id));
+    let messages = h.envelopes(names);
 
     Eval {
         convo: analyse(&messages, &name_of),
@@ -1162,21 +1147,6 @@ async fn a_coordinator_delegates_from_what_it_remembered_on_an_earlier_run() {
 mod live {
     use super::*;
 
-    fn configured() -> Option<guac_lib::config::AppConfig> {
-        let path = dirs_config()?;
-        let raw = std::fs::read_to_string(path).ok()?;
-        let config: guac_lib::config::AppConfig = serde_json::from_str(&raw).ok()?;
-        (!config.inference.api_key.trim().is_empty()).then_some(config)
-    }
-
-    fn dirs_config() -> Option<std::path::PathBuf> {
-        let home = std::env::var_os("HOME")?;
-        Some(
-            std::path::PathBuf::from(home)
-                .join("Library/Application Support/com.madebywelch.guac/config.json"),
-        )
-    }
-
     /// Everything a live scenario needs: real agents, real model, real prompt.
     async fn run_live(names: &[&'static str], instruction: &str) -> Option<Eval> {
         let crew: Vec<LiveAgent> = names.iter().map(|n| LiveAgent::generic(n)).collect();
@@ -1243,94 +1213,6 @@ mod live {
         assert!(settled, "run did not settle in {secs}s. messages so far:\n{}", h.transcript());
         let eval = read(&h, run, &names);
         Some((h, eval))
-    }
-
-    /// Answers whatever the crew asks the operator, with no.
-    ///
-    /// A live crew has no operator, and a parked turn holds its run for the
-    /// ten minutes the runtime waits before giving up on one. A scenario about
-    /// delegation that happens to trip a permission request would otherwise
-    /// spend its whole settle window waiting for a click that is never coming,
-    /// and fail as though the crew had never stopped talking. That is exactly
-    /// how a knee question in a crew of three read: two messages, one of them
-    /// blank, and five minutes of nothing.
-    ///
-    /// Declined rather than allowed, and not negotiable: the actions behind
-    /// this tool are the ones that reach outside the workspace and cannot be
-    /// taken back. An eval is not a good enough reason to send mail in the
-    /// operator's name. What was asked is returned so the scenario can print
-    /// it, because an answer nobody sees still shapes the run.
-    fn answer_permission_requests(
-        h: &Harness,
-    ) -> (tokio::task::JoinHandle<()>, std::sync::Arc<parking_lot::Mutex<Vec<String>>>) {
-        let asked = std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
-        let runtime = h.runtime.clone();
-        let sink = h.sink.clone();
-        let recorded = asked.clone();
-
-        let handle = tokio::spawn(async move {
-            let mut answered = std::collections::HashSet::new();
-            loop {
-                let requests: Vec<_> = sink
-                    .snapshot()
-                    .into_iter()
-                    .filter_map(|event| match event {
-                        guac_lib::runtime::events::UiEvent::ApprovalRequested {
-                            approval_id,
-                            ..
-                        } => Some(approval_id),
-                        _ => None,
-                    })
-                    .collect();
-                for id in requests {
-                    if !answered.insert(id) {
-                        continue;
-                    }
-                    recorded.lock().push(id.short());
-                    if let Err(err) = runtime.decide_approval(id, Decision::Deny) {
-                        eprintln!("could not decline {}: {err}", id.short());
-                    }
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-            }
-        });
-
-        (handle, asked)
-    }
-
-    /// Every sandbox this account holds, by id.
-    async fn machines_now(config: &guac_lib::config::AppConfig) -> Vec<String> {
-        match guac_lib::e2b::E2bClient::new(&config.e2b.api_key) {
-            Some(client) => client.list_ours().await.unwrap_or_default(),
-            None => Vec::new(),
-        }
-    }
-
-    /// Kills whatever this run brought into existence, and nothing else.
-    ///
-    /// A diff against a baseline rather than a walk over the crew's rows. An
-    /// agent whose first machine does not answer starts another and records
-    /// only the newest, so the rows name one of the several a single run can
-    /// leave behind; seventeen survived a cleanup written that way.
-    ///
-    /// It is also why `Runtime::sweep_computers` cannot be borrowed for this.
-    /// That kills every Guac sandbox its own store does not claim, so run from
-    /// a throwaway store it would spare this crew's machines and take the
-    /// operator's running app apart instead.
-    async fn release_machines(config: &guac_lib::config::AppConfig, before: Vec<String>) {
-        let Some(client) = guac_lib::e2b::E2bClient::new(&config.e2b.api_key) else {
-            return;
-        };
-        let existing: std::collections::HashSet<String> = before.into_iter().collect();
-        for sandbox in client.list_ours().await.unwrap_or_default() {
-            if existing.contains(&sandbox) {
-                continue;
-            }
-            match client.kill(&sandbox).await {
-                Ok(()) => println!("released {sandbox}"),
-                Err(err) => eprintln!("could not release {sandbox}: {err}"),
-            }
-        }
     }
 
     fn report(scenario: &str, eval: &Eval) {
@@ -1832,88 +1714,4 @@ mod live {
         );
         eval.expect_told_operator("Assistant", 1, "a standing preference");
     }
-}
-
-/// One agent in a live crew.
-///
-/// Skills are here because a scenario about who should get a piece of work is
-/// not testable without them: a crew of four agents with no stated skills gives
-/// a coordinator nothing to choose between, and the broadcast it produces is
-/// then the right answer.
-struct LiveAgent {
-    name: &'static str,
-    skills: &'static [&'static str],
-    /// `None` takes a serviceable default. `Some("")` means the card really
-    /// carries no instructions, which is how most agents are created and is
-    /// what the workspace rules have to hold up without.
-    prompt: Option<&'static str>,
-    /// Overrides the configured default. A crew is not obliged to share a
-    /// model, and a coordinator on a different one from the agents it directs
-    /// is the arrangement that produced the defect these evals were written
-    /// for: putting everyone on the default quietly tests a different app.
-    model: Option<&'static str>,
-}
-
-impl LiveAgent {
-    /// An agent for scenarios that are not about who does what.
-    fn generic(name: &'static str) -> Self {
-        LiveAgent { name, skills: &[], prompt: None, model: None }
-    }
-
-    /// A specialist, described only by what it does.
-    ///
-    /// `Some("")` rather than a default sentence, because a card with no
-    /// instructions is how most agents are created and is what the workspace
-    /// rules have to hold up without: a scenario whose specialists each carry a
-    /// hand-written brief is testing the brief.
-    fn skilled(name: &'static str, skills: &'static [&'static str]) -> Self {
-        LiveAgent { name, skills, prompt: Some(""), model: None }
-    }
-
-    fn system_prompt(&self) -> String {
-        match self.prompt {
-            Some(prompt) => prompt.to_string(),
-            None => format!(
-                "You are the {}. Work with your team the way the workspace rules say.",
-                self.name
-            ),
-        }
-    }
-}
-
-/// A harness pointed at the real configured endpoint rather than a stub.
-fn live_crew(config: guac_lib::config::AppConfig, crew: &[LiveAgent]) -> Harness {
-    let dir = tempfile::tempdir().unwrap();
-    let store = guac_lib::db::Store::open(&dir.path().join("guac.db")).unwrap();
-
-    let mut ids = HashMap::new();
-    for agent in crew {
-        let card = store
-            .create_agent(&CleanDraft {
-                name: agent.name.to_string(),
-                avatar: "plain".into(),
-                color: "#c7d96b".into(),
-                model: agent
-                    .model
-                    .map(str::to_string)
-                    .unwrap_or_else(|| config.inference.default_model.clone()),
-                system_prompt: agent.system_prompt(),
-                skills: agent.skills.iter().map(|s| (*s).to_string()).collect(),
-                group_id: None,
-            })
-            .unwrap();
-        ids.insert(agent.name.to_string(), card.id);
-    }
-
-    let sink = guac_lib::runtime::events::RecordingSink::new();
-    let runtime = guac_lib::runtime::Runtime::new(
-        store,
-        guac_lib::llm::openrouter::LlmClient::new().unwrap(),
-        config,
-        guac_lib::workspace::Workspace::new(dir.path().join("workspace")),
-        guac_lib::files::FileStore::new(dir.path().join("files")),
-        sink.clone(),
-    );
-    runtime.start_all().unwrap();
-    Harness { runtime, sink, ids, _dir: dir }
 }

--- a/src-tauri/tests/harness/live.rs
+++ b/src-tauri/tests/harness/live.rs
@@ -1,0 +1,249 @@
+//! A crew on the operator's own endpoint, with a real model answering.
+//!
+//! Everything here reaches the network and spends money, so nothing that uses
+//! it runs in CI. It is shared rather than owned by one suite because two ask
+//! live questions now: `evals.rs` asks whether a crew communicates like
+//! something worth watching, and `crew.rs` asks what a whole team does with one
+//! directive and what is different when you ask again. A second copy of this
+//! would drift, and the half that drifts without anybody noticing is the
+//! cleanup: a machine left running bills for its idle period whether or not the
+//! scenario that started it passed.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use guac_lib::config::AppConfig;
+use guac_lib::db::Store;
+use guac_lib::domain::agent::CleanDraft;
+use guac_lib::domain::approval::Decision;
+use guac_lib::files::FileStore;
+use guac_lib::llm::openrouter::LlmClient;
+use guac_lib::runtime::events::{EventSink, NullSink, RecordingSink, UiEvent};
+use guac_lib::runtime::Runtime;
+use guac_lib::workspace::Workspace;
+
+use super::Harness;
+
+/// One agent in a live crew.
+///
+/// Skills are here because a scenario about who should get a piece of work is
+/// not testable without them: a crew of four agents with no stated skills gives
+/// a coordinator nothing to choose between, and the broadcast it produces is
+/// then the right answer.
+pub struct LiveAgent {
+    pub name: &'static str,
+    pub skills: &'static [&'static str],
+    /// `None` takes a serviceable default. `Some("")` means the card really
+    /// carries no instructions, which is how most agents are created and is
+    /// what the workspace rules have to hold up without.
+    pub prompt: Option<&'static str>,
+    /// Overrides the configured default. A crew is not obliged to share a
+    /// model, and a coordinator on a different one from the agents it directs
+    /// is the arrangement that produced the defect these evals were written
+    /// for: putting everyone on the default quietly tests a different app.
+    pub model: Option<&'static str>,
+}
+
+impl LiveAgent {
+    /// An agent for scenarios that are not about who does what.
+    pub fn generic(name: &'static str) -> Self {
+        LiveAgent { name, skills: &[], prompt: None, model: None }
+    }
+
+    /// A specialist, described only by what it does.
+    ///
+    /// `Some("")` rather than a default sentence, because a card with no
+    /// instructions is how most agents are created and is what the workspace
+    /// rules have to hold up without: a scenario whose specialists each carry a
+    /// hand-written brief is testing the brief.
+    pub fn skilled(name: &'static str, skills: &'static [&'static str]) -> Self {
+        LiveAgent { name, skills, prompt: Some(""), model: None }
+    }
+
+    /// The same, carrying the standing instruction an operator would type on
+    /// the one agent they talk to.
+    pub fn told(name: &'static str, skills: &'static [&'static str], prompt: &'static str) -> Self {
+        LiveAgent { name, skills, prompt: Some(prompt), model: None }
+    }
+
+    pub fn system_prompt(&self) -> String {
+        match self.prompt {
+            Some(prompt) => prompt.to_string(),
+            None => format!(
+                "You are the {}. Work with your team the way the workspace rules say.",
+                self.name
+            ),
+        }
+    }
+}
+
+/// The operator's own settings, or nothing when no key has been pasted.
+///
+/// The model, endpoint and key come from the app's settings file rather than
+/// from the test, so what a live scenario measures is what the operator is
+/// actually running.
+pub fn configured() -> Option<AppConfig> {
+    let path = dirs_config()?;
+    let raw = std::fs::read_to_string(path).ok()?;
+    let config: AppConfig = serde_json::from_str(&raw).ok()?;
+    (!config.inference.api_key.trim().is_empty()).then_some(config)
+}
+
+fn dirs_config() -> Option<std::path::PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(
+        std::path::PathBuf::from(home)
+            .join("Library/Application Support/com.madebywelch.guac/config.json"),
+    )
+}
+
+/// A harness pointed at the real configured endpoint rather than at a stub.
+pub fn live_crew(config: AppConfig, crew: &[LiveAgent]) -> Harness {
+    live_crew_watched(config, crew, Arc::new(NullSink))
+}
+
+/// The same, with a second reader on every event the runtime emits.
+///
+/// The recording sink the harness keeps is memory, and memory is gone when a
+/// run overruns and takes the process with it. A watcher that writes as events
+/// arrive is what leaves a record of exactly the runs worth reading: the ones
+/// that did not finish.
+pub fn live_crew_watched(
+    config: AppConfig,
+    crew: &[LiveAgent],
+    watching: Arc<dyn EventSink>,
+) -> Harness {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open(&dir.path().join("guac.db")).unwrap();
+
+    let mut ids = HashMap::new();
+    for agent in crew {
+        let card = store
+            .create_agent(&CleanDraft {
+                name: agent.name.to_string(),
+                avatar: "plain".into(),
+                color: "#c7d96b".into(),
+                model: agent
+                    .model
+                    .map(str::to_string)
+                    .unwrap_or_else(|| config.inference.default_model.clone()),
+                system_prompt: agent.system_prompt(),
+                skills: agent.skills.iter().map(|s| (*s).to_string()).collect(),
+                group_id: None,
+            })
+            .unwrap();
+        ids.insert(agent.name.to_string(), card.id);
+    }
+
+    let kept = RecordingSink::new();
+    let runtime = Runtime::new(
+        store,
+        LlmClient::new().unwrap(),
+        config,
+        Workspace::new(dir.path().join("workspace")),
+        FileStore::new(dir.path().join("files")),
+        Arc::new(Tee { watching, kept: kept.clone() }),
+    );
+    runtime.start_all().unwrap();
+    Harness { runtime, sink: kept, ids, _dir: dir }
+}
+
+/// One event, two readers.
+struct Tee {
+    watching: Arc<dyn EventSink>,
+    kept: Arc<RecordingSink>,
+}
+
+impl EventSink for Tee {
+    fn emit(&self, event: UiEvent) {
+        // The watcher first: it is the one that might be a file, and a record
+        // on disk is worth more than the order these two are called in.
+        self.watching.emit(event.clone());
+        self.kept.emit(event);
+    }
+}
+
+/// Answers whatever the crew asks the operator, with no.
+///
+/// A live crew has no operator, and a parked turn holds its run for the ten
+/// minutes the runtime waits before giving up on one. A scenario about
+/// delegation that happens to trip a permission request would otherwise spend
+/// its whole settle window waiting for a click that is never coming, and fail
+/// as though the crew had never stopped talking. That is exactly how a knee
+/// question in a crew of three read: two messages, one of them blank, and five
+/// minutes of nothing.
+///
+/// Declined rather than allowed, and not negotiable: the actions behind this
+/// tool are the ones that reach outside the workspace and cannot be taken back.
+/// An eval is not a good enough reason to send mail in the operator's name.
+/// What was asked is returned so the scenario can print it, because an answer
+/// nobody sees still shapes the run.
+pub fn answer_permission_requests(
+    h: &Harness,
+) -> (tokio::task::JoinHandle<()>, Arc<parking_lot::Mutex<Vec<String>>>) {
+    let asked = Arc::new(parking_lot::Mutex::new(Vec::new()));
+    let runtime = h.runtime.clone();
+    let sink = h.sink.clone();
+    let recorded = asked.clone();
+
+    let handle = tokio::spawn(async move {
+        let mut answered = std::collections::HashSet::new();
+        loop {
+            let requests: Vec<_> = sink
+                .snapshot()
+                .into_iter()
+                .filter_map(|event| match event {
+                    UiEvent::ApprovalRequested { approval_id, .. } => Some(approval_id),
+                    _ => None,
+                })
+                .collect();
+            for id in requests {
+                if !answered.insert(id) {
+                    continue;
+                }
+                recorded.lock().push(id.short());
+                if let Err(err) = runtime.decide_approval(id, Decision::Deny) {
+                    eprintln!("could not decline {}: {err}", id.short());
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+    });
+
+    (handle, asked)
+}
+
+/// Every sandbox this account holds, by id.
+pub async fn machines_now(config: &AppConfig) -> Vec<String> {
+    match guac_lib::e2b::E2bClient::new(&config.e2b.api_key) {
+        Some(client) => client.list_ours().await.unwrap_or_default(),
+        None => Vec::new(),
+    }
+}
+
+/// Kills whatever this run brought into existence, and nothing else.
+///
+/// A diff against a baseline rather than a walk over the crew's rows. An agent
+/// whose first machine does not answer starts another and records only the
+/// newest, so the rows name one of the several a single run can leave behind;
+/// seventeen survived a cleanup written that way.
+///
+/// It is also why `Runtime::sweep_computers` cannot be borrowed for this. That
+/// kills every Guac sandbox its own store does not claim, so run from a
+/// throwaway store it would spare this crew's machines and take the operator's
+/// running app apart instead.
+pub async fn release_machines(config: &AppConfig, before: Vec<String>) {
+    let Some(client) = guac_lib::e2b::E2bClient::new(&config.e2b.api_key) else {
+        return;
+    };
+    let existing: std::collections::HashSet<String> = before.into_iter().collect();
+    for sandbox in client.list_ours().await.unwrap_or_default() {
+        if existing.contains(&sandbox) {
+            continue;
+        }
+        match client.kill(&sandbox).await {
+            Ok(()) => println!("released {sandbox}"),
+            Err(err) => eprintln!("could not release {sandbox}: {err}"),
+        }
+    }
+}

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -11,6 +11,10 @@
 //! replied" is exercised: tool-call assembly, the guard, channel routing, batch
 //! coalescing, and settle detection. The only thing swapped out is the model.
 
+/// The same runtime pointed at the operator's own endpoint rather than at the
+/// stub below. Nothing that uses it runs in CI.
+pub mod live;
+
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -715,6 +719,28 @@ impl Harness {
             .map(|e| e.plain_text())
             .filter(|t| !t.is_empty())
             .collect()
+    }
+
+    /// Every message filed in any of these agents' channels, in order, once
+    /// each.
+    ///
+    /// Not `feed`, which is built for the activity view and keeps only
+    /// agent-to-agent traffic: it cannot see what the operator was told, and it
+    /// cannot see the system channel, which is where refusals are recorded. A
+    /// reader blind to a refusal cannot tell a guard doing its job from a
+    /// message that silently went nowhere.
+    pub fn envelopes(&self, names: &[&str]) -> Vec<Envelope> {
+        let mut messages: Vec<Envelope> = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for name in names {
+            for envelope in self.runtime.store().channel_messages(self.id(name), 400).unwrap() {
+                if seen.insert(envelope.id) {
+                    messages.push(envelope);
+                }
+            }
+        }
+        messages.sort_by_key(|e| (e.created_at, e.id));
+        messages
     }
 
     /// Peer traffic only, which is what most of these tests reason about.


### PR DESCRIPTION
A fourth live suite, `src-tauri/tests/crew.rs` with `scripts/crew.sh`: eight roles, one directive to the Chief of Staff, run as many times as `GUACA_RUNS` asks for, with every run's events, envelopes, transcript and numbers written to a gitignored `runs/<timestamp>/` and a comparison beside them saying what differed between runs given identical instructions.

It asserts only the three things that are not a matter of taste (every run settled, no run left the machinery in a state `trajectory.rs` calls broken, somebody answered the operator), because a real model divides the work differently every time and the rest is a finding to read rather than a rule to enforce.

The live plumbing moves out of `evals.rs` into `harness/live.rs` so both live suites share one crew builder and one machine cleanup, and `Harness::envelopes` replaces a loop that was duplicated between them. `AGENTS.md` and `docs/ARCHITECTURE.md` say when to run it and what it is for.

Five runs on `openai/gpt-5.6-luna` cost $0.20 and came out bimodal: two clean, three cascading to 15-20 messages at the operator and hop 6 to 8, with zero trajectory anomalies in any of them.