### PR TITLE
fix: the issuer a redirect is checked against is the one the service published

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,6 +352,18 @@ the model takes a screenshot to see what `browse` did.
   decoration: everything under a transcript takes height from it without
   anything arriving or scrolling, so a composer growing a line or the working
   panel opening put the newest message under the fold and left it there.
+- **The issuer a redirect is checked against is the one the service published,
+  not the origin the document was fetched from.** Those are the same string only
+  for an authorization server at the root of an origin, and `guaca.bot` mounts
+  its own at `/api/auth`. Substituting the origin opened a browser, reached the
+  consent screen, took a code and refused it on the way back, every time; the
+  offline suite agreed with the substitution, because its stub published its own
+  origin as the issuer and sent no `iss` at all. An absent `issuer` still means
+  the origin, because that is what the root well-known address implies, and both
+  are checked to be on the configured origin: an issuer nobody checked is one a
+  metadata document could point at a third party whose codes Guaca would then
+  accept. `ServerMetadata::issuer`, then *The issuer is read, never assumed* in
+  `docs/ACCOUNT.md`.
 - **What a plugin's sign-in asks for is the resource's list, not its
   authorization server's.** They are two documents and two lists: RFC 9728 names
   the scopes for *that resource*, RFC 8414 names everything the server can issue

--- a/docs/ACCOUNT.md
+++ b/docs/ACCOUNT.md
@@ -88,8 +88,8 @@ service drops the device table.
 2. Bind `127.0.0.1:0`. Only now is the redirect URI known.
 3. Open the operator's browser at the authorization endpoint, with a PKCE
    challenge and a state.
-4. Catch the redirect on that port. Check the state before writing a success
-   page, so a mismatch is never told it worked.
+4. Catch the redirect on that port. Check the issuer and the state before
+   writing a success page, so a mismatch is never told it worked.
 5. `POST` the code and the verifier to the token endpoint.
 6. Spend the token once, on `/api/connectors`, before anything is written.
 
@@ -108,7 +108,41 @@ The fixed client is the smaller surface and the more honest screen.
 **The redirect URI is registered with no port.** RFC 8252 §7.3 has the
 authorization server compare a loopback redirect on scheme, host, path and query
 while ignoring the port. That is what makes "bind first, then ask" possible at
-all, and it is the one thing the service must not stop honouring.
+all, and it is the one thing the service must not stop honoring.
+
+### The issuer is read, never assumed
+
+RFC 9207 puts an `iss` on the redirect, and that check is worth exactly what the
+value it is compared against is worth. The value is the `issuer` field of the
+metadata document from step 1, and nothing else.
+
+It used to be the origin, on the reasoning that the document was fetched from the
+root of the origin so the two had to be the same string. They are the same string
+only for an authorization server mounted at that root, and `guaca.bot` mounts its
+own under a path:
+
+```json
+{
+  "issuer": "https://guaca.bot/api/auth",
+  "authorization_endpoint": "https://guaca.bot/api/auth/oauth2/authorize",
+  "authorization_response_iss_parameter_supported": true
+}
+```
+
+So every sign-in opened a browser, reached the consent screen, was issued a code,
+and was refused on the way back for naming the issuer the service publishes. RFC
+8414 §3.3 wants a document served at the root well-known path to claim the bare
+origin, so the service is bending that rule as well, but where the two disagree
+the published value is the one that wins: it is also the one the server will
+send.
+
+The origin is still what an *absent* `issuer` means, because that is what the
+address the document arrived from implies. Substituting it unconditionally was
+the bug; substituting it when nothing was published is the reading.
+
+Both are then checked to be on the configured origin, alongside the two
+endpoints. An unchecked issuer is worse than no check at all: a metadata document
+naming a third party would have Guaca accept a code minted by that third party.
 
 ## Where the service is
 
@@ -123,9 +157,10 @@ environment variable is still an input:
 - **HTTPS, or loopback.** Anything else is refused before a request is made. The
   failure this prevents is a credential on a plaintext connection across a
   network; loopback is exempt because it does not cross one.
-- **Discovered endpoints must be on the origin that published them.** A metadata
-  document is the one place discovery could move a credential to a third party,
-  and the check costs one string comparison.
+- **Everything discovered must be on the origin that published it.** Both
+  endpoints and the issuer. A metadata document is the one place discovery could
+  move a credential to a third party, or name one whose codes Guaca would then
+  accept, and the check costs three string comparisons.
 - **An override is logged at startup, and shown in the pane.** A machine left
   pointed at a development service is not a silent state, and the two hold
   different accounts.

--- a/src-tauri/src/account.rs
+++ b/src-tauri/src/account.rs
@@ -123,10 +123,38 @@ pub enum AccountError {
     Refused { error: String, description: Option<String> },
     #[error("the answer from your browser did not match the sign-in that was started")]
     StateMismatch,
+    /// RFC 9207: the redirect named an authorization server other than the one
+    /// the sign-in was started against.
+    ///
+    /// A different sentence from [`OauthError::IssuerMismatch`] on purpose. A
+    /// plugin's issuer is discovered per sign-in, so a mismatch there is an
+    /// answer arriving from somewhere unexpected. Here the expected value is
+    /// one the service itself published moments earlier, so a mismatch means
+    /// the service is contradicting its own metadata, and saying so is the
+    /// difference between an operator retrying forever and an operator
+    /// reporting it.
+    #[error(
+        "{expected} was published as the sign-in service and the answer came back naming \
+         {named}. Nothing was connected, and signing in again will not help until those two \
+         agree."
+    )]
+    IssuerMismatch { expected: String, named: String },
     #[error("{origin} answered HTTP {status}: {message}")]
     Upstream { origin: String, status: u16, message: String },
     #[error("could not reach {origin}: {detail}")]
     Transport { origin: String, detail: String },
+    /// An [`OauthError`] this flow has no way to produce.
+    ///
+    /// It exists so the conversion below can be exhaustive, which is the whole
+    /// point: the catch-all it replaced put "could not reach" in front of every
+    /// answer that arrived and disagreed, with an empty origin where the
+    /// service's name should have been. A new variant in `oauth.rs` is now a
+    /// compile error here rather than a sentence about the network.
+    #[error(
+        "the sign-in did something this build has no answer for: {detail}. That is a bug in Guaca \
+         rather than something to retry."
+    )]
+    Unexpected { detail: String },
     #[error("not signed in to a Guaca account")]
     NotSignedIn,
     #[error("the sign-in to {origin} has expired. Sign in again.")]
@@ -139,15 +167,27 @@ pub enum AccountError {
     },
 }
 
+/// Exhaustive rather than defensive.
+///
+/// [`OauthError`] describes a plugin sign-in as well, and that flow registers a
+/// client and renews its own grant where this one does neither, so three of its
+/// variants cannot arrive here. Naming them anyway is what stopped the ones
+/// that *can* arrive from being folded into `Transport`: an `IssuerMismatch` is
+/// an answer that came back and disagreed, and reporting it as a service that
+/// could not be reached sends the operator to check their network.
 impl From<OauthError> for AccountError {
     fn from(err: OauthError) -> Self {
         match err {
             OauthError::NoPort { source } => AccountError::NoPort { source },
+            OauthError::NoBrowser { detail } => AccountError::NoBrowser { detail },
             OauthError::TimedOut => AccountError::TimedOut,
             OauthError::Refused { error, description } => {
                 AccountError::Refused { error, description }
             }
             OauthError::StateMismatch => AccountError::StateMismatch,
+            OauthError::IssuerMismatch { expected, named } => {
+                AccountError::IssuerMismatch { expected, named }
+            }
             OauthError::NoMetadata { url, .. } => AccountError::NoMetadata { origin: url },
             OauthError::Status { url, status, body, .. } => {
                 AccountError::Upstream { origin: url, status, message: body }
@@ -155,7 +195,13 @@ impl From<OauthError> for AccountError {
             OauthError::Transport { url, source, .. } => {
                 AccountError::Transport { origin: url, detail: source.to_string() }
             }
-            other => AccountError::Transport { origin: String::new(), detail: other.to_string() },
+            // The three the plugin flow owns. `NoRegistration` and
+            // `NoRefreshToken` come from `oauth::connect` and `oauth::refresh`,
+            // which this module does not call; `NoToken` is raised by the one
+            // place that reads a grant rather than by `post_token`.
+            err @ (OauthError::NoRegistration { .. }
+            | OauthError::NoToken { .. }
+            | OauthError::NoRefreshToken) => AccountError::Unexpected { detail: err.to_string() },
         }
     }
 }
@@ -370,10 +416,13 @@ impl Account {
 
         open(&url).map_err(|detail| AccountError::NoBrowser { detail })?;
 
-        // The issuer is this one origin, and it is known before the browser
-        // opens rather than discovered from the answer: RFC 9207's check is
-        // only worth anything against a value recorded in advance.
-        let code = oauth::wait_for_redirect(listener, &state, &self.origin).await?;
+        // RFC 9207. The value compared against is the issuer the service
+        // published and nothing else: see `ServerMetadata::issuer`, which is
+        // where the origin used to be substituted for it. Read out of the
+        // document before the browser opens rather than out of the answer,
+        // because the check is only worth anything against a value recorded in
+        // advance.
+        let code = oauth::wait_for_redirect(listener, &state, &server.issuer).await?;
 
         let issued = oauth::post_token(
             &oauth::http()?,
@@ -487,22 +536,36 @@ impl Account {
 
     /// Where the service says to sign in, read from the service.
     ///
-    /// RFC 8414, at the root of the origin. Guaca could hard-code the two paths
-    /// and save a round trip, and then a service that moved one would be a
-    /// sign-in nobody could complete until every copy of the app was updated.
+    /// RFC 8414, at the root of the origin. Guaca could hard-code the paths and
+    /// save a round trip, and then a service that moved one would be a sign-in
+    /// nobody could complete until every copy of the app was updated.
     ///
-    /// Both endpoints are checked to be on the origin that published them. That
-    /// is not defensiveness about a document Guaca fetched over TLS from the one
-    /// place it trusts: it is the difference between a service that can change
-    /// its own paths and a service that can redirect an operator's credential to
-    /// a third party, and the check costs one string comparison.
+    /// Everything in the document is checked to be on the origin that published
+    /// it, the issuer included. That is not defensiveness about a document Guaca
+    /// fetched over TLS from the one place it trusts: it is the difference
+    /// between a service that can change its own paths and a service that can
+    /// redirect an operator's credential to a third party, and the check costs
+    /// three string comparisons.
+    ///
+    /// The issuer is filled in here when the service published none, so that
+    /// [`Self::sign_in`] has exactly one value to read and no reason to reach
+    /// for the origin itself. The origin is what an absent issuer means rather
+    /// than a guess: this document was fetched from the root well-known address,
+    /// which under RFC 8414 section 3.3 is the address of an issuer with no
+    /// path. It is also the reading the field's absence used to be given
+    /// unconditionally, and `guaca.bot` is the service that showed why that is
+    /// not the same thing.
     async fn discover(&self) -> Result<oauth::ServerMetadata, AccountError> {
         if !self.is_safe_origin() {
             return Err(AccountError::UnsafeOrigin { origin: self.origin.clone() });
         }
 
-        let server = oauth::server_metadata(&self.http, &self.origin).await?;
-        for endpoint in [&server.authorization_endpoint, &server.token_endpoint] {
+        let mut server = oauth::server_metadata(&self.http, &self.origin).await?;
+        if server.issuer.is_empty() {
+            server.issuer = self.origin.clone();
+        }
+
+        for endpoint in [&server.authorization_endpoint, &server.token_endpoint, &server.issuer] {
             if !self.is_same_origin(endpoint) {
                 return Err(AccountError::ForeignEndpoint {
                     origin: self.origin.clone(),

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -381,6 +381,23 @@ async fn protected_resource(http: &reqwest::Client, url: &str) -> Option<Resourc
 /// RFC 8414 authorization-server metadata, as far as this build reads it.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ServerMetadata {
+    /// The issuer identifier, which is the only value RFC 9207's `iss` check
+    /// may be made against.
+    ///
+    /// Not the address the document was fetched from. Those two are the same
+    /// string only for an authorization server at the root of an origin, and
+    /// `guaca.bot` mounts its own under `/api/auth`: a sign-in checked against
+    /// the origin reached the consent screen, was issued a code, and was then
+    /// refused at the redirect for naming the issuer the service publishes. RFC
+    /// 8414 section 3.3 wants the two to agree, and where they do not, the
+    /// published value wins, because it is also the one the server will send.
+    ///
+    /// `default` because the plugin flow takes its issuer from the *resource's*
+    /// metadata, where RFC 9728 has already named it, and never reads this
+    /// field. A vendor that omits a required one must not become a plugin
+    /// nobody can connect.
+    #[serde(default)]
+    pub issuer: String,
     pub authorization_endpoint: String,
     pub token_endpoint: String,
     /// Absent is a server Guaca cannot sign in to at all: with no RFC 7591
@@ -946,6 +963,7 @@ mod tests {
 
     fn server_offering(scopes: &[&str]) -> ServerMetadata {
         ServerMetadata {
+            issuer: "https://x.test".into(),
             authorization_endpoint: "https://x.test/a".into(),
             token_endpoint: "https://x.test/t".into(),
             registration_endpoint: None,

--- a/src-tauri/tests/account.rs
+++ b/src-tauri/tests/account.rs
@@ -12,6 +12,12 @@
 //! redirect is loopback, and the verifier presented at the token endpoint
 //! actually hashes to the challenge that was sent. A regression in the last one
 //! is a sign-in that still works and no longer proves anything.
+//!
+//! It also has the shape of the real service rather than the simplest one. Its
+//! authorization server is mounted under `/api/auth`, so the issuer it publishes
+//! is not its origin, and it names that issuer in the redirect. A stub at the
+//! root agreed with a substitution the app was making, and passed every test in
+//! this file while every sign-in against `guaca.bot` was refused.
 
 use std::sync::Arc;
 
@@ -61,6 +67,23 @@ struct Script {
     reject_token: bool,
     /// Seconds of life on the access token. `None` means the server did not say.
     expires_in: Option<i64>,
+    /// Sit at the root of the origin rather than under a path.
+    ///
+    /// Off by default, because `guaca.bot` mounts its authorization server at
+    /// `/api/auth` and a stub at the root is what let this suite pass while
+    /// every real sign-in was refused: the app substituted the origin for the
+    /// issuer, and a root-mounted server is the one case where those are the
+    /// same string.
+    root_mounted: bool,
+    /// Publish no `issuer` at all, which RFC 8414 requires and a server can
+    /// still omit.
+    omit_issuer: bool,
+    /// Publish an issuer on another origin while keeping the endpoints here.
+    /// Not the same failure as `foreign_endpoints`: the credential goes to the
+    /// right place and the answer is then checked against a third party's name.
+    foreign_issuer: bool,
+    /// Name somebody else as the issuer in the redirect. RFC 9207's mix-up.
+    wrong_iss: bool,
 }
 
 fn base64url(raw: &[u8]) -> String {
@@ -93,29 +116,50 @@ async fn serve(script: Script) -> Stub {
     let metadata_origin =
         if script.foreign_endpoints { "http://127.0.0.1:9".to_string() } else { origin.clone() };
 
+    // Where the authorization server sits under the origin, which is what makes
+    // its issuer identifier something other than that origin.
+    let mount = if script.root_mounted { "" } else { "/api/auth" };
+    // What the document says. The endpoints hang off it, so a foreign-endpoint
+    // script moves all three at once.
+    let published = format!("{metadata_origin}{mount}");
+    // What the redirect names: this server, wherever the document pointed.
+    let issued_by = format!("{origin}{mount}");
+
     let app = Router::new()
         .route(
             "/.well-known/oauth-authorization-server",
-            get(move || {
-                let base = metadata_origin.clone();
-                async move {
-                    Json(serde_json::json!({
-                        "issuer": base,
-                        "authorization_endpoint": format!("{base}/oauth2/authorize"),
-                        "token_endpoint": format!("{base}/oauth2/token"),
-                        "code_challenge_methods_supported": ["S256"],
-                        "scopes_supported": ["openid", "email", "offline_access", "connectors"],
-                    }))
+            get({
+                let (published, script) = (published.clone(), script.clone());
+                move || {
+                    let (published, script) = (published.clone(), script.clone());
+                    async move {
+                        let mut body = serde_json::json!({
+                            "issuer": published,
+                            "authorization_endpoint": format!("{published}/oauth2/authorize"),
+                            "token_endpoint": format!("{published}/oauth2/token"),
+                            "code_challenge_methods_supported": ["S256"],
+                            "scopes_supported": ["openid", "email", "offline_access", "connectors"],
+                        });
+                        if script.omit_issuer {
+                            body.as_object_mut().expect("an object").remove("issuer");
+                        }
+                        if script.foreign_issuer {
+                            body["issuer"] = "https://elsewhere.example".into();
+                        }
+                        Json(body)
+                    }
                 }
             }),
         )
         .route(
-            "/oauth2/authorize",
+            &format!("{mount}/oauth2/authorize"),
             get({
                 let asked = asked.clone();
                 let script = script.clone();
+                let issued_by = issued_by.clone();
                 move |Query(query): Query<std::collections::HashMap<String, String>>| {
-                    let (asked, script) = (asked.clone(), script.clone());
+                    let (asked, script, issued_by) =
+                        (asked.clone(), script.clone(), issued_by.clone());
                     async move {
                         let seen = Asked {
                             client_id: query.get("client_id").cloned().unwrap_or_default(),
@@ -145,12 +189,22 @@ async fn serve(script: Script) -> Stub {
                         };
                         *asked.lock() = Some(seen);
 
+                        // RFC 9207, percent-encoded the way a real server sends
+                        // it. The app decodes before comparing, so a value that
+                        // skipped the encoding would never exercise that.
+                        let iss = urlencoding_encode(if script.wrong_iss {
+                            "https://not-the-service.example"
+                        } else {
+                            &issued_by
+                        });
+
                         let to = if script.deny {
                             format!(
-                                "{back}?error=access_denied&error_description=Nope&state={state}"
+                                "{back}?error=access_denied&error_description=Nope\
+                                 &state={state}&iss={iss}"
                             )
                         } else {
-                            format!("{back}?code=the-code&state={state}")
+                            format!("{back}?code=the-code&state={state}&iss={iss}")
                         };
                         Redirect::temporary(&to)
                     }
@@ -158,7 +212,7 @@ async fn serve(script: Script) -> Stub {
             }),
         )
         .route(
-            "/oauth2/token",
+            &format!("{mount}/oauth2/token"),
             post({
                 let asked = asked.clone();
                 let exchanges = exchanges.clone();
@@ -251,6 +305,18 @@ async fn serve(script: Script) -> Stub {
 
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
     Stub { origin, asked, presented, exchanges }
+}
+
+/// Everything but the unreserved set, which is what a real server sends.
+fn urlencoding_encode(raw: &str) -> String {
+    raw.bytes()
+        .map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                (byte as char).to_string()
+            }
+            other => format!("%{other:02X}"),
+        })
+        .collect()
 }
 
 fn urlencoding_decode(raw: &str) -> String {
@@ -381,6 +447,58 @@ async fn an_answer_that_does_not_match_the_request_is_treated_as_an_attack() {
 }
 
 #[tokio::test]
+async fn the_answer_is_checked_against_the_issuer_the_service_published() {
+    // The live failure. `guaca.bot` mounts its authorization server at
+    // `/api/auth`, so the issuer it publishes and returns in `iss` is
+    // `https://guaca.bot/api/auth` and its origin is not. The app compared
+    // against the origin, so every sign-in reached the consent screen, was
+    // issued a code, and was refused on the way back.
+    let stub = serve(Script { expires_in: Some(3600), ..Script::default() }).await;
+    let account = Account::open_at(scratch(), &stub.origin);
+
+    let status = account.sign_in(browse).await.expect("the sign-in should complete");
+    assert!(status.signed_in);
+
+    // And the endpoints it used really were the ones under the path, rather
+    // than the flow having quietly stopped checking.
+    let asked = stub.asked.lock().clone().expect("the browser was sent somewhere");
+    assert!(asked.redirect_uri.starts_with("http://127.0.0.1:"), "{}", asked.redirect_uri);
+    assert_eq!(stub.exchanges.lock().len(), 1, "the code was traded at the mounted endpoint");
+}
+
+#[tokio::test]
+async fn an_answer_naming_another_issuer_is_refused() {
+    // RFC 9207's mix-up: a code minted by a server the operator does not use,
+    // presented to the one they do. Refused before the code is read, so there
+    // is nothing to have traded.
+    let stub = serve(Script { wrong_iss: true, ..Script::default() }).await;
+    let account = Account::open_at(scratch(), &stub.origin);
+
+    match account.sign_in(browse).await {
+        Err(AccountError::IssuerMismatch { expected, named }) => {
+            assert_eq!(expected, format!("{}/api/auth", stub.origin));
+            assert_eq!(named, "https://not-the-service.example");
+        }
+        other => panic!("expected an issuer mismatch, got {other:?}"),
+    }
+    assert!(!account.is_signed_in(), "nothing is stored");
+    assert!(stub.exchanges.lock().is_empty(), "the code was never traded");
+}
+
+#[tokio::test]
+async fn a_service_that_publishes_no_issuer_is_checked_against_its_origin() {
+    // RFC 8414 requires the field and a server can still leave it out. The
+    // address the document was fetched from is what its absence means: the root
+    // well-known path is the address of an issuer with no path. Substituting
+    // the origin *unconditionally* is the bug; substituting it when nothing was
+    // published is the reading.
+    let stub = serve(Script { root_mounted: true, omit_issuer: true, ..Script::default() }).await;
+    let account = Account::open_at(scratch(), &stub.origin);
+
+    assert!(account.sign_in(browse).await.expect("the sign-in should complete").signed_in);
+}
+
+#[tokio::test]
 async fn a_service_that_publishes_endpoints_somewhere_else_is_refused() {
     // The one thing discovery could do to move a credential. Refused before a
     // browser is opened, so nothing is sent anywhere.
@@ -392,6 +510,24 @@ async fn a_service_that_publishes_endpoints_somewhere_else_is_refused() {
             assert!(endpoint.starts_with("http://127.0.0.1:9"), "{endpoint}");
         }
         other => panic!("expected a refused endpoint, got {other:?}"),
+    }
+    assert!(stub.asked.lock().is_none(), "the browser was never opened");
+}
+
+#[tokio::test]
+async fn a_service_that_names_someone_else_as_its_issuer_is_refused() {
+    // The issuer is now what the redirect is checked against, so an unchecked
+    // one is a value a third party could put there: a code minted anywhere
+    // would arrive naming that issuer and be accepted. Refused at discovery,
+    // where the endpoints already were.
+    let stub = serve(Script { foreign_issuer: true, ..Script::default() }).await;
+    let account = Account::open_at(scratch(), &stub.origin);
+
+    match account.sign_in(browse).await {
+        Err(AccountError::ForeignEndpoint { endpoint, .. }) => {
+            assert_eq!(endpoint, "https://elsewhere.example");
+        }
+        other => panic!("expected a refused issuer, got {other:?}"),
     }
     assert!(stub.asked.lock().is_none(), "the browser was never opened");
 }
@@ -488,10 +624,21 @@ async fn the_real_service_still_publishes_where_to_sign_in() {
     let body: serde_json::Value =
         http.get(&url).send().await.expect("metadata unreachable").json().await.expect("not json");
 
-    for field in ["authorization_endpoint", "token_endpoint"] {
+    // The issuer among them, because it is the value the redirect is checked
+    // against and the one this suite could not see: the stub used to publish
+    // its own origin, agreeing with a substitution the app was making, while
+    // the live service published a path under it and every sign-in was refused.
+    for field in ["authorization_endpoint", "token_endpoint", "issuer"] {
         let endpoint = body[field].as_str().unwrap_or_default();
         assert!(endpoint.starts_with(origin.trim_end_matches('/')), "{field} is {endpoint}");
     }
+    // RFC 9207 is only a check if the service says it sends `iss`. A service
+    // that stopped would leave the redirect unverified and nothing would fail.
+    assert_eq!(
+        body["authorization_response_iss_parameter_supported"].as_bool(),
+        Some(true),
+        "the service should still name the issuer in its redirect"
+    );
     let methods = body["code_challenge_methods_supported"].as_array().cloned().unwrap_or_default();
     assert!(
         methods.iter().any(|m| m == "S256"),


### PR DESCRIPTION
Signing in to a Guaca account failed at the last step every time: `guaca.bot` mounts its authorization server under `/api/auth`, so that is the issuer identifier it publishes and returns in `iss`, and RFC 9207's check was being made against the bare origin instead. `ServerMetadata` had no `issuer` field at all, so it has one now, `discover` checks it is on the configured origin alongside the two endpoints, and `sign_in` compares against it; an absent `issuer` still means the origin, because that is what the root well-known address implies. `From<OauthError>` also folded `IssuerMismatch` into `Transport` with an empty origin, which is where the `could not reach :` in the report came from, so the conversion is exhaustive now and the three plugin-only variants say so rather than blaming the network. The offline suite could not see any of this because its stub published its own origin as the issuer and sent no `iss` at all: it now has the shape of the real service, reverting the one-line fix fails eleven of its fourteen tests, and the live gate asserts the published issuer is on the origin and that the service still says it sends `iss`.