### PR TITLE
fix: a repository edit carries no path, and repositories get their own section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,16 @@ the model takes a screenshot to see what `browse` did.
   against 16,000 and told operators their memory was about to be cut by a runtime
   storing it whole. A warning is read as a fact about what will happen, so the
   number is only worth drawing while it is the runtime's number.
+- **An edit to a repository is a `RepositoryEdit`, not a draft with a stand-in
+  path.** A `RepositoryDraft` validates the path before anything else, so an
+  edit routed through one has to invent a path it does not have. The stand-in
+  was `/`, which is the empty string once `clean` takes its trailing separator
+  off: every rename, every note and every harness switch came back *a repository
+  needs a directory; pick one to link*, about a directory the operator had
+  already picked and could read on the row above the box. Neither the panel nor
+  the store was wrong and both are tested, which is how it shipped and stayed.
+  A type with no path on it is the only version of "the path is not editable"
+  that nothing downstream can forget.
 - **A harness is two functions, and the process around them is one.** What `pi`
   and Claude Code share is the shape of a job: one process, in one directory,
   whose stdout is JSON objects one per line, that ends. So the spawn, the read

--- a/docs/CODING.md
+++ b/docs/CODING.md
@@ -75,6 +75,25 @@ row written before it was already running. An unrecognized value reads back as
 build and then a downgrade, and refusing to read it would take the repository off
 the one panel where the operator could fix it.
 
+## Editing one carries no path, and the type is what says so
+
+`update_repository` takes a `RepositoryEdit`: a name, a note and a harness, and
+nothing else. The path is not a parameter because a different directory is a
+different repository, and whoever was given this one was given that directory.
+
+It is a separate type rather than a `RepositoryDraft` with the path left out,
+because that is what it was and it did not work. A draft validates the path
+first, so an edit routed through one has to invent a stand-in, the stand-in was
+`/`, and `/` is the empty string once `clean` takes its trailing separator off.
+Every rename, every note and every harness switch was refused with *a repository
+needs a directory; pick one to link*, about a directory the operator had already
+picked and could read on the row above the box. Neither the panel nor the store
+was wrong, and both have tests, which is why it lasted from the day repositories
+shipped: the only untested seam was the shape being passed between them.
+
+The lesson is not "check the stand-in". It is that a command whose whole rule is
+*this field is not editable* must not take a type with that field on it.
+
 ## One process lifecycle, two of what genuinely differs
 
 What the two harnesses share is the shape of a job: one process, in one

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -771,17 +771,27 @@ It is sectioned on the Settings shell for the same reason Settings is: a group
 now decides who pays for its turns, which model answers them, how long a call may
 take and how far a conversation may run, and one scroll put the name and the
 delete button a page apart. The state lives in the shell, so changing section
-cannot discard a half-typed endpoint. Plugins is disabled until the group
-exists, because a sign-in and a credential both have to belong to something.
+cannot discard a half-typed endpoint. Plugins and Repositories are both disabled
+until the group exists, because a sign-in, a credential and a linked directory
+all have to belong to something.
 
-That section holds two decisions, not one. Connecting is the crew's sign-in;
-under each connected row is who in the crew may use it, which is every agent
-until an operator says otherwise. It is written the moment it is clicked, like
-the Connect and Disconnect buttons above it: a draft nobody submitted would be a
-permission the operator believes they granted. The reasoning is in
+Repositories is a section rather than a third block under Plugins, and the two
+are near-neighbors on purpose rather than by accident: both are a thing given to
+the crew and then handed to named agents, which is the only shape they share. A
+plugin is a server somewhere that this crew signs in to. A repository is a
+directory on this machine that it writes in, and it is the one place in the app
+where the operator hands over their own source. Stacked under Plugins it was
+reached by scrolling past two sign-in panels, and the panel had to draw its own
+heading to be findable at all, which is how a section earns itself.
+
+The plugins section holds two decisions, not one. Connecting is the crew's
+sign-in; under each connected row is who in the crew may use it, which is every
+agent until an operator says otherwise. It is written the moment it is clicked,
+like the Connect and Disconnect buttons above it: a draft nobody submitted
+would be a permission the operator believes they granted. The reasoning is in
 `docs/PLUGINS.md`; what the panel owes the operator is the sentence saying who
-a plugin is currently offered to, including the honest one for a plugin narrowed
-to nobody, which is otherwise indistinguishable from a working row.
+a plugin is currently offered to, including the honest one for a plugin
+narrowed to nobody, which is otherwise indistinguishable from a working row.
 
 Three rows say who pays, and the first is "follow the app settings", which is
 where every group starts. The second is the ChatGPT subscription, and the group

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -28,7 +28,7 @@ use crate::domain::now_ms;
 use crate::domain::plugin::{
     self, HeaderPair, Headers, Plugin, PluginAccess, PluginKind, PluginOffer, ServerReport,
 };
-use crate::domain::repository::{Harness, Repository, RepositoryDraft};
+use crate::domain::repository::{Harness, Repository, RepositoryDraft, RepositoryEdit};
 use crate::domain::routine::{self, Routine, RoutineRun, Trigger};
 use crate::domain::search::SearchHits;
 use crate::domain::signin::Signin;
@@ -593,6 +593,12 @@ pub async fn create_repository(
 /// work happens in a directory the operator already chose, and the day it needs
 /// changing is the day one of the two sign-ins stops paying.
 ///
+/// [`RepositoryEdit`] rather than a [`RepositoryDraft`] with a stand-in path,
+/// and that is a bug fix rather than tidying: the stand-in was `/`, which
+/// cleans down to the empty string, so every call here was refused with *a
+/// repository needs a directory; pick one to link*. Its doc comment is the
+/// long version.
+///
 /// A job already running is not affected. It is a process that was started with
 /// the old answer, and reaching into it would be a second way to stop a job that
 /// `Runtime::start_job` does not have.
@@ -604,16 +610,7 @@ pub fn update_repository(
     note: String,
     harness: Harness,
 ) -> Reply<Repository> {
-    let clean = RepositoryDraft {
-        group_id: GroupId::new(),
-        name,
-        // Not stored and not read. `clean` needs a path to validate the rest,
-        // and the row's own is what stays.
-        path: "/".to_string(),
-        note,
-        harness,
-    }
-    .clean()?;
+    let clean = RepositoryEdit { name, note, harness }.clean()?;
     let repository =
         state.runtime.store().update_repository(id, &clean.name, &clean.note, clean.harness)?;
     state.runtime.emit(UiEvent::AgentsChanged);

--- a/src-tauri/src/domain/repository.rs
+++ b/src-tauri/src/domain/repository.rs
@@ -232,10 +232,61 @@ pub struct CleanRepository {
     pub harness: Harness,
 }
 
+/// What an operator may change about a repository that is already linked.
+///
+/// The path is not on it, and the absence is the whole point of the type. A
+/// different directory is a different repository: whoever was given this one
+/// was given that directory, so editing a path in place would move their
+/// boundary, and their undo, with nothing on screen saying a decision had been
+/// taken. A shape that cannot carry a path is the only version of that rule
+/// nothing downstream can forget.
+///
+/// It is also here because the obvious alternative does not work, and fails in
+/// the one way nobody looks for. An edit routed through [`RepositoryDraft`]
+/// needs a stand-in path; the stand-in was `/`, and `/` is the empty string
+/// once [`RepositoryDraft::clean`] takes its trailing separator off. Every
+/// rename, every note and every harness switch came back as *a repository needs
+/// a directory; pick one to link*, about a directory the operator had already
+/// picked and could read on the row above the box. Neither the panel nor the
+/// store was wrong, and both have tests, which is how it survived.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RepositoryEdit {
+    pub name: String,
+    pub note: String,
+    pub harness: Harness,
+}
+
+impl RepositoryEdit {
+    /// Everything checkable about an edit, which is everything it carries.
+    ///
+    /// A blank name is refused rather than backfilled. The directory's own name
+    /// is what *linking* falls back to and there is no path here to take one
+    /// from, and keeping the stored name instead would be a save that quietly
+    /// did not do what the box in front of the operator says.
+    pub fn clean(&self) -> Result<RepositoryEdit, RepositoryError> {
+        let name = self.name.trim().to_string();
+        if name.is_empty() {
+            return Err(RepositoryError::NoName);
+        }
+        if name.chars().count() > MAX_NAME_LEN {
+            return Err(RepositoryError::NameTooLong);
+        }
+
+        let note = self.note.trim().to_string();
+        if note.chars().count() > MAX_NOTE_LEN {
+            return Err(RepositoryError::NoteTooLong);
+        }
+
+        Ok(RepositoryEdit { name, note, harness: self.harness })
+    }
+}
+
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum RepositoryError {
     #[error("a repository needs a directory; pick one to link")]
     NoPath,
+    #[error("a repository needs a name; it is what its agents are told the directory is called")]
+    NoName,
     #[error(
         "`{0}` is not an absolute path; link a directory by its full path, starting from the root"
     )]
@@ -270,25 +321,25 @@ impl RepositoryDraft {
             return Err(RepositoryError::NotAbsolute(path.to_string()));
         }
 
-        let name = match self.name.trim() {
-            "" => path.rsplit('/').next().unwrap_or(path).to_string(),
-            given => given.to_string(),
-        };
-        if name.chars().count() > MAX_NAME_LEN {
-            return Err(RepositoryError::NameTooLong);
+        // The name is decided here rather than inside the edit because only a
+        // path can supply the fallback, and everything after it is the same
+        // question an edit asks, answered in one place.
+        let edit = RepositoryEdit {
+            name: match self.name.trim() {
+                "" => path.rsplit('/').next().unwrap_or(path).to_string(),
+                given => given.to_string(),
+            },
+            note: self.note.clone(),
+            harness: self.harness,
         }
-
-        let note = self.note.trim().to_string();
-        if note.chars().count() > MAX_NOTE_LEN {
-            return Err(RepositoryError::NoteTooLong);
-        }
+        .clean()?;
 
         Ok(CleanRepository {
             group_id: self.group_id,
-            name,
+            name: edit.name,
             path: path.to_string(),
-            note,
-            harness: self.harness,
+            note: edit.note,
+            harness: edit.harness,
         })
     }
 }
@@ -332,6 +383,45 @@ mod tests {
     #[test]
     fn an_empty_path_is_refused_before_anything_else() {
         assert_eq!(draft("   ").clean().unwrap_err(), RepositoryError::NoPath);
+    }
+
+    #[test]
+    fn the_root_is_an_empty_path_once_its_separator_is_off() {
+        // Kept as an explanation rather than as a rule. `/` is what an edit
+        // routed through a draft used as its stand-in path, and this is why
+        // every rename, note and harness switch was refused for having no
+        // directory. `RepositoryEdit` is the fix; this is the reason.
+        assert_eq!(draft("/").clean().unwrap_err(), RepositoryError::NoPath);
+    }
+
+    #[test]
+    fn an_edit_is_not_refused_for_having_no_path() {
+        let clean = RepositoryEdit {
+            name: "  guac  ".into(),
+            note: "  never touch migrations  ".into(),
+            harness: Harness::Claude,
+        }
+        .clean()
+        .expect("an edit carries no path and must not be refused for one");
+
+        assert_eq!(clean.name, "guac");
+        assert_eq!(clean.note, "never touch migrations");
+        assert_eq!(clean.harness, Harness::Claude);
+    }
+
+    #[test]
+    fn an_edit_refuses_what_a_link_refuses_and_a_name_it_cannot_backfill() {
+        let refused = |name: &str, note: &str| {
+            RepositoryEdit { name: name.into(), note: note.into(), harness: Harness::Pi }
+                .clean()
+                .unwrap_err()
+        };
+
+        assert_eq!(refused(&"x".repeat(MAX_NAME_LEN + 1), ""), RepositoryError::NameTooLong);
+        assert_eq!(refused("guaca", &"x".repeat(MAX_NOTE_LEN + 1)), RepositoryError::NoteTooLong);
+        // There is no path here to take the directory's own name from, and a
+        // blank one stored would draw as a repository with no name at all.
+        assert_eq!(refused("   ", ""), RepositoryError::NoName);
     }
 
     #[test]

--- a/src/components/GroupEditor.test.tsx
+++ b/src/components/GroupEditor.test.tsx
@@ -73,6 +73,10 @@ const subscriptionStatus = vi.fn<() => Promise<SubscriptionStatus>>(async () => 
   includesCodex: false,
 }));
 const groupConnectors = vi.fn(async () => []);
+const groupPlugins = vi.fn(async () => []);
+const pluginCatalog = vi.fn(async () => []);
+const groupRepositories = vi.fn(async () => []);
+const codingHarnesses = vi.fn(async () => []);
 
 vi.mock("../lib/ipc", () => ({
   api: {
@@ -84,6 +88,10 @@ vi.mock("../lib/ipc", () => ({
     testGroupConnection: (id: string | null, draft: GroupDraft) => testGroupConnection(id, draft),
     subscriptionStatus: () => subscriptionStatus(),
     groupConnectors: () => groupConnectors(),
+    groupPlugins: () => groupPlugins(),
+    pluginCatalog: () => pluginCatalog(),
+    groupRepositories: () => groupRepositories(),
+    codingHarnesses: () => codingHarnesses(),
   },
 }));
 
@@ -288,9 +296,28 @@ describe("what the operator is shown", () => {
     expect(field(/Model calls per conversation/).placeholder).toBe("60");
   });
 
-  it("does not offer plugins for a group that does not exist yet", () => {
+  it("does not offer plugins or repositories for a group that does not exist yet", () => {
+    // A sign-in, a credential and a linked directory all have to belong to
+    // something, and there is no row to hang any of them on yet.
     open(null);
     expect((screen.getByRole("tab", { name: "Plugins" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole("tab", { name: "Repositories" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it("puts repositories in a section of their own rather than under plugins", async () => {
+    // A plugin is a server this crew signs in to and a repository is a
+    // directory on this machine it writes in. They share a shape and nothing
+    // else, and stacked in one pane the operator scrolled past two sign-in
+    // panels to reach the one about their own source.
+    open();
+    pane("Repositories");
+    expect(await screen.findByText("Link a repository")).toBeTruthy();
+
+    pane("Plugins");
+    await waitFor(() => expect(groupPlugins).toHaveBeenCalled());
+    expect(screen.queryByText("Link a repository")).toBeNull();
   });
 
   it("refuses to save a group with no name", () => {

--- a/src/components/GroupEditor.tsx
+++ b/src/components/GroupEditor.tsx
@@ -38,7 +38,7 @@ interface Props {
   onClose: () => void;
 }
 
-const SECTIONS = ["general", "provider", "limits", "plugins"] as const;
+const SECTIONS = ["general", "provider", "limits", "plugins", "repositories"] as const;
 
 type Section = (typeof SECTIONS)[number];
 
@@ -47,7 +47,16 @@ const SECTION_LABELS: Record<Section, string> = {
   provider: "Provider",
   limits: "Limits",
   plugins: "Plugins",
+  repositories: "Repositories",
 };
+
+/**
+ * The sections that are about something attached to a crew, so a crew has to
+ * exist first. A sign-in, a credential and a linked directory all have to
+ * belong to something, and there is no row to hang any of them on until the
+ * group is created.
+ */
+const NEEDS_GROUP: readonly Section[] = ["plugins", "repositories"];
 
 /** What a group says when it has no opinion about who pays. */
 const INHERIT = "inherit";
@@ -313,9 +322,7 @@ export function GroupEditor({ group, onClose }: Props) {
                 role="tab"
                 className="settings__tab"
                 aria-selected={section === key}
-                // A group that does not exist yet has nothing to connect a
-                // plugin to, and nowhere to put a credential.
-                disabled={key === "plugins" && !group}
+                disabled={NEEDS_GROUP.includes(key) && !group}
                 onClick={() => setSection(key)}
               >
                 {SECTION_LABELS[key]}
@@ -573,6 +580,24 @@ export function GroupEditor({ group, onClose }: Props) {
                 </p>
                 <PluginList groupId={group.id} crew={members} />
                 <CredentialList groupId={group.id} />
+              </>
+            )}
+
+            {/* Its own section rather than a third panel under Plugins. A
+                plugin is a server this crew signs in to and a repository is a
+                directory on this machine that it writes in: they share a shape
+                (given to the crew, then handed to named agents) and nothing
+                else, and stacked in one pane the operator scrolled past two
+                sign-in panels to reach the one about their own source. */}
+            {section === "repositories" && group && (
+              <>
+                <h3 className="settings__title">Repositories</h3>
+                <p className="settings__lede">
+                  The directories on this machine this crew may write code in, and which program
+                  does the writing in each. Linking one gives it to nobody: you hand it to an agent
+                  from that agent&rsquo;s own panel, one at a time, and an agent you hire later does
+                  not inherit it.
+                </p>
                 <RepositoryList groupId={group.id} crew={members} />
               </>
             )}

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -134,9 +134,14 @@ function worksIn(repository: Repository, crew: AgentCard[]): string {
  * question, and answering it should not mean opening six agents one at a time.
  * The same reason the plugin panel says who a sign-in is offered to.
  *
- * There is no "every agent" button here and there is one on the plugins above.
+ * There is no "every agent" button here and there is one on the plugins panel.
  * An agent hired next week must not inherit the operator's own source. Names,
  * always, and only on the agent.
+ *
+ * The heading and the sentence explaining all of that are the section's, not
+ * this panel's. It has a section of its own in the group editor rather than a
+ * third block under Plugins, so drawing its own title under the section's would
+ * be the same word twice at two sizes.
  *
  * ## Why the harness is a choice on the row and not a setting
  *
@@ -237,15 +242,6 @@ export function RepositoryList({ groupId, crew }: Props) {
 
   return (
     <div className="access">
-      <div className="routines__head">
-        <span className="field__label">Repositories</span>
-        {adding && (
-          <button type="button" className="btn btn--ghost btn--small" onClick={reset}>
-            Cancel
-          </button>
-        )}
-      </div>
-
       {repositories.map((repository) => (
         <div className="access__item" key={repository.id}>
           <div className="access__row">
@@ -362,6 +358,12 @@ export function RepositoryList({ groupId, crew }: Props) {
             >
               Link
             </button>
+            {/* Beside the thing it cancels rather than in a heading above the
+                list. The section owns the heading now, and a Cancel a panel
+                away from the form is one an operator hunts for. */}
+            <button type="button" className="btn btn--ghost btn--small" onClick={reset}>
+              Cancel
+            </button>
           </div>
           <div className="access__row">
             <input
@@ -390,16 +392,9 @@ export function RepositoryList({ groupId, crew }: Props) {
           </p>
         </div>
       ) : (
-        <>
-          <p className="field__hint">
-            A directory on this machine that this crew may write code in. Linking one gives it to
-            nobody. You hand it to an agent from that agent's own panel, one at a time, and an agent
-            you hire later does not inherit it.
-          </p>
-          <button type="button" className="btn btn--small" onClick={() => setAdding(true)}>
-            Link a repository
-          </button>
-        </>
+        <button type="button" className="btn btn--small" onClick={() => setAdding(true)}>
+          Link a repository
+        </button>
       )}
 
       {error && (


### PR DESCRIPTION
`update_repository` validated its name and note by building a `RepositoryDraft`, which checks the path first, so it invented one: the stand-in was `/`, which is the empty string once `clean` strips the trailing separator, and every rename, note and harness switch since repositories shipped came back as *a repository needs a directory; pick one to link* about a directory the operator had already picked. Neither the panel nor the store was wrong and both have tests, so the fix is a shape that cannot carry a path at all: `RepositoryEdit` holds a name, a note and a harness, `RepositoryDraft::clean` delegates to it so the rules live in one place, and a blank name is now refused rather than backfilled from a path that is not there.

Separately, Repositories moves out from under Plugins into a group-editor section of its own, because the only thing the two share is being given to the crew and then handed to named agents, and the repository panel was previously reached by scrolling past two sign-in panels. `RepositoryList` hands its heading and its explainer to the section and moves Cancel into the link form beside the Link button, and the "a crew has to exist first" rule is now a `NEEDS_GROUP` list covering both tabs.

Verified with `./scripts/ci.sh` plus three new domain tests for the edit path and two `GroupEditor` tests for the section; the section was also checked on screen with the preview harness rather than only in tests.