### PR TITLE
fix: start fresh takes both stores, not just the memories

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,9 +437,9 @@ Deleting an agent is a soft delete: it leaves the rail and can never be messaged
 again, its computer and browser are destroyed along with the browser profile
 holding its sign-ins, and its memory goes, but what it already said stays
 readable and its name becomes free to reuse. **Start fresh** on a group
-resets its whole crew (transcripts, routines, memories and spend) while keeping
-the agents themselves. Deleting a group takes the crew and the machines they
-were renting with it.
+resets its whole crew (transcripts, routines, memories, working notes and
+spend) while keeping the agents themselves. Deleting a group takes the crew and
+the machines they were renting with it.
 
 ## Working on it
 

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -250,6 +250,18 @@ failure this list has is an agent still waiting on something the operator
 settled in person. Editing a single line does not, because a list the operator
 half-rewrites is one neither of them can trust.
 
+**A reset takes both stores, and it has to take both.** *Start fresh* on a
+group deletes what the crew said, what it had scheduled and what it spent, and
+the memories with them, because an agent that opens tomorrow believing what it
+wrote about a conversation nobody can read has not started over. The working
+notes are the same argument one step closer in: they are what each agent
+thought it was in the middle of, and every one of them is about the
+conversation that just went. Left behind, a reset crew's first act is to chase
+work whose record it no longer has. `clear_group` takes both, reports each
+separately, and the panels are sent back to read again on `ChannelsCleared`:
+neither refreshes on its own, so the inspector would otherwise draw a memory
+and a list of notes beside the empty channel that says they are gone.
+
 **The tool is `update_memory`, and `update_notes` still parses.** `notes` meant
 memory everywhere the code named it for a year, which is exactly the ambiguity a
 second store cannot survive, so the internals took the operator's word. The old

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2049,6 +2049,10 @@ pub fn clear_group(state: State<'_, AppState>, group_id: GroupId) -> Reply<Group
             .filter(|id| !state.runtime.workspace().read(**id).trim().is_empty())
             .inspect(|id| state.runtime.workspace().remove(**id))
             .count(),
+        // And the other store, for the same reason from the other end: what an
+        // agent is in the middle of is the half that was true about a
+        // conversation this reset just deleted.
+        working_notes: store.delete_group_working_notes(group_id)?,
     };
 
     // Named so open channels can drop what they are holding. `AgentsChanged`
@@ -2065,7 +2069,10 @@ pub fn clear_group(state: State<'_, AppState>, group_id: GroupId) -> Reply<Group
 pub struct GroupReset {
     pub messages: usize,
     pub routines: usize,
+    /// Memories wiped. Named for the file each one is, which is `notes`.
     pub notes: usize,
+    /// Working notes dropped, which is the other store and a row count.
+    pub working_notes: usize,
     pub calls: usize,
 }
 

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -3103,6 +3103,22 @@ impl Store {
         )?)
     }
 
+    /// Every working note held by a group's agents.
+    ///
+    /// The other half of what a crew carries between turns, and it goes with
+    /// the memories for the same reason: an agent whose transcript and page are
+    /// gone but which still opens tomorrow waiting on a decision from a
+    /// conversation nobody can read has not started fresh, it has been left
+    /// holding the one part of its state nothing can now explain.
+    pub fn delete_group_working_notes(&self, group: GroupId) -> Result<usize, StoreError> {
+        let conn = self.conn()?;
+        Ok(conn.execute(
+            "DELETE FROM working_notes
+              WHERE agent_id IN (SELECT id FROM agents WHERE group_id=?1)",
+            params![group.to_string()],
+        )?)
+    }
+
     /// Everything a group has spent.
     ///
     /// Booked against the group rather than the agent, so an agent that has
@@ -4721,6 +4737,9 @@ mod tests {
             .append(&envelope(Participant::Human, agent(bystander.id), "untouched", run))
             .unwrap();
 
+        f.store.append_working_note(scholar.id, "waiting on the listings", 1_000).unwrap();
+        f.store.append_working_note(bystander.id, "waiting on Robert", 1_000).unwrap();
+
         // A deleted agent's transcript is part of what the group said, so it
         // goes too: leaving it behind is what "start fresh" is not.
         f.store.set_lifecycle(scholar.id, Lifecycle::Terminated).unwrap();
@@ -4749,8 +4768,18 @@ mod tests {
 
         assert_eq!(f.store.delete_group_messages(other.id).unwrap(), 1);
         assert_eq!(f.store.delete_group_routines(other.id).unwrap(), 1);
+        assert_eq!(f.store.delete_group_working_notes(other.id).unwrap(), 1);
         assert_eq!(f.store.delete_group_usage(other.id).unwrap(), 1);
         assert!(f.store.agent_routines(scholar.id).unwrap().is_empty());
+        assert!(
+            f.store.working_notes(scholar.id).unwrap().is_empty(),
+            "a reset crew still waiting on the conversation it can no longer read"
+        );
+        assert_eq!(
+            f.store.working_notes(bystander.id).unwrap().len(),
+            1,
+            "clearing one group must not empty another crew's notes"
+        );
         assert!(
             !f.store.usage_by_group().unwrap().contains_key(&other.id),
             "a reset group has spent nothing, or the meter keeps counting what is gone"

--- a/src/components/GroupEditor.test.tsx
+++ b/src/components/GroupEditor.test.tsx
@@ -61,6 +61,7 @@ const clearGroup = vi.fn<(id: string) => Promise<GroupReset>>(async () => ({
   messages: 0,
   routines: 0,
   notes: 0,
+  workingNotes: 0,
   calls: 0,
 }));
 const testGroupConnection = vi.fn<(id: string | null, draft: GroupDraft) => Promise<string>>(
@@ -398,6 +399,23 @@ describe("deleting a group", () => {
 
     expect(await screen.findByText(/cannot be deleted/)).toBeTruthy();
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("says what the reset took, both stores included", async () => {
+    // The operator is told rather than reassured, and the working notes are
+    // the half that says what the crew thought it was in the middle of.
+    clearGroup.mockResolvedValueOnce({
+      messages: 12,
+      routines: 2,
+      notes: 3,
+      workingNotes: 7,
+      calls: 41,
+    });
+    open();
+    fireEvent.click(button("Start fresh"));
+    fireEvent.click(button("Reset every agent"));
+
+    expect(await screen.findByText(/7 working notes/)).toBeTruthy();
   });
 
   it("does not offer to reset a group it is already deleting", () => {

--- a/src/components/GroupEditor.tsx
+++ b/src/components/GroupEditor.tsx
@@ -206,9 +206,12 @@ export function GroupEditor({ group, onClose }: Props) {
   /**
    * Start fresh: the crew stays, everything it has accumulated goes.
    *
-   * Transcripts, schedules, memories and spend together, because clearing only
-   * the transcript left agents acting on a memory of a conversation that no
-   * longer existed and keeping appointments nobody could see the reason for.
+   * Transcripts, schedules, both stores and spend together, because clearing
+   * only the transcript left agents acting on a memory of a conversation that
+   * no longer existed and keeping appointments nobody could see the reason for.
+   * The working notes go for the same reason the memories do, and they are the
+   * half that says what the crew was in the middle of: left behind, every agent
+   * opens tomorrow waiting on somebody about a conversation nobody can read.
    */
   const clear = async () => {
     if (!group) return;
@@ -607,7 +610,8 @@ export function GroupEditor({ group, onClose }: Props) {
                 <span>
                   Reset: {cleared.messages} message{cleared.messages === 1 ? "" : "s"},{" "}
                   {cleared.routines} routine{cleared.routines === 1 ? "" : "s"}, {cleared.notes}{" "}
-                  memor{cleared.notes === 1 ? "y" : "ies"}, and {cleared.calls} recorded call
+                  memor{cleared.notes === 1 ? "y" : "ies"}, {cleared.workingNotes} working note
+                  {cleared.workingNotes === 1 ? "" : "s"}, and {cleared.calls} recorded call
                   {cleared.calls === 1 ? "" : "s"}.
                 </span>
               </div>
@@ -699,7 +703,7 @@ export function GroupEditor({ group, onClose }: Props) {
                 className="btn btn--ghost"
                 disabled={busy}
                 onClick={() => setConfirmClear(true)}
-                title="Resets every agent in this group: transcripts, routines and memories, and the spend counter. The agents and their computers stay."
+                title="Resets every agent in this group: transcripts, routines, memories, working notes and the spend counter. The agents and their computers stay."
               >
                 {cleared === null ? "Start fresh" : "Reset"}
               </button>

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -701,6 +701,20 @@ describe("channelsCleared", () => {
     // for nothing.
     expect(channelMessages).toHaveBeenCalledWith("chef", 300, undefined);
   });
+
+  it("sends the panels holding the two stores back for them", () => {
+    // A reset takes the memory and the working notes as well, and neither
+    // panel reads again on its own: without this the inspector draws both
+    // beside a transcript that says they are gone.
+    reset({ chef: [envelope()] });
+    useStore.setState({ memoryVersion: {}, workingNotesVersion: {} });
+
+    apply({ type: "channelsCleared", agents: ["chef"] });
+
+    expect(useStore.getState().memoryVersion.chef).toBe(1);
+    expect(useStore.getState().workingNotesVersion.chef).toBe(1);
+    expect(useStore.getState().workingNotesVersion.manager).toBeUndefined();
+  });
 });
 
 describe("openMessage", () => {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -945,6 +945,19 @@ export const useStore = create<State>((set, get) => ({
         if (open && (emptied.has(open) || open === ACTIVITY_CHANNEL)) {
           void get().loadChannel(open);
         }
+        // The panels beside the transcript hold the two stores a reset also
+        // takes, and neither is read again on its own. Left alone, the inspector
+        // draws a memory and a list of working notes that no longer exist,
+        // beside the empty channel that says they should not.
+        set((state) => {
+          const memory = { ...state.memoryVersion };
+          const working = { ...state.workingNotesVersion };
+          for (const agent of event.agents) {
+            memory[agent] = (memory[agent] ?? 0) + 1;
+            working[agent] = (working[agent] ?? 0) + 1;
+          }
+          return { memoryVersion: memory, workingNotesVersion: working };
+        });
         // The meters are counting rows that no longer exist.
         void get().refreshUsage();
         break;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -971,6 +971,8 @@ export interface GroupReset {
   routines: number;
   /** Memories wiped. Named for the file on disk, which is `notes`. */
   notes: number;
+  /** Working notes dropped, which is the other store and a row count. */
+  workingNotes: number;
   calls: number;
 }
 


### PR DESCRIPTION
**Start fresh** deleted a crew's transcripts, routines, memories and spend and left the working notes, which is the store whose every line is about the conversation it had just deleted: a reset crew's first act was to chase work whose record was gone. `clear_group` now takes them too, bounded the way the transcripts and routines are, and `GroupReset` reports the count beside the memories rather than folded into them, because two stores with two lifetimes need two numbers to say which of them was holding anything.

The panels are also sent back to read again on `ChannelsCleared`, where the memory had the same gap already: neither refreshes on its own, so the inspector drew a page and a list of notes beside the empty channel that said they were gone, until the operator clicked away and back.

Covered by a store test (a reset takes one crew's notes and leaves another's), a reducer test, and a panel test asserting the reset report names what it took. README and the two-stores section of `docs/WORKSPACE.md` say so. `./scripts/ci.sh` passes.