### PR TITLE
fix: the plus is at the top of the rail, where the list it adds to is

### DIFF
--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -566,7 +566,7 @@ An agent is drawn once, wherever it is drawn: two rows for one agent would be tw
 nodes in the sidebar's `rowRefs`, and the wire would have to pick one to throw a
 message at.
 
-## Making something is one plus, and it is not in the rail
+## Making something is one plus, at the top of the rail
 
 The rail's footer used to carry four rows: the cafeteria, a new agent, a new
 group, and settings. Two of those are places you go and two are things you make,
@@ -574,11 +574,19 @@ and the two kinds sat together because the footer was where there was room. It
 also grew by a row every time something new became makeable, which is a footer
 that gets worse as the app gets better.
 
-Now there is one plus, at the end of the channel header, and it lists what can
-be made. The rail keeps the two places. The plus is at the top of the reading
-column rather than in the rail because the rail is a list of agents and this is
-not about any of them, and because the header is the one bar that is drawn
-whichever channel is open.
+Now there is one plus, beside the wordmark at the top of the rail, and it lists
+what can be made. The footer keeps the two places.
+
+It spent a release at the end of the channel header instead, on the argument
+that the rail is a list of agents and making one is about none of them. That is
+the wrong half of the argument, and the report that ended it came from the
+person who wrote it: an agent is a row in the rail and a group is a heading in
+it, so the rail is where somebody looks to add one, and a plus glyph at the far
+right of the reading column, beside the agent's own actions menu, is not
+somewhere anybody looks at all. The channel header was also the one place the
+plus could not be drawn on an empty workspace, because there is no channel open
+to hang a header on, and that is the state where making an agent is the only
+thing left to do.
 
 It is the shared menu, so it closes on Escape, on a click that lands away from
 it, and on anything that moves the button underneath it. The listeners are bound

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -201,6 +201,8 @@ export default function App() {
         onEditGroup={(group) => setEditingGroup(group)}
         onOpenSettings={() => setShowSettings(true)}
         onOpenSearch={() => setSearching(true)}
+        onNewAgent={() => setEditing("new")}
+        onNewGroup={() => setEditingGroup("new")}
         onOpenMenu={(agent, at) => setMenu({ agent, ...at })}
       />
 
@@ -256,8 +258,6 @@ export default function App() {
           <ChannelView
             channel={selected ?? ACTIVITY_CHANNEL}
             onOpenMenu={(agent, at) => setMenu({ agent, ...at })}
-            onNewAgent={() => setEditing("new")}
-            onNewGroup={() => setEditingGroup("new")}
           />
         )}
       </main>

--- a/src/components/ChannelView.perf.test.tsx
+++ b/src/components/ChannelView.perf.test.tsx
@@ -134,14 +134,7 @@ describe("ChannelView under streaming load", () => {
   });
 
   function draw() {
-    render(
-      <ChannelView
-        channel={AGENT}
-        onOpenMenu={() => {}}
-        onNewAgent={() => {}}
-        onNewGroup={() => {}}
-      />,
-    );
+    render(<ChannelView channel={AGENT} onOpenMenu={() => {}} />);
     rendersOfMessages = 0;
   }
 

--- a/src/components/ChannelView.test.tsx
+++ b/src/components/ChannelView.test.tsx
@@ -107,14 +107,7 @@ function open(messages: Envelope[]) {
     lastActive: {},
     banner: null,
   });
-  return render(
-    <ChannelView
-      channel={MANAGER}
-      onOpenMenu={() => {}}
-      onNewAgent={() => {}}
-      onNewGroup={() => {}}
-    />,
-  );
+  return render(<ChannelView channel={MANAGER} onOpenMenu={() => {}} />);
 }
 
 beforeEach(() => {
@@ -578,21 +571,9 @@ describe("a transcript scrolled up", () => {
     });
 
     const { container, rerender } = render(
-      <ChannelView
-        channel={ACTIVITY_CHANNEL}
-        onOpenMenu={() => {}}
-        onNewAgent={() => {}}
-        onNewGroup={() => {}}
-      />,
+      <ChannelView channel={ACTIVITY_CHANNEL} onOpenMenu={() => {}} />,
     );
-    rerender(
-      <ChannelView
-        channel={MANAGER}
-        onOpenMenu={() => {}}
-        onNewAgent={() => {}}
-        onNewGroup={() => {}}
-      />,
-    );
+    rerender(<ChannelView channel={MANAGER} onOpenMenu={() => {}} />);
 
     const scroller = container.querySelector<HTMLElement>(".pane__scroll");
     if (!scroller) throw new Error("no transcript to scroll");

--- a/src/components/ChannelView.tsx
+++ b/src/components/ChannelView.tsx
@@ -18,7 +18,6 @@ import {
 import { ActivityFlow } from "./ActivityFlow";
 import { Composer } from "./Composer";
 import { MessageItem, StreamingMessage, WhenRow } from "./MessageItem";
-import { NewMenu } from "./NewMenu";
 import { PairThread } from "./PairThread";
 import { TrailRow } from "./Trail";
 import { PeerBurstRow, RefusedRow, WritingRow } from "./WireRow";
@@ -27,9 +26,6 @@ interface Props {
   channel: ChannelKey;
   /** Where the operator asked for an agent's actions, and on whom. */
   onOpenMenu: (agent: AgentCard, at: { x: number; y: number }) => void;
-  /** The plus at the end of the header. App-level, not this channel's. */
-  onNewAgent: () => void;
-  onNewGroup: () => void;
 }
 
 /** How long a message arrived at from search stays marked. */
@@ -45,7 +41,7 @@ const FLASH_MS = 1800;
  */
 const WAITED_MS = 1000;
 
-export function ChannelView({ channel, onOpenMenu, onNewAgent, onNewGroup }: Props) {
+export function ChannelView({ channel, onOpenMenu }: Props) {
   const lookups = useAgentLookup();
   const messages = useStore((s) => s.messages[channel]);
   const activity = useStore((s) => s.activity);
@@ -167,9 +163,6 @@ export function ChannelView({ channel, onOpenMenu, onNewAgent, onNewGroup }: Pro
         ) : (
           <h1 className="pane__title">Channel unavailable</h1>
         )}
-        {/* Last, and after the conditional, so it is the same control in the
-            same place whichever of the three the header is drawing. */}
-        <NewMenu onNewAgent={onNewAgent} onNewGroup={onNewGroup} />
       </header>
 
       {isActivity ? (

--- a/src/components/NewMenu.tsx
+++ b/src/components/NewMenu.tsx
@@ -15,10 +15,16 @@ const MARGIN = 8;
  * you go. That put the rarest thing an operator does — making a crew — beside
  * the thing they do constantly, and it grew the footer by a row every time
  * something new became makeable. A plus is the one control that can absorb the
- * next one without the rail paying for it.
+ * next one without the rail paying for it, which is why it is a menu.
  *
- * It lives at the end of the channel header rather than in the rail because the
- * rail is a list of agents and this is not about any of them.
+ * It sits at the top of the rail, beside the wordmark. It spent a while at the
+ * end of the channel header instead, on the grounds that the rail is a list of
+ * agents and this is about none of them, and that turned out to be the wrong
+ * half of the argument: an agent is a row in the rail and a group is a heading
+ * in it, so the rail is exactly where somebody looks to add one. It was also
+ * the one place the plus could not be drawn when the workspace is empty, since
+ * there is no channel open to hang a header on, which is the state where making
+ * an agent is the only thing left to do.
  */
 export function NewMenu({ onNewAgent, onNewGroup }: Props) {
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -26,9 +32,10 @@ export function NewMenu({ onNewAgent, onNewGroup }: Props) {
   const [open, setOpen] = useState(false);
   const [at, setAt] = useState({ x: 0, y: 0 });
 
-  // Measured after it is in the tree, like every other menu here: the button
-  // sits at the right edge of a column whose width is the window's, so a menu
-  // laid out from the button's left would hang off the side of the app.
+  // Measured after it is in the tree, like every other menu here. It opens to
+  // the right because the button is near the left edge of the window: laid out
+  // from the button's right edge, a menu wider than the rail would be clamped
+  // to the window and end up beside the plus rather than under it.
   useLayoutEffect(() => {
     const button = buttonRef.current;
     const menu = menuRef.current;
@@ -36,9 +43,9 @@ export function NewMenu({ onNewAgent, onNewGroup }: Props) {
     const anchor = button.getBoundingClientRect();
     const { width, height } = menu.getBoundingClientRect();
     setAt({
-      // Right edges aligned, then pulled back inside the window if that is not
+      // Left edges aligned, then pulled back inside the window if that is not
       // where it fits.
-      x: Math.max(MARGIN, Math.min(anchor.right - width, window.innerWidth - width - MARGIN)),
+      x: Math.min(Math.max(MARGIN, anchor.left), window.innerWidth - width - MARGIN),
       y: Math.min(anchor.bottom + 4, window.innerHeight - height - MARGIN),
     });
   }, [open]);
@@ -84,7 +91,7 @@ export function NewMenu({ onNewAgent, onNewGroup }: Props) {
       <button
         type="button"
         ref={buttonRef}
-        className="pane__new"
+        className="rail__new"
         aria-label="Make something new"
         title="Make something new"
         aria-haspopup="menu"

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -67,16 +67,24 @@ function draw(groups: Group[], agents: AgentCard[] = [], activity: Record<string
     selected: null,
     railGroup: null,
   });
-  return render(
-    <Sidebar
-      onEditAgent={vi.fn()}
-      onEditGroup={vi.fn()}
-      onOpenCafeteria={vi.fn()}
-      onOpenSettings={vi.fn()}
-      onOpenSearch={vi.fn()}
-      onOpenMenu={vi.fn()}
-    />,
-  );
+  const onNewAgent = vi.fn();
+  const onNewGroup = vi.fn();
+  return {
+    ...render(
+      <Sidebar
+        onEditAgent={vi.fn()}
+        onEditGroup={vi.fn()}
+        onOpenCafeteria={vi.fn()}
+        onOpenSettings={vi.fn()}
+        onOpenSearch={vi.fn()}
+        onNewAgent={onNewAgent}
+        onNewGroup={onNewGroup}
+        onOpenMenu={vi.fn()}
+      />,
+    ),
+    onNewAgent,
+    onNewGroup,
+  };
 }
 
 /** A row, by the name written in it. */
@@ -128,6 +136,29 @@ describe("group header", () => {
 
     expect(container.querySelector(".rail__group-head")?.textContent).toContain("everyone");
     expect(screen.queryByText(MODEL)).toBeNull();
+  });
+});
+
+describe("the plus", () => {
+  /**
+   * Two things the channel header it used to sit in could not give it. There it
+   * was drawn at the far right of the reading column beside the agent's own
+   * actions menu, which is not where anybody looks to add an agent; and on an
+   * empty workspace there is no channel open to draw a header at all.
+   */
+  it("is drawn with nothing in the workspace, which is when it is the only thing to do", () => {
+    draw([], []);
+
+    expect(screen.getByRole("button", { name: /make something new/i })).toBeTruthy();
+  });
+
+  it("makes a group from the rail, which is the list a group is a heading in", () => {
+    const { onNewGroup } = draw([group("everyone")], [agent("Manager")]);
+
+    fireEvent.click(screen.getByRole("button", { name: /make something new/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /new group/i }));
+
+    expect(onNewGroup).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import { ACTIVITY_CHANNEL, useLiveAgents, useStore } from "../lib/store";
 import { relativeTime, useNow } from "../lib/time";
 import type { Activity, AgentCard, AgentId, Group } from "../lib/types";
 import { GroupOrb } from "./GroupOrb";
+import { NewMenu } from "./NewMenu";
 import { TokenMeter } from "./TokenMeter";
 
 interface Props {
@@ -16,6 +17,9 @@ interface Props {
   onOpenCafeteria: () => void;
   onOpenSettings: () => void;
   onOpenSearch: () => void;
+  /** The plus beside the wordmark. App-level, not any one row's. */
+  onNewAgent: () => void;
+  onNewGroup: () => void;
   /** Where the operator right-clicked, and on whom. */
   onOpenMenu: (agent: AgentCard, at: { x: number; y: number }) => void;
 }
@@ -52,6 +56,8 @@ export function Sidebar({
   onOpenCafeteria,
   onOpenSettings,
   onOpenSearch,
+  onNewAgent,
+  onNewGroup,
   onOpenMenu,
 }: Props) {
   const agents = useLiveAgents();
@@ -382,8 +388,12 @@ export function Sidebar({
 
   return (
     <nav className="rail" aria-label="Agents" data-dragging={drag ? "true" : undefined}>
+      {/* The plus rides the drag region rather than sitting under it: a button
+          inside one is still a button, and this is the row an operator reads
+          first. */}
       <div className="rail__brand" data-tauri-drag-region>
         <span className="rail__wordmark">Guaca</span>
+        <NewMenu onNewAgent={onNewAgent} onNewGroup={onNewGroup} />
       </div>
 
       {/* Looks like a field and behaves like a button, because the field it
@@ -551,9 +561,8 @@ export function Sidebar({
       </div>
 
       {/* Two rows, not four. Making somebody moved to the plus at the top of
-          the reading column, which is where every other "add one of these" in
-          this app now lives; what is left down here is the two places you go
-          rather than the two things you make. */}
+          this rail; what is left down here is the two places you go rather than
+          the two things you make. */}
       <div className="rail__foot">
         <button type="button" className="btn btn--rail" onClick={onOpenCafeteria}>
           <span aria-hidden="true" className="rail__hash">

--- a/src/styles.css
+++ b/src/styles.css
@@ -263,6 +263,37 @@ button {
   color: var(--rail-text);
 }
 
+/* The one plus in the app, at the top of the list it adds to. Drawn at the
+   rail's full text weight rather than the muted weight its other chrome uses:
+   the wordmark beside it is the only thing on this row, and a control that is
+   the only way to make an agent cannot be quieter than the furniture. */
+.rail__new {
+  margin-left: auto;
+  flex: none;
+  width: 1.6rem;
+  height: 1.6rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--rail-edge);
+  background: var(--rail-raised);
+  color: var(--rail-text);
+  font-size: 1.05rem;
+  line-height: 1;
+  border-radius: var(--radius-sm);
+  transition:
+    color 120ms ease,
+    background 120ms ease,
+    border-color 120ms ease;
+}
+
+.rail__new:hover,
+.rail__new:focus-visible,
+.rail__new[aria-expanded="true"] {
+  background: color-mix(in oklab, var(--flesh) 30%, var(--rail-raised));
+  border-color: color-mix(in oklab, var(--flesh) 45%, var(--rail-edge));
+}
+
 .rail__section {
   font-family: var(--font-mono);
   font-size: 0.64rem;
@@ -1138,39 +1169,6 @@ button {
 .pane__more:focus-visible {
   color: var(--text);
   background: var(--sunken);
-}
-
-/* The one plus in the app, at the end of the one bar that is always drawn.
-   It carries its own `margin-left: auto` because the activity header has
-   nothing else pushing to the right; on an agent's header the more button has
-   already done that, and a second auto margin there would split the free space
-   between the two and leave the dots floating in the middle of the bar. */
-.pane__new {
-  margin-left: auto;
-  flex: none;
-  border: 1px solid var(--edge);
-  background: var(--raised);
-  color: var(--muted);
-  font-size: 1rem;
-  line-height: 1;
-  padding: 0.24rem 0.5rem;
-  border-radius: var(--radius-sm);
-  transition:
-    color 120ms ease,
-    background 120ms ease,
-    border-color 120ms ease;
-}
-
-.pane__more + .pane__new {
-  margin-left: 0;
-}
-
-.pane__new:hover,
-.pane__new:focus-visible,
-.pane__new[aria-expanded="true"] {
-  color: var(--text);
-  background: var(--sunken);
-  border-color: var(--flesh);
 }
 
 .pane__scroll {


### PR DESCRIPTION
The one control that makes an agent or a group was drawn at the far right of the channel header, in muted gray beside the agent's own actions glyph, so it read as one more control belonging to that agent rather than as the way to add a row to the rail. The old argument for that spot, that the rail is a list of agents and this is about none of them, is backwards: an agent is a row in the rail and a group is a heading in it. The header was also the one place the plus could not be drawn on an empty workspace, since there is no channel open to hang a header on, and that is the state where making an agent is the only thing left to do. It now sits beside the wordmark at the rail's full text weight, and the menu aligns its left edge to the button instead of its right, because from the rail a menu wider than the rail clamps to the window and lands beside the plus rather than under it. Two Sidebar tests hold it: the plus is drawn with nothing in the workspace, and a group can be made from the rail.