### PR TITLE
feat: a crew says its name, and the whole name, wherever it is drawn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ repo: the frontend renders state and forwards intent.
 | Stopping a conversation: what a stop marks, wakes, and must never release | *A stop marks the run and releases nothing*, then `Runtime::stop_run` |
 | Permission prompts, parked turns, acting in the operator's name | *A protected action parks the turn that asked for it* |
 | Anything an agent stops to ask a person: the desk, the queue, the two kinds of request, `ask_operator` | `docs/ATTENTION.md`, then `domain/approval.rs` and `Runtime::park` |
-| The crews' column, its badges, which crew the rail is inside | *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/presence.ts` and `src/components/GroupRail.tsx` |
+| The crews' column, its badges, how a crew names itself, which crew the rail is inside | *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/presence.ts`, `src/components/GroupRail.tsx` and `src/components/OrbTag.tsx` |
 | What an agent may do with a page it has just read | *A page that was read this turn cannot quietly press a button* |
 | Screenshots, coordinates, what a screen action answers with | *A computer is looked at, never asked* in `docs/MACHINES.md` |
 | Attachments, previews, drops, handing a document to the operator | *Files are references, and what a model gets depends on what they are* |

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -531,10 +531,40 @@ which is what lets a circle carry a permanent statement about the crews nobody i
 looking at. And "which crew am I in" stops being something the rail has to
 answer, because the answer is a lit circle in a fixed place.
 
-The circles are faces, not names. A crew is recognized by who is in it long
-before its name is read. The name is not drawn under the circle at all: the
-column is four rem wide, a name cut to fit that is a name nobody can read, and
-it heads the crew column the moment the circle is clicked.
+The circles are faces, and the name is beside them. A crew is recognized by who
+is in it long before its name is read, which is true and was never enough on its
+own. The cafeteria is a copy machine with a fixed avatar and a fixed color per
+preset, so two crews hired from the same counters draw the same faces in the
+same colors, differing only by the few degrees of lean `lib/orb.ts` takes off an
+agent id; and above six members every crew draws the same six and a count. The
+operator's way out was to click through the column reading names, which is the
+navigation the column exists to replace.
+
+So pointing at a circle names it, and says the two marks in words underneath.
+The name is still not drawn *under* the circle: the column is four rem wide and
+a name cut to fit that is a name nobody can read. It is laid over the app beside
+the circle instead, which costs the column no width, the layout no reflow, and
+can hold a name long enough to wrap rather than ellipse. `src/components/OrbTag.tsx`.
+
+This is what `title` was already trying to do and could not. The native tooltip
+waits about a second, so sweeping a column of twelve shows nothing; it never
+appears on a keyboard focus, so the column was reachable by pointer only; and it
+is suppressed for the whole of a drag, which is the one moment the circle is most
+load-bearing, because dropping an agent onto an unnamed circle is how somebody
+ends up in the wrong crew. The tag opens on hover, on focus and during a drag.
+`title` is kept for the operator who has stopped and is waiting for it.
+
+The words under the name are `presenceNote`, which `presenceLabel` also composes
+its sentence from. Two functions would be one circle described two ways, and a
+tag saying "3 agents" under a label saying "working" is the version where only
+one of them is right. The tag itself is out of the accessibility tree: the button
+already says the same words as its own label, and drawn into the tree twice a
+crew is announced twice, the second time as text nobody can reach.
+
+Both rail headings carry the full name on a `title` too. They ellipse whatever
+does not fit, and after clicking a circle the heading is the only place the name
+is drawn at all, so a crew called "Customer research, EMEA" was two words and a
+hyphen wherever the operator looked.
 
 How the faces stand is the size of the crew. One is a portrait, two stand side
 by side, and three to six stand on a ring, so a strip of crews is a strip of

--- a/src/components/GroupOrb.tsx
+++ b/src/components/GroupOrb.tsx
@@ -2,8 +2,9 @@ import type { CSSProperties } from "react";
 
 import { AgentAvatar } from "../avatars/AgentAvatar";
 import { cluster } from "../lib/orb";
-import { presenceLabel, presenceOf } from "../lib/presence";
+import { presenceLabel, presenceNote, presenceOf } from "../lib/presence";
 import type { Activity, AgentCard, AgentId, Group } from "../lib/types";
+import { OrbTag, useOrbTag } from "./OrbTag";
 
 interface Props {
   group: Group;
@@ -29,10 +30,11 @@ function percent(fraction: number): string {
  *
  * Faces rather than a name, because a crew is recognized by who is in it long
  * before its name is read. How they stand is the crew's size: `lib/orb.ts` owns
- * the seating and says why. The name is not drawn at all here, because the
- * column is four rem wide and a name cut to fit it is a name nobody can read;
- * it is on the tooltip, on the label, and heading the crew column the moment
- * this is clicked.
+ * the seating and says why. The name is still not drawn *under* the circle,
+ * because the column is four rem wide and a name cut to fit it is a name nobody
+ * can read: it is drawn beside the circle, over the app, whenever the circle is
+ * pointed at or focused. `OrbTag` has the rest of that argument, including why
+ * faces alone were never enough to tell two crews apart.
  *
  * Two jobs in one control, which is why it is a circle and not a row in a menu.
  * Clicking opens the group. Dropping an agent on it puts the agent in the group,
@@ -50,6 +52,7 @@ export function GroupOrb({
   onDragOut,
 }: Props) {
   const { seats, rest } = cluster(members);
+  const tag = useOrbTag();
 
   // The two states worth interrupting a glance for, and why they are not one
   // mark: `lib/presence.ts`. This column is the only thing on screen about the
@@ -66,8 +69,19 @@ export function GroupOrb({
       data-state={presence.working ? "working" : undefined}
       data-over={over ? "true" : undefined}
       onClick={onOpen}
-      onPointerEnter={onDragOver}
-      onPointerLeave={onDragOut}
+      onFocus={tag.open}
+      onBlur={tag.close}
+      // Naming the crew and aiming a drag at it are the same gesture on
+      // purpose. A drag is when the operator most needs the circle to say which
+      // crew it is, and it is the one moment the native tooltip is suppressed.
+      onPointerEnter={(event) => {
+        tag.open(event);
+        onDragOver();
+      }}
+      onPointerLeave={() => {
+        tag.close();
+        onDragOut();
+      }}
     >
       <span className="orb__ring">
         <span className="orb__faces">
@@ -109,6 +123,9 @@ export function GroupOrb({
         <span className="orb__waiting" aria-hidden="true">
           {presence.blocked}
         </span>
+      )}
+      {tag.at !== null && (
+        <OrbTag name={group.name} note={presenceNote(members.length, presence)} at={tag.at} />
       )}
     </button>
   );

--- a/src/components/GroupRail.tsx
+++ b/src/components/GroupRail.tsx
@@ -1,6 +1,7 @@
 import type { DropTarget } from "../lib/rail";
 import type { Activity, AgentCard, AgentId, Group, GroupId } from "../lib/types";
 import { GroupOrb } from "./GroupOrb";
+import { OrbTag, useOrbTag } from "./OrbTag";
 
 interface Props {
   groups: Group[];
@@ -48,6 +49,8 @@ export function GroupRail({
   onDragOver,
   onDragOut,
 }: Props) {
+  const all = useOrbTag();
+
   if (groups.length < 2) return null;
 
   return (
@@ -63,10 +66,17 @@ export function GroupRail({
         aria-label={`All groups, ${agents.length} agents`}
         title="All groups"
         onClick={() => onFocus(null)}
+        onPointerEnter={all.open}
+        onPointerLeave={all.close}
+        onFocus={all.open}
+        onBlur={all.close}
       >
         <span className="orb__ring">
           <span className="orb__all-count">{agents.length}</span>
         </span>
+        {all.at !== null && (
+          <OrbTag name="All groups" note={`${agents.length} agents`} at={all.at} />
+        )}
       </button>
 
       <span className="grail__rule" aria-hidden="true" />

--- a/src/components/OrbTag.tsx
+++ b/src/components/OrbTag.tsx
@@ -1,0 +1,77 @@
+import type { CSSProperties } from "react";
+import { useCallback, useState } from "react";
+
+/**
+ * A crew's name, beside its circle, the moment the circle is pointed at.
+ *
+ * The column identifies a crew by the faces in it, and that premise is thinner
+ * than it looks. The cafeteria is a copy machine with a fixed avatar and a
+ * fixed color per preset, so two crews hired from the same counters draw the
+ * same faces in the same colors and differ only by the few degrees of lean
+ * `lib/orb.ts` takes off an agent id. Above six members every crew draws the
+ * same six and a count. The operator's way out was to click through the column
+ * reading names, which is the navigation the column exists to replace.
+ *
+ * So the name is said, and the two marks are said in words under it. Beside the
+ * circle rather than under it: the column is four rem wide and a name cut to fit
+ * that is a name nobody can read, which is the argument in `GroupOrb` and it
+ * still holds. Laid over the app instead, this costs the column no width and the
+ * layout no reflow, and it can hold a name long enough to wrap.
+ *
+ * This is what `title` was doing and failing at. The native tooltip waits about
+ * a second, so sweeping a column of twelve shows nothing; it never appears on a
+ * keyboard focus; and it is suppressed for the whole of a drag, which is the one
+ * moment the circle is load-bearing, because dropping an agent on an unnamed
+ * circle is how somebody is moved to the wrong crew. `title` is kept anyway, for
+ * the operator who has stopped and is waiting for it.
+ */
+interface Props {
+  /** The crew, or "All groups". */
+  name: string;
+  /** How big it is and what it is doing. `presenceNote`, or a bare count. */
+  note: string;
+  /** Middle of the circle this belongs to, in window coordinates. */
+  at: number;
+}
+
+export function OrbTag({ name, note, at }: Props) {
+  return (
+    // Said by the button's own `aria-label` already, in the same words from the
+    // same function. Drawn again in the accessibility tree it would be the crew
+    // announced twice, once as a control and once as text nobody can reach.
+    <span className="orb__tag" aria-hidden="true" style={{ "--tag-y": `${at}px` } as CSSProperties}>
+      <span className="orb__tag-name">{name}</span>
+      <span className="orb__tag-note">{note}</span>
+    </span>
+  );
+}
+
+/**
+ * Whether a circle is being pointed at, and where it is while it is.
+ *
+ * The position is measured at the moment the tag opens rather than tracked,
+ * because the tag is fixed to the window and the circle is inside a column that
+ * scrolls: a value read once is right for exactly as long as the pointer stays
+ * on the circle, and the pointer leaving is what closes it.
+ *
+ * Focus opens it too, and unconditionally rather than on `:focus-visible`. A
+ * click focuses the circle it was already hovering, so the two agree; and the
+ * pointer leaving closes what the pointer opened whether or not the button kept
+ * focus, so nothing is left hanging over the app after a click.
+ */
+export function useOrbTag(): {
+  at: number | null;
+  open: (event: { currentTarget: HTMLElement }) => void;
+  close: () => void;
+} {
+  const [at, setAt] = useState<number | null>(null);
+
+  const open = useCallback((event: { currentTarget: HTMLElement }) => {
+    const box = event.currentTarget.getBoundingClientRect();
+    setAt(box.top + box.height / 2);
+  }, []);
+
+  const close = useCallback(() => setAt(null), []);
+
+  return { at, open, close };
+}

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -424,6 +424,124 @@ describe("groups as places", () => {
     expect(orb.dataset.state).toBe("working");
   });
 
+  // Faces do not identify a crew. The cafeteria is a copy machine with a fixed
+  // avatar and color per preset, so two crews hired from the same counters draw
+  // the same faces, and above six every crew draws six and a count. Reading a
+  // name meant clicking, which is the navigation the column replaced.
+  it("names a crew beside its circle while the circle is pointed at", () => {
+    draw(
+      [group("everyone"), group("research", null, RESEARCH)],
+      [agent("Manager"), agent("Reader", { groupId: RESEARCH, railOrder: 1 })],
+    );
+
+    const orb = screen.getByLabelText("research, 1 agent");
+    expect(orb.querySelector(".orb__tag")).toBeNull();
+
+    fireEvent.pointerEnter(orb);
+    expect(orb.querySelector(".orb__tag-name")?.textContent).toBe("research");
+
+    fireEvent.pointerLeave(orb);
+    expect(orb.querySelector(".orb__tag")).toBeNull();
+  });
+
+  // A column reachable only with a pointer is a column a keyboard operator has
+  // to click through, which is the complaint this answers for everyone else.
+  it("names it on a keyboard focus too, and lets go on blur", () => {
+    draw(
+      [group("everyone"), group("research", null, RESEARCH)],
+      [agent("Manager"), agent("Reader", { groupId: RESEARCH, railOrder: 1 })],
+    );
+
+    const orb = screen.getByLabelText("research, 1 agent");
+    fireEvent.focus(orb);
+    expect(orb.querySelector(".orb__tag-name")?.textContent).toBe("research");
+
+    fireEvent.blur(orb);
+    expect(orb.querySelector(".orb__tag")).toBeNull();
+  });
+
+  // The full name, not the one the heading has room for. A tag that ellipsed
+  // would move where the name is cut off rather than stop cutting it.
+  it("draws the whole name, however long it is", () => {
+    const long = "Customer research and competitive intelligence, EMEA";
+    draw([group("everyone"), group(long, null, RESEARCH)], [agent("Manager")]);
+
+    const orb = screen.getByLabelText(`${long}, 0 agents`);
+    fireEvent.pointerEnter(orb);
+    expect(orb.querySelector(".orb__tag-name")?.textContent).toBe(long);
+  });
+
+  // The circle carries the ring and the corner count on two channels. The tag
+  // is where they are put into words, so triage does not need the crew opened.
+  it("says what the crew is doing under its name, in the label's own words", () => {
+    draw(
+      [group("everyone"), group("research", null, RESEARCH)],
+      [agent("Manager"), agent("Reader", { groupId: RESEARCH, railOrder: 1 })],
+      { Reader: { state: "awaitingApproval" } },
+    );
+
+    const orb = screen.getByLabelText("research, 1 agent, 1 turn waiting on you");
+    fireEvent.pointerEnter(orb);
+    expect(orb.querySelector(".orb__tag-note")?.textContent).toBe("1 agent, 1 turn waiting on you");
+  });
+
+  // Said once, as the button's own label. Drawn into the tree a second time it
+  // is the crew announced twice, the second time as text nobody can reach.
+  it("keeps the tag out of the accessibility tree", () => {
+    draw(
+      [group("everyone"), group("research", null, RESEARCH)],
+      [agent("Manager"), agent("Reader", { groupId: RESEARCH, railOrder: 1 })],
+    );
+
+    const orb = screen.getByLabelText("research, 1 agent");
+    fireEvent.pointerEnter(orb);
+    expect(orb.querySelector(".orb__tag")?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  // A bare number in a circle is as opaque as an unnamed crew, and it is the
+  // first thing in the column.
+  it("names the everybody circle as well", () => {
+    draw(
+      [group("everyone"), group("research", null, RESEARCH)],
+      [agent("Manager"), agent("Reader", { groupId: RESEARCH, railOrder: 1 })],
+    );
+
+    const all = screen.getByLabelText("All groups, 2 agents");
+    fireEvent.pointerEnter(all);
+    expect(all.querySelector(".orb__tag-name")?.textContent).toBe("All groups");
+    expect(all.querySelector(".orb__tag-note")?.textContent).toBe("2 agents");
+  });
+
+  // Aiming a drag at a crew is when the circle most has to say which crew it
+  // is, and it is the one moment the native tooltip is suppressed.
+  it("names the crew a dragged agent is being aimed at", () => {
+    draw(
+      [group("everyone"), group("research", null, RESEARCH)],
+      [agent("Manager"), agent("Reader", { groupId: RESEARCH, railOrder: 1 })],
+    );
+
+    fireEvent.pointerDown(row("Manager"), { button: 0, clientX: 100, clientY: 300 });
+    fireEvent.pointerMove(window, { clientX: 100, clientY: 250 });
+
+    const orb = screen.getByLabelText("research, 1 agent");
+    fireEvent.pointerEnter(orb, { clientX: 60, clientY: 200 });
+
+    expect(orb.dataset.over).toBe("true");
+    expect(orb.querySelector(".orb__tag-name")?.textContent).toBe("research");
+  });
+
+  // The heading ellipses whatever does not fit the rail, and after clicking a
+  // circle it is the only place the name is drawn at all.
+  it("keeps the whole name on the heading the rail cuts short", () => {
+    const long = "Customer research and competitive intelligence, EMEA";
+    draw([group("everyone"), group(long, null, RESEARCH)], [agent("Manager")]);
+
+    expect(document.querySelector(".rail__group-name")?.getAttribute("title")).toBe("everyone");
+
+    fireEvent.click(screen.getByLabelText(`${long}, 0 agents`));
+    expect(document.querySelector(".rail__open-name")?.getAttribute("title")).toBe(long);
+  });
+
   it("draws only that group after clicking into it, and everyone again after leaving", () => {
     draw(
       [group("everyone"), group("research", null, RESEARCH)],

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -477,7 +477,14 @@ export function Sidebar({
                 onPointerLeave={() => hover(null)}
               >
                 <div className="rail__open-head">
-                  <span className="rail__open-name">{focused.name}</span>
+                  {/* Both headings ellipse a name that does not fit the rail,
+                      and the crew column has no room to say it either, so the
+                      full one is on the heading as well as beside the circle.
+                      A crew called "Customer research, EMEA" is otherwise two
+                      words and a hyphen wherever it is drawn. */}
+                  <span className="rail__open-name" title={focused.name}>
+                    {focused.name}
+                  </span>
                   {groupTail(focused, agents.filter((a) => a.groupId === focused.id).length)}
                 </div>
                 {railOrder(
@@ -515,7 +522,9 @@ export function Sidebar({
                       onPointerLeave={() => hover(null)}
                     >
                       <div className="rail__group-head">
-                        <span className="rail__group-name">{group.name}</span>
+                        <span className="rail__group-name" title={group.name}>
+                          {group.name}
+                        </span>
                         {groupTail(group, members.length)}
                       </div>
                       {here.map(row)}

--- a/src/lib/presence.test.ts
+++ b/src/lib/presence.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { presenceLabel, presenceOf, QUIET } from "./presence";
+import { presenceLabel, presenceNote, presenceOf, QUIET } from "./presence";
 import type { Activity, AgentCard, AgentId } from "./types";
 
 function anAgent(id: string, over: Partial<AgentCard> = {}): AgentCard {
@@ -80,6 +80,32 @@ describe("presenceOf", () => {
   it("ignores an agent that is not in the crew", () => {
     const presence = presenceOf([anAgent("a")], states({ z: { state: "awaitingApproval" } }));
     expect(presence).toEqual(QUIET);
+  });
+});
+
+describe("presenceNote", () => {
+  // The tag beside a circle and the label a screen reader hears are the same
+  // sentence minus the name. Two functions here is two descriptions of one
+  // circle, and only one of them can be right.
+  it.each([
+    [3, QUIET, "3 agents"],
+    [1, QUIET, "1 agent"],
+    [2, { blocked: 0, working: true }, "2 agents, working"],
+    [2, { blocked: 1, working: false }, "2 agents, 1 turn waiting on you"],
+    [4, { blocked: 3, working: false }, "4 agents, 3 turns waiting on you"],
+  ])("says a crew of %i as words", (count, presence, said) => {
+    expect(presenceNote(count, presence)).toBe(said);
+  });
+
+  // The one place the two marks are ranked. A sentence is one channel, and
+  // "waiting on you, and working" buries the half that needs a person.
+  it("says waiting rather than working when both are true", () => {
+    expect(presenceNote(2, { blocked: 1, working: true })).toBe("2 agents, 1 turn waiting on you");
+  });
+
+  it("is what the label says under the name", () => {
+    const presence = { blocked: 2, working: true };
+    expect(presenceLabel("Sales", 5, presence)).toBe(`Sales, ${presenceNote(5, presence)}`);
   });
 });
 

--- a/src/lib/presence.ts
+++ b/src/lib/presence.ts
@@ -88,23 +88,36 @@ export function presenceOf(members: AgentCard[], activity: Record<AgentId, Activ
 }
 
 /**
- * What the circle says out loud, for anything that cannot see it.
- *
- * A number in a corner is invisible to a screen reader unless the control says
- * it, and "Sales" alone is a crew a blind operator has no reason to open.
+ * The crew in words, without its name: how big it is and what it is doing.
  *
  * The one place the two marks are ranked rather than both drawn. The circle has
  * a corner and a ring and can carry each on its own channel; a sentence is one
  * channel, and "two turns waiting on you, and working" buries the half that
  * needs a person under the half that does not.
+ *
+ * Split out because the sentence is now said twice, to two audiences that must
+ * not be given different sentences: the label below, and the line the column
+ * draws under a crew's name when it is pointed at. A tag that said "3 agents"
+ * where the label said "working" would be the same circle described two ways,
+ * and only one of them could be right.
  */
-export function presenceLabel(name: string, count: number, presence: Presence): string {
+export function presenceNote(count: number, presence: Presence): string {
   const size = count === 1 ? "1 agent" : `${count} agents`;
   if (presence.blocked > 0) {
     const waiting =
       presence.blocked === 1 ? "1 turn waiting on you" : `${presence.blocked} turns waiting on you`;
-    return `${name}, ${size}, ${waiting}`;
+    return `${size}, ${waiting}`;
   }
-  if (presence.working) return `${name}, ${size}, working`;
-  return `${name}, ${size}`;
+  if (presence.working) return `${size}, working`;
+  return size;
+}
+
+/**
+ * What the circle says out loud, for anything that cannot see it.
+ *
+ * A number in a corner is invisible to a screen reader unless the control says
+ * it, and "Sales" alone is a crew a blind operator has no reason to open.
+ */
+export function presenceLabel(name: string, count: number, presence: Presence): string {
+  return `${name}, ${presenceNote(count, presence)}`;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1224,6 +1224,65 @@ button {
   color: var(--rail-muted);
 }
 
+/* The crew's name, beside its circle, while the circle is pointed at or
+   focused. `components/OrbTag.tsx` has the argument: faces alone cannot tell
+   two crews hired from the same cafeteria counters apart, and the way out was
+   clicking through the column.
+
+   Fixed to the window rather than laid out in the column, for the reason
+   `.rail__held` is: `.grail__list` scrolls, so it clips on both axes — a box
+   with `overflow-y: auto` computes `visible` to `auto` on the other axis — and
+   a tag inside it would be cut off at the edge of a four-rem column. Its
+   vertical middle is measured off the circle when it opens and arrives as
+   `--tag-y`; the centering is `translate` rather than a transform, because the
+   arrival below animates `transform` and would land it half a box too low.
+
+   It wraps rather than ellipsing. A name cut short is the thing this exists to
+   fix, and cutting it here would only move where that happens. */
+.orb__tag {
+  --pop-origin: left center;
+
+  position: fixed;
+  left: var(--grail-w);
+  top: var(--tag-y);
+  translate: 0 -50%;
+  z-index: 30;
+  /* The circle underneath is a button and a drop target, and the tag is drawn
+     over the pane beside it. Neither may lose a pointer to a label. */
+  pointer-events: none;
+  max-width: 14rem;
+  display: flex;
+  flex-direction: column;
+  /* The circle is a button, and a button centers its text. Read as a label the
+     name and the line under it have to start at the same edge. */
+  text-align: left;
+  gap: var(--space-1);
+  margin-left: var(--space-3);
+  padding: var(--space-3) var(--space-5);
+  border-radius: var(--radius-sm);
+  background: var(--rail-raised);
+  box-shadow: inset 0 0 0 1px var(--rail-edge), var(--lift-dark);
+}
+
+.orb__tag-name {
+  font-family: var(--font-display);
+  font-size: var(--type-ui);
+  font-weight: 600;
+  letter-spacing: var(--track-tight);
+  line-height: var(--lead-ui);
+  color: var(--rail-text);
+}
+
+/* The same sentence the label says, from the same function. A circle can carry
+   the ring and the corner count on two channels; this is where they are put
+   into words, which is what makes "is anything over there my problem" readable
+   without opening the crew. */
+.orb__tag-note {
+  font-size: var(--type-small);
+  line-height: var(--lead-ui);
+  color: var(--rail-muted);
+}
+
 .orb__all-count {
   font-family: var(--font-mono);
   font-size: var(--type-aside);
@@ -4429,7 +4488,8 @@ button {
    ========================================================================== */
 .dialog,
 .palette,
-.menu {
+.menu,
+.orb__tag {
   animation: pop var(--tempo-enter) var(--ease) both;
   transform-origin: var(--pop-origin);
 }


### PR DESCRIPTION
The crews' column identified a crew by the faces in it, and the cafeteria is a copy machine with a fixed avatar and color per preset, so two crews hired from the same counters drew identical circles, and above six members every crew drew the same six and a count. Pointing at a circle now names it and says its two marks in words underneath, beside the circle rather than under it, because the column is four rem wide and a name cut to fit that is a name nobody can read. It opens on hover, on keyboard focus and during a drag, which is what `title` was already trying to do and could not: a second of delay, no keyboard path, and suppressed for the whole of a drag, the one moment dropping onto an unnamed circle puts somebody in the wrong crew. `presenceNote` is split out of `presenceLabel` so the tag and the screen reader get one sentence from one function, and both rail headings now carry the full name on a `title` because they ellipse whatever does not fit.

Eight new component tests plus `presenceNote` coverage; lint and typecheck clean. Note that `styles.test.ts` is already red on `main`: 13 `.memory*` rules violate the token gate, byte-identical before and after this branch, because #90 added the literals and #89 added the gate but branched before it.
