### PR TITLE
fix: the live bubble joins a turn's rounds the way the message will

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,6 +290,15 @@ the model takes a screenshot to see what `browse` did.
   incoming ones.** An agent that reads its last turn back without the file it
   attached has no record of handing anything over, so it attaches the document
   again and reports it as the first time.
+- **The live bubble joins a turn's rounds with `ROUND_BREAK`, exactly as the
+  accumulator does.** A model narrating its work says a sentence before each
+  tool call, and all of a turn's rounds stream into one placeholder. Without the
+  break the operator watches the next round start mid-sentence
+  (`…who is here.Two of us.`) and then watches it correct itself when the real
+  message lands. The pen writes the break in front of the round's first token,
+  so a round that turns out to be tool calls and nothing said leaves none
+  behind, and it decides from what has been *drawn* rather than from what has
+  been collected: a retry throws the bubble away and keeps the accumulator.
 - **Only the component drawing the live bubbles subscribes to `streams`.** One
   level higher, a single token re-renders every message in the transcript. The
   same split is why the line above the composer, the turn's chips and the open

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -475,6 +475,18 @@ reported on.
   where a turn begins. What was actually done is not lost by that: it is in the
   message that lands at the end of the turn, which is the record. This is only
   what that record looks like before it exists.
+- **The text is addressed to the same placeholder, and is joined across rounds
+  the way the message will be.** A model that narrates its work says a sentence
+  before each tool call, and the message that lands puts a blank line between
+  those sentences. The bubble being watched has to put one there too, or every
+  round after the first begins in the middle of the sentence the last one ended
+  with: `…who is here.Two of us.` One constant, `ROUND_BREAK`, is what both the
+  accumulator and the pen write, and the pen writes it in front of the round's
+  first token rather than at the head of the call, so a round that turns out to
+  be tool calls and nothing said leaves no blank line behind it. Which side of
+  the break the round is on comes from what has been *drawn*, not from what has
+  been collected: a retry throws the bubble away and keeps the accumulator, so
+  the two disagree exactly once per recovered turn.
 
 Nothing new reaches the webview. A call's name and arguments are the model's own
 words and are the same bytes the transcript draws a minute later; a credential's

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -247,6 +247,14 @@ struct Stream {
     agent_id: AgentId,
     run_id: RunId,
     to: Participant,
+    /// Whether anything has been drawn under the current id.
+    ///
+    /// What decides whether the next round's first token needs a `ROUND_BREAK`
+    /// in front of it. It follows the screen rather than `collected_text`,
+    /// because a retry throws away what was drawn and keeps what was collected:
+    /// read from the accumulator instead, a turn that retried its second round
+    /// would open the replacement bubble with a blank line.
+    drawn: bool,
 }
 
 impl Stream {
@@ -271,9 +279,20 @@ impl Stream {
     fn reopen(&mut self, events: &dyn EventSink) {
         self.close(events);
         self.message_id = MessageId::new();
+        self.drawn = false;
         self.open(events);
     }
 }
+
+/// What joins the text of one round of a turn to the text of the next.
+///
+/// A turn is several model calls under one placeholder, and a model that
+/// narrates its work says something before each tool call. Run together those
+/// sentences read as one with the period in the wrong place: "going straight to
+/// the directory instead.Directory loaded". The message that lands at the end
+/// of the turn and the bubble the operator watches being written are joined by
+/// this same string, or the two disagree for as long as the turn runs.
+const ROUND_BREAK: &str = "\n\n";
 
 /// How many times one model call is attempted before the operator is told.
 ///
@@ -1804,6 +1823,7 @@ impl Runtime {
             agent_id,
             run_id,
             to: stream_to,
+            drawn: false,
         };
         stream.open(&*self.inner.events);
 
@@ -1884,9 +1904,12 @@ impl Runtime {
 
             if !completion.content.is_empty() {
                 if !collected_text.is_empty() {
-                    collected_text.push_str("\n\n");
+                    collected_text.push_str(ROUND_BREAK);
                 }
                 collected_text.push_str(&completion.content);
+                // The pen wrote exactly this, so the next round's first token
+                // is the one that needs the break in front of it.
+                stream.drawn = true;
             }
 
             if completion.tool_calls.is_empty() {
@@ -2082,13 +2105,16 @@ impl Runtime {
 
             let message_id = stream.message_id;
             let channel_id = stream.channel_id;
+            // Read here rather than inside the pen: a reopen above has already
+            // cleared it, so a retry starts its bubble at the left margin.
+            let lead = if stream.drawn { ROUND_BREAK } else { "" };
             // Tokens are coalesced before they cross into the window. Each
             // event is an IPC hop and a render, and a model produces them
             // faster than a screen refreshes, so emitting per token spent the
             // operator's main thread on work no eye could resolve. With
             // several agents answering at once it stopped painting at all,
             // which read as the app freezing and the text arriving in a lump.
-            let mut pen = Pen::new(self.inner.events.clone(), message_id, channel_id);
+            let mut pen = Pen::new(self.inner.events.clone(), message_id, channel_id, lead);
             let result =
                 self.inner.llm.stream_chat(inference, request, |token| pen.write(token)).await;
             pen.flush();
@@ -4521,17 +4547,33 @@ struct Pen {
     events: Arc<dyn EventSink>,
     message_id: MessageId,
     channel_id: AgentId,
+    /// Written in front of the first text token and then gone. Empty for the
+    /// first call of a turn and for the first after a retry; `ROUND_BREAK`
+    /// otherwise, which is what keeps one round's last sentence off the front
+    /// of the next round's first.
+    ///
+    /// In front of the token rather than at the head of the call, because a
+    /// round can turn out to be tool calls and nothing said: a break written
+    /// before the call would leave a blank line under a bubble for the length
+    /// of the tool call, and a trailing one on a turn that never speaks again.
+    lead: &'static str,
     held: String,
     thought: String,
     last: Instant,
 }
 
 impl Pen {
-    fn new(events: Arc<dyn EventSink>, message_id: MessageId, channel_id: AgentId) -> Self {
+    fn new(
+        events: Arc<dyn EventSink>,
+        message_id: MessageId,
+        channel_id: AgentId,
+        lead: &'static str,
+    ) -> Self {
         Self {
             events,
             message_id,
             channel_id,
+            lead,
             held: String::new(),
             thought: String::new(),
             last: Instant::now(),
@@ -4540,7 +4582,10 @@ impl Pen {
 
     fn write(&mut self, token: Token<'_>) {
         match token {
-            Token::Text(text) => self.held.push_str(text),
+            Token::Text(text) => {
+                self.held.push_str(std::mem::take(&mut self.lead));
+                self.held.push_str(text);
+            }
             Token::Reasoning(text) => self.thought.push_str(text),
         }
         if self.last.elapsed() >= PEN_FLUSH {

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -705,6 +705,94 @@ async fn streamed_text_matches_the_persisted_message() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_turn_that_speaks_twice_is_watched_with_the_break_between_its_rounds() {
+    // A turn is several model calls under one placeholder, and a model that
+    // narrates its work says something before each tool call. The message that
+    // lands puts a blank line between those sentences; the bubble the operator
+    // watched being written has to put one there too, or every round after the
+    // first begins in the middle of the sentence the last one ended with:
+    // "...who is here.Two of us."
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Say("Two of us.".into())
+        } else {
+            Script::Narrate {
+                text: "Checking who is here.".into(),
+                then: Box::new(Script::Directory),
+            }
+        }
+    })
+    .await;
+    let h = harness(&stub, &["Manager", "Chef"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "who else is here?").unwrap();
+    h.settle(run).await;
+
+    let stream_id = h
+        .sink
+        .snapshot()
+        .into_iter()
+        .find_map(|e| match e {
+            UiEvent::StreamStarted { message_id, .. } => Some(message_id),
+            _ => None,
+        })
+        .expect("a stream should have started");
+
+    let persisted = h.channel_texts("Manager").pop().unwrap();
+    assert_eq!(persisted, "Checking who is here.\n\nTwo of us.");
+    assert_eq!(
+        h.sink.streamed_text(stream_id),
+        persisted,
+        "what the operator watched appear must equal what was saved"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_retried_round_opens_its_replacement_at_the_left_margin() {
+    // The other half of that break. A retry throws away what was drawn and
+    // starts a new placeholder, so the round it reopens for is the first thing
+    // in that bubble however many rounds came before it. Deciding the break
+    // from what has been collected rather than from what is on screen puts a
+    // blank line at the top of every recovered turn.
+    let answers = Arc::new(AtomicUsize::new(0));
+    let stub = serve(move |body| {
+        if !has_tool_result(body) {
+            return Script::Narrate {
+                text: "Checking who is here.".into(),
+                then: Box::new(Script::Directory),
+            };
+        }
+        if answers.fetch_add(1, Ordering::SeqCst) == 0 {
+            Script::Unavailable
+        } else {
+            Script::Say("Two of us.".into())
+        }
+    })
+    .await;
+    let h = harness(&stub, &["Manager", "Chef"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "who else is here?").unwrap();
+    h.settle(run).await;
+
+    let opened: Vec<_> = h
+        .sink
+        .snapshot()
+        .into_iter()
+        .filter_map(|e| match e {
+            UiEvent::StreamStarted { message_id, .. } => Some(message_id),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(opened.len(), 2, "the failed attempt should have been replaced, not appended to");
+
+    assert_eq!(
+        h.sink.streamed_text(*opened.last().unwrap()),
+        "Two of us.",
+        "the replacement bubble held nothing to be separated from"
+    );
+    // And the record is unaffected: it kept the round the screen threw away.
+    assert_eq!(h.channel_texts("Manager").pop().unwrap(), "Checking who is here.\n\nTwo of us.");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn a_model_that_thinks_out_loud_is_watched_without_being_recorded() {
     // The whole of the feature: an operator can see what a turn is doing while
     // it does it, and nothing about it survives the turn. Reasoning that leaked

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -60,6 +60,13 @@ pub enum Script {
     /// peer. The tool name is the one a model actually emitted, so the alias
     /// path is exercised wherever a scenario asks for it.
     Attach { tool: String, files: Vec<String> },
+    /// Say something and then call a tool, in one reply.
+    ///
+    /// The shape a model takes when it narrates its work: a sentence about what
+    /// it is doing, then the doing. It is the only shape that puts text in more
+    /// than one round of a turn, and therefore the only one that can run the end
+    /// of one round into the start of the next.
+    Narrate { text: String, then: Box<Script> },
     /// Emit a `directory` tool call.
     Directory,
     /// Call one of a connected plugin's tools, by its prefixed name. Nothing in
@@ -176,6 +183,18 @@ pub fn render(script: &Script) -> String {
             body.push_str(&frame(
                 serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
             ));
+        }
+        Script::Narrate { text, then } => {
+            for piece in text.as_bytes().chunks(7) {
+                let piece = String::from_utf8_lossy(piece).to_string();
+                body.push_str(&frame(
+                    serde_json::json!({"choices":[{"delta":{"content": piece}}]}),
+                ));
+            }
+            // The call it was narrating, with its own arguments and its own
+            // finish reason. A provider sends the text first and settles the
+            // reply once, which is what this concatenation is.
+            body.push_str(&render(then));
         }
         Script::Notes(content) | Script::Memory(content) => {
             let tool =


### PR DESCRIPTION
A turn is several model calls under one streaming placeholder, and a model that narrates its work says a sentence before each tool call. The message that lands joined those sentences with a blank line while the live deltas were appended with nothing between them, so an operator watched `going straight to the directory instead.Directory loaded` for as long as the turn ran and then watched it correct itself when the real message arrived. Both sides now write one constant, `ROUND_BREAK`, and the pen writes it in front of the round's first text token so a round that turns out to be tool calls and nothing said leaves no blank line behind it. Which side of the break a round is on comes from what has been drawn rather than from what has been collected, because a retry throws the bubble away and keeps the accumulator. Two cascade tests cover it, each checked against the code without its half of the fix, and `Script::Narrate` is new in the harness because text plus a tool call in one reply is the only shape that puts text in more than one round.