### PR TITLE
feat: an added server speaks both transports, takes headers, and can be tested

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,10 @@ repo: the frontend renders state and forwards intent.
 | Which of the two a piece of work belongs on, and credentials | *Connectors* in `docs/PROTOCOL.md`, then both files above |
 | Plugins: what is on the list, signing one in, calling its tools | `docs/PLUGINS.md`, then `oauth.rs` and `mcp.rs` |
 | A server the operator added: its name, its address, a pasted key | *A server the operator added* in `docs/PLUGINS.md`, then `PluginKind::custom` and `PluginKind::from_row` |
+| Headers an operator gave a server: what is refused, where they go | *Headers, which are how the request arrives* in `docs/PLUGINS.md`, then `domain::plugin::Headers`, the loops in `mcp.rs` that apply them, and `oauth::Gate`, which is why they stop at one origin |
+| Testing an address or a connected plugin without connecting it | *Testing it is the whole path, minus the browser* in `docs/PLUGINS.md`, then `plugins::inspect` and `plugins::check` |
 | Anything about the wire: protocol versions, the handshake, headers | *Two protocol eras* in `docs/PLUGINS.md`, then `mcp.rs`, whose era probe is the one thing no offline test of a single server can check |
+| Which transport a server is spoken to over, and who gets the older one | *It speaks the transport that was replaced* in `docs/PLUGINS.md`, then `mcp::probe` and `sse_exchange` |
 | Which agents in a crew get a plugin | *Signing in is one decision, and handing it out is another* in `docs/PLUGINS.md`, then `domain/plugin.rs` and `Store::plugin_tools`, which has to agree with `Store::plugin_reach` |
 | Which of a plugin's tools which agents may call | *And which of its tools, for which of them, which is a third decision* in `docs/PLUGINS.md`, then `Store::set_plugin_tool` and both readers of `plugin_tool_access` |
 | The guaca.bot account: signing in, what it is for, why it is optional | `docs/ACCOUNT.md`, then `account.rs` |
@@ -470,6 +473,66 @@ the model takes a screenshot to see what `browse` did.
   that is what migration 26 exists to clean up after. A row with neither a
   catalog slug nor an address is one nothing can dial, which is a newer build's
   plugin after a downgrade, and is skipped. `PluginKind::from_row`.
+- **A header the operator wrote is not a credential, and that is why it
+  composes.** It describes how a request *reaches* the server rather than who is
+  asking, so it goes on every one — the unauthenticated probe, the handshake,
+  the tool list, every call, and the GET that opens an event stream — whichever
+  of the other things paid for it. That is what makes a server behind Cloudflare
+  Access that also signs in work without a case of its own: the headers get past
+  the gate, and the 401 behind it starts the browser dance unchanged. A client
+  that put them only on what it thinks of as "the call" never opens the stream.
+- **A sign-in reaches more hosts than the server, so the operator's headers stop
+  at the resource's origin.** `oauth::Gate`. Both directions are load-bearing:
+  without them the gate refuses the metadata document a sign-in reads first and
+  discovery dies on a `403`, and with them everywhere the operator's gate
+  credential reaches a vendor's authorization server. The rule covers a
+  self-hosted server that is its own issuer — registration, token and refresh
+  all behind the same gate — without a case of its own. The refresh is the one
+  that would otherwise fail a day after everything looked fine.
+- **A header this client builds itself is refused rather than overwritten, and
+  `authorization` is not one of them.** Anything `mcp-*` disagreeing with the
+  body is refused by a modern server with an error that reads as the server
+  rejecting the operator's work. `authorization` is allowed because it is the
+  only way to send `Basic` or a scheme a vendor invented — and a key beside it
+  is refused, because the key box writes the same header and one would silently
+  win. `Headers::parse` does the first, `commands::presented` does the second.
+- **Header *names* cross IPC and values never do.** A panel has to be able to
+  say `x-api-key` is on the request, because that is the question an operator
+  debugging their own server is asking, and it must not be a place to read back
+  what the key is worth. Same boundary `connector_env` draws.
+- **Sending headers to `readdress_plugin` replaces the set and sending none
+  keeps it.** The rule a group's API key has, for its reason: a value that
+  cannot be read back is one the panel cannot re-send, so absent has to mean
+  keep. An empty list removes them, which is a thing the operator did. The key
+  on that command is the other way round and stays that way: it is this
+  command's own older rule, and a server that stopped needing a key would
+  otherwise be unreachable from the panel.
+- **The older transport is offered to a server the operator added and to no
+  vendor.** A vendor Guaca vouches for is one it can hold to streamable HTTP,
+  and refusing one of the six over it is a message somebody at that vendor
+  reads. A box in an operator's own network is not a vendor: refusing it is not
+  a migration incentive, it is a plugin that does not work on a server they can
+  see working in a browser. `Dial::legacy_transport`, set only in
+  `plugins::dial`.
+- **Whose refusal the operator sees after a fallback turns on how far the
+  second attempt got.** A GET that was not answered with a stream, or not
+  answered at all, says nothing the POST did not, so the POST's stands.
+  Anything past that came off the server's own stream and is the more specific
+  of the two. Reporting the `405` there sends an operator to look at a
+  transport that was working, which is why *not an event stream* is its own
+  error variant rather than a sentence inside `Malformed`.
+- **A message endpoint on another origin is refused rather than followed.** It
+  is a redirect invented by the far end after the connection was made, and
+  following it puts a crew's credential and every tool argument on a host the
+  operator never named.
+- **Testing reports a server that wants a sign-in; it does not run one.** That
+  is the single step `probe_server` stops short of `add_plugin` at. The question
+  is whether this is the right address, and answering it with a consent screen
+  is a question nobody asked — and a diagnostic that opens one is a diagnostic
+  nobody runs twice. It is also why "nothing presented and refused" and
+  "something presented and refused" are two states: one status code, opposite
+  problems, and told apart wrongly an operator re-pastes a key at a server that
+  never wanted one.
 - **A name only resolves against a crew that has it, and a catalog name always
   resolves.** `neon__run_sql` parses whether or not Neon is connected, which is
   what makes "Neon is not connected, ask the operator" reachable instead of
@@ -821,7 +884,10 @@ cargo test --manifest-path src-tauri/Cargo.toml --test account -- --ignored
 
 Another, `tests/plugins.rs`, does the same job for MCP: a scripted server that
 publishes the four metadata documents an OAuth sign-in needs, and one runtime
-turn that calls a plugin tool end to end. Its live half runs `oauth::discover`
+turn that calls a plugin tool end to end. Its `deployments` module is a second
+scripted server and deliberately not the same one: that one is the five vendors'
+shape, and this one is a box in somebody's own network — the older transport, a
+gate wanting headers, a key taped to it. Its live half runs `oauth::discover`
 against every vendor on the list and asks whether each still publishes what this
 build expects, which is the failure no offline test can see. It reaches the internet, authorizes nothing and spends nothing.
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -398,6 +398,123 @@ plugins second. A prefix that is neither is not a plugin call at all, which is
 what keeps a model composing `use_screen__click` from being reported as a server
 nobody has ever heard of.
 
+### It speaks the transport that was replaced, and a vendor does not
+
+MCP has had two HTTP transports. Streamable HTTP is one POST per request with
+the reply in its response, and it is what everything in this file assumes. The
+one it replaced — revision `2024-11-05`, still commonly called the SSE transport
+— is a GET that stays open, an `endpoint` event naming a second URL, every
+request POSTed to that URL, and every reply arriving back down the stream. It
+has been deprecated since `2025-03-26`.
+
+Guaca speaks it, for an added server only. The asymmetry is the catalog's own
+argument rather than an inconsistency in it: a vendor Guaca vouches for is a
+vendor Guaca can hold to the current transport, and refusing one of the six over
+it would be a message somebody at that vendor would read. A box in an operator's
+own network is not a vendor. Refusing that is not a migration incentive, it is a
+plugin that does not work, on a server the operator can see working in a browser,
+with nothing on screen saying why. `Dial::legacy_transport` is the switch and
+`plugins::dial` is the only thing that sets it.
+
+Which transport a server wants is probed rather than configured, exactly as the
+era is, and out of the same failure: an MCP endpoint on the older transport
+answers a POST with `405` or `404`, which is a refusal with no JSON-RPC in it,
+which is already the shape that says "this is not a modern server". So the rule
+grows one clause: for an added server, that shape is a reason to try a GET
+before concluding anything. A stream that opens identifies the transport; one
+that does not leaves the original refusal exactly as it was.
+
+**Whose refusal the operator sees turns on how far the second attempt got.** A
+GET answered with something that is not an event stream, or not answered at all,
+says nothing the first attempt did not, so the first one stands. Anything past
+that came off the server's own stream and is the more specific of the two — a
+401 that says to sign in, a revision nothing shares, a session redirected onto
+another host. Reporting the `405` there sends an operator to look at a transport
+that was working.
+
+**A session on that transport belongs to a stream, and the stream is per
+request.** `initialize` establishes a session that is scoped to the event stream
+it was sent on, so a session kept between turns is a socket per plugin per crew,
+held open through sleep and reconnect, for a handshake that costs one round trip.
+Every exchange opens a stream, shakes hands on it, sends one request and drops
+it. That is the same "a session per call" rule this file argues for on the
+current transport, arrived at from the other side.
+
+**The message endpoint has to be on the same origin the stream was.** It is a
+redirect invented by the far end after the connection was made, and following it
+puts a crew's credential and every argument of every tool call on a host the
+operator never named. Relative is the common form, absolute is legal, and an
+absolute one naming anywhere else is refused.
+
+Two older revisions came onto the list of ones this build accepts along with it,
+`2025-03-26` and `2024-11-05`, because a server of that vintage negotiates down
+to one of them and would otherwise be refused for sharing no revision. The cost
+is nothing: `tools/list` and `tools/call` are the only methods this client has
+ever sent and both are unchanged across all five.
+
+### Headers, which are how the request arrives rather than who is asking
+
+A server somebody runs can want a third thing, after an address and a token, and
+it is the one the catalog never needs because nothing can discover it: an
+`X-API-Key` because that is where its framework looks, a pair of
+`Cf-Access-Client-*` because it sits behind Cloudflare Access, a tenant id
+because one deployment serves several.
+
+These are not a third credential and they are not a `Credential` at all. They
+describe how a request *reaches* the server, so they go on every request
+whichever of the other things paid for it — the unauthenticated probe, the
+handshake, the tool list, every call, and the GET that opens an event stream. A
+client that put them only on the requests it thinks of as "the call" never opens
+the stream at all.
+
+Composing rather than choosing is what makes the awkward case work rather than
+needing a case of its own. A server behind Access that also signs in: the
+headers get the request past the gate, the 401 from behind the gate starts the
+browser dance exactly as it would anywhere, and the grant that comes back is
+spent with the headers still on every request. Nothing about that path is
+written down twice.
+
+**A sign-in reaches more hosts than the server, so the headers stop at the
+resource's origin.** `oauth::Gate` is that rule and it is load-bearing in both
+directions. Without it the composition fails before it starts: the gate refuses
+the RFC 9728 metadata document a sign-in has to read first, and the operator
+gets a `403` out of discovery with nothing to act on. Sending them to every host
+in the dance instead would hand the operator's gate credential to a vendor's
+authorization server, which is a credential leak dressed up as a convenience.
+
+The origin rule covers both shapes without a special case. A self-hosted server
+that is its own issuer has registration and the token endpoint behind the same
+gate, and they get the headers. A resource whose authorization server is
+somebody else's host does not, and nothing of the operator's crosses over. The
+refresh is included, and it is the one that would otherwise fail a day after
+everything looked fine: the token endpoint is on that host too.
+
+**Every value is a secret and is treated as one.** Stored in a column read only
+by the code that puts it on the wire, never in a prompt, a transcript, an event
+or a sandbox. What crosses IPC on the way back is the *names*: a panel has to be
+able to say that `x-api-key` is on the request, because that is the question an
+operator debugging their own server is asking, and it must not be a place to
+read back what the key is worth. Same boundary `connector_env` draws, same
+reason.
+
+**A header Guaca builds itself is refused rather than overwritten.** Anything
+starting `mcp-`, and `accept`, `content-type`, `content-length`, `host`,
+`connection`. A modern server compares the `mcp-*` headers against the request
+body and refuses a request where they disagree, so one written here would fail
+every call with an error the operator reads as the server rejecting their work.
+Names are lowercased on the way in, because two spellings of one field name are
+a duplicate rather than two headers and sending both leaves which one wins to
+insertion order. A value carrying a line break is refused: that is header
+injection, and the way it reaches a box like this is a key pasted with the
+newline still attached.
+
+**`authorization` is allowed, and a key beside it is refused.** It is the only
+way to send `Basic`, or a scheme a vendor invented, so refusing it would make
+those unreachable. But the key box sends `Authorization: Bearer` and there is
+one such header on a request: both given, one would silently overwrite the
+other. `commands::presented` refuses the pair in a sentence that says they are
+one slot rather than two.
+
 ### Changing the address is a reconnection
 
 `readdress_plugin`, not an edit, and for the reason `set_plugin_connection` is
@@ -406,6 +523,53 @@ tool list, so the list has to be re-read. What survives is what survives any
 reconnection — the row's id, who may spend it, which of its tools are whose —
 because the operator is fixing an address, not deciding what the crew may do. A
 local server changing port should not cost anybody their permissions.
+
+Headers go the other way from the key on this path, and the difference is what
+can be shown. Sending a set replaces it whole; sending none leaves the stored
+one alone. That is the rule a group's API key already has, for the same reason:
+a value that cannot be read back is one the panel cannot re-send, so "absent"
+has to mean keep or every reconnection would quietly drop it. Removing them is
+an empty set, which is a thing the operator did rather than a thing they forgot.
+The key keeps its own older rule — absent means "ask the server" — because a
+server that stopped needing one would otherwise be unreachable from this panel.
+
+### Testing it is the whole path, minus the browser
+
+An address, a key and a set of headers are four ways to be wrong and one button.
+Before this, finding out which meant pressing Add: a failure replaced nothing
+but told the operator only whichever sentence the first failing layer produced,
+and a success on the wrong address connected a crew to it.
+
+`probe_server` runs the real path — the same probe, both transports, the
+handshake, `tools/list` — with whatever has been typed and not yet saved, and
+writes nothing. What comes back is not a sentence but the things underneath it
+separately, because the failures are separate: which transport answered, which
+revision was settled on, whether there was a handshake, what the server calls
+itself, what it published, and how long it took. A `405` on the current
+transport and a working event stream are the same sentence to a person and
+opposite instructions.
+
+It stops one step short of connecting in exactly one place: **a server that
+wants a sign-in is reported as wanting one rather than sent to a browser.** The
+question being asked is whether this is the right address, and answering it with
+a consent screen is a question nobody asked — and a diagnostic that opens one is
+a diagnostic nobody runs twice.
+
+The two 401s are the reason the answer is four states rather than a boolean.
+"Nothing was presented and it refused" and "something was presented and it
+refused" are one status code and opposite problems: an operator who cannot tell
+them apart re-pastes a key at a server that never wanted one, or goes hunting
+for a sign-in that is really a typo.
+
+`check_plugin` is the same question asked of a plugin the crew already has, and
+it is a separate command because the credential is separate: it spends the grant
+in the store, which is the only way to answer "is our sign-in still good". That
+is the failure a crew notices as an agent reporting a tool it cannot call, and
+the only other way to ask it is to connect again, which replaces the tool list
+and opens a browser. A stale grant is renewed first, because the next real call
+would renew it too and a check that skipped it would report a working plugin as
+broken. It is offered on every connected plugin rather than only the added ones:
+the question is the same for a vendor.
 
 ### What the operator is told
 

--- a/src-tauri/src/account.rs
+++ b/src-tauri/src/account.rs
@@ -434,6 +434,7 @@ impl Account {
                 ("client_id".to_string(), CLIENT_ID.to_string()),
                 ("code_verifier".to_string(), verifier),
             ],
+            &oauth::Gate::none(),
         )
         .await?;
 
@@ -516,6 +517,7 @@ impl Account {
                 ("refresh_token".to_string(), refresh_token.to_string()),
                 ("client_id".to_string(), CLIENT_ID.to_string()),
             ],
+            &oauth::Gate::none(),
         )
         .await?;
 
@@ -560,7 +562,8 @@ impl Account {
             return Err(AccountError::UnsafeOrigin { origin: self.origin.clone() });
         }
 
-        let mut server = oauth::server_metadata(&self.http, &self.origin).await?;
+        let mut server =
+            oauth::server_metadata(&self.http, &self.origin, &oauth::Gate::none()).await?;
         if server.issuer.is_empty() {
             server.issuer = self.origin.clone();
         }

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -429,6 +429,8 @@ pub fn run() {
             commands::connect_plugin,
             commands::add_plugin,
             commands::readdress_plugin,
+            commands::probe_server,
+            commands::check_plugin,
             commands::disconnect_plugin,
             commands::scan_agent_signins,
             commands::agent_signins,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -25,7 +25,9 @@ use crate::domain::ids::{
     AgentId, ApprovalId, ConnectorId, GroupId, MessageId, PluginId, RoutineId, RunId,
 };
 use crate::domain::now_ms;
-use crate::domain::plugin::{self, Plugin, PluginAccess, PluginKind, PluginOffer};
+use crate::domain::plugin::{
+    self, HeaderPair, Headers, Plugin, PluginAccess, PluginKind, PluginOffer, ServerReport,
+};
 use crate::domain::routine::{self, Routine, RoutineRun, Trigger};
 use crate::domain::search::SearchHits;
 use crate::domain::signin::Signin;
@@ -534,7 +536,10 @@ pub async fn connect_plugin(
         state.runtime.plugin_endpoint(&kind)
     };
 
-    sign_in(&state, group_id, &kind, &endpoint, credential).await
+    // A catalog server is dialled at the address this build ships, with nothing
+    // on the request but the credential. Headers are the operator's answer to a
+    // server nobody vouched for, and there is nothing here to answer.
+    sign_in(&state, group_id, &kind, &endpoint, credential, &Headers::none()).await
 }
 
 /// Adds a server the operator addressed themselves, and connects it.
@@ -551,6 +556,12 @@ pub async fn connect_plugin(
 /// round trip whose only outcome is a 401 with nothing useful in it. Left out,
 /// the server is asked what it wants exactly as a vendor's is.
 ///
+/// The headers are the third thing, and they are not a third credential: they
+/// are how the request reaches the server at all, so they go on every one of
+/// them whichever of the other two paid for it. That is what makes an MCP
+/// server behind Cloudflare Access work — the headers get past the gate, and
+/// the 401 behind the gate still starts the sign-in.
+///
 /// Refused rather than silently replacing when the crew already has a server
 /// under that name: `plugins_kind_unique` would take the collision as a
 /// reconnection, which is right for the same address and wrong for a different
@@ -563,6 +574,7 @@ pub async fn add_plugin(
     name: String,
     url: String,
     key: Option<String>,
+    headers: Option<Vec<HeaderPair>>,
 ) -> Reply<Plugin> {
     let kind = PluginKind::custom(&name, &url)
         .map_err(|err| CommandError::new("validation", err.to_string()))?;
@@ -583,13 +595,43 @@ pub async fn add_plugin(
         }
     }
 
-    let key = key.map(|key| key.trim().to_string()).filter(|key| !key.is_empty());
+    let (key, headers) = presented(key, headers)?;
     let credential = match key.as_deref() {
         Some(key) => crate::plugins::Credential::Key(key),
         None => crate::plugins::Credential::Discover,
     };
     let endpoint = state.runtime.plugin_endpoint(&kind);
-    sign_in(&state, group_id, &kind, &endpoint, credential).await
+    sign_in(&state, group_id, &kind, &endpoint, credential, &headers).await
+}
+
+/// What the operator gave, as the two things the connect path takes.
+///
+/// One function because the rule it enforces has to hold in both places that
+/// take a key and headers, and because the rule is easy to state and easy to
+/// get silently wrong: a key and an `authorization` header are the same slot on
+/// the request. Both given, one would overwrite the other, and which one won
+/// would depend on the order two loops happened to run in — so both given is
+/// refused, in a sentence that says they are one thing rather than two.
+///
+/// The key comes back rather than the credential built from it, because the
+/// credential borrows it: built here, it would name a string that goes out of
+/// scope on the way back.
+fn presented(
+    key: Option<String>,
+    headers: Option<Vec<HeaderPair>>,
+) -> Result<(Option<String>, Headers), CommandError> {
+    let key = key.map(|key| key.trim().to_string()).filter(|key| !key.is_empty());
+    let headers = Headers::parse(&headers.unwrap_or_default())
+        .map_err(|err| CommandError::new("validation", err.to_string()))?;
+    if key.is_some() && headers.carries_authorization() {
+        return Err(CommandError::new(
+            "validation",
+            "you gave a key and an `authorization` header, and they are the same slot on the \
+             request. Keep the key and drop the header, or keep the header — which is how to \
+             send a scheme other than `Bearer` — and clear the key.",
+        ));
+    }
+    Ok((key, headers))
 }
 
 /// The half of connecting that is the same whatever the server is.
@@ -605,6 +647,7 @@ async fn sign_in(
     kind: &PluginKind,
     endpoint: &str,
     credential: crate::plugins::Credential<'_>,
+    headers: &Headers,
 ) -> Reply<Plugin> {
     let plugin = crate::plugins::connect(
         state.runtime.store(),
@@ -612,6 +655,7 @@ async fn sign_in(
         kind,
         endpoint,
         credential,
+        headers,
         move |url| {
             // The one line in this feature that knows the app is a Tauri app. The
             // flow itself takes a callback so that `oauth.rs` does not have to.
@@ -660,6 +704,18 @@ pub async fn set_plugin_connection(
 /// reconnection anywhere else — the row's id, who may spend it, and which of
 /// its tools are whose — because the operator is fixing an address, not
 /// deciding what the crew may do.
+///
+/// Sending headers replaces the whole set and sending none leaves them alone,
+/// which is the rule a group's API key already has and for the same reason: a
+/// value that cannot be read back is one a panel cannot re-send, so "absent"
+/// has to mean keep or every reconnection would quietly drop it. Sending an
+/// empty list is how they are removed, and it is a thing the operator did
+/// rather than a thing they forgot.
+///
+/// The key is the other way round here, and that is this command's own history
+/// rather than a second rule: absent means "ask the server", which is what the
+/// box beside it says. It stays because a server that stopped needing a key is
+/// otherwise unreachable from this panel.
 #[tauri::command]
 pub async fn readdress_plugin(
     state: State<'_, AppState>,
@@ -667,6 +723,7 @@ pub async fn readdress_plugin(
     id: PluginId,
     url: String,
     key: Option<String>,
+    headers: Option<Vec<HeaderPair>>,
 ) -> Reply<Plugin> {
     let held = state
         .runtime
@@ -691,13 +748,100 @@ pub async fn readdress_plugin(
     // by a second copy of the rules here.
     let kind = PluginKind::custom(&held.name, &url)
         .map_err(|err| CommandError::new("validation", err.to_string()))?;
-    let key = key.map(|key| key.trim().to_string()).filter(|key| !key.is_empty());
+    let (key, headers) = match headers {
+        Some(rows) => presented(key, Some(rows))?,
+        // Read back off the row rather than left out of the write, so there is
+        // one path into `save_plugin` and one meaning for what it is handed.
+        None => {
+            let stored = state
+                .runtime
+                .store()
+                .plugin_dial(id)?
+                .map(|dialed| dialed.headers)
+                .unwrap_or_default();
+            let (key, _) = presented(key, None)?;
+            if key.is_some() && stored.carries_authorization() {
+                return Err(CommandError::new(
+                    "validation",
+                    "this server already has an `authorization` header, and a key goes in the \
+                     same slot. Replace its headers, or leave the key empty.",
+                ));
+            }
+            (key, stored)
+        }
+    };
     let credential = match key.as_deref() {
         Some(key) => crate::plugins::Credential::Key(key),
         None => crate::plugins::Credential::Discover,
     };
     let endpoint = state.runtime.plugin_endpoint(&kind);
-    sign_in(&state, group_id, &kind, &endpoint, credential).await
+    sign_in(&state, group_id, &kind, &endpoint, credential, &headers).await
+}
+
+/// Dials a server and says what it found, connecting nothing.
+///
+/// The button beside the address box. It runs the real path — the same probe,
+/// both transports, the handshake, `tools/list` — with the credential and
+/// headers the operator has typed but not yet saved, and writes nothing. What
+/// comes back is either a report or the same sentence adding it would have
+/// failed with, which is the point: an operator who has to press Add to find
+/// out what is wrong is an operator connecting a server four times.
+///
+/// It stops one step short of `add_plugin` in exactly one place: a server that
+/// wants a sign-in is reported as wanting one rather than sent to a browser.
+/// The question here is whether this is the right address, and answering it
+/// with a consent screen is a question nobody asked.
+///
+/// No group, because nothing is being connected to one, and no name, because a
+/// name is what a server's tools are called by and this calls none of them.
+#[tauri::command]
+pub async fn probe_server(
+    url: String,
+    key: Option<String>,
+    headers: Option<Vec<HeaderPair>>,
+) -> Reply<ServerReport> {
+    // Through the same canonicalizer an added server goes through, so the
+    // address that is tested is the address that would be stored. A test run
+    // against `https://example.com/mcp/` that passes, followed by a sign-in
+    // scoped to `https://example.com/mcp` that fails, is worse than no test.
+    let endpoint = plugin::canonical_url(&url)
+        .map_err(|err| CommandError::new("validation", err.to_string()))?;
+    let (key, headers) = presented(key, headers)?;
+    Ok(crate::plugins::inspect(true, &endpoint, key.as_deref(), &headers).await?)
+}
+
+/// The same question, asked of a plugin this crew already has.
+///
+/// Kept apart from `probe_server` because the credential is: this one spends
+/// the grant in the store, which is the only way to answer "is our sign-in
+/// still good", and that is the failure a crew notices as an agent reporting a
+/// tool it cannot call. A stale grant is renewed first, because the next real
+/// call would renew it too and a check that skipped it would report a working
+/// plugin as broken.
+#[tauri::command]
+pub async fn check_plugin(state: State<'_, AppState>, id: PluginId) -> Reply<ServerReport> {
+    let dialed = state
+        .runtime
+        .store()
+        .plugin_dial(id)?
+        .ok_or_else(|| CommandError::new("validation", "that plugin is not connected"))?;
+
+    // The same two-line resolution `connect_plugin` does, and for the same
+    // reason: an account-backed plugin's server is the operator's own account
+    // and which identity it means is part of the address.
+    let token = if dialed.kind.account_backed() { state.account.access().await.ok() } else { None };
+    let endpoint = if dialed.kind.account_backed() {
+        crate::plugins::AccountUse::endpoint(state.account.origin(), &dialed.connection)
+    } else {
+        state.runtime.plugin_endpoint(&dialed.kind)
+    };
+    // Copied off the row before it is handed over, because the check takes the
+    // row and the identity travels with the token rather than with it.
+    let connection = dialed.connection.clone();
+    let account =
+        token.as_deref().map(|token| crate::plugins::AccountUse { token, connection: &connection });
+
+    Ok(crate::plugins::check(state.runtime.store(), id, dialed, &endpoint, account).await?)
 }
 
 /// Chooses which of a crew's agents may call one plugin.

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -1011,6 +1011,28 @@ CREATE INDEX routine_runs_routine ON routine_runs (routine_id, at DESC);
 ALTER TABLE plugins ADD COLUMN endpoint TEXT NOT NULL DEFAULT '';
 "#,
     ),
+    (
+        36,
+        r#"
+-- Headers the operator wrote, for a server they run themselves.
+--
+-- The third thing such a server can want after an address and a token, and the
+-- one the catalog never needs: an `X-API-Key` because that is where its
+-- framework looks, a pair of `Cf-Access-Client-*` because it is behind
+-- Cloudflare Access, a tenant id because one deployment serves several. None of
+-- them is discoverable, so there is nowhere for them to come from but the
+-- person who deployed the thing.
+--
+-- A grant column in everything but name. Every value here is a secret and this
+-- column is read by the one function that puts it on the wire, exactly as
+-- `access_token` is, and `Plugin` carries the names without the values for the
+-- same reason `connectors` does not return `secret`.
+--
+-- `'[]'` is a server that needs none, which is every row written before today
+-- and almost every row written after it.
+ALTER TABLE plugins ADD COLUMN headers TEXT NOT NULL DEFAULT '[]';
+"#,
+    ),
 ];
 
 /// The group every agent starts in, and the one the UI keeps out of the way
@@ -1312,6 +1334,32 @@ mod tests {
             .query_row("SELECT endpoint FROM plugins WHERE id='p1'", [], |row| row.get(0))
             .unwrap();
         assert_eq!(endpoint, "", "an address in the row is one the build can no longer change");
+    }
+
+    #[test]
+    fn a_plugin_connected_before_headers_existed_sends_none() {
+        // `'[]'` and not `''`, because the column is read by parsing it. An
+        // empty string parses as nothing either way today, and would be a
+        // corrupt row the day anything decided to tell an unreadable column
+        // apart from an empty one.
+        let mut conn = memory();
+        for (version, sql) in MIGRATIONS.iter().filter(|(v, _)| *v < 36) {
+            conn.execute_batch(sql).unwrap();
+            conn.pragma_update(None, "user_version", *version).unwrap();
+        }
+        conn.execute(
+            "INSERT INTO plugins (id,group_id,kind,account,tools,connected_at)
+             VALUES ('p1',?1,'neon','','[]',0)",
+            rusqlite::params![DEFAULT_GROUP_ID],
+        )
+        .unwrap();
+
+        run(&mut conn).unwrap();
+
+        let headers: String = conn
+            .query_row("SELECT headers FROM plugins WHERE id='p1'", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(headers, "[]");
     }
 
     #[test]

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -24,7 +24,7 @@ use crate::domain::ids::{
 };
 use crate::domain::now_ms;
 use crate::domain::plugin::{
-    Plugin, PluginAccess, PluginKind, PluginTool, PluginToolCard, PluginToolset,
+    Headers, Plugin, PluginAccess, PluginKind, PluginTool, PluginToolCard, PluginToolset,
 };
 use crate::domain::routine::{NextSlot, Routine, RoutineRun, RunKind, Trigger};
 use crate::domain::search::{
@@ -1450,7 +1450,7 @@ impl Store {
         let mut stmt = conn.prepare(&format!(
             "SELECT id,access_token,refresh_token,expires_at,client_id,client_secret,
                     token_endpoint,{PLUGIN_REACHED_BY_AGENT},
-                    {PLUGIN_TOOL_REACHED_BY_AGENT},{PLUGIN_TOOL_REACHED_BY_ANYONE},tools
+                    {PLUGIN_TOOL_REACHED_BY_AGENT},{PLUGIN_TOOL_REACHED_BY_ANYONE},tools,headers
                FROM plugins WHERE group_id=:group AND kind=:kind",
         ))?;
         let row = stmt
@@ -1474,6 +1474,7 @@ impl Store {
                         row.get::<_, i64>(8)? != 0,
                         row.get::<_, i64>(9)? != 0,
                         row.get::<_, String>(10)?,
+                        row.get::<_, String>(11)?,
                     ))
                 },
             )
@@ -1491,6 +1492,7 @@ impl Store {
             tool_mine,
             tool_anyones,
             tools,
+            headers,
         )) = row
         else {
             return Ok(PluginReach::NotConnected);
@@ -1533,7 +1535,12 @@ impl Store {
             .and_then(|all| all.into_iter().find(|held| held.name == tool))
             .map(|held| held.input_schema);
 
-        Ok(PluginReach::Granted { id, grant, schema })
+        Ok(PluginReach::Granted(Box::new(Reached {
+            id,
+            grant,
+            headers: Headers::decode(&headers),
+            schema,
+        })))
     }
 
     /// Narrows a plugin to some of the crew, or opens it to all of it.
@@ -1754,6 +1761,11 @@ impl Store {
         // account-backed kind. Empty is the account's default, which is what a
         // row written before connections existed keeps meaning.
         connection: &str,
+        // What the operator gave this server beyond a token. Replaced whole on
+        // a reconnection, exactly as the tool list is: a merge would let a
+        // caller drop a header by forgetting it, and the panel that sends these
+        // renders what it last read.
+        headers: &Headers,
     ) -> Result<Plugin, StoreError> {
         let conn = self.conn()?;
         let id = PluginId::new();
@@ -1763,8 +1775,8 @@ impl Store {
         conn.execute(
             "INSERT INTO plugins
                 (id,group_id,kind,account,tools,client_id,client_secret,token_endpoint,
-                 access_token,refresh_token,expires_at,connected_at,connection,endpoint)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14)
+                 access_token,refresh_token,expires_at,connected_at,connection,endpoint,headers)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)
              ON CONFLICT(group_id,kind) DO UPDATE SET
                 account=excluded.account,
                 connection=excluded.connection,
@@ -1776,7 +1788,8 @@ impl Store {
                 refresh_token=excluded.refresh_token,
                 expires_at=excluded.expires_at,
                 connected_at=excluded.connected_at,
-                endpoint=excluded.endpoint",
+                endpoint=excluded.endpoint,
+                headers=excluded.headers",
             params![
                 id.to_string(),
                 group.to_string(),
@@ -1794,6 +1807,7 @@ impl Store {
                 // Empty for a catalog kind, whose address belongs to the build.
                 // See `PluginKind::stored_endpoint` and migration 35.
                 kind.stored_endpoint(),
+                headers.encode(),
             ],
         )?;
 
@@ -1804,6 +1818,75 @@ impl Store {
             .into_iter()
             .find(|plugin| plugin.kind.slug() == kind.slug())
             .ok_or(StoreError::PluginNotFound(id))
+    }
+
+    /// What one plugin is dialled with, for a caller holding its id and no agent.
+    ///
+    /// Not a narrower `plugin_reach`, because it answers a different question
+    /// and must not answer that one: this is the operator asking whether their
+    /// own server is reachable, and an operator is not one of the crew. Running
+    /// it through the per-agent rule would make a diagnostic report "not for
+    /// you" about a plugin the person who connected it is looking at.
+    ///
+    /// A row this build cannot dial comes back as `None`, exactly as it is
+    /// skipped in `group_plugins`, and for the same reason.
+    pub fn plugin_dial(&self, id: PluginId) -> Result<Option<Dialed>, StoreError> {
+        let conn = self.conn()?;
+        let row = conn
+            .query_row(
+                "SELECT kind,endpoint,headers,connection,access_token,refresh_token,expires_at,
+                        client_id,client_secret,token_endpoint
+                   FROM plugins WHERE id=?1",
+                params![id.to_string()],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, String>(4)?,
+                        row.get::<_, String>(5)?,
+                        row.get::<_, Option<i64>>(6)?,
+                        row.get::<_, String>(7)?,
+                        row.get::<_, String>(8)?,
+                        row.get::<_, String>(9)?,
+                    ))
+                },
+            )
+            .optional()?;
+
+        let Some((
+            kind,
+            endpoint,
+            headers,
+            connection,
+            access,
+            refresh,
+            expires_at,
+            client_id,
+            client_secret,
+            token_endpoint,
+        )) = row
+        else {
+            return Ok(None);
+        };
+        let Some(kind) = PluginKind::from_row(&kind, &endpoint) else { return Ok(None) };
+
+        Ok(Some(Dialed {
+            kind,
+            // Empty is a server that asked for nothing, not a broken row. See
+            // the same read in `plugin_reach`.
+            grant: (!access.is_empty()).then(|| crate::oauth::Grant {
+                access_token: access,
+                refresh_token: (!refresh.is_empty()).then_some(refresh),
+                expires_at,
+                client_id,
+                client_secret: (!client_secret.is_empty()).then_some(client_secret),
+                token_endpoint,
+            }),
+            headers: Headers::decode(&headers),
+            connection,
+        }))
     }
 
     /// Writes back a renewed grant, leaving everything else alone.
@@ -2995,17 +3078,48 @@ pub enum PluginReach {
     /// Connected and this agent's, but this tool was narrowed to other agents.
     /// Somebody in the crew has it.
     ToolNotChosen,
-    /// The row, the grant to spend against it, and the shape the call takes.
+    /// The row, what to reach it with, and the shape the call takes.
     ///
-    /// The grant is `None` for a server that authorized nobody because it asked
-    /// for nothing. The schema is `None` for a tool the stored list no longer
-    /// describes, which mirrors no headers and is otherwise called exactly the
-    /// same way.
-    Granted { id: PluginId, grant: Option<crate::oauth::Grant>, schema: Option<serde_json::Value> },
+    /// Boxed and named rather than four fields on the variant, because the four
+    /// travel together everywhere and because a refusal is a discriminant with
+    /// nothing on it: inline, every "not for you" would carry the width of a
+    /// grant it does not have.
+    Granted(Box<Reached>),
+}
+
+/// What one agent's call on one plugin tool is allowed to use.
+///
+/// The grant is `None` for a server that authorized nobody because it asked for
+/// nothing. The headers are the operator's own and are usually empty: they are
+/// here rather than looked up separately because a call made without them does
+/// not fail at the server, it fails at whatever is in front of it, with a
+/// refusal that says nothing about MCP. The schema is `None` for a tool the
+/// stored list no longer describes, which mirrors no headers and is otherwise
+/// called exactly the same way.
+#[derive(Debug)]
+pub struct Reached {
+    pub id: PluginId,
+    pub grant: Option<crate::oauth::Grant>,
+    pub headers: Headers,
+    pub schema: Option<serde_json::Value>,
+}
+
+/// One plugin, as the thing that dials it needs it.
+///
+/// Four fields because dialling a server takes four answers and three of them
+/// live nowhere else: which server it is, what to present, what to send to get
+/// past whatever is in front of it, and which identity at the account when the
+/// server is the account. A caller holding three of these would be guessing the
+/// fourth, which is the bug `AccountUse` exists to prevent one level down.
+pub struct Dialed {
+    pub kind: PluginKind,
+    pub grant: Option<crate::oauth::Grant>,
+    pub headers: Headers,
+    pub connection: String,
 }
 
 const PLUGIN_COLUMNS: &str = "SELECT id,group_id,kind,account,tools,access_token,connected_at,\
-     access,connection,endpoint FROM plugins";
+     access,connection,endpoint,headers FROM plugins";
 
 /// The one rule that decides whether an agent is offered a plugin's tools and
 /// whether a call it makes may spend the grant.
@@ -3083,6 +3197,7 @@ fn row_to_plugin(
     let reach: String = row.get(7)?;
     let connection: String = row.get(8)?;
     let endpoint_raw: String = row.get(9)?;
+    let headers: String = row.get(10)?;
 
     Ok((|| {
         let Some(kind) = PluginKind::from_row(&kind_raw, &endpoint_raw) else { return Ok(None) };
@@ -3115,6 +3230,10 @@ fn row_to_plugin(
                 .collect(),
             access: PluginAccess::from_row(&reach, chosen.get(&id).cloned().unwrap_or_default()),
             connection,
+            // Names only. The values are in the same column and stay there:
+            // this struct is what every plugin command answers with, and there
+            // is no field on it for a secret to arrive in.
+            headers: Headers::decode(&headers).names(),
             signed_in: !access.is_empty(),
             connected_at: row.get(6)?,
         }))
@@ -3228,6 +3347,7 @@ mod tests {
     use crate::domain::attachment::Attachment;
     use crate::domain::envelope::channel_for;
     use crate::domain::ids::RunId;
+    use crate::domain::plugin::HeaderPair;
     use crate::domain::routine::{Cadence, EventTrigger};
 
     /// A trigger on the clock, which is what most of these are about.
@@ -5524,7 +5644,9 @@ mod tests {
             .store
             .create_group(&CleanGroup { name: "Crew".into(), ..Default::default() })
             .unwrap();
-        f.store.save_plugin(group.id, &PluginKind::Neon, "", &[], None, "").unwrap();
+        f.store
+            .save_plugin(group.id, &PluginKind::Neon, "", &[], None, "", &Headers::none())
+            .unwrap();
 
         f.store.delete_group(group.id).unwrap();
         assert!(f.store.group_plugins(group.id).unwrap().is_empty());
@@ -5546,8 +5668,20 @@ mod tests {
         let group = default_group_id();
         let mine = PluginKind::custom("Home Assistant", "https://ha.example.com/mcp").unwrap();
 
-        f.store.save_plugin(group, &mine, "", &[tool("run_sql")], None, "").unwrap();
-        f.store.save_plugin(group, &PluginKind::Neon, "", &[tool("run_sql")], None, "").unwrap();
+        f.store
+            .save_plugin(group, &mine, "", &[tool("run_sql")], None, "", &Headers::none())
+            .unwrap();
+        f.store
+            .save_plugin(
+                group,
+                &PluginKind::Neon,
+                "",
+                &[tool("run_sql")],
+                None,
+                "",
+                &Headers::none(),
+            )
+            .unwrap();
 
         let held = f.store.group_plugins(group).unwrap();
         let added = held.iter().find(|held| held.custom).expect("the added one comes back");
@@ -5574,7 +5708,17 @@ mod tests {
         // turn, which is what raising here would cost.
         let f = fixture();
         let group = default_group_id();
-        f.store.save_plugin(group, &PluginKind::Neon, "", &[tool("run_sql")], None, "").unwrap();
+        f.store
+            .save_plugin(
+                group,
+                &PluginKind::Neon,
+                "",
+                &[tool("run_sql")],
+                None,
+                "",
+                &Headers::none(),
+            )
+            .unwrap();
         f.store
             .conn()
             .unwrap()
@@ -5589,6 +5733,44 @@ mod tests {
         let held = f.store.group_plugins(group).unwrap();
         assert_eq!(held.len(), 1, "the unreadable row is dropped and the readable one is not");
         assert_eq!(f.store.plugin_tools(group, agent.id).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn headers_go_out_with_the_grant_and_come_back_as_names_alone() {
+        // Two boundaries in one row. The call path needs the values, because a
+        // call made without them does not fail at the server but at whatever is
+        // in front of it; the panel needs the names, because "is x-api-key on
+        // the request" is the question an operator debugging their own server
+        // is asking; and neither wants the other's half.
+        let f = fixture();
+        let group = default_group_id();
+        let agent = f.store.create_agent(&draft("Manager")).unwrap();
+        let kind = PluginKind::custom("Home Assistant", "https://ha.example.com/mcp").unwrap();
+        let headers =
+            Headers::parse(&[HeaderPair { name: "X-API-Key".into(), value: "hand-minted".into() }])
+                .unwrap();
+
+        let saved =
+            f.store.save_plugin(group, &kind, "", &[tool("turn_on")], None, "", &headers).unwrap();
+        assert_eq!(saved.headers, vec!["x-api-key".to_string()]);
+
+        let PluginReach::Granted(reached) =
+            f.store.plugin_reach(group, agent.id, &kind, "turn_on").unwrap()
+        else {
+            panic!("the crew can call it")
+        };
+        assert_eq!(reached.headers, headers, "the call path gets the values");
+
+        // And a caller holding the id and no agent gets the same, because an
+        // operator testing their own server is not one of the crew.
+        let dialed = f.store.plugin_dial(saved.id).unwrap().expect("the row it was written as");
+        assert_eq!(dialed.headers, headers);
+        assert_eq!(dialed.kind, kind);
+
+        // Replaced whole on a reconnection, exactly as the tool list is.
+        let again =
+            f.store.save_plugin(group, &kind, "", &[tool("turn_on")], None, "", &Headers::none());
+        assert!(again.unwrap().headers.is_empty());
     }
 
     #[test]
@@ -5615,24 +5797,25 @@ mod tests {
                 }],
                 None,
                 "",
+                &Headers::none(),
             )
             .unwrap();
 
-        let PluginReach::Granted { schema, .. } =
+        let PluginReach::Granted(reached) =
             f.store.plugin_reach(group, agent.id, &PluginKind::Neon, "run_sql").unwrap()
         else {
             panic!("the crew can call it")
         };
-        assert_eq!(schema.unwrap()["properties"]["region"]["x-mcp-header"], "Region");
+        assert_eq!(reached.schema.unwrap()["properties"]["region"]["x-mcp-header"], "Region");
 
         // And a tool the stored list no longer describes has none, which is a
         // call that mirrors nothing rather than a call that cannot be made.
-        let PluginReach::Granted { schema, .. } =
+        let PluginReach::Granted(reached) =
             f.store.plugin_reach(group, agent.id, &PluginKind::Neon, "gone").unwrap()
         else {
             panic!("the reach check is about the plugin, not about the tool list")
         };
-        assert!(schema.is_none());
+        assert!(reached.schema.is_none());
     }
 
     #[test]
@@ -5643,15 +5826,15 @@ mod tests {
         // carry `Bearer `. The kind is incidental: the column is what decides.
         let f = fixture();
         let group = default_group_id();
-        f.store.save_plugin(group, &PluginKind::Neon, "", &[], None, "").unwrap();
+        f.store.save_plugin(group, &PluginKind::Neon, "", &[], None, "", &Headers::none()).unwrap();
 
         let agent = f.store.create_agent(&draft("Manager")).unwrap();
-        let PluginReach::Granted { grant, .. } =
+        let PluginReach::Granted(reached) =
             f.store.plugin_reach(group, agent.id, &PluginKind::Neon, "run_sql").unwrap()
         else {
             panic!("a connected plugin is reachable by the crew it was connected for")
         };
-        assert!(grant.is_none());
+        assert!(reached.grant.is_none());
         assert!(!f.store.group_plugins(group).unwrap()[0].signed_in);
     }
 
@@ -5663,7 +5846,17 @@ mod tests {
         let f = fixture();
         let group = default_group_id();
         let manager = f.store.create_agent(&draft("Manager")).unwrap();
-        f.store.save_plugin(group, &PluginKind::Neon, "", &[tool("run_sql")], None, "").unwrap();
+        f.store
+            .save_plugin(
+                group,
+                &PluginKind::Neon,
+                "",
+                &[tool("run_sql")],
+                None,
+                "",
+                &Headers::none(),
+            )
+            .unwrap();
 
         assert_eq!(f.store.group_plugins(group).unwrap()[0].access, PluginAccess::Everyone);
         assert_eq!(f.store.plugin_tools(group, manager.id).unwrap().len(), 1);
@@ -5682,7 +5875,15 @@ mod tests {
         let scribe = f.store.create_agent(&draft("Scribe")).unwrap();
         let plugin = f
             .store
-            .save_plugin(group, &PluginKind::Stripe, "", &[tool("refund")], None, "")
+            .save_plugin(
+                group,
+                &PluginKind::Stripe,
+                "",
+                &[tool("refund")],
+                None,
+                "",
+                &Headers::none(),
+            )
             .unwrap();
 
         let saved = f
@@ -5698,7 +5899,7 @@ mod tests {
         // tool it was never offered.
         assert!(matches!(
             f.store.plugin_reach(group, revenue.id, &PluginKind::Stripe, "refund").unwrap(),
-            PluginReach::Granted { .. }
+            PluginReach::Granted(_)
         ));
         assert!(matches!(
             f.store.plugin_reach(group, scribe.id, &PluginKind::Stripe, "refund").unwrap(),
@@ -5716,7 +5917,15 @@ mod tests {
         let manager = f.store.create_agent(&draft("Manager")).unwrap();
         let plugin = f
             .store
-            .save_plugin(group, &PluginKind::Stripe, "", &[tool("refund")], None, "")
+            .save_plugin(
+                group,
+                &PluginKind::Stripe,
+                "",
+                &[tool("refund")],
+                None,
+                "",
+                &Headers::none(),
+            )
             .unwrap();
 
         f.store.set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![] }).unwrap();
@@ -5735,7 +5944,10 @@ mod tests {
         let f = fixture();
         let group = default_group_id();
         let revenue = f.store.create_agent(&draft("Revenue")).unwrap();
-        let plugin = f.store.save_plugin(group, &PluginKind::Stripe, "", &[], None, "").unwrap();
+        let plugin = f
+            .store
+            .save_plugin(group, &PluginKind::Stripe, "", &[], None, "", &Headers::none())
+            .unwrap();
 
         f.store
             .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![revenue.id] })
@@ -5768,7 +5980,15 @@ mod tests {
             .unwrap();
         let plugin = f
             .store
-            .save_plugin(default_group_id(), &PluginKind::Stripe, "", &[], None, "")
+            .save_plugin(
+                default_group_id(),
+                &PluginKind::Stripe,
+                "",
+                &[],
+                None,
+                "",
+                &Headers::none(),
+            )
             .unwrap();
 
         let refused = f
@@ -5790,7 +6010,15 @@ mod tests {
         let scribe = f.store.create_agent(&draft("Scribe")).unwrap();
         let plugin = f
             .store
-            .save_plugin(group, &PluginKind::Stripe, "", &[tool("refund")], None, "")
+            .save_plugin(
+                group,
+                &PluginKind::Stripe,
+                "",
+                &[tool("refund")],
+                None,
+                "",
+                &Headers::none(),
+            )
             .unwrap();
         f.store
             .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![revenue.id] })
@@ -5798,7 +6026,15 @@ mod tests {
 
         let again = f
             .store
-            .save_plugin(group, &PluginKind::Stripe, "", &[tool("refund")], None, "")
+            .save_plugin(
+                group,
+                &PluginKind::Stripe,
+                "",
+                &[tool("refund")],
+                None,
+                "",
+                &Headers::none(),
+            )
             .unwrap();
 
         assert_eq!(again.access, PluginAccess::Chosen { agents: vec![revenue.id] });
@@ -5810,7 +6046,10 @@ mod tests {
         let f = fixture();
         let group = default_group_id();
         let revenue = f.store.create_agent(&draft("Revenue")).unwrap();
-        let plugin = f.store.save_plugin(group, &PluginKind::Stripe, "", &[], None, "").unwrap();
+        let plugin = f
+            .store
+            .save_plugin(group, &PluginKind::Stripe, "", &[], None, "", &Headers::none())
+            .unwrap();
         f.store
             .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![revenue.id] })
             .unwrap();
@@ -5830,7 +6069,10 @@ mod tests {
         let f = fixture();
         let group = default_group_id();
         let revenue = f.store.create_agent(&draft("Revenue")).unwrap();
-        let plugin = f.store.save_plugin(group, &PluginKind::Stripe, "", &[], None, "").unwrap();
+        let plugin = f
+            .store
+            .save_plugin(group, &PluginKind::Stripe, "", &[], None, "", &Headers::none())
+            .unwrap();
         f.store
             .set_plugin_access(plugin.id, &PluginAccess::Chosen { agents: vec![revenue.id] })
             .unwrap();
@@ -5861,6 +6103,7 @@ mod tests {
                 &[tool("run_sql"), tool("drop_project")],
                 None,
                 "",
+                &Headers::none(),
             )
             .unwrap();
 
@@ -5895,6 +6138,7 @@ mod tests {
                 &[tool("run_sql"), tool("drop_project")],
                 None,
                 "",
+                &Headers::none(),
             )
             .unwrap();
 
@@ -5921,7 +6165,7 @@ mod tests {
         ));
         assert!(matches!(
             f.store.plugin_reach(group, manager.id, &PluginKind::Neon, "run_sql").unwrap(),
-            PluginReach::Granted { .. }
+            PluginReach::Granted(_)
         ));
     }
 
@@ -5944,6 +6188,7 @@ mod tests {
                 &[tool("charges"), tool("refund")],
                 None,
                 "",
+                &Headers::none(),
             )
             .unwrap();
 
@@ -5985,6 +6230,7 @@ mod tests {
                 &[tool("read_thread"), tool("send")],
                 None,
                 "",
+                &Headers::none(),
             )
             .unwrap();
 
@@ -6017,7 +6263,7 @@ mod tests {
         ));
         assert!(matches!(
             f.store.plugin_reach(group, reply.id, &PluginKind::Agentmail, "send").unwrap(),
-            PluginReach::Granted { .. }
+            PluginReach::Granted(_)
         ));
         assert!(matches!(
             f.store.plugin_reach(group, reply.id, &PluginKind::Agentmail, "read_thread").unwrap(),
@@ -6043,6 +6289,7 @@ mod tests {
                 &[tool("refund"), tool("charges")],
                 None,
                 "",
+                &Headers::none(),
             )
             .unwrap();
 
@@ -6090,7 +6337,15 @@ mod tests {
         let outside = f.store.create_agent(&draft("Outside")).unwrap();
         let plugin = f
             .store
-            .save_plugin(group, &PluginKind::Neon, "", &[tool("run_sql")], None, "")
+            .save_plugin(
+                group,
+                &PluginKind::Neon,
+                "",
+                &[tool("run_sql")],
+                None,
+                "",
+                &Headers::none(),
+            )
             .unwrap();
 
         f.store
@@ -6132,7 +6387,15 @@ mod tests {
             .unwrap();
         let plugin = f
             .store
-            .save_plugin(default_group_id(), &PluginKind::Neon, "", &[tool("run_sql")], None, "")
+            .save_plugin(
+                default_group_id(),
+                &PluginKind::Neon,
+                "",
+                &[tool("run_sql")],
+                None,
+                "",
+                &Headers::none(),
+            )
             .unwrap();
 
         let refused = f
@@ -6165,7 +6428,15 @@ mod tests {
         let gone = f.store.create_agent(&draft("Gone")).unwrap();
         let plugin = f
             .store
-            .save_plugin(group, &PluginKind::Neon, "", &[tool("run_sql")], None, "")
+            .save_plugin(
+                group,
+                &PluginKind::Neon,
+                "",
+                &[tool("run_sql")],
+                None,
+                "",
+                &Headers::none(),
+            )
             .unwrap();
         f.store
             .set_plugin_tool(plugin.id, "run_sql", &PluginAccess::Chosen { agents: vec![gone.id] })
@@ -6194,7 +6465,15 @@ mod tests {
         let manager = f.store.create_agent(&draft("Manager")).unwrap();
         let plugin = f
             .store
-            .save_plugin(group, &PluginKind::Neon, "", &[tool("run_sql")], None, "")
+            .save_plugin(
+                group,
+                &PluginKind::Neon,
+                "",
+                &[tool("run_sql")],
+                None,
+                "",
+                &Headers::none(),
+            )
             .unwrap();
 
         f.store
@@ -6228,7 +6507,15 @@ mod tests {
         let f = fixture();
         let plugin = f
             .store
-            .save_plugin(default_group_id(), &PluginKind::Neon, "", &[tool("run_sql")], None, "")
+            .save_plugin(
+                default_group_id(),
+                &PluginKind::Neon,
+                "",
+                &[tool("run_sql")],
+                None,
+                "",
+                &Headers::none(),
+            )
             .unwrap();
 
         let refused = f.store.set_plugin_tool(plugin.id, "drop_project", &nobody()).unwrap_err();
@@ -6250,8 +6537,10 @@ mod tests {
         let group = default_group_id();
         let manager = f.store.create_agent(&draft("Manager")).unwrap();
         let published = [tool("run_sql"), tool("drop_project")];
-        let plugin =
-            f.store.save_plugin(group, &PluginKind::Neon, "", &published, None, "").unwrap();
+        let plugin = f
+            .store
+            .save_plugin(group, &PluginKind::Neon, "", &published, None, "", &Headers::none())
+            .unwrap();
         f.store.set_plugin_tool(plugin.id, "drop_project", &nobody()).unwrap();
 
         // And a tool the vendor started publishing since arrives switched on,
@@ -6267,6 +6556,7 @@ mod tests {
                 &[tool("run_sql"), tool("drop_project"), tool("list_branches")],
                 None,
                 "",
+                &Headers::none(),
             )
             .unwrap();
 
@@ -6292,7 +6582,15 @@ mod tests {
         let group = default_group_id();
         let plugin = f
             .store
-            .save_plugin(group, &PluginKind::Neon, "", &[tool("run_sql")], None, "")
+            .save_plugin(
+                group,
+                &PluginKind::Neon,
+                "",
+                &[tool("run_sql")],
+                None,
+                "",
+                &Headers::none(),
+            )
             .unwrap();
         let manager = f.store.create_agent(&draft("Manager")).unwrap();
         f.store
@@ -6322,7 +6620,15 @@ mod tests {
             .unwrap();
         let plugin = f
             .store
-            .save_plugin(group.id, &PluginKind::Neon, "", &[tool("run_sql")], None, "")
+            .save_plugin(
+                group.id,
+                &PluginKind::Neon,
+                "",
+                &[tool("run_sql")],
+                None,
+                "",
+                &Headers::none(),
+            )
             .unwrap();
         let hand = f
             .store
@@ -6355,7 +6661,15 @@ mod tests {
         let manager = f.store.create_agent(&draft("Manager")).unwrap();
         let plugin = f
             .store
-            .save_plugin(group, &PluginKind::Neon, "", &[tool("run_sql")], None, "")
+            .save_plugin(
+                group,
+                &PluginKind::Neon,
+                "",
+                &[tool("run_sql")],
+                None,
+                "",
+                &Headers::none(),
+            )
             .unwrap();
         f.store
             .conn()

--- a/src-tauri/src/domain/plugin.rs
+++ b/src-tauri/src/domain/plugin.rs
@@ -142,6 +142,213 @@ pub enum CustomError {
 /// type and short enough to leave a real tool name room on the other side.
 pub const MAX_CUSTOM_NAME: usize = 32;
 
+/// Headers the operator wrote, sent on every request to their own server.
+///
+/// The third thing a server somebody runs can want, after an address and a
+/// token, and the one the catalog never needs: an `X-API-Key` because that is
+/// where its framework looks, a pair of `Cf-Access-Client-*` because it sits
+/// behind Cloudflare Access, a tenant id because one deployment serves several.
+/// None of those is a sign-in and none of them is discoverable, so there is
+/// nowhere for them to come from but the person who deployed the thing.
+///
+/// They are a property of *reaching* the server rather than of who the crew is,
+/// which is why they are not a [`crate::plugins::Credential`] and compose with
+/// every one of them. A server gated by Access and signed in to with OAuth is
+/// the case that proves it: the headers get the request past the gate, and the
+/// 401 behind the gate still starts the browser dance.
+///
+/// Every value is a secret and is stored, spent and hidden exactly as a pasted
+/// key is. What crosses IPC on the way back out is [`Headers::names`] and never
+/// a value, which is the same boundary a connector's secret has: the panel can
+/// say what this server is being sent, and cannot say what it is worth.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Headers(Vec<(String, String)>);
+
+/// One header, as it crosses IPC and as it is stored.
+///
+/// A named pair rather than a tuple because it is what an operator fills in and
+/// what a column holds, and both of those are read by somebody: a two-element
+/// array in a settings file is a row nobody can tell the halves of apart. What
+/// the transport takes is the tuple, which is what `reqwest` wants.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HeaderPair {
+    pub name: String,
+    pub value: String,
+}
+
+/// Why a header an operator typed cannot be sent.
+///
+/// Each names the header and says what to change. An operator pasting a header
+/// out of a vendor's `curl` example has no idea which of these Guaca reserves,
+/// and a refusal that only says no gets retyped verbatim.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum HeaderError {
+    #[error("a header needs a name, such as `X-API-Key`. Remove the empty row or fill it in.")]
+    NoName,
+    #[error(
+        "{0} is not a header name. Use letters, digits and `-`, such as `X-API-Key`: a header \
+         name cannot contain spaces, colons or quotes. Paste only the part before the colon."
+    )]
+    BadName(String),
+    #[error(
+        "{0} needs a value. If the header is meant to be empty, remove it: a server that treats \
+         an absent header and an empty one alike is rare enough not to guess at."
+    )]
+    NoValue(String),
+    #[error(
+        "{0}'s value has a line break or a control character in it. That is usually a key pasted \
+         with the newline after it: paste the key alone."
+    )]
+    BadValue(String),
+    #[error(
+        "{0} is a header Guaca builds itself, and one written here would contradict the request \
+         it is on. The server would refuse the call and say nothing you could act on."
+    )]
+    Reserved(String),
+    #[error("{0} is given twice. A header has one value; remove the row you did not mean.")]
+    Repeated(String),
+    #[error(
+        "that is more than {MAX_HEADERS} headers. A server needing more than that is one being \
+         configured through Guaca rather than reached through it."
+    )]
+    TooMany,
+    #[error(
+        "{0}'s value is longer than {MAX_HEADER_VALUE} characters. That is longer than any \
+         credential, and a proxy will refuse the request before the server sees it."
+    )]
+    LongValue(String),
+}
+
+/// How many headers one server may be sent.
+///
+/// Two is the real answer — Cloudflare Access wants a pair — and eight is room
+/// for a deployment nobody anticipated. A list past that is a configuration
+/// file, and this is not one.
+pub const MAX_HEADERS: usize = 8;
+
+/// The longest value a header may carry.
+///
+/// Long enough for a signed JWT, which is the largest credential anybody sends
+/// this way, and short enough that the whole set stays inside the header
+/// budget of every proxy between here and the server.
+pub const MAX_HEADER_VALUE: usize = 4096;
+
+/// The headers this client builds from the request it is on.
+///
+/// Written here rather than checked against what `mcp.rs` happens to send,
+/// because the failure is silent: a modern server compares `mcp-method` and
+/// `mcp-param-*` against the body and refuses a request where they disagree,
+/// with an error the operator sees as "the server rejected the call". The
+/// `mcp-` prefix covers those and everything the protocol adds later; the rest
+/// are the ones an HTTP client owns.
+const RESERVED: [&str; 5] = ["accept", "content-type", "content-length", "host", "connection"];
+
+impl Headers {
+    /// None, which is what a catalog server and most added ones send.
+    pub fn none() -> Headers {
+        Headers(Vec::new())
+    }
+
+    /// What the operator typed, if every row of it holds up.
+    ///
+    /// Names are lowercased, because HTTP field names are case-insensitive and
+    /// two spellings of one header are the duplicate this refuses rather than
+    /// two headers. What the panel shows is therefore the stored spelling and
+    /// not the typed one, which is the same rule the server's name follows and
+    /// for the same reason: the webview draws what came back.
+    pub fn parse(rows: &[HeaderPair]) -> Result<Headers, HeaderError> {
+        if rows.len() > MAX_HEADERS {
+            return Err(HeaderError::TooMany);
+        }
+        let mut out: Vec<(String, String)> = Vec::new();
+        for row in rows {
+            let name = row.name.trim().to_ascii_lowercase();
+            let value = row.value.trim().to_string();
+            if name.is_empty() {
+                return Err(HeaderError::NoName);
+            }
+            if !name.bytes().all(is_token) {
+                return Err(HeaderError::BadName(row.name.trim().to_string()));
+            }
+            if name.starts_with("mcp-") || RESERVED.contains(&name.as_str()) {
+                return Err(HeaderError::Reserved(name));
+            }
+            if value.is_empty() {
+                return Err(HeaderError::NoValue(name));
+            }
+            if value.len() > MAX_HEADER_VALUE {
+                return Err(HeaderError::LongValue(name));
+            }
+            // Visible ASCII and space only. A newline is the common one and it
+            // is not cosmetic: a value carrying CRLF is header injection, and
+            // the only way it gets into a box like this is a key copied with
+            // the line ending attached.
+            if !value.bytes().all(|b| (0x20..=0x7e).contains(&b)) {
+                return Err(HeaderError::BadValue(name));
+            }
+            if out.iter().any(|(held, _)| held == &name) {
+                return Err(HeaderError::Repeated(name));
+            }
+            out.push((name, value));
+        }
+        Ok(Headers(out))
+    }
+
+    /// The stored form: JSON, in the one column that holds it.
+    pub fn encode(&self) -> String {
+        let rows: Vec<HeaderPair> = self
+            .0
+            .iter()
+            .map(|(name, value)| HeaderPair { name: name.clone(), value: value.clone() })
+            .collect();
+        serde_json::to_string(&rows).unwrap_or_else(|_| "[]".to_string())
+    }
+
+    /// A stored row, back as headers.
+    ///
+    /// A column that will not parse is no headers rather than an error, for the
+    /// reason an unreadable plugin row is skipped: it can only come from a
+    /// newer build writing to the same file, and a crew losing a routing header
+    /// is a plugin that stops working with a message the operator can act on,
+    /// where a raised error is every agent in the crew losing its turn.
+    pub fn decode(stored: &str) -> Headers {
+        serde_json::from_str::<Vec<HeaderPair>>(stored)
+            .ok()
+            .and_then(|rows| Headers::parse(&rows).ok())
+            .unwrap_or_default()
+    }
+
+    /// What the panel is allowed to know: which headers, never their values.
+    pub fn names(&self) -> Vec<String> {
+        self.0.iter().map(|(name, _)| name.clone()).collect()
+    }
+
+    /// Whether the operator supplied the credential themselves.
+    ///
+    /// `authorization` is allowed here on purpose — it is the only way to send
+    /// `Basic`, or a scheme a vendor invented — and it is the one header that
+    /// collides with a pasted key, which goes in the same slot. The caller that
+    /// has both refuses rather than picking one: see `commands::add_plugin`.
+    pub fn carries_authorization(&self) -> bool {
+        self.0.iter().any(|(name, _)| name == "authorization")
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// The pairs, for the one caller that puts them on a request.
+    pub fn wire(&self) -> &[(String, String)] {
+        &self.0
+    }
+}
+
+/// The characters RFC 9110 allows in a field name.
+fn is_token(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b"!#$%&'*+-.^_`|~".contains(&b)
+}
+
 impl PluginKind {
     /// The servers Guaca ships the address of. Not every kind: a custom one is
     /// not offered, it is added.
@@ -390,7 +597,7 @@ fn normalize_name(name: &str) -> String {
 /// themselves, and nothing on that connection leaves the machine. Everything
 /// else carries a crew's grant, so it is https or it is refused here rather
 /// than in a packet capture.
-fn canonical_url(url: &str) -> Result<String, CustomError> {
+pub fn canonical_url(url: &str) -> Result<String, CustomError> {
     let url = url.trim();
     if url.is_empty() {
         return Err(CustomError::NoUrl);
@@ -511,6 +718,61 @@ pub fn catalog() -> Vec<PluginOffer> {
             kind,
         })
         .collect()
+}
+
+/// What one dial of a server found out, without connecting anything.
+///
+/// The answer to "why does my server not work", which before this was a single
+/// sentence out of whichever layer failed first. An operator debugging their own
+/// deployment needs the things underneath separately: a `404` on the current
+/// transport and a working event stream are the same failure to a sentence and
+/// opposite instructions to a person.
+///
+/// It authorizes nothing and writes nothing. A server that wants a sign-in is
+/// reported as wanting one rather than sent to a browser: a diagnostic that
+/// opens a consent screen is a diagnostic nobody runs twice.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerReport {
+    /// The address as Guaca canonicalized it, which is not always the address
+    /// that was typed and is the one every later request will use.
+    pub endpoint: String,
+    /// Which transport it answered on, in the words the docs use for them.
+    pub transport: String,
+    /// The revision the two of them settled on. Empty when nothing was settled,
+    /// which is a server that refused before the question was reached.
+    pub protocol: String,
+    /// Whether it wanted `initialize`. Not the same question as the transport:
+    /// both eras are served over streamable HTTP and only one of them over the
+    /// other transport, so an operator reading a bug report needs both.
+    pub handshake: bool,
+    pub signin: SigninNeed,
+    /// How the server names itself, when it says. Often blank.
+    pub server: String,
+    /// Every tool it published, by name. Empty for a server that wants a
+    /// sign-in, because nothing has been signed in to.
+    pub tools: Vec<String>,
+    /// How long the whole exchange took. The number an operator is actually
+    /// after when a turn using this plugin feels slow.
+    pub ms: u64,
+}
+
+/// What the server did about a credential.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SigninNeed {
+    /// It asked for nothing and answered. A public server, or one the
+    /// operator's own headers already authenticate.
+    None,
+    /// It refused without one. Not a failure and not a sign-in: connecting is
+    /// what runs that, and this is what says it will be needed.
+    Wanted,
+    /// Something was presented and it was accepted.
+    Accepted,
+    /// Something was presented and it was refused. The one outcome that is
+    /// neither reachable-and-fine nor unreachable, and the one an operator
+    /// spends longest guessing at: the address is right and the key is not.
+    Refused,
 }
 
 /// One tool a connected server offers.
@@ -720,6 +982,13 @@ pub struct Plugin {
     /// and a personal one — and those are two grants with two ids; this is how
     /// one group says which of them it means while another says the other.
     pub connection: String,
+    /// Which headers the operator gave this server, by name and never by value.
+    ///
+    /// Drawn so the panel can say what is being sent — an operator debugging
+    /// their own server needs to know whether `x-api-key` is on the request —
+    /// without the panel being a place a credential can be read back out of.
+    /// Empty for every catalog server and for most added ones.
+    pub headers: Vec<String>,
     /// False for a server that authorized nothing because it asked for nothing.
     /// Every server on the list today asks, so this is true in practice; it is
     /// read off whether a grant was actually issued rather than off the fact
@@ -802,6 +1071,92 @@ mod tests {
             assert_eq!(json, format!("\"{}\"", kind.slug()));
             assert_eq!(serde_json::from_str::<PluginKind>(&json).unwrap(), kind);
         }
+    }
+
+    fn header(name: &str, value: &str) -> HeaderPair {
+        HeaderPair { name: name.into(), value: value.into() }
+    }
+
+    #[test]
+    fn a_header_is_stored_lowercased_and_goes_out_that_way() {
+        // Field names are case-insensitive on the wire, so the stored spelling
+        // is the one the panel shows and the one duplicates are found by.
+        let headers = Headers::parse(&[header("X-API-Key", " abc ")]).unwrap();
+        assert_eq!(headers.wire(), [("x-api-key".to_string(), "abc".to_string())]);
+        assert_eq!(headers.names(), ["x-api-key"]);
+    }
+
+    #[test]
+    fn two_spellings_of_one_header_are_a_duplicate_rather_than_two_headers() {
+        // Sent as written, one would silently win. Which one is `reqwest`'s
+        // insertion order, which is not a decision anybody made.
+        let both = Headers::parse(&[header("X-Api-Key", "a"), header("x-api-key", "b")]);
+        assert_eq!(both, Err(HeaderError::Repeated("x-api-key".into())));
+    }
+
+    #[test]
+    fn a_header_this_client_builds_itself_is_refused() {
+        // The failure is silent otherwise: a modern server compares the
+        // `mcp-*` headers against the body and refuses the request, with an
+        // error the operator reads as the server rejecting their call.
+        use HeaderError::*;
+        assert!(matches!(Headers::parse(&[header("mcp-method", "x")]), Err(Reserved(_))));
+        assert!(matches!(Headers::parse(&[header("Mcp-Param-Region", "x")]), Err(Reserved(_))));
+        assert!(matches!(Headers::parse(&[header("content-type", "x")]), Err(Reserved(_))));
+        assert!(matches!(Headers::parse(&[header("Accept", "x")]), Err(Reserved(_))));
+    }
+
+    #[test]
+    fn authorization_is_allowed_because_it_is_the_only_way_to_send_another_scheme() {
+        // `Basic`, or a scheme a vendor invented. The key box sends `Bearer`
+        // and nothing else, so refusing this header would make those
+        // unreachable. Who refuses the pair is `commands::presented`.
+        let headers = Headers::parse(&[header("Authorization", "Basic dXNlcjpwYXNz")]).unwrap();
+        assert!(headers.carries_authorization());
+    }
+
+    #[test]
+    fn a_value_with_a_line_break_in_it_is_refused() {
+        // Header injection, and the way it gets into a box like this is a key
+        // copied with the newline after it.
+        use HeaderError::*;
+        assert!(matches!(Headers::parse(&[header("x-key", "a\r\nX-Admin: 1")]), Err(BadValue(_))));
+        // Trailing whitespace alone is trimmed rather than refused: that is a
+        // paste, not an attack, and refusing it teaches nothing.
+        assert_eq!(
+            Headers::parse(&[header("x-key", "abc\n")]).unwrap().wire(),
+            [("x-key".to_string(), "abc".to_string())]
+        );
+    }
+
+    #[test]
+    fn a_name_that_is_not_a_field_name_says_which_part_to_paste() {
+        use HeaderError::*;
+        assert!(matches!(Headers::parse(&[header("X-API-Key:", "a")]), Err(BadName(_))));
+        assert!(matches!(Headers::parse(&[header("X API Key", "a")]), Err(BadName(_))));
+        assert_eq!(Headers::parse(&[header("  ", "a")]), Err(NoName));
+        assert!(matches!(Headers::parse(&[header("x-key", " ")]), Err(NoValue(_))));
+    }
+
+    #[test]
+    fn a_stored_column_that_will_not_parse_is_no_headers_rather_than_an_error() {
+        // Same rule as an unreadable plugin row. It can only come from a newer
+        // build writing to the same file, and a plugin that stops working with
+        // a message beats every agent in the crew losing its turn.
+        assert_eq!(Headers::decode("not json"), Headers::none());
+        assert_eq!(Headers::decode(""), Headers::none());
+        let round = Headers::parse(&[header("x-key", "abc")]).unwrap();
+        assert_eq!(Headers::decode(&round.encode()), round);
+    }
+
+    #[test]
+    fn a_header_a_server_could_never_receive_is_refused_before_it_is_stored() {
+        use HeaderError::*;
+        let many: Vec<HeaderPair> =
+            (0..MAX_HEADERS + 1).map(|n| header(&format!("x-{n}"), "v")).collect();
+        assert_eq!(Headers::parse(&many), Err(TooMany));
+        let long = header("x-key", &"a".repeat(MAX_HEADER_VALUE + 1));
+        assert!(matches!(Headers::parse(&[long]), Err(LongValue(_))));
     }
 
     #[test]

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -55,14 +55,29 @@
 //! is where the spec puts the address of the metadata that says who can issue
 //! one. `oauth.rs` reads it.
 //!
+//! ## Two transports, and who gets the older one
+//!
+//! Streamable HTTP is one POST per request and is what everything here assumes.
+//! The transport it replaced — HTTP+SSE, revision `2024-11-05` — is a GET that
+//! stays open, an `endpoint` event naming a second URL, and every request POSTed
+//! to that URL with its reply arriving back down the stream. Deprecated since
+//! `2025-03-26`, and still what a great many self-hosted servers speak, because
+//! the framework somebody deployed two years ago has not been updated.
+//!
+//! Guaca falls back to it for a server the operator added and not for one on the
+//! catalog, and the asymmetry is the catalog's whole argument rather than an
+//! inconsistency. A vendor Guaca vouches for is a vendor Guaca can hold to the
+//! current transport; a box in somebody's own network is not a vendor, and
+//! refusing to speak to it is not a migration incentive, it is a plugin that
+//! does not work. [`Dial::legacy_transport`] is the switch and `plugins.rs` is
+//! the only thing that sets it.
+//!
 //! ## What is deliberately not here
 //!
-//! The 2024-11-05 HTTP+SSE transport, which has been deprecated since
-//! `2025-03-26` and is scheduled for removal: a client that falls back to it
-//! keeps servers alive that should be migrating. Resources, prompts,
-//! `subscriptions/listen` and the server-to-client input requests a modern
-//! server can embed in a result: an agent here is offered tools and nothing
-//! else, and a half-implemented capability is worse than an absent one.
+//! Resources, prompts, `subscriptions/listen` and the server-to-client input
+//! requests a modern server can embed in a result: an agent here is offered
+//! tools and nothing else, and a half-implemented capability is worse than an
+//! absent one.
 
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
@@ -75,7 +90,16 @@ use serde::Deserialize;
 /// Order is the preference order: the first is what a modern request declares,
 /// and a server that refuses it names what it has instead, out of which the
 /// first of these that appears is taken.
-pub const SUPPORTED: [&str; 3] = ["2026-07-28", "2025-11-25", "2025-06-18"];
+///
+/// The two oldest are here for the servers an operator runs rather than for the
+/// catalog, which negotiates down to neither. `tools/list` and `tools/call` are
+/// the only methods this client has ever sent and both are unchanged across all
+/// five, so the cost of accepting an old revision is nothing and the cost of
+/// refusing one is a working server Guaca will not talk to. A server that
+/// answers `2024-11-05` is usually on the older transport as well: see
+/// [`Transport`].
+pub const SUPPORTED: [&str; 5] =
+    ["2026-07-28", "2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"];
 
 /// What a modern request declares, and the newest revision this build knows.
 pub const PROTOCOL_VERSION: &str = SUPPORTED[0];
@@ -167,6 +191,23 @@ pub enum McpError {
     /// here rather than anything the operator did, and it says so.
     #[error("{endpoint} refused the request as malformed ({detail}); this is a bug in Guaca")]
     HeaderMismatch { endpoint: String, detail: String },
+    /// A GET that answered with something other than an event stream.
+    ///
+    /// Its own variant rather than a `Malformed` with a sentence in it, because
+    /// the era probe has to tell "this address is not on the older transport"
+    /// apart from "it is, and something on the stream was wrong": the first
+    /// keeps the refusal the current transport already gave, and the second
+    /// replaces it. A message match would put that decision in a string.
+    #[error("{endpoint} answered a GET with {content_type}, not an event stream")]
+    NotAStream { endpoint: String, content_type: String },
+    /// An event stream that opened and then said nothing.
+    ///
+    /// Its own sentence rather than a timeout on the transport, because it is
+    /// the one failure the older transport has that the current one does not:
+    /// the socket is up, the request was accepted, and the answer was supposed
+    /// to arrive on a stream that is still technically connected.
+    #[error("{endpoint} opened an event stream and did not answer {method} on it within {secs}s")]
+    Silent { endpoint: String, method: String, secs: u64 },
 }
 
 impl McpError {
@@ -204,6 +245,59 @@ pub struct ToolDescriptor {
     pub input_schema: Option<serde_json::Value>,
 }
 
+/// Which of the two transports a server turned out to want.
+///
+/// Remembered per endpoint beside the era, and for the same reasons: it is a
+/// property of the deployed server, it cannot expire, and re-probing it in
+/// front of every tool call would be an internet round trip the answer to which
+/// is already known.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Transport {
+    /// One POST per request, the reply in its response. Everything current.
+    Streamable,
+    /// `2024-11-05`: a GET that stays open, an `endpoint` event naming a second
+    /// URL, every request POSTed there and every reply arriving on the stream.
+    ///
+    /// Only ever reached for a server the operator added. See the module docs.
+    Sse,
+}
+
+/// Everything needed to open a session, and nothing that comes back from one.
+///
+/// A struct rather than four arguments because two of them are `Option`-shaped
+/// booleans that read identically at a call site, and the failure of getting
+/// them the wrong way round is a crew's credential sent to a server that was
+/// never asked whether it wanted one.
+#[derive(Clone, Copy)]
+pub struct Dial<'a> {
+    pub endpoint: &'a str,
+    /// The grant, a pasted key, or nothing. Sent as `Authorization: Bearer`.
+    pub token: Option<&'a str>,
+    /// What the operator gave this server beyond a credential: an API-key
+    /// header, a pair of Access headers, a tenant id. Empty for the catalog.
+    pub headers: &'a [(String, String)],
+    /// Whether this server may be spoken to over the transport that streamable
+    /// HTTP replaced.
+    ///
+    /// True only for a server the operator added. A vendor on the catalog is
+    /// one Guaca vouched for, and vouching includes the transport; a box in
+    /// somebody's own network is not a vendor, and refusing it is not a
+    /// migration incentive. See the module docs.
+    pub legacy_transport: bool,
+}
+
+impl<'a> Dial<'a> {
+    /// An address and nothing else: no credential, no headers, current
+    /// transport only. What a test and the era probe want.
+    pub fn to(endpoint: &'a str) -> Dial<'a> {
+        Dial { endpoint, token: None, headers: &[], legacy_transport: false }
+    }
+
+    pub fn with_token(self, token: Option<&'a str>) -> Dial<'a> {
+        Dial { token, ..self }
+    }
+}
+
 /// What a request needs to carry, and what the handshake established.
 ///
 /// A modern session is established by nothing at all — it is the era, the
@@ -213,7 +307,15 @@ pub struct ToolDescriptor {
 pub struct Session {
     pub endpoint: String,
     pub token: Option<String>,
+    /// The operator's own headers, on every request this session makes.
+    ///
+    /// Owned rather than borrowed because a session outlives the call that
+    /// opened it by exactly one await point per request, and a lifetime here
+    /// would spread through every caller for a vector that is almost always
+    /// empty and never longer than eight.
+    headers: Vec<(String, String)>,
     pub era: Era,
+    pub transport: Transport,
     /// Whatever the server said, or nothing. Never invented: a server that
     /// issued no session id rejects a request that carries one, and a modern
     /// server never issues one.
@@ -233,6 +335,11 @@ pub struct Session {
 }
 
 impl Session {
+    /// Whether this session talks over the transport streamable HTTP replaced.
+    pub fn sse(&self) -> bool {
+        self.transport == Transport::Sse
+    }
+
     /// The revision every request on this session declares.
     fn version(&self) -> &str {
         match &self.era {
@@ -243,8 +350,14 @@ impl Session {
         }
     }
 
-    fn modern(&self) -> bool {
+    /// Whether this session is on the revision that deleted the handshake.
+    pub fn modern(&self) -> bool {
         matches!(self.era, Era::Modern { .. })
+    }
+
+    /// The revision the two of them settled on, for whoever is reporting it.
+    pub fn protocol(&self) -> &str {
+        self.version()
     }
 }
 
@@ -255,78 +368,143 @@ impl Session {
 /// that was already open; one that does not answers 401 and says where its
 /// authorization server is. That happens before the era is known, because a 401
 /// is the same answer in both.
-pub async fn open(endpoint: &str, token: Option<&str>) -> Result<Session, McpError> {
+pub async fn open(dial: Dial<'_>) -> Result<Session, McpError> {
     let http = client()?;
 
-    // What this endpoint was last time. A remembered era that turns out to be
-    // wrong is a server upgraded underneath a running Guaca: the handshake it
-    // wanted yesterday is a `400` today. One failure, then the truth.
+    // What this endpoint was last time. A remembered answer that turns out to
+    // be wrong is a server upgraded underneath a running Guaca: the handshake
+    // it wanted yesterday is a `400` today. One failure, then the truth.
     //
     // Only a protocol-level failure means that. A 401 is the sign-in and says
     // nothing about the era, and a transport failure says nothing about
     // anything, so both are handed back rather than spent on a second probe of
     // a server that is not answering.
-    if let Some(era) = remembered(endpoint) {
-        match establish(&http, endpoint, token, era, String::new()).await {
+    if let Some(spoken) = remembered(dial.endpoint) {
+        match establish(&http, dial, spoken, String::new()).await {
             Ok(session) => return Ok(session),
             Err(err) if err.is_unauthorized() || matches!(err, McpError::Transport { .. }) => {
                 return Err(err)
             }
-            Err(_) => forget(endpoint),
+            Err(_) => forget(dial.endpoint),
         }
     }
 
-    let probed = probe(&http, endpoint, token).await?;
-    remember(endpoint, &probed.era);
-    establish(&http, endpoint, token, probed.era, probed.server_name).await
+    let probed = probe(&http, dial).await?;
+    remember(dial.endpoint, &probed.spoken);
+    establish(&http, dial, probed.spoken, probed.server_name).await
 }
 
-/// A session for an era that has already been decided.
+/// A session for an era and a transport that have already been decided.
 ///
 /// Free for a modern server, which is the whole of what that revision changed:
-/// there is nothing to establish, because every POST carries what it needs. A
-/// legacy one still has to shake hands.
+/// there is nothing to establish, because every POST carries what it needs.
+/// Free for the older transport too, but for the opposite reason: its handshake
+/// belongs to a stream that has not been opened yet, so every request on it
+/// shakes hands inside itself and there is nothing a session could hold. Only a
+/// legacy server on the current transport establishes anything here.
 async fn establish(
     http: &reqwest::Client,
-    endpoint: &str,
-    token: Option<&str>,
-    era: Era,
+    dial: Dial<'_>,
+    spoken: Spoken,
     server_name: String,
 ) -> Result<Session, McpError> {
-    match era {
-        Era::Modern { .. } => Ok(Session {
-            endpoint: endpoint.to_string(),
-            token: token.map(str::to_string),
-            era,
-            session_id: None,
-            server_name,
-            negotiated: None,
-        }),
-        Era::Legacy => initialize(http, endpoint, token).await,
+    let Spoken { era, transport, negotiated } = spoken;
+    let free = |era: Era, negotiated: Option<String>| Session {
+        endpoint: dial.endpoint.to_string(),
+        token: dial.token.map(str::to_string),
+        headers: dial.headers.to_vec(),
+        era,
+        transport: transport.clone(),
+        session_id: None,
+        server_name: server_name.clone(),
+        negotiated,
+    };
+    match (&era, &transport) {
+        (Era::Modern { .. }, _) => Ok(free(era.clone(), None)),
+        (Era::Legacy, Transport::Sse) => Ok(free(Era::Legacy, negotiated)),
+        (Era::Legacy, Transport::Streamable) => initialize(http, dial).await,
     }
 }
 
 /// How the server names itself.
 ///
-/// Free on a legacy session, because the handshake it already paid for said so.
-/// A round trip on a modern one, where nothing has asked: this is the only
-/// caller of `server/discover` outside the era probe, and only the connect path
-/// calls it. A tool call must never pay for a label nobody reads.
+/// Free on a legacy session over the current transport, because the handshake
+/// it already paid for said so. A round trip on the other two, for opposite
+/// reasons: a modern session has no handshake and nothing has asked, and a
+/// session on the older transport has a handshake that belonged to a stream
+/// which has already been dropped. Only the connect path calls this. A tool
+/// call must never pay for a label nobody reads.
 pub async fn describe(session: &Session) -> Result<String, McpError> {
-    if !session.server_name.is_empty() || !session.modern() {
+    if !session.server_name.is_empty() {
         return Ok(session.server_name.clone());
     }
-    let http = client()?;
-    let (result, _) = post(
-        &http,
-        Wire::of(session),
-        "server/discover",
-        None,
-        serde_json::json!({}),
-        CONNECT_TIMEOUT,
-    )
-    .await?;
+    if session.sse() {
+        let http = client()?;
+        return sse_probe(&http, dial_for(session)).await.map(|(name, _)| name);
+    }
+    if !session.modern() {
+        return Ok(session.server_name.clone());
+    }
+    let result =
+        request(session, "server/discover", None, serde_json::json!({}), CONNECT_TIMEOUT).await?;
     Ok(server_name(&result))
+}
+
+/// This session, as the address and credential it was opened with.
+///
+/// The older transport takes a `Dial` rather than a session, because every
+/// exchange on it establishes its own: the session on that side is the stream,
+/// and the stream lasts one request.
+fn dial_for(session: &Session) -> Dial<'_> {
+    Dial {
+        endpoint: &session.endpoint,
+        token: session.token.as_deref(),
+        headers: &session.headers,
+        legacy_transport: true,
+    }
+}
+
+/// One request, over whichever transport this session turned out to want.
+///
+/// The one place the two meet, and everything above it is written once. A
+/// transport branch inside `list_tools` or `call_tool` would be the same
+/// decision taken twice, and the second copy is the one that gets forgotten
+/// when a third method is added.
+async fn request(
+    session: &Session,
+    method: &str,
+    name: Option<&str>,
+    params: serde_json::Value,
+    timeout: Duration,
+) -> Result<serde_json::Value, McpError> {
+    request_mirroring(session, method, name, params, Vec::new(), timeout).await
+}
+
+/// The same, for the one call that has arguments a modern server wants mirrored.
+async fn request_mirroring(
+    session: &Session,
+    method: &str,
+    name: Option<&str>,
+    params: serde_json::Value,
+    mirrored: Vec<(String, String)>,
+    timeout: Duration,
+) -> Result<serde_json::Value, McpError> {
+    let http = client()?;
+    if session.sse() {
+        // Mirroring is a modern-server rule and a modern server is never on
+        // this transport, so there is nothing here to drop.
+        let answered =
+            sse_exchange(&http, dial_for(session), Some((method, params)), timeout).await?;
+        // What this endpoint is remembered as, kept in step with what its last
+        // handshake actually settled on. A session on this transport has
+        // nowhere of its own to hold the answer, so a report built without this
+        // would name the revision Guaca asked for rather than the one agreed.
+        settled(&session.endpoint, &answered.negotiated);
+        return Ok(answered.result);
+    }
+    let mut wire = Wire::of(session);
+    wire.headers = mirrored;
+    post(&http, wire, method, name, params, timeout).await.map(|(result, _)| result)
 }
 
 /// Everything this server offers, once.
@@ -338,10 +516,8 @@ pub async fn describe(session: &Session) -> Result<String, McpError> {
 /// legacy one the annotation means nothing, and dropping the tool would take a
 /// working capability away over a field nobody reads.
 pub async fn list_tools(session: &Session) -> Result<Vec<ToolDescriptor>, McpError> {
-    let http = client()?;
-    let (value, _) =
-        post(&http, Wire::of(session), "tools/list", None, serde_json::json!({}), CONNECT_TIMEOUT)
-            .await?;
+    let value =
+        request(session, "tools/list", None, serde_json::json!({}), CONNECT_TIMEOUT).await?;
 
     #[derive(Deserialize)]
     struct Listed {
@@ -396,20 +572,17 @@ pub async fn call_tool(
     arguments: &serde_json::Value,
     schema: Option<&serde_json::Value>,
 ) -> Result<String, McpError> {
-    let http = client()?;
-    let mut wire = Wire::of(session);
     let mirrored = match schema {
         Some(schema) if session.modern() => mirror(schema, arguments),
         _ => Vec::new(),
     };
-    wire.headers = mirrored;
 
-    let (value, _) = post(
-        &http,
-        wire,
+    let value = request_mirroring(
+        session,
         "tools/call",
         Some(tool),
         serde_json::json!({ "name": tool, "arguments": arguments }),
+        mirrored,
         CALL_TIMEOUT,
     )
     .await?;
@@ -432,8 +605,24 @@ pub async fn call_tool(
 
 /// What a server turned out to be, and what it called itself while saying so.
 struct Probed {
-    era: Era,
+    spoken: Spoken,
     server_name: String,
+}
+
+/// The two things about a server that are fixed once it has been asked.
+///
+/// One value rather than two memos, because they are decided by one probe and
+/// a build that remembered them separately could hold a transport for an
+/// endpoint whose era it had just forgotten.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Spoken {
+    era: Era,
+    transport: Transport,
+    /// What the last handshake on this endpoint settled on, for a server on the
+    /// older transport. `None` everywhere else: a modern session declares its
+    /// own revision and a legacy streamable one is told by `initialize` on
+    /// every open, so only this transport has an answer with nowhere to live.
+    negotiated: Option<String>,
 }
 
 /// Which era this endpoint speaks, by asking it something only a modern server
@@ -455,14 +644,12 @@ struct Probed {
 /// - Anything else — a `400`, a `404`, an unknown-method JSON-RPC error, a body
 ///   that is not MCP at all: a server that has never heard of `server/discover`,
 ///   which is a legacy server.
-async fn probe(
-    http: &reqwest::Client,
-    endpoint: &str,
-    token: Option<&str>,
-) -> Result<Probed, McpError> {
+async fn probe(http: &reqwest::Client, dial: Dial<'_>) -> Result<Probed, McpError> {
+    let endpoint = dial.endpoint;
     let wire = Wire {
         endpoint,
-        token,
+        token: dial.token,
+        extra: dial.headers,
         version: PROTOCOL_VERSION.to_string(),
         modern: true,
         session_id: None,
@@ -470,7 +657,11 @@ async fn probe(
     };
     match post(http, wire, "server/discover", None, serde_json::json!({}), CONNECT_TIMEOUT).await {
         Ok((result, _)) => Ok(Probed {
-            era: Era::Modern { version: PROTOCOL_VERSION.to_string() },
+            spoken: Spoken {
+                era: Era::Modern { version: PROTOCOL_VERSION.to_string() },
+                transport: Transport::Streamable,
+                negotiated: None,
+            },
             server_name: server_name(&result),
         }),
         Err(McpError::NoSharedVersion { endpoint, supported }) => {
@@ -484,11 +675,12 @@ async fn probe(
                 return Err(McpError::NoSharedVersion { endpoint, supported });
             };
             if !modern(&version) {
-                return Ok(Probed { era: Era::Legacy, server_name: String::new() });
+                return Ok(Probed { spoken: handshaking(), server_name: String::new() });
             }
             let wire = Wire {
                 endpoint: &endpoint,
-                token,
+                token: dial.token,
+                extra: dial.headers,
                 version: version.clone(),
                 modern: true,
                 session_id: None,
@@ -497,13 +689,60 @@ async fn probe(
             let (result, _) =
                 post(http, wire, "server/discover", None, serde_json::json!({}), CONNECT_TIMEOUT)
                     .await?;
-            Ok(Probed { era: Era::Modern { version }, server_name: server_name(&result) })
+            Ok(Probed {
+                spoken: Spoken {
+                    era: Era::Modern { version },
+                    transport: Transport::Streamable,
+                    negotiated: None,
+                },
+                server_name: server_name(&result),
+            })
         }
         Err(err @ (McpError::Transport { .. } | McpError::Unauthorized { .. })) => Err(err),
         Err(err @ McpError::HeaderMismatch { .. }) => Err(err),
+        // A refusal that is not MCP at all. On the current transport that is a
+        // server which has never heard of `server/discover`, which is a legacy
+        // server; but it is also exactly what the older transport looks like
+        // from here, because a POST to its event stream lands on a URL that
+        // only answers GET. So an operator's own server gets the older
+        // transport tried before it is called legacy, and the original refusal
+        // is what stands if that turns out to be wrong too.
+        Err(err @ (McpError::Status { .. } | McpError::Malformed { .. }))
+            if dial.legacy_transport =>
+        {
+            match sse_probe(http, dial).await {
+                Ok((server_name, negotiated)) => Ok(Probed {
+                    spoken: Spoken {
+                        era: Era::Legacy,
+                        transport: Transport::Sse,
+                        negotiated: Some(negotiated),
+                    },
+                    server_name,
+                }),
+                // Whose refusal the operator sees turns on how far the second
+                // attempt got. A GET that was not answered with a stream, or
+                // not answered at all, says nothing the first attempt did not;
+                // anything past that came off the server's own event stream and
+                // is the more specific of the two — a 401 that says to sign in,
+                // a revision nothing shares, a session redirected onto another
+                // host. Reporting the `405` there would send an operator to
+                // look at a transport that was working.
+                Err(
+                    McpError::NotAStream { .. }
+                    | McpError::Status { .. }
+                    | McpError::Transport { .. },
+                ) => Err(err),
+                Err(refused) => Err(refused),
+            }
+        }
         // Everything else identifies a server that wants a handshake.
-        Err(_) => Ok(Probed { era: Era::Legacy, server_name: String::new() }),
+        Err(_) => Ok(Probed { spoken: handshaking(), server_name: String::new() }),
     }
+}
+
+/// A server that wants `initialize`, on the transport it was asked over.
+fn handshaking() -> Spoken {
+    Spoken { era: Era::Legacy, transport: Transport::Streamable, negotiated: None }
 }
 
 /// The newest revision this build and that server both have.
@@ -517,14 +756,12 @@ fn agreed(theirs: &[String]) -> Option<String> {
 /// that only knows an older revision answers with that one, and every later
 /// request has to declare it. A revision this build has never heard of is
 /// refused here rather than by sending it back and being refused there.
-async fn initialize(
-    http: &reqwest::Client,
-    endpoint: &str,
-    token: Option<&str>,
-) -> Result<Session, McpError> {
+async fn initialize(http: &reqwest::Client, dial: Dial<'_>) -> Result<Session, McpError> {
+    let endpoint = dial.endpoint;
     let wire = Wire {
         endpoint,
-        token,
+        token: dial.token,
+        extra: dial.headers,
         version: LEGACY_VERSION.to_string(),
         modern: false,
         session_id: None,
@@ -555,8 +792,10 @@ async fn initialize(
 
     let session = Session {
         endpoint: endpoint.to_string(),
-        token: token.map(str::to_string),
+        token: dial.token.map(str::to_string),
+        headers: dial.headers.to_vec(),
         era: Era::Legacy,
+        transport: Transport::Streamable,
         session_id,
         server_name: value
             .get("serverInfo")
@@ -578,26 +817,40 @@ async fn initialize(
 }
 
 /// What every endpoint turned out to speak, for the life of the process.
-fn eras() -> &'static Mutex<HashMap<String, Era>> {
-    static ERAS: OnceLock<Mutex<HashMap<String, Era>>> = OnceLock::new();
+fn eras() -> &'static Mutex<HashMap<String, Spoken>> {
+    static ERAS: OnceLock<Mutex<HashMap<String, Spoken>>> = OnceLock::new();
     ERAS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-fn remembered(endpoint: &str) -> Option<Era> {
+fn remembered(endpoint: &str) -> Option<Spoken> {
     eras().lock().ok()?.get(endpoint).cloned()
 }
 
-fn remember(endpoint: &str, era: &Era) {
+/// Records what the last handshake on this endpoint settled on.
+///
+/// Only ever called for the older transport, and only for a report: nothing on
+/// a request path reads it, because every exchange on that transport
+/// re-negotiates inside itself.
+fn settled(endpoint: &str, negotiated: &str) {
     if let Ok(mut map) = eras().lock() {
-        map.insert(endpoint.to_string(), era.clone());
+        if let Some(spoken) = map.get_mut(endpoint) {
+            spoken.negotiated = Some(negotiated.to_string());
+        }
+    }
+}
+
+fn remember(endpoint: &str, spoken: &Spoken) {
+    if let Ok(mut map) = eras().lock() {
+        map.insert(endpoint.to_string(), spoken.clone());
     }
 }
 
 /// Forgets what an endpoint was, so the next call probes again.
 ///
-/// Called when a remembered era turns out to be wrong, which is what a server
-/// upgraded underneath a running Guaca looks like: the handshake it wanted
-/// yesterday is a `400` today. One failure, then the truth.
+/// Called when a remembered era or transport turns out to be wrong, which is
+/// what a server upgraded underneath a running Guaca looks like: the handshake
+/// it wanted yesterday is a `400` today, and the event stream it served last
+/// month is a `405`. One failure, then the truth.
 pub fn forget(endpoint: &str) {
     if let Ok(mut map) = eras().lock() {
         map.remove(endpoint);
@@ -624,6 +877,11 @@ fn client_info() -> serde_json::Value {
 struct Wire<'a> {
     endpoint: &'a str,
     token: Option<&'a str>,
+    /// The operator's own headers. Applied before anything this client builds,
+    /// so a name that would contradict the request cannot be written from here
+    /// — `Headers::parse` refuses those, and this ordering is what makes that
+    /// refusal the only thing standing between them.
+    extra: &'a [(String, String)],
     version: String,
     modern: bool,
     session_id: Option<&'a str>,
@@ -636,6 +894,7 @@ impl<'a> Wire<'a> {
         Wire {
             endpoint: &session.endpoint,
             token: session.token.as_deref(),
+            extra: &session.headers,
             version: session.version().to_string(),
             modern: session.modern(),
             session_id: session.session_id.as_deref(),
@@ -684,6 +943,9 @@ async fn post(
         // make a different one per request.
         .header("accept", "application/json, text/event-stream")
         .header("mcp-protocol-version", &wire.version);
+    for (name, value) in wire.extra {
+        request = request.header(name.as_str(), value.as_str());
+    }
     if let Some(token) = wire.token {
         request = request.header("authorization", format!("Bearer {token}"));
     }
@@ -725,32 +987,7 @@ async fn post(
     let envelope = decode(&content_type, &text);
 
     if let Some(error) = envelope.as_ref().and_then(|value| value.get("error")) {
-        let code = error.get("code").and_then(serde_json::Value::as_i64).unwrap_or_default();
-        let message = error
-            .get("message")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("it refused and gave no reason");
-        return Err(match code {
-            UNSUPPORTED_VERSION => McpError::NoSharedVersion {
-                endpoint: wire.endpoint.to_string(),
-                supported: error
-                    .get("data")
-                    .and_then(|data| data.get("supported"))
-                    .and_then(serde_json::Value::as_array)
-                    .map(|all| {
-                        all.iter()
-                            .filter_map(serde_json::Value::as_str)
-                            .map(str::to_string)
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-            },
-            HEADER_MISMATCH => McpError::HeaderMismatch {
-                endpoint: wire.endpoint.to_string(),
-                detail: message.to_string(),
-            },
-            _ => McpError::Rejected { message: message.to_string() },
-        });
+        return Err(refusal(wire.endpoint, error));
     }
 
     if !status.is_success() {
@@ -772,6 +1009,47 @@ async fn post(
     })?;
 
     Ok((result, issued))
+}
+
+/// A JSON-RPC `error` object, as the refusal it means here.
+///
+/// One function because both transports produce one and the three codes mean
+/// the same thing on either: two of them are how a modern server is recognized,
+/// and everything else is a server that understood the call and said no.
+fn refusal(endpoint: &str, error: &serde_json::Value) -> McpError {
+    let code = error.get("code").and_then(serde_json::Value::as_i64).unwrap_or_default();
+    let message = error
+        .get("message")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("it refused and gave no reason");
+    match code {
+        UNSUPPORTED_VERSION => McpError::NoSharedVersion {
+            endpoint: endpoint.to_string(),
+            supported: error
+                .get("data")
+                .and_then(|data| data.get("supported"))
+                .and_then(serde_json::Value::as_array)
+                .map(|all| {
+                    all.iter().filter_map(serde_json::Value::as_str).map(str::to_string).collect()
+                })
+                .unwrap_or_default(),
+        },
+        HEADER_MISMATCH => {
+            McpError::HeaderMismatch { endpoint: endpoint.to_string(), detail: message.to_string() }
+        }
+        _ => McpError::Rejected { message: message.to_string() },
+    }
+}
+
+/// The `result` out of a decoded reply, or the refusal it carried instead.
+fn result_of(endpoint: &str, envelope: &serde_json::Value) -> Result<serde_json::Value, McpError> {
+    if let Some(error) = envelope.get("error") {
+        return Err(refusal(endpoint, error));
+    }
+    envelope.get("result").cloned().ok_or_else(|| McpError::Malformed {
+        endpoint: endpoint.to_string(),
+        detail: "a reply with neither a result nor an error".to_string(),
+    })
 }
 
 /// A modern request's `params`, with the metadata every one of them carries.
@@ -806,6 +1084,9 @@ async fn notify(
         .header("content-type", "application/json")
         .header("accept", "application/json, text/event-stream")
         .header("mcp-protocol-version", session.version());
+    for (name, value) in &session.headers {
+        request = request.header(name.as_str(), value.as_str());
+    }
     if let Some(token) = &session.token {
         request = request.header("authorization", format!("Bearer {token}"));
     }
@@ -818,6 +1099,362 @@ async fn notify(
         .await
         .map(|_| ())
         .map_err(|source| McpError::Transport { endpoint: session.endpoint.clone(), source })
+}
+
+// ---- the transport streamable HTTP replaced -------------------------------
+
+/// One request over HTTP+SSE, handshake and all, on a stream of its own.
+///
+/// `call` is `None` for the probe, which only wants to know that the server is
+/// there and what it calls itself. Whatever comes back, the stream is dropped
+/// when this returns.
+///
+/// That is the same "a session per call" rule the module argues for on the
+/// current transport, reached from the other side. There, keeping a session
+/// would be a second thing that can go stale. Here there is nothing to keep:
+/// `initialize` establishes a session that belongs to *this* event stream, and
+/// a stream held open between turns is a socket per plugin per crew, kept alive
+/// through sleep and reconnect, for a handshake that costs one round trip.
+///
+/// The whole thing is inside one timeout rather than one per request, because
+/// the failure this transport actually has is a stream that opens and then says
+/// nothing, and a per-request timeout on a socket that is technically still
+/// connected never fires.
+async fn sse_exchange(
+    http: &reqwest::Client,
+    dial: Dial<'_>,
+    call: Option<(&str, serde_json::Value)>,
+    timeout: Duration,
+) -> Result<Answered, McpError> {
+    let endpoint = dial.endpoint;
+    let method = call.as_ref().map(|(method, _)| *method).unwrap_or("initialize").to_string();
+
+    let work = async {
+        let mut request = http.get(endpoint).header("accept", "text/event-stream");
+        for (name, value) in dial.headers {
+            request = request.header(name.as_str(), value.as_str());
+        }
+        if let Some(token) = dial.token {
+            request = request.header("authorization", format!("Bearer {token}"));
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|source| McpError::Transport { endpoint: endpoint.to_string(), source })?;
+
+        let status = response.status();
+        if status.as_u16() == 401 {
+            return Err(McpError::Unauthorized {
+                endpoint: endpoint.to_string(),
+                challenge: header(&response, "www-authenticate"),
+            });
+        }
+        if !status.is_success() {
+            return Err(McpError::Status {
+                endpoint: endpoint.to_string(),
+                status: status.as_u16(),
+                body: String::new(),
+            });
+        }
+        // The one thing that says this is an event stream rather than a page
+        // that happened to answer a GET. Without it, an endpoint behind a login
+        // wall answers 200 with HTML and this would sit reading it for two
+        // minutes before reporting a timeout.
+        let content_type = header(&response, "content-type").unwrap_or_default();
+        if !content_type.contains("text/event-stream") {
+            return Err(McpError::NotAStream { endpoint: endpoint.to_string(), content_type });
+        }
+
+        let mut stream = response.bytes_stream();
+        let mut buffer = String::new();
+
+        // Where requests on this stream go. The server names it first and names
+        // it once, and nothing can be sent until it has.
+        let named =
+            read_until(endpoint, &mut stream, &mut buffer, |name, _| name == "endpoint").await?.1;
+        let messages = same_origin(endpoint, &named)?;
+
+        let hello = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": LEGACY_VERSION,
+                "capabilities": {},
+                "clientInfo": client_info(),
+            },
+        });
+        post_message(http, dial, &messages, &hello).await?;
+        let established = reply_to(endpoint, &mut stream, &mut buffer, 1).await?;
+
+        let agreed = established
+            .get("protocolVersion")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or(LEGACY_VERSION)
+            .to_string();
+        if !SUPPORTED.contains(&agreed.as_str()) {
+            return Err(McpError::NoSharedVersion {
+                endpoint: endpoint.to_string(),
+                supported: vec![agreed],
+            });
+        }
+        let server_name = established
+            .get("serverInfo")
+            .and_then(|info| info.get("name"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+
+        // A notification, and the servers that gate on it refuse every later
+        // call with "not initialized" if it is skipped. Nothing comes back.
+        let ready = serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" });
+        let _ = post_message(http, dial, &messages, &ready).await;
+
+        let Some((method, params)) = call else {
+            return Ok(Answered {
+                result: serde_json::Value::Null,
+                server_name,
+                negotiated: agreed,
+            });
+        };
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": method,
+            "params": params,
+        });
+        // A server that answers the POST with the reply rather than putting it
+        // on the stream is out of spec and is in the field, so an answer here
+        // is taken and the stream is not waited on for a second copy of it.
+        let result = match post_message(http, dial, &messages, &body).await? {
+            Some(inline) => result_of(endpoint, &inline)?,
+            None => reply_to(endpoint, &mut stream, &mut buffer, 2).await?,
+        };
+        Ok(Answered { result, server_name, negotiated: agreed })
+    };
+
+    tokio::time::timeout(timeout, work).await.map_err(|_| McpError::Silent {
+        endpoint: endpoint.to_string(),
+        method,
+        secs: timeout.as_secs(),
+    })?
+}
+
+/// Opens a stream, shakes hands and asks for nothing else.
+///
+/// The era probe's second question: a server that answers this is one on the
+/// older transport, and its own name comes back as the by-product the connect
+/// path was going to ask for anyway.
+async fn sse_probe(http: &reqwest::Client, dial: Dial<'_>) -> Result<(String, String), McpError> {
+    let answered = sse_exchange(http, dial, None, CONNECT_TIMEOUT).await?;
+    Ok((answered.server_name, answered.negotiated))
+}
+
+/// What one exchange on the older transport produced.
+///
+/// Three, because the handshake on this transport belongs to the stream rather
+/// than to a session, so the two things a handshake establishes come back with
+/// every request instead of being read off the session that has them.
+struct Answered {
+    result: serde_json::Value,
+    server_name: String,
+    negotiated: String,
+}
+
+/// POSTs one JSON-RPC message, and takes a reply if the server gave one.
+///
+/// The documented answer is `202` and an empty body: the reply comes down the
+/// stream. Some servers answer with it directly, which is what the `Some` is
+/// for, and there is no cost to accepting both.
+async fn post_message(
+    http: &reqwest::Client,
+    dial: Dial<'_>,
+    messages: &str,
+    body: &serde_json::Value,
+) -> Result<Option<serde_json::Value>, McpError> {
+    let mut request = http
+        .post(messages)
+        .timeout(CONNECT_TIMEOUT)
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream");
+    for (name, value) in dial.headers {
+        request = request.header(name.as_str(), value.as_str());
+    }
+    if let Some(token) = dial.token {
+        request = request.header("authorization", format!("Bearer {token}"));
+    }
+    let response = request
+        .json(body)
+        .send()
+        .await
+        .map_err(|source| McpError::Transport { endpoint: messages.to_string(), source })?;
+
+    let status = response.status();
+    let challenge = header(&response, "www-authenticate");
+    let content_type = header(&response, "content-type").unwrap_or_default();
+    let text = response
+        .text()
+        .await
+        .map_err(|source| McpError::Transport { endpoint: messages.to_string(), source })?;
+
+    if status.as_u16() == 401 {
+        return Err(McpError::Unauthorized { endpoint: messages.to_string(), challenge });
+    }
+    if !status.is_success() {
+        return Err(McpError::Status {
+            endpoint: messages.to_string(),
+            status: status.as_u16(),
+            body: text.chars().take(400).collect(),
+        });
+    }
+    Ok(decode(&content_type, &text).filter(|value| value.get("jsonrpc").is_some()))
+}
+
+/// Reads the stream until the reply to one request arrives.
+///
+/// Matched on the id rather than taken as the next message, because a server
+/// may push a notification — a log line, a progress report — between the POST
+/// and the answer, and reading one of those as the result is a tool call that
+/// returns somebody else's message.
+async fn reply_to<S, T>(
+    endpoint: &str,
+    stream: &mut S,
+    buffer: &mut String,
+    id: i64,
+) -> Result<serde_json::Value, McpError>
+where
+    S: futures_util::Stream<Item = Result<T, reqwest::Error>> + Unpin,
+    T: AsRef<[u8]>,
+{
+    let matching = |_: &str, data: &str| {
+        serde_json::from_str::<serde_json::Value>(data)
+            .is_ok_and(|value| value.get("id").and_then(serde_json::Value::as_i64) == Some(id))
+    };
+    let (_, data) = read_until(endpoint, stream, buffer, matching).await?;
+    let envelope: serde_json::Value =
+        serde_json::from_str(&data).map_err(|err| McpError::Malformed {
+            endpoint: endpoint.to_string(),
+            detail: format!("an event on its stream did not parse: {err}"),
+        })?;
+    result_of(endpoint, &envelope)
+}
+
+/// Reads events off an open stream until one the caller wants goes past.
+///
+/// A closed stream is the failure this returns rather than looping on: a server
+/// that hangs up mid-session leaves an empty read forever, and an outer timeout
+/// would report it two minutes later as silence, which reads as a slow server
+/// rather than a dropped connection.
+async fn read_until<S, T>(
+    endpoint: &str,
+    stream: &mut S,
+    buffer: &mut String,
+    want: impl Fn(&str, &str) -> bool,
+) -> Result<(String, String), McpError>
+where
+    S: futures_util::Stream<Item = Result<T, reqwest::Error>> + Unpin,
+    T: AsRef<[u8]>,
+{
+    use futures_util::StreamExt;
+    loop {
+        while let Some((name, data)) = take_event(buffer) {
+            if want(&name, &data) {
+                return Ok((name, data));
+            }
+        }
+        let Some(chunk) = stream.next().await else {
+            return Err(McpError::Malformed {
+                endpoint: endpoint.to_string(),
+                detail: "its event stream closed before it answered".to_string(),
+            });
+        };
+        let chunk = chunk
+            .map_err(|source| McpError::Transport { endpoint: endpoint.to_string(), source })?;
+        buffer.push_str(&String::from_utf8_lossy(chunk.as_ref()));
+    }
+}
+
+/// Pulls one complete event off the front of the buffer.
+///
+/// Its own function rather than `SseDecoder` because this transport needs the
+/// event *name*: `endpoint` and `message` are two different things arriving on
+/// one stream, and the decoder beside the model client throws the name away.
+fn take_event(buffer: &mut String) -> Option<(String, String)> {
+    // An event ends at a blank line, which is two newlines with nothing but an
+    // optional carriage return between them.
+    let end = [buffer.find("\n\n").map(|at| (at, 2)), buffer.find("\r\n\r\n").map(|at| (at, 4))]
+        .into_iter()
+        .flatten()
+        .min_by_key(|(at, _)| *at)?;
+    let (at, width) = end;
+    let block: String = buffer.drain(..at + width).collect();
+
+    let mut name = String::new();
+    let mut data = String::new();
+    for raw in block.lines() {
+        let line = raw.strip_suffix('\r').unwrap_or(raw);
+        if let Some(rest) = line.strip_prefix("event:") {
+            name = rest.trim().to_string();
+        } else if let Some(rest) = line.strip_prefix("data:") {
+            if !data.is_empty() {
+                data.push('\n');
+            }
+            data.push_str(rest.strip_prefix(' ').unwrap_or(rest));
+        }
+    }
+    // The default event name, per the SSE specification.
+    if name.is_empty() {
+        name = "message".to_string();
+    }
+    Some((name, data))
+}
+
+/// The URL the server named for messages, if it is on the server's own origin.
+///
+/// Relative is the common form and absolute is legal, and an absolute one
+/// pointing somewhere else is refused rather than followed. This is a redirect
+/// invented by the far end after the connection was made, and following it
+/// would put the crew's credential and every argument of every tool call on a
+/// host the operator never named.
+fn same_origin(endpoint: &str, named: &str) -> Result<String, McpError> {
+    let named = named.trim();
+    let refuse = |detail: String| McpError::Malformed { endpoint: endpoint.to_string(), detail };
+    if named.is_empty() {
+        return Err(refuse("its event stream named an empty message endpoint".to_string()));
+    }
+    let origin = origin_of(endpoint)
+        .ok_or_else(|| refuse(format!("{endpoint} is not an address with an origin")))?;
+
+    let resolved = if named.contains("://") {
+        let theirs = origin_of(named)
+            .ok_or_else(|| refuse(format!("its event stream named {named}, which is not a URL")))?;
+        if theirs != origin {
+            return Err(refuse(format!(
+                "its event stream named {named} for messages, which is a different server; a \
+                 crew's credential is not sent to an address the operator did not name"
+            )));
+        }
+        named.to_string()
+    } else if let Some(path) = named.strip_prefix('/') {
+        format!("{origin}/{path}")
+    } else {
+        // Relative to the directory the stream itself was opened in, which is
+        // what a browser would do with it.
+        let path = endpoint.strip_prefix(&origin).unwrap_or("");
+        let base = path.rsplit_once('/').map(|(before, _)| before).unwrap_or("");
+        format!("{origin}{base}/{named}")
+    };
+    Ok(resolved)
+}
+
+/// Scheme and authority, which is what "the same server" means here.
+fn origin_of(url: &str) -> Option<String> {
+    let (scheme, rest) = url.split_once("://")?;
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or_default();
+    if authority.is_empty() {
+        return None;
+    }
+    Some(format!("{}://{}", scheme.to_ascii_lowercase(), authority.to_ascii_lowercase()))
 }
 
 fn header(response: &reqwest::Response, name: &str) -> Option<String> {
@@ -1025,6 +1662,81 @@ fn decode(content_type: &str, body: &str) -> Option<serde_json::Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn an_event_carries_its_name_as_well_as_its_data() {
+        // The whole reason this is not `SseDecoder`: `endpoint` and `message`
+        // arrive on one stream and mean entirely different things.
+        let mut buffer = String::from("event: endpoint\ndata: /messages?s=1\n\n");
+        assert_eq!(take_event(&mut buffer), Some(("endpoint".into(), "/messages?s=1".into())));
+        assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn an_unnamed_event_is_a_message() {
+        // The SSE default, and servers rely on it.
+        let mut buffer = String::from("data: {\"id\":1}\n\n");
+        assert_eq!(take_event(&mut buffer), Some(("message".into(), "{\"id\":1}".into())));
+    }
+
+    #[test]
+    fn an_event_split_across_chunks_waits_for_the_rest() {
+        // A JSON payload cut mid-token is the routine case on a socket, and
+        // parsing half of it is a tool call that comes back as a parse error.
+        let mut buffer = String::from("event: message\ndata: {\"id\":2,\"resu");
+        assert_eq!(take_event(&mut buffer), None);
+        buffer.push_str("lt\":{}}\n\n");
+        let (name, data) = take_event(&mut buffer).unwrap();
+        assert_eq!(name, "message");
+        assert_eq!(serde_json::from_str::<serde_json::Value>(&data).unwrap()["id"], 2);
+    }
+
+    #[test]
+    fn crlf_framing_is_the_same_event() {
+        let mut buffer = String::from("event: endpoint\r\ndata: /m\r\n\r\n");
+        assert_eq!(take_event(&mut buffer), Some(("endpoint".into(), "/m".into())));
+    }
+
+    #[test]
+    fn a_message_endpoint_is_resolved_against_the_stream_it_was_named_on() {
+        let at = "https://box.example.com/sse";
+        assert_eq!(
+            same_origin(at, "/messages?s=1").unwrap(),
+            "https://box.example.com/messages?s=1"
+        );
+        assert_eq!(
+            same_origin(at, "messages?s=1").unwrap(),
+            "https://box.example.com/messages?s=1"
+        );
+        assert_eq!(
+            same_origin(at, "https://box.example.com/messages").unwrap(),
+            "https://box.example.com/messages"
+        );
+    }
+
+    #[test]
+    fn a_message_endpoint_on_another_server_is_refused() {
+        // A redirect invented by the far end after the connection was made.
+        // Followed, it puts the crew's credential and every tool argument on a
+        // host the operator never named.
+        let refused = same_origin("https://box.example.com/sse", "https://evil.example/m");
+        let message = refused.unwrap_err().to_string();
+        assert!(message.contains("different server"), "{message}");
+        assert!(message.contains("did not name"), "{message}");
+    }
+
+    #[test]
+    fn every_revision_this_build_speaks_sorts_as_a_date() {
+        // `modern` is a string comparison, which only works because a revision
+        // is `YYYY-MM-DD`. A revision named any other way would silently sort
+        // into the wrong era.
+        let mut sorted = SUPPORTED;
+        sorted.sort_unstable();
+        sorted.reverse();
+        assert_eq!(sorted, SUPPORTED, "SUPPORTED has to be newest first");
+        assert!(modern(SUPPORTED[0]));
+        assert!(!modern("2024-11-05"), "the transport this build falls back to is not modern");
+    }
 
     #[test]
     fn a_json_reply_decodes() {

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -39,6 +39,7 @@
 
 use std::time::Duration;
 
+use reqwest::RequestBuilder;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -158,6 +159,63 @@ impl Grant {
     }
 }
 
+/// Headers the operator gave the resource, and the rule about where they go.
+///
+/// A sign-in normally reaches several hosts: the resource publishes its
+/// metadata, an authorization server publishes its own, and registration and
+/// the token exchange happen at that server. Most of the time those are two
+/// different origins.
+///
+/// The operator's headers belong to *their* server and nowhere else. A gate in
+/// front of a self-hosted MCP server refuses everything on that host including
+/// the metadata document a sign-in has to read first, so leaving them off makes
+/// the composition — behind a gate, and signing in — fail at discovery with a
+/// `403` nobody can act on. Sending them to every host in the dance instead
+/// would hand the operator's gate credential to a vendor's authorization
+/// server, which is a credential leak dressed up as a convenience.
+///
+/// So the rule is the origin: same origin as the resource, headers go on;
+/// anywhere else, they do not. That covers the self-hosted server that is its
+/// own issuer, where every request in the flow is behind the same gate, and it
+/// covers a challenge that names metadata on somebody else's host, where none
+/// of them are.
+#[derive(Clone, Default)]
+pub struct Gate<'a> {
+    origin: String,
+    headers: &'a [(String, String)],
+}
+
+impl<'a> Gate<'a> {
+    /// Nothing to send, which is every catalog server and most added ones.
+    pub fn none() -> Gate<'static> {
+        Gate::default()
+    }
+
+    pub fn on(resource: &str, headers: &'a [(String, String)]) -> Gate<'a> {
+        Gate {
+            origin: split_origin(resource).map(|(origin, _)| origin).unwrap_or_default(),
+            headers,
+        }
+    }
+
+    /// This request, with the operator's headers on it if it is going to their
+    /// own server.
+    fn apply(&self, request: RequestBuilder, url: &str) -> RequestBuilder {
+        if self.headers.is_empty() || self.origin.is_empty() {
+            return request;
+        }
+        let Some((origin, _)) = split_origin(url) else { return request };
+        if !origin.eq_ignore_ascii_case(&self.origin) {
+            return request;
+        }
+        let mut request = request;
+        for (name, value) in self.headers {
+            request = request.header(name.as_str(), value.as_str());
+        }
+        request
+    }
+}
+
 /// Runs the whole flow and hands back a usable grant.
 ///
 /// `open` is given the URL the operator has to visit. It is a callback rather
@@ -167,11 +225,12 @@ impl Grant {
 pub async fn authorize(
     resource: &str,
     challenge_header: Option<&str>,
+    gate: &Gate<'_>,
     open: impl FnOnce(&str) -> Result<(), String>,
     now_ms: impl Fn() -> i64,
 ) -> Result<Grant, OauthError> {
     let http = http()?;
-    let discovered = discover(resource, challenge_header).await?;
+    let discovered = discover_through(resource, challenge_header, gate).await?;
     let scope = discovered.requested_scope();
     let Discovered { issuer, server, .. } = discovered;
 
@@ -188,7 +247,7 @@ pub async fn authorize(
     let port = listener.local_addr().map_err(|source| OauthError::NoPort { source })?.port();
     let redirect_uri = format!("http://127.0.0.1:{port}/callback");
 
-    let client = register(&http, &registration_endpoint, &redirect_uri).await?;
+    let client = register(&http, &registration_endpoint, &redirect_uri, gate).await?;
 
     let verifier = secret();
     let challenge = pkce_challenge(&verifier);
@@ -219,7 +278,8 @@ pub async fn authorize(
     // the operator does not use hands back a code this client would then present
     // to the one they do.
     let code = wait_for_redirect(listener, &state, &issuer).await?;
-    exchange(&http, &server, &client, &code, &verifier, &redirect_uri, resource, &now_ms).await
+    exchange(&http, &server, &client, &code, &verifier, &redirect_uri, resource, gate, &now_ms)
+        .await
 }
 
 /// Trades a refresh token for a fresh grant.
@@ -227,7 +287,11 @@ pub async fn authorize(
 /// Keeps the old refresh token when the server does not issue a new one, which
 /// is legal and common: dropping it would make the next renewal impossible and
 /// the plugin would quietly stop working a day later.
-pub async fn refresh(grant: &Grant, now_ms: impl Fn() -> i64) -> Result<Grant, OauthError> {
+pub async fn refresh(
+    grant: &Grant,
+    gate: &Gate<'_>,
+    now_ms: impl Fn() -> i64,
+) -> Result<Grant, OauthError> {
     let Some(refresh_token) = grant.refresh_token.clone() else {
         return Err(OauthError::NoRefreshToken);
     };
@@ -242,7 +306,7 @@ pub async fn refresh(grant: &Grant, now_ms: impl Fn() -> i64) -> Result<Grant, O
         form.push(("client_secret".to_string(), secret.clone()));
     }
 
-    let issued = post_token(&http, &grant.token_endpoint, &form).await?;
+    let issued = post_token(&http, &grant.token_endpoint, &form, gate).await?;
     Ok(Grant {
         access_token: issued.access_token,
         refresh_token: issued.refresh_token.or(Some(refresh_token)),
@@ -285,9 +349,18 @@ pub async fn discover(
     resource: &str,
     challenge_header: Option<&str>,
 ) -> Result<Discovered, OauthError> {
+    discover_through(resource, challenge_header, &Gate::none()).await
+}
+
+/// The same, for a resource that is behind something.
+async fn discover_through(
+    resource: &str,
+    challenge_header: Option<&str>,
+    gate: &Gate<'_>,
+) -> Result<Discovered, OauthError> {
     let http = http()?;
-    let Resource { issuer, scopes } = resource_for(&http, resource, challenge_header).await?;
-    let server = server_metadata(&http, &issuer).await?;
+    let Resource { issuer, scopes } = resource_for(&http, resource, challenge_header, gate).await?;
+    let server = server_metadata(&http, &issuer, gate).await?;
     Ok(Discovered {
         issuer,
         server,
@@ -337,19 +410,20 @@ async fn resource_for(
     http: &reqwest::Client,
     resource: &str,
     challenge: Option<&str>,
+    gate: &Gate<'_>,
 ) -> Result<Resource, OauthError> {
     let mut tried = Vec::new();
 
     if let Some(url) = challenge.and_then(resource_metadata_url) {
         tried.push(url.clone());
-        if let Some(found) = protected_resource(http, &url).await {
+        if let Some(found) = protected_resource(http, &url, gate).await {
             return Ok(found);
         }
     }
 
     for url in well_known(resource, "oauth-protected-resource") {
         tried.push(url.clone());
-        if let Some(found) = protected_resource(http, &url).await {
+        if let Some(found) = protected_resource(http, &url, gate).await {
             return Ok(found);
         }
     }
@@ -360,7 +434,11 @@ async fn resource_for(
     })
 }
 
-async fn protected_resource(http: &reqwest::Client, url: &str) -> Option<Resource> {
+async fn protected_resource(
+    http: &reqwest::Client,
+    url: &str,
+    gate: &Gate<'_>,
+) -> Option<Resource> {
     #[derive(Deserialize)]
     struct Metadata {
         #[serde(default)]
@@ -369,7 +447,7 @@ async fn protected_resource(http: &reqwest::Client, url: &str) -> Option<Resourc
         scopes_supported: Vec<String>,
     }
 
-    let response = http.get(url).timeout(HTTP_TIMEOUT).send().await.ok()?;
+    let response = gate.apply(http.get(url), url).timeout(HTTP_TIMEOUT).send().await.ok()?;
     if !response.status().is_success() {
         return None;
     }
@@ -415,12 +493,14 @@ pub struct ServerMetadata {
 pub(crate) async fn server_metadata(
     http: &reqwest::Client,
     issuer: &str,
+    gate: &Gate<'_>,
 ) -> Result<ServerMetadata, OauthError> {
     let mut tried = Vec::new();
     for name in ["oauth-authorization-server", "openid-configuration"] {
         for url in well_known(issuer, name) {
             tried.push(url.clone());
-            let Ok(response) = http.get(&url).timeout(HTTP_TIMEOUT).send().await else {
+            let Ok(response) = gate.apply(http.get(&url), &url).timeout(HTTP_TIMEOUT).send().await
+            else {
                 continue;
             };
             if !response.status().is_success() {
@@ -556,6 +636,7 @@ async fn register(
     http: &reqwest::Client,
     endpoint: &str,
     redirect_uri: &str,
+    gate: &Gate<'_>,
 ) -> Result<Registered, OauthError> {
     let body = serde_json::json!({
         "client_name": "Guaca",
@@ -565,9 +646,16 @@ async fn register(
         "token_endpoint_auth_method": "none",
     });
 
-    let response =
-        http.post(endpoint).timeout(HTTP_TIMEOUT).json(&body).send().await.map_err(|source| {
-            OauthError::Transport { what: "to register", url: endpoint.to_string(), source }
+    let response = gate
+        .apply(http.post(endpoint), endpoint)
+        .timeout(HTTP_TIMEOUT)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|source| OauthError::Transport {
+            what: "to register",
+            url: endpoint.to_string(),
+            source,
         })?;
 
     let status = response.status();
@@ -717,6 +805,7 @@ async fn exchange(
     verifier: &str,
     redirect_uri: &str,
     resource: &str,
+    gate: &Gate<'_>,
     now_ms: &impl Fn() -> i64,
 ) -> Result<Grant, OauthError> {
     let secret = client.secret();
@@ -734,7 +823,7 @@ async fn exchange(
         form.push(("client_secret".to_string(), secret.clone()));
     }
 
-    let issued = post_token(http, &server.token_endpoint, &form).await?;
+    let issued = post_token(http, &server.token_endpoint, &form, gate).await?;
     if issued.access_token.is_empty() {
         return Err(OauthError::NoToken { issuer: server.token_endpoint.clone() });
     }
@@ -753,10 +842,18 @@ pub(crate) async fn post_token(
     http: &reqwest::Client,
     endpoint: &str,
     form: &[(String, String)],
+    gate: &Gate<'_>,
 ) -> Result<Issued, OauthError> {
-    let response =
-        http.post(endpoint).timeout(HTTP_TIMEOUT).form(form).send().await.map_err(|source| {
-            OauthError::Transport { what: "for a token", url: endpoint.to_string(), source }
+    let response = gate
+        .apply(http.post(endpoint), endpoint)
+        .timeout(HTTP_TIMEOUT)
+        .form(form)
+        .send()
+        .await
+        .map_err(|source| OauthError::Transport {
+            what: "for a token",
+            url: endpoint.to_string(),
+            source,
         })?;
 
     let status = response.status();

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -20,16 +20,17 @@
 //!
 //! ## What the agent is never told
 //!
-//! The token. A plugin tool call is made by Guaca, not by the machine: the
-//! agent names a tool and arguments and reads a result, and the grant does not
-//! appear in the prompt, the transcript, an event, or the sandbox's
+//! The token, and the headers beside it. A plugin tool call is made by Guaca,
+//! not by the machine: the agent names a tool and arguments and reads a result,
+//! and neither the grant nor anything [`crate::domain::plugin::Headers`] holds
+//! appears in the prompt, the transcript, an event, or the sandbox's
 //! environment. This is the same boundary a pasted credential has, and it is
 //! stronger, because with a plugin there is no variable for the agent to echo.
 
 use crate::db::store::{PluginReach, Store, StoreError};
 use crate::domain::ids::{AgentId, GroupId, PluginId};
 use crate::domain::now_ms;
-use crate::domain::plugin::{Plugin, PluginKind, PluginTool};
+use crate::domain::plugin::{Headers, Plugin, PluginKind, PluginTool, ServerReport, SigninNeed};
 use crate::mcp::{self, McpError};
 use crate::oauth::{self, Grant, OauthError};
 
@@ -87,6 +88,13 @@ pub enum PluginError {
 /// vendors discover theirs; the operator's own account lends its own; and a
 /// server somebody wrote themselves very often wants a key that was minted by
 /// hand and has no authorization server behind it at all.
+///
+/// [`Headers`] is not a fourth and is passed beside this rather than into it.
+/// It answers a different question — how a request *reaches* the server, not
+/// who is asking — so it composes with all three instead of replacing one. The
+/// server that proves the difference is one behind a gate that also signs in:
+/// the headers get past the gate, and the 401 from behind it is still
+/// `Discover`'s to answer.
 #[derive(Debug, Clone, Copy)]
 pub enum Credential<'a> {
     /// Whatever the server asks for: nothing, or the browser dance.
@@ -131,6 +139,11 @@ pub async fn connect(
     // moved it, and the account's own address for an account-backed kind.
     endpoint: &str,
     credential: Credential<'_>,
+    // What the operator gave this server beyond a credential. Empty for the
+    // catalog, which needs none, and for most added servers. Passed rather than
+    // read back off the row because this is the call that writes the row: a
+    // reconnection is where they change.
+    headers: &Headers,
     open: impl FnOnce(&str) -> Result<(), String>,
 ) -> Result<Plugin, PluginError> {
     // An account-backed plugin never runs the browser dance. Its server is the
@@ -141,33 +154,53 @@ pub async fn connect(
         let Credential::Account(used) = credential else {
             return Err(PluginError::NoAccount { label: kind.label().to_string() });
         };
-        let (_session, tools) = ask(endpoint, Some(used.token)).await?;
+        let (_session, tools) =
+            ask(dial(kind.is_custom(), endpoint, headers).with_token(Some(used.token))).await?;
         // No account label. An MCP server's own name is not an account, and for
         // this one it is "Guaca Connectors", which on a card reading "Signed in
         // as ..." looks exactly like an answer to whose mailbox this is and is
         // not. Which identity this row uses is `connection`, and the operator's
         // own name for it lives at the account, where it can change without
         // this row going stale.
-        return Ok(store.save_plugin(group, kind, "", &tools, None, used.connection)?);
+        return Ok(store.save_plugin(group, kind, "", &tools, None, used.connection, headers)?);
     }
 
+    let dialed = dial(kind.is_custom(), endpoint, headers);
     let (session, tools, grant) = match credential {
         // A pasted key is a grant with nothing to renew it. Everything after
         // this line — where it is stored, how it is spent, what happens when the
         // server stops accepting it — is the OAuth path's, unchanged.
         Credential::Key(key) => {
-            let (session, tools) = ask(endpoint, Some(key)).await?;
+            let (session, tools) = ask(dialed.with_token(Some(key))).await?;
             (session, tools, Some(Grant::key(key)))
         }
-        _ => match ask(endpoint, None).await {
+        // Headers the operator wrote are not a second credential path and do
+        // not skip this. A server they authenticate answers the first request,
+        // and nothing is discovered because nothing was refused; one that gates
+        // on them *and* signs in — an MCP server behind Cloudflare Access is the
+        // shape — answers 401 from behind the gate, and the browser dance runs
+        // with the headers on every request it makes from here on.
+        _ => match ask(dialed).await {
             Ok((session, tools)) => (session, tools, None),
             Err(err) if err.is_unauthorized() => {
                 let challenge = match &err {
                     McpError::Unauthorized { challenge, .. } => challenge.clone(),
                     _ => None,
                 };
-                let grant = oauth::authorize(endpoint, challenge.as_deref(), open, now_ms).await?;
-                let (session, tools) = ask(endpoint, Some(&grant.access_token)).await?;
+                // The operator's own headers go with it. A gate in front of
+                // a self-hosted server refuses the metadata document a
+                // sign-in has to read first, so without them this composition
+                // fails at discovery with a 403 nobody can act on. `Gate` is
+                // what keeps them off the authorization server's own host.
+                let grant = oauth::authorize(
+                    endpoint,
+                    challenge.as_deref(),
+                    &oauth::Gate::on(endpoint, headers.wire()),
+                    open,
+                    now_ms,
+                )
+                .await?;
+                let (session, tools) = ask(dialed.with_token(Some(&grant.access_token))).await?;
                 (session, tools, Some(grant))
             }
             Err(err) => return Err(err.into()),
@@ -178,7 +211,115 @@ pub async fn connect(
 
     // Only an account-backed kind carries one; the others sign in per group and
     // their grant already names the identity it was issued to.
-    Ok(store.save_plugin(group, kind, &account_label, &tools, grant.as_ref(), "")?)
+    Ok(store.save_plugin(group, kind, &account_label, &tools, grant.as_ref(), "", headers)?)
+}
+
+/// How this server is reached, before anything is presented to it.
+///
+/// The one place the transport question is answered, and it is answered off
+/// the kind: a server the operator added may be spoken to over the transport
+/// streamable HTTP replaced, and one on the catalog may not. `mcp.rs` has the
+/// argument; this is where it is applied, because the kind is a plugin concept
+/// and that file has never heard of one.
+fn dial<'a>(custom: bool, endpoint: &'a str, headers: &'a Headers) -> mcp::Dial<'a> {
+    mcp::Dial { endpoint, token: None, headers: headers.wire(), legacy_transport: custom }
+}
+
+/// Dials a server and says what it found, without connecting or authorizing it.
+///
+/// The whole of "test this". It runs the same probe, the same handshake and the
+/// same `tools/list` a connection runs, over the same two transports, with
+/// whatever credential and headers it was given — and then throws the answer
+/// away instead of writing a row. Anything less than the real path is a test
+/// that passes for a server the crew cannot use.
+///
+/// A 401 is a finding rather than a failure, and it is the one place this
+/// deliberately stops short of `connect`: the browser dance is not run. An
+/// operator testing an address is asking whether it is the right address, and
+/// answering that by sending them to a consent screen is a question they did
+/// not ask.
+pub async fn inspect(
+    custom: bool,
+    endpoint: &str,
+    token: Option<&str>,
+    headers: &Headers,
+) -> Result<ServerReport, PluginError> {
+    let started = std::time::Instant::now();
+    let dialed = dial(custom, endpoint, headers).with_token(token);
+    let report =
+        |session: &mcp::Session, server: String, tools: Vec<PluginTool>, signin| ServerReport {
+            endpoint: endpoint.to_string(),
+            transport: if session.sse() {
+                "HTTP+SSE (2024-11-05)".to_string()
+            } else {
+                "streamable HTTP".to_string()
+            },
+            protocol: session.protocol().to_string(),
+            handshake: !session.modern(),
+            signin,
+            server,
+            tools: tools.into_iter().map(|tool| tool.name).collect(),
+            ms: started.elapsed().as_millis() as u64,
+        };
+
+    match ask(dialed).await {
+        Ok((session, tools)) => {
+            let server = mcp::describe(&session).await.unwrap_or_default();
+            let signin = if token.is_some() { SigninNeed::Accepted } else { SigninNeed::None };
+            Ok(report(&session, server, tools, signin))
+        }
+        // Reachable, and it wants something. Which of the two it is turns on
+        // what was presented, and the difference is the whole value of asking:
+        // with nothing presented this is a server that signs in, and with a key
+        // presented it is a key the server does not accept. Those have nothing
+        // in common except the status code.
+        Err(err) if err.is_unauthorized() => Ok(ServerReport {
+            endpoint: endpoint.to_string(),
+            // Unknown, and said as nothing rather than guessed at: the refusal
+            // arrived before either question was settled.
+            transport: String::new(),
+            protocol: String::new(),
+            handshake: false,
+            signin: if token.is_some() { SigninNeed::Refused } else { SigninNeed::Wanted },
+            server: String::new(),
+            tools: Vec::new(),
+            ms: started.elapsed().as_millis() as u64,
+        }),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// The same question, asked of a plugin the crew has already connected.
+///
+/// Not a narrower `connect`: connecting replaces the row, re-reads the tool
+/// list and can open a browser, which is a lot to do to somebody who asked
+/// whether their server was up. This spends the grant that is already there and
+/// writes nothing but a renewal.
+///
+/// The renewal is not a side effect to avoid. A stale token is what the next
+/// real call would refresh, so a check that skipped it would report "the
+/// sign-in was refused" about a plugin that works.
+pub async fn check(
+    store: &Store,
+    id: PluginId,
+    dialed: crate::db::store::Dialed,
+    endpoint: &str,
+    account: Option<AccountUse<'_>>,
+) -> Result<ServerReport, PluginError> {
+    let crate::db::store::Dialed { kind, grant, headers, .. } = dialed;
+    if kind.account_backed() {
+        let used =
+            account.ok_or_else(|| PluginError::NoAccount { label: kind.label().to_string() })?;
+        return inspect(kind.is_custom(), endpoint, Some(used.token), &headers).await;
+    }
+    let grant = match grant {
+        Some(held) if held.stale(now_ms()) => {
+            Some(renew(store, id, &held, &kind, endpoint, &headers).await?)
+        }
+        other => other,
+    };
+    inspect(kind.is_custom(), endpoint, grant.as_ref().map(|g| g.access_token.as_str()), &headers)
+        .await
 }
 
 /// Opens a session and asks for the tool list, as one question.
@@ -193,11 +334,8 @@ pub async fn connect(
 /// the first connect probes and gets the 401, and every connect after it finds
 /// the era remembered, makes no request at all, and reports a raw 401 out of
 /// the tool list instead of starting the sign-in.
-async fn ask(
-    endpoint: &str,
-    token: Option<&str>,
-) -> Result<(mcp::Session, Vec<PluginTool>), McpError> {
-    let session = mcp::open(endpoint, token).await?;
+async fn ask(dial: mcp::Dial<'_>) -> Result<(mcp::Session, Vec<PluginTool>), McpError> {
+    let session = mcp::open(dial).await?;
     let tools = read_tools(&session).await?;
     Ok((session, tools))
 }
@@ -308,8 +446,10 @@ pub async fn call(
 ) -> Result<String, PluginError> {
     let Target { group, agent, kind, endpoint, account } = target;
     let label = || kind.label().to_string();
-    let (id, grant, schema) = match store.plugin_reach(group, agent, kind, tool)? {
-        PluginReach::Granted { id, grant, schema } => (id, grant, schema),
+    let (id, grant, headers, schema) = match store.plugin_reach(group, agent, kind, tool)? {
+        PluginReach::Granted(reached) => {
+            (reached.id, reached.grant, reached.headers, reached.schema)
+        }
         PluginReach::NotConnected => return Err(PluginError::NotConnected { label: label() }),
         PluginReach::NotChosen => return Err(PluginError::NotChosen { label: label() }),
         PluginReach::ToolDenied => {
@@ -329,16 +469,21 @@ pub async fn call(
     // rather than failing on the wire.
     if kind.account_backed() {
         let used = account.ok_or_else(|| PluginError::NoAccount { label: label() })?;
-        let session = mcp::open(endpoint, Some(used.token)).await?;
+        let session =
+            mcp::open(dial(kind.is_custom(), endpoint, &headers).with_token(Some(used.token)))
+                .await?;
         return Ok(mcp::call_tool(&session, tool, arguments, schema.as_ref()).await?);
     }
 
     let grant = match grant {
-        Some(held) if held.stale(now_ms()) => Some(renew(store, id, &held, kind).await?),
+        Some(held) if held.stale(now_ms()) => {
+            Some(renew(store, id, &held, kind, endpoint, &headers).await?)
+        }
         other => other,
     };
 
-    let attempt = run(endpoint, grant.as_ref(), tool, arguments, schema.as_ref()).await;
+    let dialed = dial(kind.is_custom(), endpoint, &headers);
+    let attempt = run(dialed, grant.as_ref(), tool, arguments, schema.as_ref()).await;
     match attempt {
         Err(McpError::Unauthorized { .. }) => {
             // One retry, and only for a grant there is something to renew. A
@@ -348,34 +493,40 @@ pub async fn call(
             let Some(held) = grant else {
                 return Err(PluginError::SigninExpired { label: label() });
             };
-            let renewed = renew(store, id, &held, kind).await?;
-            run(endpoint, Some(&renewed), tool, arguments, schema.as_ref())
-                .await
-                .map_err(Into::into)
+            let renewed = renew(store, id, &held, kind, endpoint, &headers).await?;
+            run(dialed, Some(&renewed), tool, arguments, schema.as_ref()).await.map_err(Into::into)
         }
         other => other.map_err(Into::into),
     }
 }
 
 async fn run(
-    endpoint: &str,
+    dial: mcp::Dial<'_>,
     grant: Option<&Grant>,
     tool: &str,
     arguments: &serde_json::Value,
     schema: Option<&serde_json::Value>,
 ) -> Result<String, McpError> {
-    let session = mcp::open(endpoint, grant.map(|g| g.access_token.as_str())).await?;
+    let session = mcp::open(dial.with_token(grant.map(|g| g.access_token.as_str()))).await?;
     mcp::call_tool(&session, tool, arguments, schema).await
 }
 
 /// Renews a grant and writes it back, so the next turn does not renew it again.
+///
+/// Takes the operator's headers for the same reason the sign-in does: when the
+/// token endpoint is on their own server — a self-hosted MCP server that is its
+/// own issuer, behind a gate — a refresh without them is a `403` a day after
+/// everything worked. `Gate` is what keeps them off a vendor's token endpoint,
+/// which is a different origin and none of its business.
 async fn renew(
     store: &Store,
     id: PluginId,
     grant: &Grant,
     kind: &PluginKind,
+    endpoint: &str,
+    headers: &Headers,
 ) -> Result<Grant, PluginError> {
-    let renewed = oauth::refresh(grant, now_ms)
+    let renewed = oauth::refresh(grant, &oauth::Gate::on(endpoint, headers.wire()), now_ms)
         .await
         .map_err(|_| PluginError::SigninExpired { label: kind.label().to_string() })?;
     store.refresh_plugin_grant(id, &renewed)?;

--- a/src-tauri/tests/plugins.rs
+++ b/src-tauri/tests/plugins.rs
@@ -35,7 +35,7 @@ use guac_lib::db::Store;
 use guac_lib::domain::agent::CleanDraft;
 use guac_lib::domain::group::CleanGroup;
 use guac_lib::domain::ids::{AgentId, GroupId};
-use guac_lib::domain::plugin::{PluginAccess, PluginKind};
+use guac_lib::domain::plugin::{HeaderPair, Headers, PluginAccess, PluginKind, SigninNeed};
 use guac_lib::llm::tools::{self, ToolInvocation};
 use guac_lib::mcp::PROTOCOL_VERSION;
 use guac_lib::plugins;
@@ -76,6 +76,15 @@ struct Rules {
     /// prove Guaca does it is a server that demands it and refuses a call that
     /// arrives without it — which is exactly what a real one does.
     mirrors: bool,
+    /// A gate in front of every route on this host, refusing anything without
+    /// the header the operator was given. Cloudflare Access, in one field.
+    ///
+    /// It sits in front of the metadata documents too, which is the whole point
+    /// of it being here rather than in the deployment scripted below: a client
+    /// that puts the operator's headers only on MCP requests gets past the gate
+    /// on the first call, reads the 401, and then fails discovery on a `403`
+    /// nobody can act on.
+    gated: Option<(String, String)>,
 }
 
 /// Which shape of the protocol the scripted server speaks.
@@ -102,6 +111,7 @@ impl Default for Rules {
             era: Era::Legacy,
             versions: Vec::new(),
             mirrors: false,
+            gated: None,
         }
     }
 }
@@ -167,9 +177,13 @@ async fn serve(rules: Rules) -> Server {
         .route("/.well-known/oauth-protected-resource", get(protected_resource))
         .route("/.well-known/oauth-authorization-server", get(authorization_server))
         .route("/register", post(register))
-        .route("/authorize", get(authorize))
         .route("/token", post(token))
         .route("/mcp", post(rpc))
+        // In front of everything a program asks for, and not in front of the
+        // page a person visits: a browser going through Access has a cookie of
+        // its own, which is exactly why the header exists for everything else.
+        .layer(axum::middleware::from_fn_with_state(server.clone(), gate))
+        .route("/authorize", get(authorize))
         .with_state(server.clone());
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -177,6 +191,25 @@ async fn serve(rules: Rules) -> Server {
     *server.base.lock() = format!("http://{addr}");
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
     server
+}
+
+/// A gate in front of the host, refusing anything without the operator's header.
+///
+/// `403` and not `401`, which is the point: a gate is not the server asking to
+/// be signed in to, and a client that read it as one would send the operator to
+/// a browser over a missing header.
+async fn gate(
+    State(server): State<Server>,
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    if let Some((name, value)) = &server.rules.gated {
+        let sent = request.headers().get(name.as_str()).and_then(|v| v.to_str().ok());
+        if sent != Some(value.as_str()) {
+            return (axum::http::StatusCode::FORBIDDEN, "no").into_response();
+        }
+    }
+    next.run(request).await
 }
 
 async fn protected_resource(State(server): State<Server>) -> impl IntoResponse {
@@ -626,6 +659,7 @@ async fn a_server_that_asks_for_nothing_connects_without_sending_anybody_to_a_br
         &PluginKind::Neon,
         &format!("{}/mcp", server.base()),
         plugins::Credential::Discover,
+        &Headers::none(),
         |_| panic!("a public server must not open a browser"),
     )
     .await
@@ -652,6 +686,7 @@ async fn a_protected_server_signs_in_and_the_grant_stays_in_the_store() {
         &PluginKind::Neon,
         &format!("{}/mcp", server.base()),
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -683,6 +718,7 @@ async fn a_redirect_that_does_not_match_is_refused() {
         &PluginKind::Neon,
         &format!("{}/mcp", server.base()),
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::WrongState),
     )
     .await
@@ -703,6 +739,7 @@ async fn a_refusal_in_the_browser_is_reported_as_one() {
         &PluginKind::Neon,
         &format!("{}/mcp", server.base()),
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Refused),
     )
     .await
@@ -729,6 +766,7 @@ async fn a_server_with_no_registration_says_so_rather_than_failing_obscurely() {
         &PluginKind::Neon,
         &format!("{}/mcp", server.base()),
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -749,6 +787,7 @@ async fn a_tool_call_carries_the_grant_and_the_answer_comes_back() {
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -810,6 +849,7 @@ mod account_backed {
             &PluginKind::Google,
             &format!("{}/mcp", server.base()),
             plugins::Credential::Account(plugins::AccountUse { token: ACCOUNT, connection: "" }),
+            &Headers::none(),
             |_| panic!("an account-backed plugin must not send anyone to a browser"),
         )
         .await
@@ -851,6 +891,7 @@ mod account_backed {
                 token: ACCOUNT,
                 connection: "work",
             }),
+            &Headers::none(),
             |_| Ok(()),
         )
         .await
@@ -871,6 +912,7 @@ mod account_backed {
                 token: ACCOUNT,
                 connection: "personal",
             }),
+            &Headers::none(),
             |_| Ok(()),
         )
         .await
@@ -904,14 +946,18 @@ mod account_backed {
             &PluginKind::Google,
             &endpoint,
             plugins::Credential::Account(plugins::AccountUse { token: ACCOUNT, connection: "" }),
+            &Headers::none(),
             |_| Ok(()),
         )
         .await
         .unwrap();
 
         match store.plugin_reach(group, agent, &PluginKind::Google, "gmail_search").unwrap() {
-            guac_lib::db::store::PluginReach::Granted { grant, .. } => {
-                assert!(grant.is_none(), "an account-backed plugin holds no grant of its own");
+            guac_lib::db::store::PluginReach::Granted(reached) => {
+                assert!(
+                    reached.grant.is_none(),
+                    "an account-backed plugin holds no grant of its own"
+                );
             }
             other => panic!("expected the plugin to be reachable, got {other:?}"),
         }
@@ -928,6 +974,7 @@ mod account_backed {
             &PluginKind::Google,
             &format!("{}/mcp", server.base()),
             plugins::Credential::Discover,
+            &Headers::none(),
             |_| Ok(()),
         )
         .await
@@ -951,6 +998,7 @@ mod account_backed {
             &PluginKind::Google,
             &endpoint,
             plugins::Credential::Account(plugins::AccountUse { token: ACCOUNT, connection: "" }),
+            &Headers::none(),
             |_| Ok(()),
         )
         .await
@@ -989,6 +1037,7 @@ mod account_backed {
             &PluginKind::Google,
             &endpoint,
             plugins::Credential::Account(plugins::AccountUse { token: ACCOUNT, connection: "" }),
+            &Headers::none(),
             |_| Ok(()),
         )
         .await
@@ -1027,6 +1076,7 @@ mod account_backed {
             &PluginKind::Google,
             &endpoint,
             plugins::Credential::Account(plugins::AccountUse { token: ACCOUNT, connection: "" }),
+            &Headers::none(),
             |_| Ok(()),
         )
         .await
@@ -1099,6 +1149,7 @@ async fn the_real_account_server_still_speaks_what_this_client_sends() {
         &PluginKind::Google,
         &endpoint,
         plugins::Credential::Account(plugins::AccountUse { token: &token, connection: "" }),
+        &Headers::none(),
         |_| panic!("an account-backed plugin must not open a browser"),
     )
     .await
@@ -1169,6 +1220,7 @@ mod added {
             &kind,
             kind.endpoint(),
             plugins::Credential::Discover,
+            &Headers::none(),
             browser(Outcome::Allowed),
         )
         .await
@@ -1244,6 +1296,7 @@ mod added {
             &kind,
             kind.endpoint(),
             plugins::Credential::Discover,
+            &Headers::none(),
             browser(Outcome::Allowed),
         )
         .await
@@ -1282,6 +1335,7 @@ mod added {
             &kind,
             kind.endpoint(),
             plugins::Credential::Discover,
+            &Headers::none(),
             browser(Outcome::Allowed),
         )
         .await
@@ -1338,6 +1392,7 @@ mod added {
             &kind,
             kind.endpoint(),
             plugins::Credential::Key("hand-minted"),
+            &Headers::none(),
             |_| panic!("a pasted key must not send anybody to a browser"),
         )
         .await
@@ -1379,6 +1434,7 @@ mod added {
             &kind,
             kind.endpoint(),
             plugins::Credential::Key("hand-minted"),
+            &Headers::none(),
             |_| Ok(()),
         )
         .await
@@ -1417,6 +1473,7 @@ mod added {
             &kind,
             kind.endpoint(),
             plugins::Credential::Discover,
+            &Headers::none(),
             browser(Outcome::Allowed),
         )
         .await
@@ -1429,7 +1486,7 @@ mod added {
 
         assert!(matches!(
             store.plugin_reach(group, answerer, &kind, "run_sql").unwrap(),
-            PluginReach::Granted { .. }
+            PluginReach::Granted(_)
         ));
         assert!(matches!(
             store.plugin_reach(group, triage, &kind, "run_sql").unwrap(),
@@ -1481,6 +1538,7 @@ mod added {
                 kind,
                 kind.endpoint(),
                 plugins::Credential::Discover,
+                &Headers::none(),
                 |_| Ok(()),
             )
             .await
@@ -1510,6 +1568,57 @@ mod added {
         assert_eq!(second.called.lock().len(), 1);
         assert!(first.called.lock().is_empty());
     }
+
+    #[tokio::test]
+    async fn a_gated_server_that_also_signs_in_gets_the_headers_on_the_whole_dance() {
+        // The composition, and the reason headers are not a `Credential`. A
+        // gate in front of a self-hosted server refuses the metadata document a
+        // sign-in has to read first, so a client that puts the operator's
+        // headers only on MCP requests gets past the gate on the first call,
+        // reads the 401, and then fails discovery on a `403` nobody can act on.
+        let server = serve(Rules {
+            gated: Some(("cf-access-client-id".into(), "abc.access".into())),
+            issue_expired: true,
+            ..Rules::default()
+        })
+        .await;
+        let (_dir, store, group, agent) = workspace();
+        let kind = PluginKind::custom("Home Assistant", &format!("{}/mcp", server.base())).unwrap();
+        let headers = Headers::parse(&[HeaderPair {
+            name: "Cf-Access-Client-Id".into(),
+            value: "abc.access".into(),
+        }])
+        .unwrap();
+
+        let plugin = plugins::connect(
+            &store,
+            group,
+            &kind,
+            kind.endpoint(),
+            plugins::Credential::Discover,
+            &headers,
+            browser(Outcome::Allowed),
+        )
+        .await
+        .expect("past the gate, and then signed in from behind it");
+
+        assert!(plugin.signed_in, "the 401 behind the gate is still a sign-in");
+        assert_eq!(server.registrations.load(Ordering::SeqCst), 1);
+
+        // And the renewal too, which is the one that would fail a day later:
+        // the token endpoint is on the same host, so a refresh without the
+        // header is a 403 long after everything looked fine.
+        let answer = plugins::call(
+            &store,
+            plugins::Target { group, agent, kind: &kind, endpoint: kind.endpoint(), account: None },
+            "run_sql",
+            &serde_json::json!({ "sql": "select 1" }),
+        )
+        .await
+        .expect("the grant was stale, so this had to renew before it could call");
+        assert_eq!(answer, "run_sql ran");
+        assert_eq!(server.refreshes.load(Ordering::SeqCst), 1);
+    }
 }
 
 // ---- the two protocol eras ----------------------------------------------
@@ -1536,6 +1645,7 @@ mod eras {
             &kind,
             kind.endpoint(),
             plugins::Credential::Discover,
+            &Headers::none(),
             |_| panic!("this server authorizes everybody"),
         )
         .await
@@ -1592,6 +1702,7 @@ mod eras {
             &kind,
             kind.endpoint(),
             plugins::Credential::Discover,
+            &Headers::none(),
             |_| Ok(()),
         )
         .await
@@ -1631,6 +1742,7 @@ mod eras {
                 &kind,
                 kind.endpoint(),
                 plugins::Credential::Discover,
+                &Headers::none(),
                 browser(Outcome::Allowed),
             )
             .await
@@ -1660,6 +1772,7 @@ mod eras {
             &kind,
             kind.endpoint(),
             plugins::Credential::Discover,
+            &Headers::none(),
             |_| Ok(()),
         )
         .await
@@ -1687,6 +1800,7 @@ mod eras {
             &kind,
             kind.endpoint(),
             plugins::Credential::Discover,
+            &Headers::none(),
             |_| Ok(()),
         )
         .await
@@ -1758,6 +1872,7 @@ async fn a_stale_grant_is_renewed_before_it_is_spent() {
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -1805,6 +1920,7 @@ async fn a_grant_revoked_at_the_vendor_is_renewed_once_and_the_call_retried() {
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -1832,12 +1948,12 @@ async fn a_grant_revoked_at_the_vendor_is_renewed_once_and_the_call_retried() {
 
     // And the renewed grant is written back, or every later turn pays for the
     // same discovery.
-    let PluginReach::Granted { grant, .. } =
+    let PluginReach::Granted(reached) =
         store.plugin_reach(group, agent, &PluginKind::Neon, "run_sql").unwrap()
     else {
         panic!("the plugin is connected and this agent was not excluded from it")
     };
-    assert_eq!(grant.unwrap().access_token, "access-1");
+    assert_eq!(reached.grant.unwrap().access_token, "access-1");
 }
 
 #[tokio::test]
@@ -1852,6 +1968,7 @@ async fn disconnecting_forgets_the_plugin_and_its_grant() {
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -1880,6 +1997,7 @@ async fn connecting_twice_replaces_the_grant_rather_than_refusing() {
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -1890,18 +2008,23 @@ async fn connecting_twice_replaces_the_grant_rather_than_refusing() {
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
     .unwrap();
 
     assert_eq!(store.group_plugins(group).unwrap().len(), 1);
-    let PluginReach::Granted { grant, .. } =
+    let PluginReach::Granted(reached) =
         store.plugin_reach(group, agent, &PluginKind::Neon, "run_sql").unwrap()
     else {
         panic!("connecting again leaves a plugin the crew can use")
     };
-    assert_eq!(grant.unwrap().access_token, "access-1", "the newer sign-in is the one held");
+    assert_eq!(
+        reached.grant.unwrap().access_token,
+        "access-1",
+        "the newer sign-in is the one held"
+    );
 }
 
 #[tokio::test]
@@ -1919,6 +2042,7 @@ async fn what_the_crew_connected_is_what_the_model_is_offered() {
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -1988,6 +2112,7 @@ async fn a_crew_with_a_plugin_calls_it_through_a_real_turn() {
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -2092,6 +2217,7 @@ async fn an_agent_the_plugin_was_narrowed_away_from_is_neither_told_nor_allowed(
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -2164,6 +2290,7 @@ async fn a_tool_the_operator_switched_off_is_named_in_the_prompt_and_refused_on_
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -2225,6 +2352,7 @@ async fn a_narrowed_plugin_shows_up_as_a_peer_who_can_do_it() {
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -2281,6 +2409,7 @@ async fn two_agents_on_one_plugin_are_offered_different_tools_and_told_whose_is_
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -2362,6 +2491,7 @@ async fn a_tool_that_is_a_peer_s_is_refused_here_and_not_at_the_vendor() {
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -2414,6 +2544,7 @@ async fn a_plugin_with_everything_switched_off_is_not_a_peer_worth_asking() {
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -2447,6 +2578,7 @@ async fn a_plugin_call_from_an_agent_outside_the_crew_is_refused() {
         &PluginKind::Neon,
         &endpoint,
         plugins::Credential::Discover,
+        &Headers::none(),
         browser(Outcome::Allowed),
     )
     .await
@@ -2489,6 +2621,495 @@ async fn a_plugin_call_from_an_agent_outside_the_crew_is_refused() {
     )
     .await
     .expect("the crew that signed in still has it");
+}
+
+// ---- the transport streamable HTTP replaced -------------------------------
+
+/// A server on the transport that streamable HTTP replaced, and a server that
+/// wants headers nobody could have discovered.
+///
+/// Both are the same shape of problem and neither is a vendor's: an operator
+/// running their own box has whatever their framework shipped two years ago,
+/// behind whatever their company puts in front of things. The catalog answers
+/// neither question because a catalog server is one somebody checked.
+///
+/// Scripted separately from `serve` on purpose. That server is the five
+/// vendors' shape — OAuth metadata, registration, a token endpoint — and this
+/// one is a box with a key taped to it. Merging them would put an `if` in front
+/// of every route for a case the other never reaches.
+mod deployments {
+    use super::*;
+
+    use axum::body::Body;
+    use axum::extract::Query;
+    use axum::http::StatusCode;
+    use futures_util::StreamExt;
+
+    /// What the scripted deployment insists on before it answers anything.
+    #[derive(Clone, Default)]
+    struct Wants {
+        /// A header and its value, refused with a 403 when it is absent. Not a
+        /// 401: a gate in front of a server is not the server asking for a
+        /// sign-in, and a client that read it as one would open a browser.
+        header: Option<(String, String)>,
+        /// A bearer the server accepts. `None` is a server that asks for
+        /// nothing at all.
+        bearer: Option<String>,
+        /// Where the `endpoint` event points, when it is not this server's own
+        /// `/messages`.
+        redirect: Option<String>,
+    }
+
+    #[derive(Clone)]
+    struct Deployment {
+        wants: Wants,
+        base: Arc<Mutex<String>>,
+        /// One sender per open event stream, by the id its `endpoint` named.
+        streams: Arc<Mutex<HashMap<String, tokio::sync::mpsc::UnboundedSender<String>>>>,
+        /// Every header set this server was sent, so a test can assert what
+        /// went out rather than only that the call succeeded.
+        seen: Arc<Mutex<Vec<HashMap<String, String>>>>,
+    }
+
+    impl Deployment {
+        fn base(&self) -> String {
+            self.base.lock().clone()
+        }
+
+        fn endpoint(&self) -> String {
+            format!("{}/sse", self.base())
+        }
+    }
+
+    async fn deploy(wants: Wants) -> Deployment {
+        let server = Deployment {
+            wants,
+            base: Arc::new(Mutex::new(String::new())),
+            streams: Arc::new(Mutex::new(HashMap::new())),
+            seen: Arc::new(Mutex::new(Vec::new())),
+        };
+        let app = Router::new()
+            .route("/sse", get(stream).post(no_post))
+            .route("/messages", post(message))
+            .with_state(server.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        *server.base.lock() = format!("http://{addr}");
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        server
+    }
+
+    /// What this transport's endpoint does with a POST, which is the thing that
+    /// makes Guaca try the older transport at all.
+    async fn no_post() -> impl IntoResponse {
+        (StatusCode::METHOD_NOT_ALLOWED, "this endpoint is an event stream")
+    }
+
+    fn note(server: &Deployment, headers: &axum::http::HeaderMap) {
+        server.seen.lock().push(
+            headers
+                .iter()
+                .filter_map(|(name, value)| {
+                    value.to_str().ok().map(|v| (name.as_str().to_string(), v.to_string()))
+                })
+                .collect(),
+        );
+    }
+
+    /// Whether the request got past the gate and past the sign-in.
+    fn refuse(server: &Deployment, headers: &axum::http::HeaderMap) -> Option<StatusCode> {
+        if let Some((name, value)) = &server.wants.header {
+            let sent = headers.get(name.as_str()).and_then(|v| v.to_str().ok());
+            if sent != Some(value.as_str()) {
+                return Some(StatusCode::FORBIDDEN);
+            }
+        }
+        if let Some(bearer) = &server.wants.bearer {
+            let sent = headers
+                .get("authorization")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.strip_prefix("Bearer "));
+            if sent != Some(bearer.as_str()) {
+                return Some(StatusCode::UNAUTHORIZED);
+            }
+        }
+        None
+    }
+
+    async fn stream(
+        State(server): State<Deployment>,
+        headers: axum::http::HeaderMap,
+    ) -> axum::response::Response {
+        note(&server, &headers);
+        if let Some(status) = refuse(&server, &headers) {
+            return (status, "").into_response();
+        }
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let id = format!("s{}", server.streams.lock().len() + 1);
+        server.streams.lock().insert(id.clone(), tx);
+
+        let named =
+            server.wants.redirect.clone().unwrap_or_else(|| format!("/messages?sessionId={id}"));
+        let first = format!("event: endpoint\ndata: {named}\n\n");
+
+        let opening =
+            futures_util::stream::once(async move { Ok::<String, std::io::Error>(first) });
+        let rest = futures_util::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|line| (Ok::<String, std::io::Error>(line), rx))
+        });
+
+        axum::response::Response::builder()
+            .header("content-type", "text/event-stream")
+            .body(Body::from_stream(opening.chain(rest)))
+            .unwrap()
+    }
+
+    async fn message(
+        State(server): State<Deployment>,
+        Query(params): Query<HashMap<String, String>>,
+        headers: axum::http::HeaderMap,
+        axum::Json(body): axum::Json<serde_json::Value>,
+    ) -> axum::response::Response {
+        note(&server, &headers);
+        if let Some(status) = refuse(&server, &headers) {
+            return (status, "").into_response();
+        }
+
+        let method = body["method"].as_str().unwrap_or_default().to_string();
+        let id = body.get("id").cloned().unwrap_or(serde_json::Value::Null);
+        let result = match method.as_str() {
+            // The revision this transport belongs to, negotiated down from
+            // whatever was asked for — which is what a server of this vintage
+            // actually does, and the reason the list this build accepts had to
+            // grow two entries.
+            "initialize" => serde_json::json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "tools": {} },
+                "serverInfo": { "name": "Scripted Deployment" },
+            }),
+            "notifications/initialized" => return StatusCode::ACCEPTED.into_response(),
+            "tools/list" => serde_json::json!({
+                "tools": [{
+                    "name": "turn_on",
+                    "description": "Turn something on.",
+                    "inputSchema": { "type": "object", "properties": { "what": { "type": "string" } } },
+                }],
+            }),
+            "tools/call" => serde_json::json!({
+                "content": [{
+                    "type": "text",
+                    "text": format!("{} ran", body["params"]["name"].as_str().unwrap_or_default()),
+                }],
+            }),
+            other => {
+                push(
+                    &server,
+                    &params,
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "error": { "code": -32601, "message": format!("no method {other}") },
+                    }),
+                );
+                return StatusCode::ACCEPTED.into_response();
+            }
+        };
+
+        // The documented answer: 202, and the reply down the stream the request
+        // belongs to. A client that reads the POST's own body for it hangs here.
+        push(&server, &params, serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": result }));
+        StatusCode::ACCEPTED.into_response()
+    }
+
+    fn push(server: &Deployment, params: &HashMap<String, String>, reply: serde_json::Value) {
+        let Some(id) = params.get("sessionId") else { return };
+        if let Some(sender) = server.streams.lock().get(id) {
+            let _ = sender.send(format!("event: message\ndata: {reply}\n\n"));
+        }
+    }
+
+    fn mine(server: &Deployment) -> PluginKind {
+        PluginKind::custom("Home Assistant", &server.endpoint()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_server_on_the_older_transport_connects_and_answers_a_call() {
+        // The whole feature. Every one of these servers answers a POST to its
+        // stream with a 405, so before this they read as unreachable — which
+        // is a plugin the operator can see working in a browser and cannot
+        // connect, with nothing on screen saying why.
+        let server = deploy(Wants::default()).await;
+        let (_dir, store, group, agent) = workspace();
+        let kind = mine(&server);
+
+        let plugin = plugins::connect(
+            &store,
+            group,
+            &kind,
+            kind.endpoint(),
+            plugins::Credential::Discover,
+            &Headers::none(),
+            |_| panic!("a server that asks for nothing must not open a browser"),
+        )
+        .await
+        .expect("a server on the older transport is still a server");
+
+        assert_eq!(plugin.name, "home_assistant");
+        assert!(!plugin.signed_in, "it asked for nothing, so nothing was authorized");
+        assert_eq!(
+            plugin.tools.iter().map(|tool| tool.name.as_str()).collect::<Vec<_>>(),
+            vec!["turn_on"],
+        );
+
+        let answer = plugins::call(
+            &store,
+            plugins::Target { group, agent, kind: &kind, endpoint: kind.endpoint(), account: None },
+            "turn_on",
+            &serde_json::json!({ "what": "the kettle" }),
+        )
+        .await
+        .expect("and its tools are callable");
+        assert_eq!(answer, "turn_on ran");
+    }
+
+    #[tokio::test]
+    async fn a_catalog_server_is_never_offered_the_older_transport() {
+        // The asymmetry, and it is the catalog's argument rather than an
+        // oversight: a vendor Guaca vouches for is one it can hold to the
+        // current transport. Pointed at the same deployment, a catalog kind
+        // fails on the POST and never tries the GET.
+        let server = deploy(Wants::default()).await;
+        let (_dir, store, group, _agent) = workspace();
+
+        let refused = plugins::connect(
+            &store,
+            group,
+            &PluginKind::Neon,
+            &server.endpoint(),
+            plugins::Credential::Discover,
+            &Headers::none(),
+            |_| panic!("nothing here signs in"),
+        )
+        .await;
+
+        assert!(refused.is_err(), "a vendor is held to the transport it publishes");
+        assert!(server.streams.lock().is_empty(), "and the event stream was never even opened",);
+    }
+
+    #[tokio::test]
+    async fn a_header_the_operator_wrote_is_on_every_request_including_the_stream() {
+        // The Cloudflare Access shape: a gate in front of the server that
+        // refuses anything without a pair of headers, on the GET as well as on
+        // the POST. A client that only put them on requests it thought of as
+        // "the call" never opens the stream at all.
+        let server = deploy(Wants {
+            header: Some(("cf-access-client-id".into(), "abc.access".into())),
+            ..Wants::default()
+        })
+        .await;
+        let (_dir, store, group, agent) = workspace();
+        let kind = mine(&server);
+        let headers = Headers::parse(&[HeaderPair {
+            name: "Cf-Access-Client-Id".into(),
+            value: "abc.access".into(),
+        }])
+        .unwrap();
+
+        let plugin = plugins::connect(
+            &store,
+            group,
+            &kind,
+            kind.endpoint(),
+            plugins::Credential::Discover,
+            &headers,
+            |_| panic!("a gate is not a sign-in"),
+        )
+        .await
+        .expect("the headers get the request past the gate");
+
+        // Names on the row, and never the value: the panel has to be able to
+        // say what is being sent without being a place to read it back.
+        assert_eq!(plugin.headers, vec!["cf-access-client-id".to_string()]);
+
+        plugins::call(
+            &store,
+            plugins::Target { group, agent, kind: &kind, endpoint: kind.endpoint(), account: None },
+            "turn_on",
+            &serde_json::json!({ "what": "the kettle" }),
+        )
+        .await
+        .expect("and stay on every later request too");
+
+        let seen = server.seen.lock().clone();
+        assert!(seen.len() > 3, "the stream, the handshake and the calls: {}", seen.len());
+        assert!(
+            seen.iter().all(|headers| headers.get("cf-access-client-id").map(String::as_str)
+                == Some("abc.access")),
+            "every request has to carry it, including the GET that opens the stream",
+        );
+    }
+
+    #[tokio::test]
+    async fn a_key_in_a_header_the_operator_named_authenticates_without_a_sign_in() {
+        // The other half of the ask, and the one the bearer box cannot express:
+        // a server whose framework reads `X-API-Key` and has no authorization
+        // server behind it at all.
+        let server = deploy(Wants {
+            header: Some(("x-api-key".into(), "hand-minted".into())),
+            ..Wants::default()
+        })
+        .await;
+        let (_dir, store, group, _agent) = workspace();
+        let kind = mine(&server);
+        let headers =
+            Headers::parse(&[HeaderPair { name: "X-API-Key".into(), value: "hand-minted".into() }])
+                .unwrap();
+
+        let plugin = plugins::connect(
+            &store,
+            group,
+            &kind,
+            kind.endpoint(),
+            plugins::Credential::Discover,
+            &headers,
+            |_| panic!("nothing here has an authorization server"),
+        )
+        .await
+        .expect("a header is a credential when that is what the server reads");
+
+        // Nothing was authorized, and the row says so rather than claiming a
+        // sign-in that never happened.
+        assert!(!plugin.signed_in);
+    }
+
+    #[tokio::test]
+    async fn a_message_endpoint_on_another_host_is_refused_rather_than_followed() {
+        // A redirect invented by the far end after the connection was made.
+        // Followed, the crew's credential and every tool argument go to a host
+        // the operator never named.
+        let server = deploy(Wants {
+            redirect: Some("https://evil.example/messages".into()),
+            ..Wants::default()
+        })
+        .await;
+        let (_dir, store, group, _agent) = workspace();
+        let kind = mine(&server);
+
+        let refused = plugins::connect(
+            &store,
+            group,
+            &kind,
+            kind.endpoint(),
+            plugins::Credential::Discover,
+            &Headers::none(),
+            |_| panic!("nothing signs in"),
+        )
+        .await
+        .expect_err("a server may not redirect a session onto another host");
+        let message = refused.to_string();
+        assert!(message.contains("different server"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn testing_an_address_says_what_it_is_without_connecting_it() {
+        // What the button beside the address box answers. Every field is one an
+        // operator debugging their own deployment has to guess at otherwise,
+        // and the transport is the one that costs the most: a 405 on the
+        // current transport and a working event stream are the same sentence
+        // and opposite instructions.
+        let server = deploy(Wants::default()).await;
+
+        let report = plugins::inspect(true, &server.endpoint(), None, &Headers::none())
+            .await
+            .expect("a reachable server reports");
+
+        assert_eq!(report.transport, "HTTP+SSE (2024-11-05)");
+        assert_eq!(report.protocol, "2024-11-05");
+        assert!(report.handshake);
+        assert_eq!(report.signin, SigninNeed::None);
+        assert_eq!(report.server, "Scripted Deployment");
+        // Twice in one process, and it still names itself. The handshake that
+        // said so belongs to a stream that was dropped, and the second dial
+        // finds the transport remembered and no name with it, so `describe`
+        // has to ask again rather than report a server that lost its name.
+        let again = plugins::inspect(true, &server.endpoint(), None, &Headers::none())
+            .await
+            .expect("a second dial of the same address");
+        assert_eq!(again.server, "Scripted Deployment");
+        assert_eq!(again.protocol, "2024-11-05");
+        assert_eq!(report.tools, vec!["turn_on".to_string()]);
+
+        // And it connected nothing: no crew, no row, no grant.
+        let (_dir, store, group, _agent) = workspace();
+        assert!(store.group_plugins(group).unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn testing_tells_a_wrong_key_apart_from_a_server_that_wants_a_sign_in() {
+        // The two 401s, which are the same status code and opposite problems.
+        // An operator who cannot tell them apart re-pastes a key at a server
+        // that never wanted one, or goes looking for a sign-in that is really a
+        // typo in a key.
+        let server = deploy(Wants { bearer: Some("right".into()), ..Wants::default() }).await;
+
+        let asked = plugins::inspect(true, &server.endpoint(), None, &Headers::none())
+            .await
+            .expect("a 401 is a finding rather than a failure");
+        assert_eq!(asked.signin, SigninNeed::Wanted);
+        assert!(asked.tools.is_empty(), "nothing has been signed in to");
+
+        let wrong = plugins::inspect(true, &server.endpoint(), Some("wrong"), &Headers::none())
+            .await
+            .expect("and so is a refused key");
+        assert_eq!(wrong.signin, SigninNeed::Refused);
+
+        let right = plugins::inspect(true, &server.endpoint(), Some("right"), &Headers::none())
+            .await
+            .expect("a key the server takes");
+        assert_eq!(right.signin, SigninNeed::Accepted);
+        assert_eq!(right.tools, vec!["turn_on".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn testing_a_connected_plugin_spends_the_grant_that_is_already_there() {
+        // The other half of "test it", and the one a crew needs: whether the
+        // sign-in the operator did last month is still good. Nothing else in
+        // the app can answer that without reconnecting, which opens a browser.
+        let server = deploy(Wants { bearer: Some("hand-minted".into()), ..Wants::default() }).await;
+        let (_dir, store, group, _agent) = workspace();
+        let kind = mine(&server);
+
+        let plugin = plugins::connect(
+            &store,
+            group,
+            &kind,
+            kind.endpoint(),
+            plugins::Credential::Key("hand-minted"),
+            &Headers::none(),
+            |_| panic!("a pasted key skips discovery"),
+        )
+        .await
+        .expect("connected with a key");
+
+        let dialed = store.plugin_dial(plugin.id).unwrap().expect("the row it was written as");
+        let report = plugins::check(&store, plugin.id, dialed, kind.endpoint(), None)
+            .await
+            .expect("and the key is still accepted");
+        assert_eq!(report.signin, SigninNeed::Accepted);
+        assert_eq!(report.tools, vec!["turn_on".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn a_server_that_is_not_there_reports_the_address_rather_than_a_shape() {
+        // The commonest failure of all, and the one where a report is worse
+        // than useless if it invents a transport it never established.
+        let refused =
+            plugins::inspect(true, "http://127.0.0.1:1/mcp", None, &Headers::none()).await;
+        assert!(refused.is_err(), "an address nothing answers on is an error, not a report");
+        let message = refused.unwrap_err().to_string();
+        assert!(message.contains("127.0.0.1:1"), "{message}");
+    }
 }
 
 // ---- live --------------------------------------------------------------
@@ -2539,7 +3160,7 @@ async fn every_server_on_the_list_still_publishes_what_this_build_expects() {
         // believes the fallback rule is; whether six real vendors actually
         // refuse `server/discover` in a shape that reads as legacy is the thing
         // only this can answer.
-        let opened = guac_lib::mcp::open(endpoint, None).await;
+        let opened = guac_lib::mcp::open(guac_lib::mcp::Dial::to(endpoint)).await;
         let challenge = match &opened {
             Ok(session) => {
                 let tools = guac_lib::mcp::list_tools(session).await.unwrap_or_else(|err| {

--- a/src/components/PluginList.test.tsx
+++ b/src/components/PluginList.test.tsx
@@ -4,10 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AccountConnectors,
   AgentCard,
+  HeaderPair,
   Plugin,
   PluginAccess,
   PluginOffer,
   PluginToolCard,
+  ServerReport,
 } from "../lib/types";
 import { PluginList } from "./PluginList";
 
@@ -19,9 +21,28 @@ const disconnectPlugin = vi.fn();
 const setPluginAccess = vi.fn<(id: string, access: PluginAccess) => Promise<Plugin>>();
 const setPluginTool = vi.fn<(id: string, tool: string, access: PluginAccess) => Promise<Plugin>>();
 const addPlugin =
-  vi.fn<(groupId: string, name: string, url: string, key?: string) => Promise<Plugin>>();
+  vi.fn<
+    (
+      groupId: string,
+      name: string,
+      url: string,
+      key?: string,
+      headers?: HeaderPair[],
+    ) => Promise<Plugin>
+  >();
 const readdressPlugin =
-  vi.fn<(groupId: string, id: string, url: string, key?: string) => Promise<Plugin>>();
+  vi.fn<
+    (
+      groupId: string,
+      id: string,
+      url: string,
+      key?: string,
+      headers?: HeaderPair[],
+    ) => Promise<Plugin>
+  >();
+const probeServer =
+  vi.fn<(url: string, key?: string, headers?: HeaderPair[]) => Promise<ServerReport>>();
+const checkPlugin = vi.fn<(id: string) => Promise<ServerReport>>();
 const openExternal = vi.fn();
 
 vi.mock("../lib/ipc", () => ({
@@ -37,10 +58,18 @@ vi.mock("../lib/ipc", () => ({
     setPluginAccess: (id: string, access: PluginAccess) => setPluginAccess(id, access),
     setPluginTool: (id: string, tool: string, access: PluginAccess) =>
       setPluginTool(id, tool, access),
-    addPlugin: (groupId: string, name: string, url: string, key?: string) =>
-      addPlugin(groupId, name, url, key),
-    readdressPlugin: (groupId: string, id: string, url: string, key?: string) =>
-      readdressPlugin(groupId, id, url, key),
+    addPlugin: (groupId: string, name: string, url: string, key?: string, headers?: HeaderPair[]) =>
+      addPlugin(groupId, name, url, key, headers),
+    readdressPlugin: (
+      groupId: string,
+      id: string,
+      url: string,
+      key?: string,
+      headers?: HeaderPair[],
+    ) => readdressPlugin(groupId, id, url, key, headers),
+    probeServer: (url: string, key?: string, headers?: HeaderPair[]) =>
+      probeServer(url, key, headers),
+    checkPlugin: (id: string) => checkPlugin(id),
   },
   openExternal: (url: string) => openExternal(url),
 }));
@@ -101,6 +130,7 @@ function plugin(over: Partial<Plugin> = {}): Plugin {
     tools: [tool("run_sql"), tool("create_branch")],
     access: { mode: "everyone" },
     connection: "",
+    headers: [],
     signedIn: true,
     connectedAt: 0,
     ...over,
@@ -675,6 +705,8 @@ describe("a server the operator added", () => {
     addPlugin.mockReset();
     readdressPlugin.mockReset();
     disconnectPlugin.mockReset();
+    probeServer.mockReset();
+    checkPlugin.mockReset();
     pluginCatalog.mockResolvedValue(OFFERS);
     groupPlugins.mockResolvedValue([]);
   });
@@ -727,6 +759,7 @@ describe("a server the operator added", () => {
         "Home Assistant",
         "https://ha.example.com/mcp",
         undefined,
+        [],
       ),
     );
     // Cleared only once it worked, and the row it produced is what is drawn.
@@ -760,6 +793,7 @@ describe("a server the operator added", () => {
         "Vault",
         "https://vault.example.com/mcp",
         "abc123",
+        [],
       ),
     );
   });
@@ -782,9 +816,166 @@ describe("a server the operator added", () => {
         "p2",
         "http://localhost:9000/mcp",
         undefined,
+        // Untouched, which is what keeps the stored set: a value cannot be read
+        // back, so a reconnection that meant "replace" would drop it.
+        undefined,
       ),
     );
     expect(disconnectPlugin).not.toHaveBeenCalled();
+  });
+
+  it("sends the headers that were typed, and never sends a name back as a value", async () => {
+    // The third thing a server somebody runs can want, and the one nothing can
+    // discover: an `X-API-Key` because that is where its framework looks.
+    addPlugin.mockResolvedValue(added());
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+    fireEvent.click(await screen.findByText("Add a server"));
+
+    fireEvent.change(screen.getByPlaceholderText("Home Assistant"), {
+      target: { value: "Vault" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("https://example.com/mcp"), {
+      target: { value: "https://vault.example.com/mcp" },
+    });
+    fireEvent.click(screen.getByText("Add a header"));
+    fireEvent.change(screen.getByLabelText("Header 1 name"), { target: { value: "X-API-Key" } });
+    fireEvent.change(screen.getByLabelText("Header 1 value"), { target: { value: "abc123" } });
+    fireEvent.click(screen.getByText("Add and connect"));
+
+    await waitFor(() =>
+      expect(addPlugin).toHaveBeenCalledWith(
+        GROUP,
+        "Vault",
+        "https://vault.example.com/mcp",
+        undefined,
+        [{ name: "X-API-Key", value: "abc123" }],
+      ),
+    );
+  });
+
+  it("keeps a half-typed header on the row it was typed on", async () => {
+    // Keyed by position instead, removing the first row hands its DOM node —
+    // and whatever is in it — to the second, which is exactly when the operator
+    // is looking at two boxes that both say something they did not type.
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+    fireEvent.click(await screen.findByText("Add a server"));
+    fireEvent.click(screen.getByText("Add a header"));
+    fireEvent.click(screen.getByText("Add a header"));
+    fireEvent.change(screen.getByLabelText("Header 1 name"), { target: { value: "first" } });
+    fireEvent.change(screen.getByLabelText("Header 2 name"), { target: { value: "second" } });
+
+    fireEvent.click(screen.getByLabelText("Remove header 1"));
+
+    expect((screen.getByLabelText("Header 1 name") as HTMLInputElement).value).toBe("second");
+  });
+
+  it("hides a header's value and shows its name on the row", async () => {
+    // Both halves. The value is a credential and the panel must not be a place
+    // to read one back; the name is what an operator debugging their own
+    // server needs, because "is x-api-key on the request" is the question.
+    groupPlugins.mockResolvedValue([added({ headers: ["x-api-key", "cf-access-client-id"] })]);
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    expect(await screen.findByText(/Sends x-api-key, cf-access-client-id/)).toBeTruthy();
+  });
+
+  it("leaves stored headers alone unless the operator replaces them", async () => {
+    // A value cannot be read back, so a reconnection that meant "replace" would
+    // drop it: the same rule a group's API key has. Replacing is a thing the
+    // operator does on purpose, and the box starts with the names and no
+    // values, because that is exactly what is knowable.
+    groupPlugins.mockResolvedValue([added({ headers: ["x-api-key"] })]);
+    readdressPlugin.mockResolvedValue(added());
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    fireEvent.click(await screen.findByText("Change address"));
+    fireEvent.click(screen.getByText("Replace headers"));
+    expect((screen.getByLabelText("Header 1 name") as HTMLInputElement).value).toBe("x-api-key");
+    expect((screen.getByLabelText("Header 1 value") as HTMLInputElement).value).toBe("");
+
+    fireEvent.change(screen.getByLabelText("Header 1 value"), { target: { value: "new" } });
+    fireEvent.click(screen.getByText("Save and reconnect"));
+
+    await waitFor(() =>
+      expect(readdressPlugin).toHaveBeenCalledWith(
+        GROUP,
+        "p2",
+        "https://ha.example.com/mcp",
+        undefined,
+        [{ name: "x-api-key", value: "new" }],
+      ),
+    );
+  });
+
+  it("tests an address before anything is connected, and says what it found", async () => {
+    // The whole point of the button: an operator who has to press Add to find
+    // out what is wrong connects the same server four times.
+    probeServer.mockResolvedValue({
+      endpoint: "https://ha.example.com/mcp",
+      transport: "HTTP+SSE (2024-11-05)",
+      protocol: "2024-11-05",
+      handshake: true,
+      signin: "none",
+      server: "Home Assistant",
+      tools: ["turn_on"],
+      ms: 42,
+    });
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+    fireEvent.click(await screen.findByText("Add a server"));
+    fireEvent.change(screen.getByPlaceholderText("https://example.com/mcp"), {
+      target: { value: "https://ha.example.com/mcp" },
+    });
+    fireEvent.click(screen.getByText("Test"));
+
+    // The transport is the field that costs the most to guess at: a refusal on
+    // the current one and a working event stream are the same sentence and
+    // opposite instructions.
+    expect(await screen.findByText(/HTTP\+SSE \(2024-11-05\)/)).toBeTruthy();
+    expect(screen.getByText(/1 tool: turn_on/)).toBeTruthy();
+    // And it connected nothing.
+    expect(addPlugin).not.toHaveBeenCalled();
+  });
+
+  it("keeps a refusal on screen rather than clearing the form it was about", async () => {
+    // `run` reloads the panel and drops what it was told; a test has to keep
+    // its answer on a failure, because a server that refused is what somebody
+    // pressed this to find out.
+    probeServer.mockRejectedValue(new Error("could not reach https://ha.example.com/mcp"));
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+    fireEvent.click(await screen.findByText("Add a server"));
+    fireEvent.change(screen.getByPlaceholderText("https://example.com/mcp"), {
+      target: { value: "https://ha.example.com/mcp" },
+    });
+    fireEvent.click(screen.getByText("Test"));
+
+    expect(await screen.findByText(/could not reach/)).toBeTruthy();
+    expect((screen.getByPlaceholderText("https://example.com/mcp") as HTMLInputElement).value).toBe(
+      "https://ha.example.com/mcp",
+    );
+  });
+
+  it("tests a connected plugin against the sign-in it already has", async () => {
+    // The question a crew notices as an agent reporting a tool it cannot call,
+    // and the only other way to ask it is to connect again, which replaces the
+    // tool list and opens a browser.
+    groupPlugins.mockResolvedValue([added()]);
+    checkPlugin.mockResolvedValue({
+      endpoint: "https://ha.example.com/mcp",
+      transport: "",
+      protocol: "",
+      handshake: false,
+      signin: "refused",
+      server: "",
+      tools: [],
+      ms: 31,
+    });
+    render(<PluginList groupId={GROUP} crew={CREW} />);
+
+    fireEvent.click(await screen.findByText("Test it"));
+
+    await waitFor(() => expect(checkPlugin).toHaveBeenCalledWith("p2"));
+    expect(await screen.findByText(/refused what you gave it/)).toBeTruthy();
+    expect(readdressPlugin).not.toHaveBeenCalled();
   });
 
   it("draws a mark for a server named after something on Object's prototype", async () => {

--- a/src/components/PluginList.tsx
+++ b/src/components/PluginList.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { api, openExternal } from "../lib/ipc";
-import { hostOf, markFor } from "../lib/plugins";
+import { hostOf, markFor, reportLine } from "../lib/plugins";
 import {
   type AccountConnection,
   type AgentCard,
@@ -9,11 +9,13 @@ import {
   type CatalogKind,
   errorMessage,
   type GroupId,
+  type HeaderPair,
   type Plugin,
   type PluginAccess,
   type PluginKind,
   type PluginOffer,
   type PluginToolCard,
+  type ServerReport,
 } from "../lib/types";
 
 interface Props {
@@ -39,6 +41,112 @@ const ACCESS_MODES = [
   { value: "everyone", label: "Every agent", short: "Everyone" },
   { value: "chosen", label: "Only chosen agents", short: "Chosen" },
 ] as const;
+
+/**
+ * One header row while it is being typed.
+ *
+ * The id is the editor's and never leaves it. A header has no identity until it
+ * has a name, and a name is exactly what is half-typed when the operator adds
+ * the second row: keyed by position instead, removing the first row hands its
+ * DOM node — and the focus and the selection in it — to the second.
+ */
+interface HeaderDraft extends HeaderPair {
+  id: number;
+}
+
+/** Ids for the rows above. Monotonic, per session, and read by nothing else. */
+let headerRows = 0;
+function blankHeader(name = "", value = ""): HeaderDraft {
+  headerRows += 1;
+  return { id: headerRows, name, value };
+}
+
+/** What Rust takes: the pairs, without the identity the editor gave them. */
+function sent(rows: HeaderDraft[]): HeaderPair[] {
+  return rows.map(({ name, value }) => ({ name, value }));
+}
+
+/**
+ * The headers an operator gives a server they run themselves.
+ *
+ * The third thing such a server can want, after an address and a token, and the
+ * one nothing can discover: an `X-API-Key` because that is where its framework
+ * looks, a pair of `Cf-Access-Client-*` because it sits behind a gate, a tenant
+ * id because one deployment serves several.
+ *
+ * Values are write-only here for the reason a connector's secret is: they are
+ * sent, stored and spent, and the panel can say which headers a server is being
+ * given without being a place to read what they are worth. What comes back on a
+ * connected row is the names.
+ *
+ * The rules — which names are refused, how many, how long a value may be — are
+ * in Rust and are not repeated here. A second copy would be a second place for
+ * them to be wrong, and the refusal that comes back names the header and the
+ * fix, which is what an operator pasting out of a vendor's `curl` example
+ * needs.
+ */
+function HeaderFields({
+  rows,
+  onChange,
+  disabled,
+}: {
+  rows: HeaderDraft[];
+  onChange: (rows: HeaderDraft[]) => void;
+  disabled: boolean;
+}) {
+  const edit = (id: number, part: Partial<HeaderPair>) =>
+    onChange(rows.map((was) => (was.id === id ? { ...was, ...part } : was)));
+
+  return (
+    <div className="field">
+      <span className="field__label">Headers (optional)</span>
+      {rows.map((row, at) => (
+        <div className="choices" key={row.id}>
+          <input
+            className="input"
+            placeholder="X-API-Key"
+            aria-label={`Header ${at + 1} name`}
+            value={row.name}
+            disabled={disabled}
+            onChange={(event) => edit(row.id, { name: event.target.value })}
+          />
+          <input
+            className="input"
+            type="password"
+            placeholder="value"
+            aria-label={`Header ${at + 1} value`}
+            value={row.value}
+            disabled={disabled}
+            onChange={(event) => edit(row.id, { value: event.target.value })}
+          />
+          <button
+            type="button"
+            className="btn btn--small btn--ghost"
+            aria-label={`Remove header ${at + 1}`}
+            disabled={disabled}
+            onClick={() => onChange(rows.filter((was) => was.id !== row.id))}
+          >
+            Remove
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        className="toolset__more"
+        disabled={disabled}
+        onClick={() => onChange([...rows, blankHeader()])}
+      >
+        Add a header
+      </button>
+      <span className="field__hint">
+        Sent on every request to this server, whatever else authorizes it: an API key the server
+        reads from a header it named, or the pair a gate in front of it wants. They stay here — a
+        value never reaches a model, a transcript or an agent's machine, and never comes back to
+        this panel.
+      </span>
+    </div>
+  );
+}
 
 /** The chosen set with one agent added or taken out. */
 function toggled(access: PluginAccess, agent: AgentId): AgentId[] {
@@ -245,12 +353,30 @@ export function PluginList({ groupId, crew }: Props) {
   // neither is submitted on a keystroke, which is the one place on this panel
   // that is true: everything else here is a decision about a plugin that
   // already exists, and a half-typed URL is not a decision at all.
-  const [draft, setDraft] = useState({ name: "", url: "", key: "" });
+  const [draft, setDraft] = useState<{
+    name: string;
+    url: string;
+    key: string;
+    headers: HeaderDraft[];
+  }>({ name: "", url: "", key: "", headers: [] });
   const [adding, setAdding] = useState(false);
   // Keyed by plugin id, and absent until the operator opens the control: an
   // address box standing open under every added server is an invitation to
   // change something nobody came here to change.
-  const [moving, setMoving] = useState<Record<string, { url: string; key: string }>>({});
+  //
+  // `headers` is `null` until the operator opens that control too, and the
+  // difference is what reaches Rust: null keeps the stored set, a list replaces
+  // it whole. Same rule a group's API key has, for the same reason — a value
+  // that cannot be read back is one this panel cannot re-send, so a
+  // reconnection that meant "replace" would quietly drop it.
+  const [moving, setMoving] = useState<
+    Record<string, { url: string; key: string; headers: HeaderDraft[] | null }>
+  >({});
+  // What the last test of each thing found. Keyed the way `busy` is, and
+  // cleared whenever the thing it was about changes: a report that outlived the
+  // address it was run against is worse than no report, because it reads as one
+  // about the address on screen.
+  const [tested, setTested] = useState<Record<string, ServerReport>>({});
 
   const load = useCallback(async () => {
     try {
@@ -289,6 +415,28 @@ export function PluginList({ groupId, crew }: Props) {
       await action();
       await load();
     } catch (caught) {
+      setError(errorMessage(caught));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  /**
+   * Dials a server and keeps what it said, without reloading the panel.
+   *
+   * Its own runner rather than `run`, because a test changes nothing: reloading
+   * after it would redraw every row in the crew to report that one address
+   * answered. It also keeps its answer on a failure, which `run` cannot: a
+   * server that refused is exactly what somebody pressed this to find out.
+   */
+  const test = async (key: string, dial: () => Promise<ServerReport>) => {
+    setBusy(key);
+    setError(null);
+    try {
+      const report = await dial();
+      setTested((was) => ({ ...was, [key]: report }));
+    } catch (caught) {
+      setTested(({ [key]: _gone, ...rest }) => rest);
       setError(errorMessage(caught));
     } finally {
       setBusy(null);
@@ -452,7 +600,7 @@ export function PluginList({ groupId, crew }: Props) {
                       onChange={(event) =>
                         setMoving((was) => ({
                           ...was,
-                          [held.id]: { url: event.target.value, key: was[held.id]?.key ?? "" },
+                          [held.id]: { ...was[held.id]!, url: event.target.value },
                         }))
                       }
                     />
@@ -467,7 +615,7 @@ export function PluginList({ groupId, crew }: Props) {
                       onChange={(event) =>
                         setMoving((was) => ({
                           ...was,
-                          [held.id]: { url: was[held.id]?.url ?? "", key: event.target.value },
+                          [held.id]: { ...was[held.id]!, key: event.target.value },
                         }))
                       }
                     />
@@ -480,6 +628,48 @@ export function PluginList({ groupId, crew }: Props) {
                       the server what it wants, the way it does for a new one.
                     </span>
                   </label>
+                  {/* The headers go the other way, and the difference is what
+                      can be shown: their names come back, so the panel can say
+                      what is stored and leave it alone unless the operator says
+                      otherwise. Opening this replaces the whole set, and an
+                      empty set removes them. */}
+                  {moving[held.id]?.headers ? (
+                    <HeaderFields
+                      rows={moving[held.id]?.headers ?? []}
+                      disabled={busy !== null}
+                      onChange={(rows) =>
+                        setMoving((was) => ({
+                          ...was,
+                          [held.id]: { ...was[held.id]!, headers: rows },
+                        }))
+                      }
+                    />
+                  ) : (
+                    <p className="field__hint">
+                      {held.headers.length === 0
+                        ? "No headers. "
+                        : `Sends ${held.headers.join(", ")}. `}
+                      <button
+                        type="button"
+                        className="toolset__more"
+                        disabled={busy !== null}
+                        onClick={() =>
+                          setMoving((was) => ({
+                            ...was,
+                            [held.id]: {
+                              ...was[held.id]!,
+                              // Prefilled with the names and no values, because
+                              // that is exactly what is knowable: a value never
+                              // comes back, so replacing a set is retyping it.
+                              headers: held.headers.map((name) => blankHeader(name)),
+                            },
+                          }))
+                        }
+                      >
+                        Replace headers
+                      </button>
+                    </p>
+                  )}
                   <div className="choices">
                     <button
                       type="button"
@@ -493,12 +683,34 @@ export function PluginList({ groupId, crew }: Props) {
                             held.id,
                             change?.url ?? "",
                             change?.key || undefined,
+                            change?.headers ? sent(change.headers) : undefined,
                           );
                           setMoving(({ [held.id]: _gone, ...rest }) => rest);
                         })
                       }
                     >
                       {busy === `${kind}-address` ? "Reconnecting…" : "Save and reconnect"}
+                    </button>
+                    {/* Before the reconnection rather than after it, because a
+                        reconnection replaces the tool list: an address that
+                        turns out to be wrong costs the crew every tool the
+                        server used to publish until somebody fixes it. */}
+                    <button
+                      type="button"
+                      className="btn btn--small btn--ghost"
+                      disabled={busy !== null || !moving[held.id]?.url.trim()}
+                      onClick={() =>
+                        void test(`${kind}-address-test`, () => {
+                          const change = moving[held.id];
+                          return api.probeServer(
+                            change?.url ?? "",
+                            change?.key || undefined,
+                            change?.headers ? sent(change.headers) : undefined,
+                          );
+                        })
+                      }
+                    >
+                      {busy === `${kind}-address-test` ? "Testing…" : "Test"}
                     </button>
                     <button
                       type="button"
@@ -509,17 +721,24 @@ export function PluginList({ groupId, crew }: Props) {
                       Cancel
                     </button>
                   </div>
+                  {tested[`${kind}-address-test`] && (
+                    <p className="field__hint">{reportLine(tested[`${kind}-address-test`]!)}</p>
+                  )}
                 </>
               ) : (
                 <p className="field__hint">
                   You added this one, so nobody has checked it. It gets everything a server on the
-                  list above gets. <code>{held.endpoint}</code>{" "}
+                  list above gets. <code>{held.endpoint}</code>
+                  {held.headers.length > 0 && ` Sends ${held.headers.join(", ")}.`}{" "}
                   <button
                     type="button"
                     className="toolset__more"
                     disabled={busy !== null}
                     onClick={() =>
-                      setMoving((was) => ({ ...was, [held.id]: { url: held.endpoint, key: "" } }))
+                      setMoving((was) => ({
+                        ...was,
+                        [held.id]: { url: held.endpoint, key: "", headers: null },
+                      }))
                     }
                   >
                     Change address
@@ -536,8 +755,25 @@ export function PluginList({ groupId, crew }: Props) {
                       an account. */}
                   {held.account && ` Signed in as ${held.account}.`}
                   {!held.signedIn &&
-                    " This server asked for no sign-in, so nothing was authorized."}
+                    " This server asked for no sign-in, so nothing was authorized."}{" "}
+                  {/* On every connected row and not only the added ones. The
+                      question it answers — is this reachable, and is our
+                      sign-in still good — is the same for a vendor, and the
+                      only other way to ask it is to connect again, which
+                      replaces the tool list and opens a browser. */}
+                  <button
+                    type="button"
+                    className="toolset__more"
+                    disabled={busy !== null}
+                    onClick={() => void test(`${kind}-check`, () => api.checkPlugin(held.id))}
+                  >
+                    {busy === `${kind}-check` ? "Testing…" : "Test it"}
+                  </button>
                 </p>
+
+                {tested[`${kind}-check`] && (
+                  <p className="field__hint">{reportLine(tested[`${kind}-check`]!)}</p>
+                )}
 
                 {/* Two buttons rather than a list with an "all" entry at the
                     top: every agent is a standing answer that covers whoever
@@ -815,6 +1051,11 @@ export function PluginList({ groupId, crew }: Props) {
                 reaches a model, a transcript or an agent's machine.
               </span>
             </label>
+            <HeaderFields
+              rows={draft.headers}
+              disabled={busy !== null}
+              onChange={(headers) => setDraft((was) => ({ ...was, headers }))}
+            />
             <div className="choices">
               <button
                 type="button"
@@ -822,16 +1063,37 @@ export function PluginList({ groupId, crew }: Props) {
                 disabled={busy !== null || !draft.name.trim() || !draft.url.trim()}
                 onClick={() =>
                   void run("add", async () => {
-                    await api.addPlugin(groupId, draft.name, draft.url, draft.key || undefined);
+                    await api.addPlugin(
+                      groupId,
+                      draft.name,
+                      draft.url,
+                      draft.key || undefined,
+                      sent(draft.headers),
+                    );
                     // Cleared only once it worked. A refused address the
                     // operator has to retype is a refusal that costs more than
                     // the mistake did.
-                    setDraft({ name: "", url: "", key: "" });
+                    setDraft({ name: "", url: "", key: "", headers: [] });
                     setAdding(false);
                   })
                 }
               >
                 {busy === "add" ? "Connecting…" : "Add and connect"}
+              </button>
+              {/* Needs no name, because nothing is being called by one: this
+                  dials the address and reports what is there. It is the one
+                  control on this panel that can be pressed before the operator
+                  knows whether they have got the right thing. */}
+              <button
+                type="button"
+                className="btn btn--small btn--ghost"
+                disabled={busy !== null || !draft.url.trim()}
+                onClick={() =>
+                  void test("add-test", () =>
+                    api.probeServer(draft.url, draft.key || undefined, draft.headers))
+                }
+              >
+                {busy === "add-test" ? "Testing…" : "Test"}
               </button>
               <button
                 type="button"
@@ -842,6 +1104,7 @@ export function PluginList({ groupId, crew }: Props) {
                 Cancel
               </button>
             </div>
+            {tested["add-test"] && <p className="field__hint">{reportLine(tested["add-test"]!)}</p>}
           </>
         ) : (
           <>

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -40,6 +40,7 @@ import type {
   GroupId,
   GroupReset,
   GroupUsage,
+  HeaderPair,
   MessageId,
   Plugin,
   PluginAccess,
@@ -54,6 +55,7 @@ import type {
   RunId,
   RunUsage,
   SearchHits,
+  ServerReport,
   Settings,
   SettingsPatch,
   Signin,
@@ -149,9 +151,13 @@ export const api = {
    * The key is for a server with no authorization server behind it, which is
    * most of the ones somebody wrote: left out, the server is asked what it
    * wants exactly as a vendor's is.
+   *
+   * The headers are a third thing and not a third credential: they go on every
+   * request whichever of the other two paid for it, which is what makes an
+   * `X-API-Key` server and a server behind Cloudflare Access both work.
    */
-  addPlugin: (groupId: GroupId, name: string, url: string, key?: string) =>
-    invoke<Plugin>("add_plugin", { groupId, name, url, key: key ?? null }),
+  addPlugin: (groupId: GroupId, name: string, url: string, key?: string, headers?: HeaderPair[]) =>
+    invoke<Plugin>("add_plugin", { groupId, name, url, key: key ?? null, headers }),
 
   /**
    * Points a crew's own server at a different address, or hands it a new key.
@@ -159,9 +165,37 @@ export const api = {
    * A reconnection rather than an edit, because a server at a new address is
    * not the one that published the old tool list. Who may spend it and which of
    * its tools are whose survive, for the reason they survive any reconnection.
+   *
+   * The headers are the whole set every time, and leaving them out removes
+   * them. That is the opposite of the key, whose absence means "ask the
+   * server", and the two differ because the panel can read the header names
+   * back and cannot read a key back at all.
    */
-  readdressPlugin: (groupId: GroupId, id: PluginId, url: string, key?: string) =>
-    invoke<Plugin>("readdress_plugin", { groupId, id, url, key: key ?? null }),
+  readdressPlugin: (
+    groupId: GroupId,
+    id: PluginId,
+    url: string,
+    key?: string,
+    headers?: HeaderPair[],
+  ) => invoke<Plugin>("readdress_plugin", { groupId, id, url, key: key ?? null, headers }),
+
+  /**
+   * Dials a server and says what it found, connecting nothing.
+   *
+   * The whole path a connection runs — both transports, the handshake, the
+   * tool list — with whatever has been typed and not yet saved. It stops one
+   * step short in one place: a server that wants a sign-in is reported as
+   * wanting one rather than sent to a browser.
+   */
+  probeServer: (url: string, key?: string, headers?: HeaderPair[]) =>
+    invoke<ServerReport>("probe_server", { url, key: key ?? null, headers }),
+
+  /**
+   * The same question, asked of a plugin this crew already has, using the grant
+   * in the store. The only way to find out whether a sign-in is still good
+   * without reconnecting, which opens a browser.
+   */
+  checkPlugin: (id: PluginId) => invoke<ServerReport>("check_plugin", { id }),
 
   /**
    * Narrows a plugin to named agents, or opens it back up to the crew.

--- a/src/lib/plugins.test.ts
+++ b/src/lib/plugins.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { hostOf, markFor, reportLine } from "./plugins";
+import type { ServerReport } from "./types";
+
+function report(over: Partial<ServerReport> = {}): ServerReport {
+  return {
+    endpoint: "https://box.example.com/mcp",
+    transport: "streamable HTTP",
+    protocol: "2025-11-25",
+    handshake: true,
+    signin: "none",
+    server: "Home Assistant",
+    tools: ["turn_on", "turn_off"],
+    ms: 84,
+    ...over,
+  };
+}
+
+describe("markFor", () => {
+  it("draws a server nobody vouched for as a plug rather than nothing", () => {
+    // A lookup with a truthy fallback finds `constructor` on the prototype and
+    // draws an empty square, which reads as a broken row.
+    expect(markFor("home_assistant").color).toBe("var(--accent)");
+    expect(markFor("constructor" as never).color).toBe("var(--accent)");
+    expect(markFor("neon").color).toBe("#34d59a");
+  });
+});
+
+describe("hostOf", () => {
+  it("falls back to the address when it is not one", () => {
+    expect(hostOf("https://mcp.neon.tech/mcp")).toBe("mcp.neon.tech");
+    expect(hostOf("not a url")).toBe("not a url");
+  });
+});
+
+describe("reportLine", () => {
+  it("names the tools rather than counting them", () => {
+    // The operator is checking that what they expect is what this address
+    // publishes. A count answers a question nobody has.
+    const line = reportLine(report());
+    expect(line).toContain("Home Assistant answered in 84 ms");
+    expect(line).toContain("streamable HTTP, MCP 2025-11-25, with a handshake");
+    expect(line).toContain("2 tools: turn_on, turn_off");
+  });
+
+  it("says which transport it was, because that is the field that costs the most", () => {
+    const line = reportLine(report({ transport: "HTTP+SSE (2024-11-05)", handshake: true }));
+    expect(line).toContain("HTTP+SSE (2024-11-05)");
+  });
+
+  it("tells a server that wants a sign-in apart from a key it refused", () => {
+    // One status code, opposite problems. Told apart wrongly, an operator
+    // re-pastes a key at a server that never wanted one.
+    const wanted = reportLine(report({ signin: "wanted", transport: "", protocol: "", tools: [] }));
+    expect(wanted).toContain("wants a sign-in");
+    expect(wanted).not.toContain("MCP ");
+
+    const refused = reportLine(
+      report({ signin: "refused", transport: "", protocol: "", tools: [] }),
+    );
+    expect(refused).toContain("refused what you gave it");
+    expect(refused).not.toContain("MCP ");
+  });
+
+  it("says that a server publishing nothing would offer the crew nothing", () => {
+    // Reachable and useless is a real outcome, and "0 tools" reads as a bug in
+    // Guaca rather than as the server having nothing on it.
+    expect(reportLine(report({ tools: [] }))).toContain("would be offered nothing");
+  });
+
+  it("stands in for a server that does not name itself", () => {
+    expect(reportLine(report({ server: "" }))).toMatch(/^It answered/);
+  });
+});

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -24,7 +24,7 @@
  * the one true thing about it — that it is a server somebody plugged in.
  */
 
-import type { CatalogKind, PluginKind } from "./types";
+import type { CatalogKind, PluginKind, ServerReport } from "./types";
 
 export interface Brand {
   /** The `d` of a single path on a 24x24 viewBox, verbatim from Simple Icons. */
@@ -101,4 +101,42 @@ export function hostOf(endpoint: string): string {
   } catch {
     return endpoint;
   }
+}
+
+/**
+ * What one dial of a server found out, as the sentence a person reads.
+ *
+ * Written here rather than assembled in the panel because it is a decision
+ * rather than a layout: which of the four outcomes this was, and which of the
+ * facts underneath are worth saying about each. A server that wants a sign-in
+ * has no transport, no revision and no tools, and a line built by concatenating
+ * whatever was set would say "answered over , MCP" about it.
+ *
+ * The two 401s get different sentences on purpose. They are one status code and
+ * opposite problems: an operator who cannot tell them apart re-pastes a key at
+ * a server that never wanted one, or goes hunting for a sign-in that is really
+ * a typo. Each says what to do next rather than what went wrong.
+ */
+export function reportLine(report: ServerReport): string {
+  const took = `${report.ms} ms`;
+  if (report.signin === "wanted") {
+    return `Reached it in ${took}. It wants a sign-in: connecting opens your browser.`;
+  }
+  if (report.signin === "refused") {
+    return `Reached it in ${took} and it refused what you gave it. The address is right and the key is not.`;
+  }
+
+  const who = report.server || "It";
+  const how = report.handshake
+    ? `${report.transport}, MCP ${report.protocol}, with a handshake`
+    : `${report.transport}, MCP ${report.protocol}`;
+  // Named rather than counted, because the operator is checking that the tools
+  // they expect are the ones this address publishes. A count answers a
+  // different question, and it is one nobody has.
+  const offers =
+    report.tools.length === 0
+      ? "It published no tools, so a crew connecting it would be offered nothing"
+      : `${report.tools.length} tool${report.tools.length === 1 ? "" : "s"}: ${report.tools.join(", ")}`;
+  const paid = report.signin === "accepted" ? " It accepted what you gave it." : "";
+  return `${who} answered in ${took} over ${how}.${paid} ${offers}.`;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -379,9 +379,62 @@ export interface Plugin {
   access: PluginAccess;
   /** Which authorized identity at the Guaca account this crew uses, if any. */
   connection: string;
+  /**
+   * Which headers the operator gave this server, by name and never by value.
+   *
+   * Drawn so the panel can say what is being sent — an operator debugging their
+   * own server needs to know whether `x-api-key` is on the request — without
+   * being a place a credential can be read back out of. Empty for every server
+   * on the catalog and for most added ones.
+   */
+  headers: string[];
   signedIn: boolean;
   connectedAt: number;
 }
+
+/**
+ * One header the operator wrote, on its way to Rust.
+ *
+ * The value only ever travels in this direction. What comes back on a `Plugin`
+ * is the names, for the reason a connector's secret never comes back either.
+ */
+export interface HeaderPair {
+  name: string;
+  value: string;
+}
+
+/**
+ * What one dial of a server found out, without connecting anything.
+ *
+ * The answer to "why does my server not work", which is otherwise a single
+ * sentence out of whichever layer failed first. The fields are separate because
+ * the failures are: a 405 on the current transport and a working event stream
+ * are the same sentence and opposite instructions to a person.
+ */
+export interface ServerReport {
+  /** The address as Rust canonicalized it, which is what would be stored. */
+  endpoint: string;
+  /** Which transport it answered on. Blank when nothing was established. */
+  transport: string;
+  /** The revision the two of them settled on. Blank for the same reason. */
+  protocol: string;
+  /** Whether it wanted a handshake. Not the same question as the transport. */
+  handshake: boolean;
+  signin: SigninNeed;
+  /** How the server names itself, when it says. Often blank. */
+  server: string;
+  /** Every tool it published. Empty for a server that wants a sign-in. */
+  tools: string[];
+  ms: number;
+}
+
+/**
+ * What the server did about a credential.
+ *
+ * `wanted` and `refused` are the same status code on the wire and opposite
+ * problems: one is a server that signs in, the other is a key it will not take.
+ */
+export type SigninNeed = "none" | "wanted" | "accepted" | "refused";
 
 /**
  * Which of an agent's two places holds a session.


### PR DESCRIPTION
A server the operator added got the catalog's two strings and nothing else, and these are the three things a server somebody runs themselves routinely needs.

It now falls back to the HTTP+SSE transport that streamable HTTP replaced, probed rather than configured, and offered to added servers only: a vendor Guaca vouches for is one it can hold to the current transport, and a box in somebody's network is not a vendor.

Operator-supplied headers ride every request as a thing separate from the credential, so `X-API-Key`, `Authorization: Basic` and a server behind Cloudflare Access all work without a case each, with `oauth::Gate` carrying them through the sign-in and the refresh while stopping them at the resource's origin.

`probe_server` and `check_plugin` run the real path (both transports, the handshake, `tools/list`), write nothing, and report a server that wants a sign-in instead of opening a browser.

Covered by a second scripted server in `tests/plugins.rs` for the older transport, gated headers and cross-origin refusal, plus unit, migration, store and panel tests; `./scripts/ci.sh` passes.
