### PR TITLE
fix: the plugin panel names the Guaca account, and does not claim a grant it has not made

### DIFF
--- a/src/components/PluginList.test.tsx
+++ b/src/components/PluginList.test.tsx
@@ -469,6 +469,15 @@ describe("PluginList", () => {
  * reached whichever the service returned first.
  */
 describe("choosing which account a crew uses", () => {
+  /**
+   * Matches against an element's whole text content.
+   *
+   * The default matcher reads only an element's direct text-node children, and
+   * these sentences are built from several JSX interpolations, so it sees each
+   * fragment separately and matches none of them.
+   */
+  const saying = (pattern: RegExp) => (_content: string, element: Element | null) =>
+    element?.tagName === "P" && pattern.test(element.textContent ?? "");
   const GOOGLE_OFFER: PluginOffer = {
     kind: "google",
     name: "Google",
@@ -500,8 +509,46 @@ describe("choosing which account a crew uses", () => {
     groupPlugins.mockResolvedValue([plugin({ kind: "google", connection: "acct_work" })]);
     render(<PluginList groupId={GROUP} crew={CREW} />);
 
-    await waitFor(() => expect(screen.getByText(/Acting as work@example.com/)).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByText(saying(/Acting as work@example.com/))).toBeTruthy(),
+    );
     expect(screen.queryByLabelText(/^Account/)).toBeNull();
+  });
+
+  it("does not claim a group is acting as anyone before it is connected", async () => {
+    // A group with nothing connected is not acting as anybody, and saying it is
+    // reads as a grant that exists and does not.
+    accountConnectors.mockResolvedValue(one);
+    groupPlugins.mockResolvedValue([]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    await waitFor(() => expect(screen.getByText(saying(/Will connect as/))).toBeTruthy());
+    expect(screen.queryByText(saying(/Acting as/))).toBeNull();
+  });
+
+  it("names the Guaca account the identities came from", async () => {
+    // The failure that costs the most time is a machine signed in to the
+    // account that does not hold the grant the operator is looking at in a
+    // browser. Nothing else on this panel can tell those two apart.
+    accountConnectors.mockResolvedValue(one);
+    groupPlugins.mockResolvedValue([plugin({ kind: "google", connection: "acct_work" })]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    expect(
+      await screen.findByText(saying(/from your Guaca account robert@example.com/)),
+    ).toBeTruthy();
+  });
+
+  it("names it in the empty state too, which is where it matters most", async () => {
+    accountConnectors.mockResolvedValue({ ...two, connections: [] });
+    groupPlugins.mockResolvedValue([]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    expect(
+      await screen.findByText(
+        saying(/No Google account is authorized on your Guaca account, robert@example.com/),
+      ),
+    ).toBeTruthy();
   });
 
   it("offers the picker before connecting, not only after", async () => {
@@ -536,9 +583,7 @@ describe("choosing which account a crew uses", () => {
     groupPlugins.mockResolvedValue([]);
     render(<PluginList groupId={GROUP} crew={CREW} />);
 
-    expect(
-      await screen.findByText(/No Google account is authorized on your Guaca account yet/),
-    ).toBeTruthy();
+    expect(await screen.findByText(saying(/No Google account is authorized/))).toBeTruthy();
     expect(screen.getByText("Authorize a Google account")).toBeTruthy();
   });
 

--- a/src/components/PluginList.tsx
+++ b/src/components/PluginList.tsx
@@ -173,6 +173,11 @@ export function PluginList({ groupId, crew }: Props) {
   // which is why a failure here is swallowed rather than surfaced: it means
   // there is nothing to choose between, not that the panel is broken.
   const [connections, setConnections] = useState<AccountConnection[]>([]);
+  // Which Guaca account those came from. Named on screen because an operator
+  // can have more than one, and the failure that costs the most time is a
+  // machine signed in to the account that does not hold the grant they are
+  // looking at in a browser. Nothing else can tell them apart.
+  const [accountEmail, setAccountEmail] = useState<string>("");
   // Which identity the operator picked for a plugin that is not connected yet,
   // keyed by kind. Only ever holds a pre-connect choice: once connected, the
   // stored row is what the picker reads, because that is what a turn will use.
@@ -192,8 +197,14 @@ export function PluginList({ groupId, crew }: Props) {
       // not keep the plugin list from drawing.
       void api
         .accountConnectors()
-        .then((account) => setConnections(account.connections))
-        .catch(() => setConnections([]));
+        .then((account) => {
+          setConnections(account.connections);
+          setAccountEmail(account.email);
+        })
+        .catch(() => {
+          setConnections([]);
+          setAccountEmail("");
+        });
     } catch (caught) {
       setError(errorMessage(caught));
       setOffers([]);
@@ -292,8 +303,9 @@ export function PluginList({ groupId, crew }: Props) {
               (mine.length === 0 ? (
                 <div className="access__empty">
                   <p className="field__hint">
-                    No {offer.name} account is authorized on your Guaca account yet. Authorize one,
-                    then connect it here.
+                    No {offer.name} account is authorized on
+                    {accountEmail ? ` your Guaca account, ${accountEmail}` : " your Guaca account"}.
+                    Authorize one there, then connect it here.
                   </p>
                   <button
                     type="button"
@@ -309,8 +321,12 @@ export function PluginList({ groupId, crew }: Props) {
                 // It is still said out loud: a crew acting as somebody's mail
                 // should never leave you guessing whose.
                 <p className="field__hint">
-                  Acting as{" "}
-                  {mine.find((connection) => connection.id === using)?.label ?? mine[0]?.label}.
+                  {/* Tense matters. A group that has not connected this plugin
+                      is not acting as anybody, and saying it is reads as a
+                      grant that exists and does not. */}
+                  {held ? "Acting as " : "Will connect as "}
+                  {mine.find((connection) => connection.id === using)?.label ?? mine[0]?.label}
+                  {accountEmail ? `, from your Guaca account ${accountEmail}.` : "."}
                 </p>
               ) : (
                 <label className="field">
@@ -341,7 +357,8 @@ export function PluginList({ groupId, crew }: Props) {
                     ))}
                   </select>
                   <span className="field__hint">
-                    Which {offer.name} account this crew acts as.{" "}
+                    Which {offer.name} account this crew acts as
+                    {accountEmail ? `, from your Guaca account ${accountEmail}` : ""}.{" "}
                     {held
                       ? "Its tools are re-read when you change it, because two accounts do not always authorize the same things."
                       : "Pick before connecting; you can change it afterwards."}


### PR DESCRIPTION
Two failures, and the second is why the first cost hours.

A group with nothing connected still read "Acting as someone@example.com". It
was not acting as anybody: the line renders whether or not the plugin is
connected, and the tense never changed with it. A sentence claiming a grant that
does not exist is worse than no sentence.

The panel also never said which Guaca account the identities came from. An
operator can have more than one — signing in with a second address makes a
second account, quietly and correctly — and their provider grants then live
under whichever account authorized them. A machine signed in to one of those
while a browser is signed in to the other shows a Plugins panel with one Google
and a dashboard with two, and nothing on either screen can tell you why. That is
exactly the state this was reported from.

So both places now name it: the picker, the single-identity line, and the empty
state, which is where it matters most. "No Google account is authorized on your
Guaca account, robert@example.com" is a sentence somebody can act on. "No Google
account is authorized" is not.

Both were rendered and looked at before this was committed, rather than trusted
to the tests. The previous two rounds of this feature were not, and both shipped
wrong.