### PR TITLE
feat: a mention is drawn as one thing, in the box and in the message

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ repo: the frontend renders state and forwards intent.
 | Running a model's own HTML, or anything about that origin | *A page an agent wrote runs somewhere else* in `docs/WORKSPACE.md`, then `src-tauri/src/artifact.rs` |
 | A turn's tool calls in a channel: what folds, what a chip says, what opens | *A turn's own work is chips* in `docs/WORKSPACE.md`, then `src/lib/trail.ts` |
 | What an agent changed about its own memory, and where the version before it came from | *A memory rewrite opens as a diff* in `docs/WORKSPACE.md`, then `Workspace::write` and `src/lib/diff.ts` |
+| An `@` that names an agent: what resolves, and what it draws in either place | *A mention is one thing, in the box and in the message* in `docs/WORKSPACE.md`, then `src/lib/mentions.ts` and the layer under `Composer`'s textarea |
 | Anything announced to a screen reader, or a live region | *A transcript is a log, and says one thing out loud* in `docs/WORKSPACE.md` |
 | Scrolling a transcript, following the newest line, when the view may move | *A transcript follows the end for whoever is at the end, and nobody else* in `docs/WORKSPACE.md`, then `src/lib/follow.ts` |
 | The menu bar: the glyph, the count, what the menu offers, closing the window | *The menu bar is Guaca with the window shut* in `docs/WORKSPACE.md`, then `src-tauri/src/menubar.rs` |

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -335,6 +335,68 @@ holds is not one: a channel opened from the activity board spent the session
 listening to a node that had been thrown away, which is the shape the report
 arrived in.
 
+## A mention is one thing, in the box and in the message
+
+An `@` that names an agent is drawn as a chip: a rounded tint behind the name,
+so an operator can see at a glance who a message actually reaches. It happens in
+two places, and the point is that they agree. What the box paints while a draft
+is typed is what the transcript paints after it is sent.
+
+**Resolution against the roster is the whole rule.** `@Critic` is a mention
+because there is a Critic; `@lunch` is a word somebody wrote. Nothing else can
+decide it, because `@` in front of a word is also a handle, a Python decorator,
+a shell flag and half an email address, and a chip around one of those tells the
+operator this app knows something it does not. `splitMentions` in
+`lib/mentions.ts` is the one answer, and it opens on the same word-boundary rule
+the typeahead does, so what lights up is exactly what could have been completed.
+It takes the longest name that fits, or a crew holding both "Head" and
+"Head Chef" gets a chip on the first word and the rest of a name reading as
+prose. It stops at the end of the name rather than inside a longer word, which
+is why `@Critical` is nobody.
+
+Two rosters, and the difference is which question is being asked. The composer
+completes against the live crew, because a mention is about to become a
+delivery. A transcript resolves against everyone the store holds, retired agents
+included, because it is history: an agent that has since been let go was still
+an agent when somebody wrote to it, and dropping its name back into prose
+rewrites what the message looked like the day it was sent.
+
+**In a message, the chip is a remark plugin, not a pass over the rendered
+output.** A mention turns up inside a bold run, a list item, a heading and a
+table cell, and the mdast is the one place all four are the same node. It is
+declared with `hName` and `hProperties`, so what `react-markdown` builds is
+still plain hast and the rule about raw HTML is untouched: no `rehype-raw`, no
+markup from a model reaching the document. Code and fences never reach the walk,
+because they carry a value rather than text children, and links are skipped on
+purpose. A chip inside an anchor is two things claiming one click, and
+`remark-gfm` autolinks a bare email address, which is the one place an `@` is
+guaranteed not to be a mention.
+
+**In the composer, the chip is painted on a copy of the draft, underneath the
+operator's own characters.** The textarea is still the text. A contenteditable
+would make a mention a real element that backspace deletes whole, and it would
+also cost the caret, the undo stack, an input method and every native thing a
+box does. Making the textarea's own text transparent and reading the copy
+instead is the other way, and it is worse where it matters: a selection over
+transparent text is an empty highlight, and the box an operator drags across is
+the one they are about to retype.
+
+So the copy carries the pill and nothing else. That is a constraint on the chip
+rather than a note about it: `.mention` may not declare a padding, a weight, a
+letter-spacing or anything else that moves a glyph, because the copy would move
+and the characters on top of it would not. The room around a name is a spread
+shadow, which takes up none. `styles.test.ts` reads the two elements back
+through the cascade and compares every property that decides where a character
+lands, and it reads `.mention` out of the source to check it declares nothing
+that shifts one. Neither is visible in review and neither renders in a window
+with no layout, which is the whole reason they are assertions.
+
+The copy is out of flow, so the textarea is still what gives the row its height
+and still what grows as the draft does. Past the twelve-rem cap the box scrolls,
+and the copy is scrolled with it from two places: the scroll event, and the
+effect that resizes it. Typing at the bottom of a full box moves the view
+without the operator having scrolled anything.
+
 ## The rail is arranged by hand, and lends the top of a section out
 
 Two orders, not one. `railOrder` on the card is the arrangement: the operator

--- a/src/components/Composer.test.tsx
+++ b/src/components/Composer.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Attachment, Staged } from "../lib/types";
+import type { AgentCard, Attachment, Staged } from "../lib/types";
 import { Composer } from "./Composer";
 
 /** The drop handlers the component registered, so a test can fire one. */
@@ -39,12 +39,40 @@ vi.mock("../lib/ipc", () => ({
   },
 }));
 
-vi.mock("../lib/store", () => ({ useLiveAgents: () => [] }));
+/** The crew the box can complete against. Set per test where it matters. */
+let roster: AgentCard[] = [];
+
+vi.mock("../lib/store", () => ({ useLiveAgents: () => roster }));
+
+/** An agent as the rail hands one over: only the fields the composer draws. */
+function anAgent(name: string): AgentCard {
+  return {
+    id: `00000000-0000-4000-8000-${name.length.toString().padStart(12, "0")}`,
+    groupId: "00000000-0000-4000-8000-000000000001",
+    name,
+    avatar: "plain",
+    color: "#c7d96b",
+    model: "",
+    systemPrompt: "",
+    skills: [],
+    lifecycle: "active",
+    pinned: false,
+    railOrder: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    sandboxId: null,
+    browserId: null,
+    hasComputer: false,
+    hasBrowser: false,
+    version: 1,
+  };
+}
 
 describe("Composer", () => {
   beforeEach(() => {
     dropped = null;
     over = null;
+    roster = [];
     staging = async (paths) => ({ attached: paths.map(stored), refused: [] });
   });
 
@@ -169,6 +197,79 @@ describe("Composer", () => {
       over?.(true);
     });
     expect(screen.getByText("Drop to attach")).toBeTruthy();
+  });
+});
+
+describe("a mention in the box", () => {
+  /** The layer under the textarea, which is where a draft's mentions are drawn. */
+  const painted = () => document.querySelector(".composer__mirror");
+
+  async function draw() {
+    render(<Composer placeholder="Message Manager" onSend={vi.fn(async () => {})} />);
+    await waitFor(() => expect(dropped).not.toBeNull());
+  }
+
+  it("marks a name the crew has, as it is typed", async () => {
+    roster = [anAgent("Critic"), anAgent("Head Chef")];
+    await draw();
+    await type("ask @Critic and @Head Chef about @lunch");
+
+    const chips = [...(painted()?.querySelectorAll(".mention") ?? [])];
+    expect(chips.map((chip) => chip.getAttribute("data-mention"))).toEqual(["Critic", "Head Chef"]);
+  });
+
+  it("paints exactly the characters the box holds, and no others", async () => {
+    // The layer sits under the operator's own text, so a copy that is one
+    // character out is a pill beside the name instead of behind it. Nothing in
+    // a window with no layout can see that; that the two strings agree is what
+    // can be checked here, and `styles.test.ts` holds the metrics.
+    roster = [anAgent("Critic")];
+    await draw();
+    await type("ask @Critic to review\nand say so");
+
+    const box = screen.getByRole("combobox") as HTMLTextAreaElement;
+    expect(painted()?.textContent).toBe(box.value);
+  });
+
+  it("is the same text twice, so only one of them is read out", async () => {
+    roster = [anAgent("Critic")];
+    await draw();
+    await type("@Critic");
+
+    expect(painted()?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("marks nothing when the name is nobody's", async () => {
+    roster = [anAgent("Critic")];
+    await draw();
+    await type("mail bob@example.com about @lunch");
+
+    expect(painted()?.querySelectorAll(".mention")).toHaveLength(0);
+  });
+
+  it("marks the name the typeahead just completed", async () => {
+    // The two have to agree: a completion the operator accepted that then drew
+    // as prose reads as the app having refused it.
+    roster = [anAgent("Head Chef")];
+    await draw();
+    await type("ask @Head");
+    await act(async () => {
+      fireEvent.keyDown(screen.getByRole("combobox"), { key: "Enter" });
+    });
+
+    await waitFor(() =>
+      expect(painted()?.querySelector(".mention")?.getAttribute("data-mention")).toBe("Head Chef"),
+    );
+  });
+
+  it("lets go of a mention that stops being one", async () => {
+    roster = [anAgent("Critic")];
+    await draw();
+    await type("@Critic");
+    expect(painted()?.querySelectorAll(".mention")).toHaveLength(1);
+
+    await type("@Critical");
+    expect(painted()?.querySelectorAll(".mention")).toHaveLength(0);
   });
 });
 

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 
 import { AgentAvatar } from "../avatars/AgentAvatar";
 import { fileUrl, previewKind, readableSize } from "../lib/files";
 import { api, onFileDrop } from "../lib/ipc";
-import { applyMention, matchMentions, mentionAt } from "../lib/mentions";
+import { applyMention, matchMentions, mentionAt, splitMentions } from "../lib/mentions";
 import { useLiveAgents } from "../lib/store";
 import { type Attachment, errorMessage } from "../lib/types";
 
@@ -25,6 +25,7 @@ export function Composer({ placeholder, disabled, disabledReason, onSend }: Prop
   const [refused, setRefused] = useState<string[]>([]);
   const [dragging, setDragging] = useState(false);
   const ref = useRef<HTMLTextAreaElement>(null);
+  const mirror = useRef<HTMLDivElement>(null);
 
   // Dropping anywhere on the window attaches to whatever channel is open,
   // because the alternative is a small target the operator has to aim at while
@@ -61,22 +62,22 @@ export function Composer({ placeholder, disabled, disabledReason, onSend }: Prop
   }, [disabled]);
 
   const agents = useLiveAgents();
+  const names = useMemo(() => agents.map((a) => a.name), [agents]);
   const query = dismissed ? null : mentionAt(text, caret);
-  const matches = query
-    ? matchMentions(
-        agents.map((a) => a.name),
-        query.term,
-      )
-    : [];
+  const matches = query ? matchMentions(names, query.term) : [];
   const showing = query !== null && matches.length > 0;
   const selected = matches.length > 0 ? Math.min(highlighted, matches.length - 1) : 0;
 
-  // Grow with the content instead of scrolling a three-line box.
+  // Grow with the content instead of scrolling a three-line box. Past the cap
+  // it does scroll, which is why the layer under it is re-aligned here as well
+  // as on a scroll event: typing at the bottom of a full box moves the view
+  // without the operator having scrolled anything.
   useEffect(() => {
     const node = ref.current;
     if (!node) return;
     node.style.height = "auto";
     node.style.height = `${node.scrollHeight}px`;
+    if (mirror.current) mirror.current.scrollTop = node.scrollTop;
   }, [text]);
 
   const choose = (name: string) => {
@@ -245,28 +246,50 @@ export function Composer({ placeholder, disabled, disabledReason, onSend }: Prop
       )}
 
       <div className="composer__row">
-        <textarea
-          ref={ref}
-          className="composer__input"
-          rows={1}
-          value={text}
-          placeholder={disabled ? (disabledReason ?? placeholder) : placeholder}
-          disabled={disabled}
-          onChange={(event) => {
-            setText(event.target.value);
-            setCaret(event.target.selectionStart ?? 0);
-            setDismissed(false);
-            setHighlighted(0);
-          }}
-          onKeyUp={track}
-          onClick={track}
-          onKeyDown={onKeyDown}
-          role="combobox"
-          aria-expanded={showing}
-          aria-controls={showing ? "mention-list" : undefined}
-          aria-activedescendant={showing ? `mention-${selected}` : undefined}
-          aria-autocomplete="list"
-        />
+        <div className="composer__field">
+          {/* The draft, with its mentions drawn, under the box it belongs to.
+              The operator's own characters are still the textarea's: this
+              paints the pill behind them and nothing else, so the caret, a
+              selection, undo and an input method are all left as they were.
+              `aria-hidden` because it is the same text twice, and the copy a
+              screen reader should read is the field. */}
+          <div className="composer__mirror" aria-hidden="true" ref={mirror}>
+            {splitMentions(text, names).map((run) =>
+              run.kind === "mention" ? (
+                <span key={run.at} className="mention" data-mention={run.name}>
+                  {run.text}
+                </span>
+              ) : (
+                <Fragment key={run.at}>{run.text}</Fragment>
+              ),
+            )}
+          </div>
+          <textarea
+            ref={ref}
+            className="composer__input"
+            rows={1}
+            value={text}
+            placeholder={disabled ? (disabledReason ?? placeholder) : placeholder}
+            disabled={disabled}
+            onChange={(event) => {
+              setText(event.target.value);
+              setCaret(event.target.selectionStart ?? 0);
+              setDismissed(false);
+              setHighlighted(0);
+            }}
+            onKeyUp={track}
+            onClick={track}
+            onKeyDown={onKeyDown}
+            onScroll={(event) => {
+              if (mirror.current) mirror.current.scrollTop = event.currentTarget.scrollTop;
+            }}
+            role="combobox"
+            aria-expanded={showing}
+            aria-controls={showing ? "mention-list" : undefined}
+            aria-activedescendant={showing ? `mention-${selected}` : undefined}
+            aria-autocomplete="list"
+          />
+        </div>
         <button
           type="button"
           className="composer__send"

--- a/src/components/Markdown.test.tsx
+++ b/src/components/Markdown.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 const openExternal = vi.fn<(url: string) => Promise<void>>(async () => {});
 vi.mock("../lib/ipc", () => ({ openExternal: (url: string) => openExternal(url) }));
 
-const { Markdown } = await import("./Markdown");
+const { Markdown, Roster } = await import("./Markdown");
 
 describe("Markdown", () => {
   it("renders the formatting models actually emit", () => {
@@ -63,5 +63,69 @@ describe("Markdown", () => {
 
   it("renders an empty body without crashing", () => {
     expect(() => render(<Markdown>{""}</Markdown>)).not.toThrow();
+  });
+});
+
+describe("a mention in a body", () => {
+  const NAMES = ["Critic", "Head Chef"];
+
+  /** A body drawn with a roster behind it, which is what the app provides. */
+  function drawn(body: string) {
+    return render(
+      <Roster.Provider value={NAMES}>
+        <Markdown>{body}</Markdown>
+      </Roster.Provider>,
+    ).container;
+  }
+
+  it("is drawn as one thing, wherever in the document it lands", () => {
+    // A tree walk rather than a pass over the prose: a mention turns up inside
+    // a bold run, a heading, a list item and a table cell, and the tree is the
+    // one place all four are the same node.
+    const container = drawn("# @Critic\n\n- **@Head Chef** cooks\n\n| who |\n| - |\n| @Critic |");
+    const chips = [...container.querySelectorAll(".mention")];
+
+    expect(chips.map((chip) => chip.getAttribute("data-mention"))).toEqual([
+      "Critic",
+      "Head Chef",
+      "Critic",
+    ]);
+    expect(container.querySelector("h1 .mention")).toBeTruthy();
+    expect(container.querySelector("strong .mention")).toBeTruthy();
+    expect(container.querySelector("td .mention")).toBeTruthy();
+  });
+
+  it("names nobody the roster does not have", () => {
+    // Which is most of them. A model writes `@` in front of a flag, a handle
+    // and an email address, and a chip on one of those says this app knows who
+    // that is.
+    const container = drawn("try @lunch, or mail bob@example.com, or @Critical thinking");
+    expect(container.querySelectorAll(".mention")).toHaveLength(0);
+  });
+
+  it("leaves code alone, where an @ is a decorator", () => {
+    const container = drawn("`@Critic` and\n\n```py\n@Critic\ndef go(): ...\n```");
+    expect(container.querySelectorAll(".mention")).toHaveLength(0);
+  });
+
+  it("leaves a link's own words alone", () => {
+    // A chip inside an anchor is two things claiming one click, and an
+    // autolinked address is the one place an @ is certainly not a mention.
+    const container = drawn("[@Critic](https://example.com) and bob@example.com");
+    expect(container.querySelectorAll(".mention")).toHaveLength(0);
+    expect(container.querySelectorAll("a")).toHaveLength(2);
+  });
+
+  it("draws the prose the model wrote when no roster was provided", () => {
+    // The default, and every surface that has not opted in gets it: nothing
+    // resolves, so nothing is claimed.
+    const { container } = render(<Markdown>{"ask @Critic"}</Markdown>);
+    expect(container.querySelectorAll(".mention")).toHaveLength(0);
+    expect(container.textContent).toBe("ask @Critic");
+  });
+
+  it("keeps the words either side of it", () => {
+    const container = drawn("ask @Critic to review");
+    expect(container.textContent).toBe("ask @Critic to review");
   });
 });

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,10 +1,22 @@
-import type { ReactNode } from "react";
+import { createContext, type ReactNode, useContext, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { fenceLanguage, fenceText, readFigure } from "../lib/figure";
 import { openExternal } from "../lib/ipc";
+import { splitMentions } from "../lib/mentions";
 import { Figure } from "./Figure";
+
+/**
+ * Every name an `@` in a body is allowed to resolve to.
+ *
+ * A context rather than a store subscription, and the difference is a hundred
+ * of them: a body is drawn once per message, and this is read by every one of
+ * them on every render. It is also what keeps the default honest. Nothing
+ * resolves against an empty roster, so a surface that has not provided one
+ * draws exactly the prose the model wrote instead of guessing at names.
+ */
+export const Roster = createContext<string[]>([]);
 
 /**
  * Renders message bodies as Markdown.
@@ -21,10 +33,13 @@ import { Figure } from "./Figure";
  * origin of its own that can reach nothing. `artifact.rs` is the argument.
  */
 export function Markdown({ children }: { children: string }) {
+  const names = useContext(Roster);
+  const plugins = useMemo(() => [remarkGfm, remarkMentions(names)], [names]);
+
   return (
     <div className="md">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={plugins}
         components={{
           a: ({ href, children }) => (
             <a
@@ -95,4 +110,83 @@ function asFence(children: ReactNode): { language: string; source: string } | nu
   const language = fenceLanguage(props.className);
   if (!language) return null;
   return { language, source: fenceText(props.children) };
+}
+
+/**
+ * mdast, in the shape this walk needs and no more.
+ *
+ * The real types live in `@types/mdast`, which is not a dependency of this app:
+ * it arrives under `react-markdown` and would be a version nothing here pins.
+ * A tree walk needs three fields and a name for them.
+ */
+interface Node {
+  type: string;
+  value?: string;
+  children?: Node[];
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Node types whose text is not prose, so an `@` inside one is left alone.
+ *
+ * Code and fences never reach the walk at all, because they carry a value
+ * rather than text children. A link does have text children, and a chip inside
+ * an anchor is two things claiming the same click; `remark-gfm` also autolinks
+ * a bare email address, which is the one place an `@` is guaranteed not to be
+ * a mention.
+ */
+const NOT_PROSE = new Set(["link", "linkReference"]);
+
+/**
+ * Wraps every resolved `@` in its own element, before anything is rendered.
+ *
+ * A remark plugin rather than a pass over the rendered output: a mention can
+ * appear inside a bold run, a list item, a heading or a table cell, and the
+ * tree is the one place all of those are the same thing. The chip is a `span`
+ * with a class, declared through `hName` and `hProperties`, so the document
+ * `react-markdown` builds is still plain hast and the rule about raw HTML is
+ * untouched.
+ */
+function remarkMentions(names: string[]) {
+  return () => (tree: Node) => {
+    if (names.length > 0) mark(tree, names);
+  };
+}
+
+function mark(node: Node, names: string[]): void {
+  if (!node.children || NOT_PROSE.has(node.type)) return;
+
+  const next: Node[] = [];
+  for (const child of node.children) {
+    if (child.type !== "text" || typeof child.value !== "string") {
+      mark(child, names);
+      next.push(child);
+      continue;
+    }
+
+    const runs = splitMentions(child.value, names);
+    // The common answer: nothing in this text names anybody, so the node it
+    // arrived as is the node that goes back.
+    if (!runs.some((run) => run.kind === "mention")) {
+      next.push(child);
+      continue;
+    }
+
+    for (const run of runs) {
+      next.push(
+        run.kind === "text"
+          ? { type: "text", value: run.text }
+          : {
+              type: "mention",
+              data: {
+                hName: "span",
+                hProperties: { className: "mention", "data-mention": run.name },
+              },
+              children: [{ type: "text", value: run.text }],
+            },
+      );
+    }
+  }
+
+  node.children = next;
 }

--- a/src/lib/mentions.test.ts
+++ b/src/lib/mentions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { applyMention, matchMentions, mentionAt } from "./mentions";
+import { applyMention, matchMentions, mentionAt, splitMentions } from "./mentions";
 
 const NAMES = ["Manager", "Researcher", "Critic", "Scribe", "Head Chef"];
 
@@ -88,5 +88,61 @@ describe("applyMention", () => {
     // Exact names are the point: send_message resolves recipients by name.
     const query = mentionAt("@Head", 5)!;
     expect(applyMention("@Head", query, "Head Chef").text).toBe("@Head Chef ");
+  });
+});
+
+describe("splitMentions", () => {
+  /** The runs that resolved, as they were typed. */
+  const marked = (text: string, names = NAMES) =>
+    splitMentions(text, names)
+      .filter((run) => run.kind === "mention")
+      .map((run) => run.text);
+
+  it("marks a name the roster has and leaves one it does not", () => {
+    // The whole rule. `@` and a word is also a handle, a decorator and half an
+    // email address, and a chip around one of those claims a fact nobody has.
+    expect(marked("ask @Critic about @lunch")).toEqual(["@Critic"]);
+  });
+
+  it("puts the prose back exactly as it arrived", () => {
+    const text = "ask @Critic, then @Scribe.";
+    expect(
+      splitMentions(text, NAMES)
+        .map((run) => run.text)
+        .join(""),
+    ).toBe(text);
+  });
+
+  it("takes the longest name, so a two-word one is not cut to its first word", () => {
+    expect(marked("@Head Chef please")).toEqual(["@Head Chef"]);
+    expect(marked("@Head Chef please", ["Head", "Head Chef"])).toEqual(["@Head Chef"]);
+  });
+
+  it("stops at the end of the name rather than inside a longer word", () => {
+    expect(marked("@Critical thinking")).toEqual([]);
+    expect(marked("@Critic's review")).toEqual(["@Critic"]);
+    expect(marked("@Critic, @Scribe")).toEqual(["@Critic", "@Scribe"]);
+  });
+
+  it("ignores an @ inside a word, which is where an email address lives", () => {
+    expect(marked("write to critic@Manager.com")).toEqual([]);
+  });
+
+  it("matches however it was typed and reports the name as the roster spells it", () => {
+    const [run] = splitMentions("@critic", NAMES);
+    expect(run).toEqual({ kind: "mention", at: 0, text: "@critic", name: "Critic" });
+  });
+
+  it("hands back one run of prose when nobody could be named", () => {
+    expect(splitMentions("@Critic is not here", [])).toEqual([
+      { kind: "text", at: 0, text: "@Critic is not here" },
+    ]);
+    expect(splitMentions("", NAMES)).toEqual([]);
+  });
+
+  it("offsets every run, because they are the keys the two surfaces draw with", () => {
+    const runs = splitMentions("ask @Critic now", NAMES);
+    expect(runs.map((run) => run.at)).toEqual([0, 4, 11]);
+    expect(new Set(runs.map((run) => run.at)).size).toBe(runs.length);
   });
 });

--- a/src/lib/mentions.ts
+++ b/src/lib/mentions.ts
@@ -68,3 +68,76 @@ export function applyMention(
   const next = text.slice(0, query.start) + inserted + text.slice(query.end);
   return { text: next, caret: query.start + inserted.length };
 }
+
+/** A stretch of a message body: prose, or one `@` that resolved to an agent. */
+export type Run =
+  | { kind: "text"; at: number; text: string }
+  | { kind: "mention"; at: number; text: string; name: string };
+
+/** Letters, digits and underscore, in any script an operator types in. */
+const WORD = /[\p{L}\p{N}_]/u;
+
+/**
+ * Splits a body into prose and the mentions inside it.
+ *
+ * Resolution against the roster is the whole rule: `@Critic` is a mention
+ * because there is a Critic, and `@lunch` is a word somebody wrote. Nothing
+ * else can decide it, because `@` followed by a word is also a handle, a
+ * decorator and half an email address, and drawing a chip around one of those
+ * tells the operator this app knows something it does not.
+ *
+ * Runs carry the text as it was typed rather than the roster's spelling, which
+ * matters in the composer: the layer this paints sits under the operator's own
+ * characters, so a chip drawn one glyph wider than the name under it is a pill
+ * that has slid off. `name` is the canonical one, for anything asking who was
+ * meant.
+ */
+export function splitMentions(text: string, names: string[]): Run[] {
+  if (!text) return [];
+  // Longest first, because a roster can hold both "Head" and "Head Chef": the
+  // shorter one matches first otherwise and the rest of the name reads as prose.
+  const roster = names.filter((name) => name.length > 0).sort((a, b) => b.length - a.length);
+  if (roster.length === 0) return [{ kind: "text", at: 0, text }];
+
+  const runs: Run[] = [];
+  let plain = 0;
+  let from = 0;
+
+  while (from < text.length) {
+    const found = text.indexOf("@", from);
+    if (found === -1) break;
+    const name = resolve(text, found, roster);
+    if (!name) {
+      from = found + 1;
+      continue;
+    }
+    if (found > plain) runs.push({ kind: "text", at: plain, text: text.slice(plain, found) });
+    const end = found + 1 + name.length;
+    runs.push({ kind: "mention", at: found, text: text.slice(found, end), name });
+    from = end;
+    plain = end;
+  }
+
+  if (plain < text.length) runs.push({ kind: "text", at: plain, text: text.slice(plain) });
+  return runs;
+}
+
+/** The agent an `@` at this index names, or null if it names nobody. */
+function resolve(text: string, at: number, roster: string[]): string | null {
+  // The same rule the typeahead opens on, so what lights up is what could have
+  // been completed: an `@` mid-word is an email address, not a mention.
+  const preceding = at === 0 ? "" : text[at - 1]!;
+  if (preceding && !/\s|[([{]/.test(preceding)) return null;
+
+  const rest = text.slice(at + 1);
+  const lower = rest.toLowerCase();
+  for (const name of roster) {
+    if (!lower.startsWith(name.toLowerCase())) continue;
+    // "Critic" must not light up inside "@Critical". Punctuation after a name
+    // is ordinary prose and ends it.
+    const after = rest[name.length];
+    if (after !== undefined && WORD.test(after)) continue;
+    return name;
+  }
+  return null;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,13 +2,15 @@ import "@fontsource-variable/inter";
 import "@fontsource-variable/space-grotesk";
 import "@fontsource-variable/jetbrains-mono";
 
-import React from "react";
+import React, { useMemo } from "react";
 import ReactDOM from "react-dom/client";
 
 import App from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { Roster } from "./components/Markdown";
 import { applyAppearance } from "./lib/appearance";
 import { loadPrefs } from "./lib/prefs";
+import { useStore } from "./lib/store";
 import "./styles.css";
 
 /**
@@ -73,10 +75,31 @@ window.addEventListener("unhandledrejection", (event) =>
 const root = document.getElementById("root");
 if (!root) throw new Error("missing #root");
 
+/**
+ * The names an `@` in a message body is allowed to resolve to.
+ *
+ * At the root because a body is drawn in a channel, in a pair's thread, in the
+ * activity board and behind a search hit, and none of those should have to
+ * remember to say so. The whole roster rather than the live one: a transcript
+ * is history, and an agent that has since been let go was still an agent when
+ * somebody wrote to it. The composer answers the other question, which is who
+ * a message can be delivered to, so it completes against the live crew.
+ */
+function Guaca() {
+  const everyone = useStore((state) => state.agents);
+  const roster = useMemo(() => everyone.map((agent) => agent.name), [everyone]);
+
+  return (
+    <Roster.Provider value={roster}>
+      <App />
+    </Roster.Provider>
+  );
+}
+
 ReactDOM.createRoot(root).render(
   <React.StrictMode>
     <ErrorBoundary>
-      <App />
+      <Guaca />
     </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/src/styles.css
+++ b/src/styles.css
@@ -3742,23 +3742,71 @@ button {
   padding: 0.3rem 0.35rem 0.3rem 0;
 }
 
-.composer__input {
+/* The box and the layer that paints its mentions, stacked. The layer is out of
+   flow, so the textarea is still what gives the row its height and still what
+   grows as the draft does. */
+.composer__field {
+  position: relative;
   flex: 1;
   min-width: 0;
-  resize: none;
-  border: 0;
-  background: none;
-  color: var(--text);
+}
+
+/* Every property that decides where a character lands, declared once for both.
+   They have to wrap identically to the pixel or a pill sits beside the name it
+   belongs to instead of behind it, and that is a mismatch no assertion in a
+   window with no layout can see. `styles.test.ts` holds the two together. */
+.composer__mirror,
+.composer__input {
   font: inherit;
   font-size: 0.925rem;
   line-height: 1.55;
+  /* A textarea does not inherit these; the layer under it does. Both are said
+     out loud so the two cannot come apart on a UA default. */
+  letter-spacing: inherit;
+  word-spacing: inherit;
   padding: 0.28rem 0.2rem 0.28rem 0.85rem;
+  border: 0;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+.composer__mirror {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  /* The text is here to place the pill, not to be read: the operator reads the
+     textarea's own characters, directly on top of these. */
+  color: transparent;
+  user-select: none;
+  pointer-events: none;
+}
+
+.composer__input {
+  display: block;
+  width: 100%;
+  position: relative;
+  resize: none;
+  background: none;
+  color: var(--text);
   outline: none;
   max-height: 12rem;
 }
 
 .composer__input::placeholder {
   color: var(--faint);
+}
+
+/* A name that resolved, drawn as one thing rather than as punctuation and a
+   word. The same class does the job in a sent message and under the composer,
+   which is why it changes no metric: no padding, no weight, no letter-spacing,
+   nothing that moves a glyph by half a pixel. The room around the name is a
+   spread shadow, which takes up none. */
+.mention {
+  border-radius: 0.3rem;
+  background: color-mix(in oklab, var(--flesh) 26%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--flesh) 26%, transparent);
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 /* Round, in the accent, and the size of the line it sits beside. A word-width

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -200,3 +200,88 @@ describe("a message's clock", () => {
     expect(getComputedStyle(at).gridColumn).not.toBe(getComputedStyle(body).gridColumn);
   });
 });
+
+describe("the composer's mention layer", () => {
+  /**
+   * The pill is painted on a copy of the draft, under the operator's own text.
+   *
+   * Which only works while the copy wraps and spaces its characters exactly as
+   * the textarea does. One extra pixel of padding on either and every pill in
+   * the box sits beside the name it belongs to rather than behind it, on a
+   * surface where nothing renders in review and nothing lays out in a test.
+   * So the properties that decide where a glyph lands are read back off both
+   * elements and compared to each other.
+   */
+  const PLACES_A_GLYPH = [
+    "fontSize",
+    "fontFamily",
+    "fontWeight",
+    "lineHeight",
+    "letterSpacing",
+    "wordSpacing",
+    "paddingTop",
+    "paddingRight",
+    "paddingBottom",
+    "paddingLeft",
+    "borderTopWidth",
+    "borderLeftWidth",
+    "whiteSpace",
+    "overflowWrap",
+  ] as const;
+
+  function drawn(): { mirror: CSSStyleDeclaration; input: CSSStyleDeclaration } {
+    const field = document.createElement("div");
+    field.className = "composer__field";
+    const mirror = document.createElement("div");
+    mirror.className = "composer__mirror";
+    const input = document.createElement("textarea");
+    input.className = "composer__input";
+    field.append(mirror, input);
+    document.body.append(field);
+    return { mirror: getComputedStyle(mirror), input: getComputedStyle(input) };
+  }
+
+  it("wraps the copy exactly as the box wraps the original", () => {
+    const { mirror, input } = drawn();
+
+    // Vacuous if the rule stopped reaching either element.
+    expect(mirror.fontSize).toBeTruthy();
+    expect(mirror.paddingLeft).toBeTruthy();
+
+    for (const property of PLACES_A_GLYPH) {
+      expect(mirror[property], `${property} differs from the box's`).toBe(input[property]);
+    }
+  });
+
+  it("keeps the copy out of the flow and out of the way", () => {
+    const { mirror } = drawn();
+
+    // The textarea is what gives the row its height and grows as the draft
+    // does. A copy in the flow would double both.
+    expect(mirror.position).toBe("absolute");
+    // And it is under the box: a click that landed on it would take the caret.
+    expect(mirror.pointerEvents).toBe("none");
+  });
+
+  /**
+   * The chip is one class, drawn in a sent message and under the composer, and
+   * the second of those is why it may not change a metric. Padding, a weight or
+   * a letter-spacing on it moves the characters in the copy and leaves the ones
+   * in the textarea where they were, which is the same drift by another route.
+   * The room around a name is a spread shadow, which takes up none.
+   */
+  it("draws the chip without moving a character", () => {
+    const rule = css.match(/^\.mention \{\n([\s\S]*?)^\}/m);
+    expect(rule).toBeTruthy();
+
+    const declared = [...rule![1]!.matchAll(/^\s{2}([a-z-]+):/gm)].map((found) => found[1]!);
+    const moves = declared.filter((property) =>
+      /^(padding|margin|border(?!-radius)|font|letter-spacing|word-spacing|display|line-height|vertical-align)/.test(
+        property,
+      ),
+    );
+    expect(moves, `.mention declares ${moves.join(", ")}, which moves the text under it`).toEqual(
+      [],
+    );
+  });
+});


### PR DESCRIPTION
An `@` that names an agent now draws as a chip while it is typed and after it is sent, so the operator can see which agents a message actually reaches. Resolution against the roster is the whole rule: `@Critic` is a mention because there is a Critic, while `@lunch`, a Python decorator and half an email address stay prose. In a message the chip is a remark plugin over the mdast, so it works inside bold, headings, lists and table cells without touching the rule about raw HTML, and code, fences and links are left alone. In the composer it is painted on a copy of the draft underneath the operator's own characters, so the textarea is still the text and the caret, selection and undo are untouched, which is also why `.mention` may not declare anything that moves a glyph. Neither the wrapping nor that constraint renders in review or lays out in a test, so `styles.test.ts` asserts both, alongside 23 new tests across the parsing, the transcript and the box.