### PR TITLE
fix: a message's clock is a lane beside the words, not a box over them

### DIFF
--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -295,10 +295,11 @@ function ChatBubble({
         ))}
       </div>
 
-      {/* Out of the flow, and revealed by the pointer. Every message has a time
-          and almost none of them are worth a line: four in a row are usually
-          the same minute. Asking for one is a hover; noticing that an hour
-          passed is the line the transcript draws by itself. */}
+      {/* In a lane of its own at the end of the row, and inked by the pointer.
+          Every message has a time and almost none of them are worth a line:
+          four in a row are usually the same minute. Asking for one is a hover;
+          noticing that an hour passed is the line the transcript draws by
+          itself. */}
       <time className="msg__at" dateTime={new Date(message.createdAt).toISOString()}>
         {clockTime(message.createdAt)}
       </time>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1200,11 +1200,25 @@ button {
    ========================================================================== */
 
 .msg {
-  position: relative;
+  /* The lane the clock is drawn in, floored at what a twelve-hour one needs.
+     A floor and not a width, because the string is the operator's locale
+     rather than this file's: "22:37", "10:37 PM" and "10:37 p.m." are 1.8rem,
+     2.9rem and 3.6rem of it. Both halves of that earn their keep. Held open
+     whether or not the row has a clock, a bubble settling out of the stream
+     lands at the width it was already being drawn at. Free to grow past the
+     floor, there is no locale where the words run under the time. */
+  --clock: 2.9rem;
+
   display: grid;
-  grid-template-columns: 2.1rem 1fr;
+  /* Three lanes: the portrait, the words, and the clock. The clock is a lane
+     of its own rather than something laid over the top right corner, because
+     the top right corner is where the first line of a full-measure paragraph
+     already ends. A reserve in the padding is the same bug one number later:
+     whatever is written there is too small for somebody's locale, and what it
+     is too small by is a word of the message underneath it. */
+  grid-template-columns: 2.1rem minmax(0, 1fr) minmax(var(--clock), auto);
   gap: 0.75rem;
-  padding: 0.3rem 1.5rem 0.3rem 1.15rem;
+  padding: 0.3rem 0.5rem 0.3rem 1.15rem;
 }
 
 .msg:hover {
@@ -1230,15 +1244,18 @@ button {
 }
 
 /* Yours: no portrait, no gutter, and held off the right edge. Nothing in the
-   log has to say who wrote it, because the side it is on already has. */
+   log has to say who wrote it, because the side it is on already has. Mirrored
+   down to the clock, which takes the lane on the left, so the bubble is held
+   off that edge by the width of a time rather than by a figure that was about
+   that wide. */
 .msg[data-operator="true"] {
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(var(--clock), auto) minmax(0, 1fr);
   justify-items: end;
-  padding-left: 4rem;
+  padding-left: 0.5rem;
+  padding-right: 1.5rem;
 }
 
 .msg[data-operator="true"] .msg__body {
-  grid-column: 1;
   /* Shorter than an agent's. What you type is a question or an instruction,
      and a bubble is the wrong shape for anything longer than a few lines. */
   max-width: min(32rem, 100%);
@@ -1269,13 +1286,22 @@ button {
   letter-spacing: -0.003em;
 }
 
-/* Out of the flow entirely, so revealing it moves nothing. Every message has a
-   time; almost none of them are worth a line of their own, and the transcript
-   already draws a line wherever the gap was long enough to notice. */
+/* In its own lane and inked on hover, so revealing it moves nothing and
+   nothing is under it to move. Every message has a time; almost none of them
+   are worth a line of their own, and the transcript already draws a line
+   wherever the gap was long enough to notice. */
 .msg__at {
-  position: absolute;
-  top: 0.42rem;
-  right: 0.5rem;
+  grid-column: 3;
+  /* Stated, because it is the one child placed behind the cursor. Sparse
+     auto-placement only ever moves forward, so the operator's clock, which is
+     written after the bubble and drawn in the lane before it, lands on a
+     second row of its own without this. */
+  grid-row: 1;
+  justify-self: end;
+  align-self: start;
+  /* Onto the first line of the message rather than the top of the row. */
+  margin-top: 0.12rem;
+  white-space: nowrap;
   font-family: var(--font-mono);
   font-size: 0.6rem;
   font-variant-numeric: tabular-nums;
@@ -1286,8 +1312,8 @@ button {
 }
 
 .msg[data-operator="true"] .msg__at {
-  right: auto;
-  left: 1.15rem;
+  grid-column: 1;
+  justify-self: start;
 }
 
 .msg:hover .msg__at {

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -92,3 +92,36 @@ describe("dialog modifiers", () => {
     }
   });
 });
+
+describe("a message's clock", () => {
+  /**
+   * The clock is a lane, not something laid over the corner.
+   *
+   * It used to be absolutely positioned in the top right of the row, which is
+   * also where the first line of a full-measure paragraph ends: on any window
+   * narrow enough that the words reached the edge, hovering a message put the
+   * time over the last word of its own first line. A reserve in the row's
+   * padding does not fix it, because the width being reserved for is the
+   * operator's locale rather than this file's, so the check is that the clock
+   * and the words are in different columns and neither is out of flow.
+   */
+  it.each([
+    ["an agent's", undefined],
+    ["the operator's", "true"],
+  ])("is beside %s words rather than over them", (_whose, operator) => {
+    const msg = document.createElement("article");
+    msg.className = "msg";
+    if (operator) msg.dataset.operator = operator;
+    const body = document.createElement("div");
+    body.className = "msg__body";
+    const at = document.createElement("time");
+    at.className = "msg__at";
+    msg.append(body, at);
+    document.body.append(msg);
+
+    // Read back as declared: jsdom does not default a property nobody set, so
+    // in the flow is the empty string rather than `static`.
+    expect(getComputedStyle(at).position).not.toBe("absolute");
+    expect(getComputedStyle(at).gridColumn).not.toBe(getComputedStyle(body).gridColumn);
+  });
+});


### PR DESCRIPTION
The hover time on a message was absolutely positioned in the top right of the row against 1.5rem of reserved padding, and a twelve-hour clock is 2.9rem wide, so on any window narrow enough that the body stopped filling its 42rem measure (the 900px minimum, or anything with the inspector open) the time landed on the last word of the message's own first line, depending on where the sentence happened to wrap.

Widening the padding would be the same bug one number later, because the string is the operator's locale rather than the stylesheet's: `"22:37"`, `"10:37 PM"` and `"10:37 p.m."` measure 1.8rem, 2.9rem and 3.6rem. So `.msg` becomes three lanes (portrait, words, clock) with the operator's row mirroring it, the lane replacing the 4rem indent that was standing in for one; the lane is floored at what a twelve-hour clock needs so the clockless streaming bubble reserves the same width and does not reflow when it settles, and free to grow past that floor so no locale can push words back under the time.

`position: relative` comes off `.msg` with the absolute positioning, since nothing else was anchored to it, and `styles.test.ts` gains a case per variant asserting the clock is in flow and in a different column from the words.