### PR TITLE
fix: a token's expiry is a floor, and the backend decides when to refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ repo: the frontend renders state and forwards intent.
 | Streaming, retries, the budget, when a run settles | *A failed model call is retried*, *A thought is shown and never kept*, *The budget counts model calls* |
 | What a turn shows of itself while it runs: the thinking, the calls, the line above the composer | *A thought is shown and never kept* and *A turn's own work is watched while it happens*, then `src/lib/reasoning.ts` |
 | How a turn is paid for: providers, the ChatGPT sign-in, the Responses API | *A subscription is a second provider, not a second endpoint*, then `llm/codex.rs` and `subscription.rs` |
+| A sign-in that stopped working, refreshing, expiry, signing out | *A token's `exp` is a floor on its life, not a ceiling* in `docs/ARCHITECTURE.md`, then `Subscription::renew` and the 401 path in `codex::stream` |
 | What a group decides for itself: provider, models, timeout, limits | *A group chooses its own provider*, *Nothing about who pays is inferred* and *A run is measured against the limits of the group it happens in*, then `domain/group.rs` |
 | Stopping a conversation: what a stop marks, wakes, and must never release | *A stop marks the run and releases nothing*, then `Runtime::stop_run` |
 | Permission prompts, parked turns, acting in the operator's name | *A protected action parks the turn that asked for it* |
@@ -223,6 +224,21 @@ the model takes a screenshot to see what `browse` did.
 
 ## What looks like a simplification and is not
 
+- **A ChatGPT access token's `exp` is not when it stops working.** OpenAI mints
+  one ten days out and the backend refuses it after about three, with
+  `token_expired`. The local claim is the only signal on the machine and it is
+  wrong in the direction that strands an operator: refreshing against it alone
+  left a dead token in place for a week, refused every turn, and kept reporting
+  a healthy sign-in in Settings, because "signed in" was a file existing. So a
+  401 from the backend is what triggers a refresh, and the same request goes
+  again under the new token. `Subscription::renew`, and *A token's `exp` is a
+  floor on its life* in `docs/ARCHITECTURE.md`.
+- **A refresh is serialized, and one the service refuses forgets the sign-in.**
+  The refresh token rotates, so a crew that all hit the dead token at once would
+  race to retire each other's and the losers would hold one the service already
+  threw away. And a 4xx from the token endpoint is the sign-in genuinely being
+  over: the file goes, so Settings offers signing in rather than signing out. A
+  5xx is the service having a bad minute and costs nobody their sign-in.
 - **A group's settings are two blocks, and each is all-or-nothing.** A draft
   that mentions `inference` or `limits` replaces every override in that block,
   and one that leaves it out changes none of them. Per-field "absent means leave

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -337,6 +337,32 @@ set rotates on refresh, which is Guaca writing in the background, while
 writers on one file lose a refreshed token to a stale in-memory copy, and the
 symptom is a sign-in that works until an unrelated setting changes.
 
+**A token's `exp` is a floor on its life, not a ceiling, and the backend is the
+authority.** OpenAI mints a ChatGPT access token with ten days on its `exp` claim
+and `chatgpt.com/backend-api/codex` stops accepting one after about three, with
+`token_expired`. Nothing on the machine can tell: the claim is the only local
+signal there is and it is wrong in the dangerous direction. A build that refreshed
+only against the claim therefore sat on a dead token for the rest of its nominal
+week, refused every turn in the app, and went on drawing a healthy sign-in in
+Settings the whole time, because "signed in" was answered by a file existing.
+
+So the 401 decides. `codex::stream` refuses once, calls `Subscription::renew`,
+and sends the same request again under whatever came back. That is safe because a
+refusal is decided on the status line, before `consume` is reached, so no token
+has been handed to the operator and there is no half a sentence on screen to
+write twice. The `exp` check stays in front of it as the latency optimization it
+always was: without it the common case pays a wasted round trip, and without the
+401 path the operator pays a week.
+
+Two consequences worth keeping. **`renew` is serialized**, because the refresh
+token rotates and eight agents discovering one dead token at the same moment
+would race to retire each other's; whoever is first refreshes, and everyone
+behind them finds the new token already stored and takes it rather than spending
+a second one. And **a refresh the service refuses forgets the sign-in**, on a 4xx
+only: that is the case where the operator genuinely has to sign in again, and
+keeping the file is exactly what made Settings disagree with every turn. A 5xx is
+the service having a bad minute and must not cost anybody a working sign-in.
+
 **A group chooses its own provider, and the sign-in is still one credential.**
 Which of the two is paying is a setting, not an account, so a group can be moved
 onto the ChatGPT subscription while the app settings still say a pasted key, and

--- a/src-tauri/src/llm/codex.rs
+++ b/src-tauri/src/llm/codex.rs
@@ -397,7 +397,7 @@ pub async fn stream<F>(
 where
     F: FnMut(Token<'_>),
 {
-    let access = subscription.access().await.map_err(auth_error)?;
+    let mut access = subscription.access().await.map_err(auth_error)?;
 
     // From the credential rather than from the constant: the account and the
     // backend that will accept it are one fact, and it is what lets the
@@ -406,31 +406,52 @@ where
     let timeout = Duration::from_secs(cfg.request_timeout_secs.clamp(5, 900));
     let body = build(request, &request.model);
 
-    let mut send = http
-        .post(&url)
-        .bearer_auth(&access.token)
-        .header("originator", ORIGINATOR)
-        .header("Accept", "text/event-stream")
-        .timeout(timeout)
-        .json(&body);
+    // At most twice, and the second time only after a refresh. The backend is
+    // the authority on whether a token still works and it disagrees with the
+    // token's own `exp`, so a 401 is not "sign in again" until the refresh
+    // token has been offered: `Subscription::renew`. Retrying here is safe
+    // because nothing has been streamed yet: a refusal is decided on the status
+    // line, before `consume` is reached, so no `on_token` has run and there is
+    // no half a sentence on screen to be written twice.
+    let mut renewed = false;
+    loop {
+        let mut send = http
+            .post(&url)
+            .bearer_auth(&access.token)
+            .header("originator", ORIGINATOR)
+            .header("Accept", "text/event-stream")
+            .timeout(timeout)
+            .json(&body);
 
-    // Which workspace the call is billed to. Omitted rather than sent empty for
-    // a personal account that has never had one: the backend rejects a blank
-    // value and accepts an absent one.
-    if !access.account_id.is_empty() {
-        send = send.header("ChatGPT-Account-Id", &access.account_id);
-    }
-
-    let response = send.send().await.map_err(|source| {
-        if source.is_timeout() {
-            LlmError::Timeout { secs: timeout.as_secs() }
-        } else {
-            LlmError::Transport { url: url.clone(), source }
+        // Which workspace the call is billed to. Omitted rather than sent empty
+        // for a personal account that has never had one: the backend rejects a
+        // blank value and accepts an absent one.
+        if !access.account_id.is_empty() {
+            send = send.header("ChatGPT-Account-Id", &access.account_id);
         }
-    })?;
 
-    let status = response.status();
-    if !status.is_success() {
+        let response = send.send().await.map_err(|source| {
+            if source.is_timeout() {
+                LlmError::Timeout { secs: timeout.as_secs() }
+            } else {
+                LlmError::Transport { url: url.clone(), source }
+            }
+        })?;
+
+        let status = response.status();
+        if status.is_success() {
+            return consume(response, &url, timeout, on_token).await;
+        }
+
+        // Only a 401, and only once. A 403 is a plan or a workspace saying no,
+        // which a fresh token spells exactly the same way, and a second 401
+        // after a refresh is a sign-in that is genuinely finished.
+        if status == reqwest::StatusCode::UNAUTHORIZED && !renewed {
+            renewed = true;
+            access = subscription.renew(&access.token).await.map_err(auth_error)?;
+            continue;
+        }
+
         let retry_after = response
             .headers()
             .get("retry-after")
@@ -439,8 +460,6 @@ where
         let text = response.text().await.unwrap_or_default();
         return Err(classify(status.as_u16(), &text, &request.model, retry_after));
     }
-
-    consume(response, &url, timeout, on_token).await
 }
 
 async fn consume<F>(

--- a/src-tauri/src/subscription.rs
+++ b/src-tauri/src/subscription.rs
@@ -65,6 +65,9 @@ pub const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 /// wait on a round trip that was never going to work, and the retry it triggers
 /// looks like an outage. Five minutes is long enough to cover a slow refresh
 /// and a clock that is a little wrong in either direction.
+///
+/// This is the optimization, not the guarantee. What decides whether a token
+/// still works is the backend refusing it: see [`Subscription::renew`].
 const REFRESH_SKEW: Duration = Duration::from_secs(5 * 60);
 
 /// How long the whole device flow may take before it is abandoned.
@@ -98,6 +101,11 @@ pub enum SigninError {
     Malformed(String),
     #[error("nobody entered the code within fifteen minutes. Start the sign-in again.")]
     TimedOut,
+    #[error(
+        "no ChatGPT subscription is signed in on this machine. Open Settings, choose Provider, \
+         and sign in."
+    )]
+    NotSignedIn,
     #[error("could not save the sign-in to {path}: {source}")]
     Io {
         path: PathBuf,
@@ -150,7 +158,12 @@ struct Stored {
     account_id: String,
     /// Unix seconds, read from the access token rather than from a duration the
     /// service quoted. A quoted lifetime plus the local clock at the moment of
-    /// exchange drifts; the token says when it actually stops working.
+    /// exchange drifts.
+    ///
+    /// It is a floor on the token's life and not a ceiling: the backend stops
+    /// accepting one well before this, which is what [`Subscription::renew`]
+    /// exists for. A token observed three days old, with seven days of `exp`
+    /// still on it, was refused with `token_expired`.
     expires_at: i64,
     /// Denormalized out of the id token so a signed-in status can be answered
     /// without decoding a JWT on every read.
@@ -192,6 +205,17 @@ pub struct Subscription {
     backend: String,
     http: reqwest::Client,
     tokens: Mutex<Option<Stored>>,
+    /// Held across a refresh, so a crew that all discover a dead token at once
+    /// spends one.
+    ///
+    /// The refresh token rotates, so concurrent refreshes race to retire each
+    /// other's: the losers are left holding one the service has already thrown
+    /// away, and the sign-in dies with nothing on screen able to say why.
+    /// Whoever gets in first refreshes, and everyone behind them finds the new
+    /// token already stored and takes it. Async rather than `parking_lot`
+    /// because it is held across an await, which is the one thing the other
+    /// lock here is careful never to be.
+    renewing: tokio::sync::Mutex<()>,
 }
 
 impl Subscription {
@@ -239,6 +263,7 @@ impl Subscription {
                 .build()
                 .unwrap_or_default(),
             tokens: Mutex::new(tokens),
+            renewing: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -390,10 +415,7 @@ impl Subscription {
     pub async fn access(&self) -> Result<Access, SigninError> {
         let stored = self.tokens.lock().clone();
         let Some(stored) = stored else {
-            return Err(SigninError::Upstream {
-                status: 401,
-                message: "not signed in".to_string(),
-            });
+            return Err(SigninError::NotSignedIn);
         };
 
         if !expiring_soon(stored.expires_at) {
@@ -402,28 +424,68 @@ impl Subscription {
 
         // A refresh that fails on the network leaves the stored token in place:
         // it may still have minutes left, and a turn that could have run is
-        // worth more than a tidy cache. A refusal is different and is allowed to
-        // surface, because the operator has to sign in again.
-        match self.refresh(&stored.refresh_token).await {
-            Ok(fresh) => {
-                let status = self.store(fresh)?;
-                debug_assert!(status.signed_in);
-                let held = self.tokens.lock().clone();
-                match held {
-                    Some(held) => {
-                        Ok(Access { token: held.access_token, account_id: held.account_id })
-                    }
-                    None => Err(SigninError::Upstream {
-                        status: 401,
-                        message: "the sign-in was cleared mid-refresh".to_string(),
-                    }),
-                }
-            }
+        // worth more than a tidy cache. Every other failure surfaces, because
+        // the token it was called to replace is already inside its own last
+        // five minutes.
+        match self.renew(&stored.access_token).await {
+            Ok(access) => Ok(access),
             Err(err @ SigninError::Transport { .. }) => {
                 tracing::warn!(%err, "using the stored token: its refresh could not be reached");
                 Ok(Access { token: stored.access_token, account_id: stored.account_id })
             }
             Err(err) => Err(err),
+        }
+    }
+
+    /// Trades the refresh token in for a new one, whatever the stored expiry
+    /// says, and hands back what to spend next.
+    ///
+    /// This is the recovery path, and it exists because `exp` is not the truth.
+    /// OpenAI mints a ChatGPT access token with ten days on its `exp` claim and
+    /// the backend stops accepting it long before that, with `token_expired`.
+    /// A build that believed the claim sat on a three-day-old token for a week,
+    /// refused every turn, and went on reporting a healthy sign-in in Settings
+    /// the whole time. So the backend is the authority: [`crate::llm::codex`]
+    /// calls this on a 401 and tries the call again.
+    ///
+    /// `refused` is the token that was just turned down. If somebody else
+    /// refreshed while this call was queued behind them, theirs is by
+    /// definition not the one that failed, and it is handed back untouched
+    /// rather than burned on a second refresh.
+    pub async fn renew(&self, refused: &str) -> Result<Access, SigninError> {
+        let _gate = self.renewing.lock().await;
+
+        let Some(held) = self.tokens.lock().clone() else {
+            return Err(SigninError::NotSignedIn);
+        };
+        if held.access_token != refused {
+            return Ok(Access { token: held.access_token, account_id: held.account_id });
+        }
+
+        let fresh = match self.refresh(&held.refresh_token).await {
+            Ok(fresh) => fresh,
+            Err(err) => {
+                // A refused refresh is the end of this sign-in, and keeping the
+                // file is what let Settings claim a credential every turn had
+                // already been told was dead. Forgetting it is what makes "sign
+                // in again" a thing the operator can actually do.
+                if is_terminal(&err) {
+                    if let Err(gone) = self.sign_out() {
+                        tracing::warn!(%gone, "could not remove a sign-in the service refused");
+                    }
+                }
+                return Err(err);
+            }
+        };
+
+        let status = self.store(fresh)?;
+        debug_assert!(status.signed_in);
+        match self.tokens.lock().clone() {
+            Some(held) => Ok(Access { token: held.access_token, account_id: held.account_id }),
+            // Signed out from Settings while this refresh was in flight. The
+            // operator's click wins: a token stored back over it would sign
+            // them silently back in.
+            None => Err(SigninError::NotSignedIn),
         }
     }
 
@@ -669,6 +731,17 @@ fn expiring_soon(expires_at: i64) -> bool {
     expires_at <= now.saturating_add(REFRESH_SKEW.as_secs() as i64)
 }
 
+/// Whether a refused refresh means this sign-in is finished.
+///
+/// The token endpoint answers a refresh token it has retired with a 4xx and an
+/// `invalid_grant`, and that is the one case where the operator has to sign in
+/// again. A 5xx is the service having a bad minute and must not cost them a
+/// working sign-in; neither must a body this build could not read, which is a
+/// deployment that changed shape rather than a credential that expired.
+fn is_terminal(err: &SigninError) -> bool {
+    matches!(err, SigninError::Upstream { status: 400 | 401 | 403, .. })
+}
+
 /// Whether a plan can call Codex at all.
 ///
 /// A free account signs in perfectly well and then cannot make one model call.
@@ -767,8 +840,11 @@ mod tests {
         }))
     }
 
-    fn access_token(expires_at: i64) -> String {
-        jwt(serde_json::json!({ "exp": expires_at }))
+    /// `nth` distinguishes one issue from the next, exactly as a real service's
+    /// tokens do. Two refreshes a millisecond apart otherwise mint the same
+    /// string, and a test about not refreshing twice cannot see the difference.
+    fn access_token(expires_at: i64, nth: usize) -> String {
+        jwt(serde_json::json!({ "exp": expires_at, "nth": nth }))
     }
 
     fn hour_ahead() -> i64 {
@@ -829,14 +905,14 @@ mod tests {
                         assert!(body.contains("code_verifier=verifier-1"), "verifier not sent");
                         assert!(body.contains("deviceauth%2Fcallback"), "redirect not sent");
                         return axum::Json(serde_json::json!({
-                            "access_token": access_token(hour_ahead()),
+                            "access_token": access_token(hour_ahead(), 0),
                             "refresh_token": "refresh-1",
                             "id_token": id_token("pro", "acct-1", "a@example.com"),
                         }))
                         .into_response();
                     }
 
-                    stub.refreshes.fetch_add(1, Ordering::SeqCst);
+                    let nth = stub.refreshes.fetch_add(1, Ordering::SeqCst) + 1;
                     let status = stub.refresh_status.load(Ordering::SeqCst);
                     if status != 0 {
                         return (
@@ -849,7 +925,7 @@ mod tests {
                     let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
                     assert_eq!(parsed["grant_type"], "refresh_token");
                     let mut fresh = serde_json::json!({
-                        "access_token": access_token(hour_ahead()),
+                        "access_token": access_token(hour_ahead(), nth),
                         // The refresh token is deliberately absent, to pin that
                         // the old one is kept.
                     });
@@ -1021,6 +1097,95 @@ mod tests {
         let err = subscription.access().await.unwrap_err();
         let message = err.to_string();
         assert!(message.contains("expired"), "the reason has to reach the operator: {message}");
+
+        // And it is forgotten, because it is finished. A stored sign-in the
+        // service has retired is what makes Settings say "signed in" while
+        // every turn says the opposite, with no way out of the disagreement.
+        assert!(!subscription.is_signed_in());
+        assert!(!dir.path().join("subscription.json").exists());
+    }
+
+    #[tokio::test]
+    async fn a_sign_in_service_having_a_bad_minute_does_not_cost_the_sign_in() {
+        let stub = Stub { refresh_status: Arc::new(AtomicUsize::new(503)), ..Default::default() };
+        let base = serve(stub.clone()).await;
+        let dir = tempfile::tempdir().unwrap();
+        let subscription = store(&dir, &base);
+        let code = subscription.begin().await.unwrap();
+        subscription.complete(&code).await.unwrap();
+
+        subscription.tokens.lock().as_mut().unwrap().expires_at = 0;
+        subscription.access().await.unwrap_err();
+
+        // A 5xx is the service, not the credential. Signing the operator out
+        // over one turns a wait into a sign-in they have to do by hand.
+        assert!(subscription.is_signed_in());
+        assert!(dir.path().join("subscription.json").exists());
+    }
+
+    #[tokio::test]
+    async fn a_token_the_backend_refused_is_replaced_however_current_it_looks() {
+        let stub = Stub::default();
+        let base = serve(stub.clone()).await;
+        let dir = tempfile::tempdir().unwrap();
+        let subscription = store(&dir, &base);
+        let code = subscription.begin().await.unwrap();
+        subscription.complete(&code).await.unwrap();
+
+        // A whole week of `exp` left, which is exactly the state the live
+        // backend refuses: OpenAI mints ten days and stops accepting one after
+        // about three. Nothing local can tell, so the refusal is the only
+        // signal there is, and `renew` has to act on it.
+        subscription.tokens.lock().as_mut().unwrap().expires_at =
+            chrono::Utc::now().timestamp() + 7 * 86_400;
+        let refused = subscription.access().await.unwrap();
+        assert_eq!(stub.refreshes.load(Ordering::SeqCst), 0, "nothing was due yet");
+
+        let fresh = subscription.renew(&refused.token).await.unwrap();
+        assert_eq!(stub.refreshes.load(Ordering::SeqCst), 1);
+        assert_ne!(fresh.token, refused.token, "the refused token cannot be handed back");
+    }
+
+    #[tokio::test]
+    async fn one_refusal_seen_by_a_whole_crew_spends_one_refresh() {
+        let stub = Stub::default();
+        let base = serve(stub.clone()).await;
+        let dir = tempfile::tempdir().unwrap();
+        let subscription = Arc::new(store(&dir, &base));
+        let code = subscription.begin().await.unwrap();
+        subscription.complete(&code).await.unwrap();
+
+        let refused = subscription.access().await.unwrap().token;
+
+        // Eight agents, one dead token, all of them told so at once. The
+        // refresh token rotates, so eight refreshes would race to retire each
+        // other's and the last seven would be holding one the service has
+        // already thrown away.
+        let mut crew = Vec::new();
+        for _ in 0..8 {
+            let subscription = subscription.clone();
+            let refused = refused.clone();
+            crew.push(tokio::spawn(async move { subscription.renew(&refused).await }));
+        }
+        let mut tokens = Vec::new();
+        for agent in crew {
+            tokens.push(agent.await.unwrap().unwrap().token);
+        }
+
+        assert_eq!(stub.refreshes.load(Ordering::SeqCst), 1, "one dead token, one refresh");
+        assert!(tokens.iter().all(|t| *t == tokens[0]), "everyone leaves with the same token");
+        assert_ne!(tokens[0], refused);
+    }
+
+    #[tokio::test]
+    async fn renewing_without_a_sign_in_says_so_in_words() {
+        let dir = tempfile::tempdir().unwrap();
+        let subscription = store(&dir, "http://unused");
+        let err = subscription.renew("anything").await.unwrap_err();
+        assert!(matches!(err, SigninError::NotSignedIn), "got {err}");
+        // The operator reads this one after the app has signed them out for
+        // them, so it has to say where to go rather than quote a status code.
+        assert!(err.to_string().contains("Settings"), "{err}");
     }
 
     #[tokio::test]
@@ -1142,7 +1307,7 @@ mod tests {
 
     #[test]
     fn an_expiry_is_read_from_the_access_token_itself() {
-        assert_eq!(expiry_of(&access_token(1_700_000_000)), Some(1_700_000_000));
+        assert_eq!(expiry_of(&access_token(1_700_000_000, 0)), Some(1_700_000_000));
         assert_eq!(expiry_of("nonsense"), None);
     }
 

--- a/src-tauri/tests/subscription.rs
+++ b/src-tauri/tests/subscription.rs
@@ -159,11 +159,17 @@ impl Stub {
     }
 
     fn header(&self, name: &str) -> Option<String> {
+        self.headers(name).into_iter().next()
+    }
+
+    /// Every request's value for one header, in order.
+    fn headers(&self, name: &str) -> Vec<String> {
         self.headers
             .lock()
             .iter()
-            .find(|(key, _)| key.eq_ignore_ascii_case(name))
+            .filter(|(key, _)| key.eq_ignore_ascii_case(name))
             .map(|(_, value)| value.clone())
+            .collect()
     }
 }
 
@@ -190,6 +196,19 @@ fn has_tool_result(body: &serde_json::Value) -> bool {
 }
 
 async fn serve<F>(decide: F) -> Stub
+where
+    F: Fn(&serde_json::Value) -> Say + Clone + Send + Sync + 'static,
+{
+    serve_refusing(0, decide).await
+}
+
+/// The same backend, with the first `refusals` calls answered 401.
+///
+/// What an access token the backend has stopped accepting looks like from here:
+/// a well-formed request, a credential that is not, and nothing about it
+/// visible on this machine. The refusal is counted and recorded like any other
+/// call, so a test can say what the retry sent as well as that it happened.
+async fn serve_refusing<F>(refusals: usize, decide: F) -> Stub
 where
     F: Fn(&serde_json::Value) -> Say + Clone + Send + Sync + 'static,
 {
@@ -241,9 +260,16 @@ where
                         );
                     }
 
-                    calls.fetch_add(1, Ordering::SeqCst);
+                    let nth = calls.fetch_add(1, Ordering::SeqCst);
                     let script = decide(&parsed);
                     seen.lock().push(parsed);
+                    if nth < refusals {
+                        return (
+                            axum::http::StatusCode::UNAUTHORIZED,
+                            r#"{"detail":"Provided authentication token is expired."}"#,
+                        )
+                            .into_response();
+                    }
                     ([("content-type", "text/event-stream")], render(&script)).into_response()
                 }
             }
@@ -256,10 +282,69 @@ where
     Stub { backend: format!("http://{addr}"), seen, headers, calls }
 }
 
+/// The sign-in service, as far as a running turn ever touches it.
+///
+/// Only `/oauth/token`, and only the refresh grant: the device flow that put
+/// the file there has its own tests in `subscription.rs`, and driving it again
+/// here would make every test below depend on a second stub answering a browser
+/// nobody is at.
+struct Signin {
+    issuer: String,
+    refreshes: Arc<AtomicUsize>,
+}
+
+/// A sign-in service that either mints a new token or says the refresh token is
+/// finished.
+///
+/// The two are the whole fork after a 401: one is a token the backend quietly
+/// stopped accepting, which the operator should never hear about, and the other
+/// is a sign-in they have to repeat by hand.
+async fn signin_service(refusing: bool) -> Signin {
+    let refreshes = Arc::new(AtomicUsize::new(0));
+
+    let app = Router::new().route(
+        "/oauth/token",
+        post({
+            let refreshes = refreshes.clone();
+            move |body: String| {
+                let refreshes = refreshes.clone();
+                async move {
+                    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+                    assert_eq!(parsed["grant_type"], "refresh_token", "got {body}");
+                    let nth = refreshes.fetch_add(1, Ordering::SeqCst) + 1;
+                    if refusing {
+                        return (
+                            axum::http::StatusCode::BAD_REQUEST,
+                            r#"{"error":"invalid_grant","error_description":"refresh token expired"}"#,
+                        )
+                            .into_response();
+                    }
+                    axum::Json(serde_json::json!({
+                        // A different token every time, as a real service
+                        // issues them, so a test can see which one a call
+                        // carried.
+                        "access_token": format!("refreshed-token-{nth}"),
+                        "refresh_token": format!("refresh-token-{nth}"),
+                    }))
+                    .into_response()
+                }
+            }
+        }),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    Signin { issuer: format!("http://{addr}"), refreshes }
+}
+
 struct Signed {
     runtime: Runtime,
     sink: Arc<RecordingSink>,
     ids: std::collections::HashMap<String, AgentId>,
+    /// The same store the runtime is spending, so a test can ask whether a
+    /// refused sign-in was kept.
+    subscription: Arc<Subscription>,
     _dir: tempfile::TempDir,
 }
 
@@ -325,7 +410,19 @@ impl Signed {
 /// because the flow that produces that file has its own tests and repeating it
 /// here would make every one of these depend on a second stub.
 fn signed_in(stub: &Stub, names: &[&str], plan: &str) -> Signed {
-    signed_in_where(stub, names, plan, false)
+    signed_in_where(stub, names, plan, false, NO_SIGNIN_SERVICE)
+}
+
+/// A closed port, for every test whose turn is never refused.
+///
+/// Reaching it at all is a failure the test should see: a sign-in service is
+/// only touched when a token needs replacing, and one being replaced under a
+/// test that did not arrange for it is the thing worth finding out about.
+const NO_SIGNIN_SERVICE: &str = "http://127.0.0.1:1";
+
+/// Signed in, and able to refresh: the arrangement a stale token needs.
+fn signed_in_at(stub: &Stub, names: &[&str], plan: &str, signin: &Signin) -> Signed {
+    signed_in_where(stub, names, plan, false, &signin.issuer)
 }
 
 /// The same, with the choice of who pays made by the group rather than the app.
@@ -335,7 +432,13 @@ fn signed_in(stub: &Stub, names: &[&str], plan: &str) -> Signed {
 /// work: one sign-in on the machine, and each crew deciding whether to spend it.
 /// The app's endpoint is left pointing at a closed port either way, so a
 /// resolution that read the wrong layer fails rather than passing quietly.
-fn signed_in_where(stub: &Stub, names: &[&str], plan: &str, by_the_group: bool) -> Signed {
+fn signed_in_where(
+    stub: &Stub,
+    names: &[&str],
+    plan: &str,
+    by_the_group: bool,
+    issuer: &str,
+) -> Signed {
     let dir = tempfile::tempdir().unwrap();
     let store = Store::open(&dir.path().join("guac.db")).unwrap();
 
@@ -368,7 +471,7 @@ fn signed_in_where(stub: &Stub, names: &[&str], plan: &str, by_the_group: bool) 
     std::fs::write(
         &path,
         serde_json::json!({
-            "access_token": "access-token-for-tests",
+            "access_token": "first-token-for-tests",
             "refresh_token": "refresh-token-for-tests",
             "id_token": jwt(plan),
             "account_id": "acct-test",
@@ -382,8 +485,7 @@ fn signed_in_where(stub: &Stub, names: &[&str], plan: &str, by_the_group: bool) 
     )
     .unwrap();
 
-    let subscription =
-        Arc::new(Subscription::open_at(path, "http://127.0.0.1:1", stub.backend.clone()));
+    let subscription = Arc::new(Subscription::open_at(path, issuer, stub.backend.clone()));
     assert!(subscription.is_signed_in(), "the written sign-in has to be readable");
 
     let config = AppConfig {
@@ -408,7 +510,7 @@ fn signed_in_where(stub: &Stub, names: &[&str], plan: &str, by_the_group: bool) 
     let sink = RecordingSink::new();
     let runtime = Runtime::new(
         store,
-        LlmClient::new().unwrap().with_subscription(subscription),
+        LlmClient::new().unwrap().with_subscription(subscription.clone()),
         config,
         Workspace::new(dir.path().join("workspace")),
         FileStore::new(dir.path().join("files")),
@@ -416,7 +518,7 @@ fn signed_in_where(stub: &Stub, names: &[&str], plan: &str, by_the_group: bool) 
     );
     runtime.start_all().unwrap();
 
-    Signed { runtime, sink, ids, _dir: dir }
+    Signed { runtime, sink, ids, subscription, _dir: dir }
 }
 
 /// An unsigned id token carrying the claims the store reads.
@@ -481,7 +583,7 @@ async fn a_group_can_spend_the_subscription_while_the_app_pays_with_a_key() {
     // that resolved the app's provider instead of the group's cannot reach
     // anything, and this test would fail rather than pass by accident.
     let stub = serve(|_| Say::Text("On the plan.".into())).await;
-    let app = signed_in_where(&stub, &["Manager"], "pro", true);
+    let app = signed_in_where(&stub, &["Manager"], "pro", true, NO_SIGNIN_SERVICE);
 
     let run = app.ask("Manager", "Say hello.");
     app.settle(run).await;
@@ -503,7 +605,7 @@ async fn the_call_is_authorized_by_the_sign_in_and_billed_to_its_account() {
 
     assert_eq!(
         stub.header("authorization").as_deref(),
-        Some("Bearer access-token-for-tests"),
+        Some("Bearer first-token-for-tests"),
         "the stored token has to reach the request"
     );
     // Dropping this header is a 403 from the backend, which reads as a rejected
@@ -657,13 +759,57 @@ async fn testing_the_connection_reaches_the_subscription() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn a_turn_that_is_refused_says_to_sign_in_again() {
-    // A 401 here is a sign-in to repeat, not a key to check. An operator sent to
-    // the API key field they have never used does not get back on their feet.
-    let app = signed_in(&refusing(401).await, &["Manager"], "pro");
+async fn a_token_the_backend_has_stopped_accepting_is_replaced_mid_turn() {
+    // The failure this exists for. OpenAI mints a ChatGPT access token with ten
+    // days on its `exp` claim and the backend stops accepting one after about
+    // three, with `token_expired`. Nothing on this machine can tell, so a build
+    // that trusted the claim refused every turn for a week while Settings went
+    // on reporting a healthy sign-in.
+    let signin = signin_service(false).await;
+    let stub = serve_refusing(1, |_| Say::Text("Working on it.".into())).await;
+    let app = signed_in_at(&stub, &["Manager"], "pro", &signin);
 
     let run = app.ask("Manager", "Go.");
     app.settle(run).await;
+
+    // The operator sees a reply, not a sign-in they have to repeat.
+    let said = app.texts("Manager").join("\n");
+    assert!(said.contains("Working on it."), "the turn has to survive the refusal: {said}");
+    let all = app.everything("Manager");
+    assert!(
+        !all.to_lowercase().contains("sign in"),
+        "a token the app can replace itself is not the operator's problem: {all}"
+    );
+
+    assert_eq!(signin.refreshes.load(Ordering::SeqCst), 1, "one refusal, one refresh");
+    assert_eq!(stub.calls.load(Ordering::SeqCst), 2, "the refused call and the retry");
+
+    // The retry is the same request under a new credential, which is what makes
+    // it safe to send twice: nothing had streamed when the refusal landed.
+    let bodies = stub.bodies();
+    assert_eq!(bodies[0], bodies[1], "the retry must not be a different question");
+    let bearers = stub.headers("authorization");
+    assert_eq!(bearers[0], "Bearer first-token-for-tests");
+    assert_eq!(bearers[1], "Bearer refreshed-token-1", "the retry has to carry the new token");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_sign_in_that_cannot_be_refreshed_is_forgotten_and_says_so() {
+    // A 401 the refresh token cannot fix is the one case the operator has to
+    // act on. It is also a sign-in to repeat, not a key to check: an operator
+    // sent to the API key field they have never used does not get back on their
+    // feet.
+    let signin = signin_service(true).await;
+    let app = signed_in_at(&refusing(401).await, &["Manager"], "pro", &signin);
+
+    let run = app.ask("Manager", "Go.");
+    app.settle(run).await;
+
+    assert!(signin.refreshes.load(Ordering::SeqCst) >= 1, "the refresh token has to be tried");
+    // And the dead sign-in is gone, so Settings offers signing in rather than
+    // signing out. Claiming a credential every turn has already been told is
+    // dead is the disagreement that leaves an operator with nothing to press.
+    assert!(!app.subscription.is_signed_in(), "a refused sign-in must not be kept");
 
     let all = app.everything("Manager");
     assert!(all.to_lowercase().contains("sign in"), "the way out has to be in the message: {all}");
@@ -784,7 +930,7 @@ async fn a_real_subscription_answers_a_real_turn() {
     let sink = RecordingSink::new();
     let runtime = Runtime::new(
         store,
-        LlmClient::new().unwrap().with_subscription(subscription),
+        LlmClient::new().unwrap().with_subscription(subscription.clone()),
         config,
         Workspace::new(dir.path().join("workspace")),
         FileStore::new(dir.path().join("files")),
@@ -805,6 +951,7 @@ async fn a_real_subscription_answers_a_real_turn() {
         runtime,
         sink,
         ids: [("Manager".to_string(), manager)].into_iter().collect(),
+        subscription,
         _dir: dir,
     };
 

--- a/src/components/GroupEditor.test.tsx
+++ b/src/components/GroupEditor.test.tsx
@@ -230,6 +230,19 @@ describe("who pays for a group's turns", () => {
     expect((await save()).inference?.provider).toBe("chatgpt");
   });
 
+  it("says where the sign-in is managed whether or not there is one", async () => {
+    // Signed in is the state that matters. A group editor is where an operator
+    // whose turns are being refused looks first, and this row deliberately has
+    // no sign-out button of its own: the credential belongs to the app. Saying
+    // only "robert@example.com · Pro" leaves them looking at a healthy sign-in
+    // with nothing to press and nowhere named to go.
+    subscriptionStatus.mockResolvedValueOnce(signedIn());
+    open();
+    pane("Provider");
+    await screen.findByText(/robert@example.com/);
+    expect(screen.getByText(/Settings . Provider/)).toBeTruthy();
+  });
+
   it("offers the subscription's own models once it is the one paying", async () => {
     subscriptionStatus.mockResolvedValueOnce(signedIn());
     open(

--- a/src/components/GroupEditor.tsx
+++ b/src/components/GroupEditor.tsx
@@ -406,7 +406,7 @@ export function GroupEditor({ group, onClose }: Props) {
                         ? `${subscription.email || "signed in"}${
                             subscription.plan ? ` · ${planLabel(subscription.plan)}` : ""
                           }`
-                        : "Not signed in. Settings → Provider is where that happens."}
+                        : "Not signed in."}
                     </span>
                   </span>
                   {subscription?.signedIn &&
@@ -425,6 +425,17 @@ export function GroupEditor({ group, onClose }: Props) {
                       </button>
                     ))}
                 </div>
+
+                {/* Said in both states, not only when nobody is signed in.
+                    Whichever it is, this row is the whole subscription as far
+                    as a group is concerned, and an operator whose turns are
+                    being refused reads "signed in" here and has nothing to
+                    press: signing out and back in is two panes away and this
+                    was the only place saying so. */}
+                <p className="hint">
+                  Signing in and out happens in Settings → Provider. There is one sign-in on this
+                  machine and every group spends the same one.
+                </p>
 
                 {onSubscription && (
                   <SubscriptionModel


### PR DESCRIPTION
OpenAI mints a ChatGPT access token with ten days on its `exp` claim and `chatgpt.com/backend-api/codex` stops accepting one after about three, with `token_expired`; measured on a live account, a three-day-old token was refused while a four-hour-old one was not. `Subscription::access` refreshed only within five minutes of `exp`, so a real sign-in sat on a dead token for the rest of its nominal week, refusing every turn while Settings went on reporting a healthy sign-in, because "signed in" was answered by a file existing.

So the 401 decides: `codex::stream` refuses once, calls `Subscription::renew`, and sends the same request again under whatever came back, which is safe because a refusal lands on the status line before `consume` is reached and nothing has streamed. `renew` is serialized, since the refresh token rotates and a crew that all hit one dead token would race to retire each other's, and a refresh the service refuses with a 4xx forgets the sign-in so Settings offers signing in rather than claiming a credential every turn has been told is dead.

The group editor's provider row now names where the sign-in is managed in both states, not only when nobody is signed in, because it deliberately has no sign-out button of its own. Five new unit tests and two end-to-end ones cover the recovery, the serialized refresh and the dead sign-in; the recovery test was checked to fail without the fix.