### PR TITLE
feat: deleting an agent is a thirty-day hold, and the compost is where it waits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ src/                  React + TypeScript. A view over the runtime, nothing more.
   lib/diff.ts         Two versions of a page, as the lines between them.
   lib/reasoning.ts    A turn's own thinking: how much is held, what is drawn.
   lib/cafeteria.ts    Preset agents, waiting to be hired. Content, not runtime.
+  lib/compost.ts      Where a deleted agent waits, and how long it has left.
   lib/roles.ts        What an agent is for, in OpenRouter's twelve words.
   lib/plugins.ts      A plugin's mark and color. Everything else is Rust's.
   lib/ipc.ts          Every call into Rust.
@@ -146,7 +147,8 @@ repo: the frontend renders state and forwards intent.
 | Scrolling a transcript, following the newest line, when the view may move | *A transcript follows the end for whoever is at the end, and nobody else* in `docs/WORKSPACE.md`, then `src/lib/follow.ts` |
 | The menu bar: the glyph, the count, what the menu offers, closing the window | *The menu bar is Guaca with the window shut* in `docs/WORKSPACE.md`, then `src-tauri/src/menubar.rs` |
 | The rail's order, dragging a row, groups as places you go inside | *The rail is arranged by hand*, *A drop is one call* and *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/rail.ts` and `src/lib/orb.ts` |
-| Deleting a group, deleting an agent, what goes with either | *Deleting a group deletes the crew, and the machines they were renting* in `docs/WORKSPACE.md`, then `retire_agent` in `src-tauri/src/commands.rs` |
+| Deleting an agent, putting one back, what the thirty days hold | *Deleting an agent is a thirty-day hold* in `docs/WORKSPACE.md`, then `Runtime::discard_agent` and `Runtime::purge_agent`, which are the two halves of what used to be one act |
+| Deleting a group, and why a disband does not use the compost | *Deleting a group deletes the crew, and the machines they were renting* in `docs/WORKSPACE.md`, then `disband_group` in `src-tauri/src/commands.rs` |
 | Preset agents, hiring a crew | *The cafeteria is a copy machine* in `docs/WORKSPACE.md`, then `src/lib/cafeteria.ts` |
 | Settings, the surface, the scale, what may interrupt the operator | *Settings is nine places*, *The reading column has two surfaces* and *An interruption has to earn it* in `docs/WORKSPACE.md` |
 | The group editor: what a crew overrides and what it inherits | *A group's settings are the app's, with the crew's answer on top* in `docs/WORKSPACE.md`, then `src/components/GroupEditor.tsx` |
@@ -341,6 +343,27 @@ the model takes a screenshot to see what `browse` did.
   against 16,000 and told operators their memory was about to be cut by a runtime
   storing it whole. A warning is read as a fact about what will happen, so the
   number is only worth drawing while it is the runtime's number.
+- **A deleted agent is `Terminated` with a stamp, not a fourth lifecycle.** The
+  compost holds it for thirty days and everything it owns privately waits with
+  it, but to the rest of the app it is deleted: unreachable, undiscoverable, out
+  of the rail, out of every crew and out of the partial index that frees its
+  name. That is the point of the column. Fifteen queries ask `lifecycle <>
+  'terminated'` and every one of them is still right; a fourth state would be
+  fifteen places to remember, each failing quietly and differently — a composted
+  agent in a directory listing, in a crew count, in a disband, in the roster a
+  peer is told to ask. `NULL` is both ends of the wait, and the lifecycle tells
+  them apart. `docs/WORKSPACE.md`.
+- **A composted agent still holds its sandbox, and `claimed_sandboxes` has to
+  agree.** Deleting sleeps the machine rather than killing it, because the disk
+  is where the operator's own sign-ins live and only they can put them back.
+  Under the old rule — only a live agent holds a claim — the next sweep would
+  kill it inside the minute, and a restore three weeks later would hand back an
+  agent signed in to nothing.
+- **A restore comes back paused, and settles its name on the way.** Paused
+  because thirty days of a schedule have come due without it; renamed because
+  the name was freed the moment it was thrown out and the crew may have hired
+  into it, so `copy_name` steps around the clash rather than letting the unique
+  index refuse a button whose job is to succeed.
 - **An edit to a repository is a `RepositoryEdit`, not a draft with a stand-in
   path.** A `RepositoryDraft` validates the path before anything else, so an
   edit routed through one has to invent a path it does not have. The stand-in

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -934,6 +934,96 @@ preset prompt states a stopping condition. A prompt without one makes a crew
 that talks to itself, no automated suite can see it, and the evals are what
 catch it. Run `./scripts/evals.sh` after touching a preset.
 
+## Deleting an agent is a thirty-day hold, and the compost is where it waits
+
+Deleting used to be one act. The click killed the computer, destroyed the
+browser and the profile holding its cookies, removed the memory the agent had
+spent months writing, deleted the schedule, the working notes, the sign-ins and
+every standing permission the operator had given it, and marked the row
+terminated. All of that behind one menu item, with nothing between the press and
+the loss but a confirmation. There was no way back and nothing on screen said
+there had been.
+
+So the destructive half waits thirty days. What a delete does now is stamp the
+row and stop the actor: the agent is out of the rail, out of the directory,
+unreachable by any peer, and everything it held privately is exactly where it
+was. `Runtime::discard_agent` is the first half, `Runtime::purge_agent` is the
+second, and the thirty days between them are the feature.
+
+**It is a column, not a fourth lifecycle.** An agent in the compost is
+`Terminated`, which is what every other part of the store has always meant by
+deleted, and `discarded_at` is what says it can still come back. That is not
+timidity about the type: there are fifteen queries in this app that ask
+`lifecycle <> 'terminated'` and every one of them is still asking exactly the
+right question, including the partial unique index that frees the name. A
+fourth state would have been fifteen places to remember, each failing silently
+in a different way — a composted agent in a directory listing, in a crew count,
+in a disband, in the roster a peer is told to ask. `NULL` in the column is both
+ends of the wait: an agent nobody deleted and one whose thirty days are over.
+The lifecycle tells those apart.
+
+**A restore comes back paused, and may come back renamed.** Paused because the
+wait is what makes it a different question from unpausing: an agent restored
+three weeks on returns to a schedule that has been coming due every morning
+without it and to peers that carried on, so starting it is a decision the
+operator takes on a row that is already drawn as stopped. Renamed because
+throwing an agent out frees its name at once — that is the whole point of the
+partial index — so the crew may have hired somebody into it since, and
+`copy_name` settles it exactly as a duplicate does. Refusing the restore instead
+would show the operator a unique-index violation for a button whose job is to
+succeed.
+
+**The machines are released, not destroyed, and the sweep has to know that.** A
+sandbox is put to sleep and keeps its disk, because that disk holds the accounts
+the operator signed it in to and nothing else can sign them in again; a browser
+is closed, which is what writes its cookies back to the profile. Both are what a
+restore has to find. `claimed_sandboxes` therefore counts a composted agent as
+holding its machine, which is the one exception to "only a live agent holds a
+claim": swept on the old rule, that machine would be killed inside the minute
+and a restore three weeks later would hand back an agent signed in to nothing.
+
+**Nothing about the transcript changes.** What an agent said stays readable in
+every channel it said it in, through the hold and after the sweep, for the
+reason it always did: hard-deleting punches holes in transcripts that had
+nothing to do with this agent. What goes at the end is what the agent held
+privately.
+
+**A disband does not use the compost.** Deleting a group takes the place a
+restore would come back to: `delete_group` files whatever is left under the
+default group, so a composted crew would be offered a restore into a crew that
+no longer exists, holding sign-ins belonging to a group whose credentials went
+with it. A disband purges each agent outright and its confirmation names the
+count, which is what makes it the irreversible one on screen as well as in the
+code. See *Deleting a group deletes the crew* above.
+
+**The sweep is its own loop, and runs hourly.** Not a third statement in the
+scheduler's: a routine is late by however long the tick is, so that one is paced
+in seconds, and a thirty-day deadline is not made better by being met to the
+second. It also makes provider calls when it finds something, which a schedule
+sweep should never wait behind. Swept once before the first wait, so an app left
+closed for a month empties on the next launch rather than an hour into it.
+
+The panel is the cafeteria's shape at the cafeteria's opposite end, and the two
+being alike is deliberate: one is hiring and one is letting go. Where the
+cafeteria is a grid of tiles to browse, this is a list of decisions, each with
+its clock and each saying what is still inside the agent — its memory, its
+working notes, its schedule, its sign-ins. That sentence is the reason the panel
+exists. None of it is visible at the moment somebody presses delete, and this is
+the one screen where they are deciding whether they meant it.
+
+The rail's footer draws the compost only while there is something in it. That is
+what keeps the footer two rows for an operator who has never deleted anybody,
+and it is also how the feature is discovered: the row turns up at the moment it
+has a reason to, which is the moment somebody has just deleted an agent and
+might want it back. The count is on the row because whether there is anything in
+there at all is the question it is read for.
+
+`COMPOST_DAYS` lives in `domain/agent.rs` and `Compost.test.tsx` reads it out of
+the Rust rather than restating it. The panel draws a countdown to the moment an
+operator's memory is deleted, nothing else in the build compares the two sides,
+and a mirror that has drifted is a promise the app does not keep. Same rule, and
+the same reason, as the memory cap.
+
 ## The model field suggests three, and is still a text box
 
 An agent's model is any slug its endpoint accepts, and the endpoint is the

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -315,6 +315,8 @@ pub fn run() {
             // And find out what their browsers are already signed in to, so the
             // roster is right before anybody asks rather than after.
             runtime.start_signin_sweep();
+            // The compost empties itself, whether or not anybody opens it.
+            runtime.start_compost();
 
             // The viewer for agents' computers. Loopback only: it holds the
             // tokens that reach a running machine.
@@ -458,6 +460,8 @@ pub fn run() {
             commands::create_agent,
             commands::update_agent,
             commands::delete_agent,
+            commands::restore_agent,
+            commands::purge_agent,
             commands::duplicate_agent,
             commands::hire_agents,
             commands::set_agent_paused,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1265,11 +1265,18 @@ pub fn delete_group(state: State<'_, AppState>, id: GroupId) -> Reply<()> {
 /// then the group, and stopping halfway left a group with three agents in it
 /// and no reason to keep any of them.
 ///
-/// Every agent goes exactly as `delete_agent` sends one: its computer killed,
-/// its browser and profile destroyed, its memory, schedule, sign-ins and
-/// standing permission gone. What each of them said stays readable, because a
-/// disband is a delete at the scale of a crew and not a different rule about
-/// history.
+/// Every agent goes the whole way, and none of them lands in the compost: its
+/// computer killed, its browser and profile destroyed, its memory, schedule,
+/// sign-ins and standing permission gone. What each of them said stays
+/// readable, because a disband is a delete at the scale of a crew and not a
+/// different rule about history.
+///
+/// The compost is a hold on one agent, and a disband takes the place it would
+/// come back to. `delete_group` files whoever is left under the default group,
+/// so a composted crew would be offered a restore into a crew that no longer
+/// exists, holding a sign-in belonging to a group whose credentials went with
+/// it. The confirmation names the count for that reason: this is the
+/// irreversible one, and it says so.
 ///
 /// Refused before anything irreversible. `group_for_removal` asks the one
 /// question that does not depend on the crew: killing four computers and then
@@ -1285,7 +1292,7 @@ pub async fn disband_group(state: State<'_, AppState>, id: GroupId) -> Reply<()>
 
     let outcome = async {
         for card in state.runtime.store().group_crew(id)? {
-            retire_agent(&state, &card).await?;
+            state.runtime.purge_agent(&card).await?;
         }
         state.runtime.store().delete_group(id)?;
         Ok(())
@@ -1327,89 +1334,48 @@ pub fn update_agent(
     Ok(card)
 }
 
-/// Everything one agent takes with it, in the order that leaves nothing
-/// running and nothing billing.
+/// Deletes an agent, into the compost.
 ///
-/// Shared by deleting a single agent and disbanding a whole crew, because the
-/// two are the same act at different scales: a disband that only marked the
-/// rows would leave a group's worth of sandboxes and browser profiles alive
-/// with nothing left on screen pointing at them.
+/// It leaves the rail and the directory immediately and can never be messaged
+/// again, and what it already said stays readable in the other agents'
+/// channels: hard-deleting would punch holes in transcripts that had nothing to
+/// do with this agent.
 ///
-/// A provider that refuses is logged and stepped over. The rows are the record
-/// the operator sees, and stopping halfway through would leave an agent that is
-/// still in the rail and has already lost its memory.
-async fn retire_agent(state: &State<'_, AppState>, card: &AgentCard) -> Reply<()> {
-    let id = card.id;
-    // The machine goes first. A deleted agent cannot be asked to tidy up after
-    // itself, and a sandbox nobody holds a reference to keeps billing.
-    //
-    // A missing key means no machine was ever made through this build, so there
-    // is nothing to release.
-    if let (Some(sandbox), Ok(client)) = (card.sandbox_id.as_ref(), computers(state)) {
-        if let Err(err) = client.kill(sandbox).await {
-            tracing::warn!(%err, %sandbox, "could not destroy the agent's computer");
-        }
-    }
-    // And its browser, which is a second provider with a second bill. The
-    // profile behind it goes too: it holds the cookies of accounts belonging to
-    // an agent that no longer exists, and a name is free to reuse the moment an
-    // agent is deleted, so whoever takes it next must not inherit its sessions.
-    if let Ok(client) = browsers(state) {
-        if let Some(browser) = card.browser_id.as_ref() {
-            if let Err(err) = client.delete(browser).await {
-                tracing::warn!(%err, %browser, "could not destroy the agent's browser");
-            }
-        }
-        // Attempted whether or not a browser was live, because the profile
-        // outlives every browser made against it and is the thing holding the
-        // cookies.
-        if let Err(err) = client.delete_profile(&id.to_string()).await {
-            tracing::warn!(%err, agent = %id, "could not destroy the agent's browser profile");
-        }
-    }
-
-    state.runtime.store().set_lifecycle(id, Lifecycle::Terminated)?;
-    state.runtime.stop_agent(id);
-    // The transcript survives a deletion, but the agent's private memory is
-    // its own and goes with it.
-    state.runtime.workspace().remove(id);
-    // Its schedule goes too, or it would keep coming due for an agent that can
-    // no longer act on it.
-    let _ = state.runtime.store().delete_agent_routines(id);
-    // And what it was in the middle of, for the reason the memory above goes:
-    // it is the agent's own account of its work and belongs to nobody else. The
-    // row is only marked terminated rather than deleted, so the table's own
-    // cascade never fires and this is the whole cleanup.
-    let _ = state.runtime.store().clear_working_notes(id);
-    // And what its browser was signed in to, which was cookies on the disk
-    // destroyed above. Left behind, the roster would keep telling the crew to
-    // ask this agent for an account nothing can reach any more.
-    let _ = state.runtime.store().delete_agent_signins(id);
-    // Permission the operator gave this agent dies with it. A name is free to
-    // reuse the moment an agent is deleted, and whoever takes it next must not
-    // inherit a standing grant given to somebody else.
-    let _ = state.runtime.store().delete_agent_approvals(id);
-    // And its place on any plugin the operator narrowed to named agents, for
-    // the same reason: a row naming an agent that no longer exists grants
-    // nothing and draws as nobody in the panel that lists them.
-    let _ = state.runtime.store().delete_agent_plugin_access(id);
-    // And its reach into whatever the crew was working in. Same argument, and
-    // one more that only applies here: a repository is the operator's own
-    // source, so a retired agent must not leave one drawn as handed out.
-    let _ = state.runtime.store().clear_agent_repository(id);
-    Ok(())
-}
-
-/// Deletes an agent.
-///
-/// A soft delete: the agent leaves the sidebar and the directory immediately
-/// and can never be messaged again, but what it already said stays readable in
-/// the other agents' channels. Hard-deleting would punch holes in transcripts
-/// that had nothing to do with this agent.
+/// What is new is that nothing it held privately is destroyed yet. For thirty
+/// days its memory, working notes, schedule, sign-ins and permissions sit
+/// exactly where they were and the operator can pull it back out;
+/// `Runtime::sweep_compost` is what eventually spends the other half.
 #[tauri::command]
 pub async fn delete_agent(state: State<'_, AppState>, id: AgentId) -> Reply<()> {
     let card = agent_card(&state, id)?;
-    retire_agent(&state, &card).await?;
+    state.runtime.discard_agent(&card).await?;
+    state.runtime.emit(UiEvent::AgentsChanged);
+    Ok(())
+}
+
+/// Pulls an agent back out of the compost, paused.
+///
+/// Refused for an agent whose thirty days are up, which is the same refusal as
+/// for one nobody deleted: both are rows with no stamp on them, and neither has
+/// anything left to bring back.
+#[tauri::command]
+pub fn restore_agent(state: State<'_, AppState>, id: AgentId) -> Reply<AgentCard> {
+    let card = agent_card(&state, id)?;
+    let restored = state.runtime.restore_agent(&card)?;
+    state.runtime.emit(UiEvent::AgentsChanged);
+    Ok(restored)
+}
+
+/// Ends the wait early: the thirty days, now.
+///
+/// The same act the sweep performs, on the operator's own timing, and the only
+/// thing in this app that destroys an agent's memory on a click. What it leaves
+/// is what the sweep leaves: a terminated row with no stamp, whose transcript
+/// still reads.
+#[tauri::command]
+pub async fn purge_agent(state: State<'_, AppState>, id: AgentId) -> Reply<()> {
+    let card = agent_card(&state, id)?;
+    state.runtime.purge_agent(&card).await?;
     state.runtime.emit(UiEvent::AgentsChanged);
     Ok(())
 }

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -1152,6 +1152,34 @@ CREATE INDEX working_notes_agent ON working_notes (agent_id, id DESC);
 ALTER TABLE repositories ADD COLUMN harness TEXT NOT NULL DEFAULT 'pi';
 "#,
     ),
+    (
+        41,
+        r#"
+-- When an agent was thrown out, for the thirty days it can still be pulled back.
+--
+-- Deleting used to be one act: the machines destroyed, the memory removed, the
+-- schedule, the sign-ins and every standing permission deleted, and the row
+-- marked terminated. All of it on a button an operator presses by accident, on
+-- an agent that had six months of memory in it, with nothing between the click
+-- and the loss but a menu item.
+--
+-- So the destructive half now waits. A delete stamps this column and stops the
+-- agent; everything it holds privately stays exactly where it is until the
+-- thirty days are up, at which point the old act runs in full. `NULL` is both
+-- ends of that: an agent nobody has deleted, and one whose wait is over and
+-- whose things are already gone. Which of the two a row is, its `lifecycle`
+-- says.
+--
+-- Nothing else changes about `terminated`, and that is why this is a column
+-- rather than a fourth lifecycle. An agent in the compost is unreachable,
+-- undiscoverable, out of the rail and out of every crew, exactly as a deleted
+-- one has always been: every query in the store that asks `lifecycle <>
+-- 'terminated'` is still asking the right question, including the partial
+-- index that frees the name. What the column adds is a way back, which nothing
+-- else was asking about.
+ALTER TABLE agents ADD COLUMN discarded_at INTEGER;
+"#,
+    ),
 ];
 
 /// The group every agent starts in, and the one the UI keeps out of the way

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -176,6 +176,7 @@ fn new_card(draft: &CleanDraft, rail_order: i32) -> AgentCard {
         version: 1,
         created_at: now,
         updated_at: now,
+        discarded_at: None,
     }
 }
 
@@ -391,11 +392,115 @@ impl Store {
         self.get_agent(id)?.ok_or(StoreError::AgentNotFound(id))
     }
 
+    /// Throws an agent out, keeping everything it holds.
+    ///
+    /// The row goes to `Terminated`, which is what makes it unreachable,
+    /// undiscoverable and absent from the rail, and is stamped, which is what
+    /// makes it findable again. Nothing private is touched here: that is the
+    /// half that waits, and [`Store::forget_discard`] is where it stops
+    /// waiting.
+    ///
+    /// Refused for an agent that is already gone. Re-stamping one would restart
+    /// a wait that is most of the way through, so a double click on a delete
+    /// button would quietly buy an agent another thirty days in a list the
+    /// operator thought they had emptied.
+    pub fn discard_agent(&self, id: AgentId, at: i64) -> Result<AgentCard, StoreError> {
+        let conn = self.conn()?;
+        let changed = conn.execute(
+            "UPDATE agents SET lifecycle='terminated', discarded_at=?2, updated_at=?2
+              WHERE id=?1 AND lifecycle <> 'terminated'",
+            params![id.to_string(), at],
+        )?;
+        if changed == 0 {
+            return Err(StoreError::AgentNotFound(id));
+        }
+        self.get_agent(id)?.ok_or(StoreError::AgentNotFound(id))
+    }
+
+    /// Pulls one back out, under whatever name is free.
+    ///
+    /// Paused rather than active, and the reason is the wait. An agent restored
+    /// three weeks after it was thrown out comes back to a schedule that has
+    /// been due every morning since, and to peers that have moved on without
+    /// it. Coming back stopped means the operator decides when it starts, on a
+    /// row that already says `paused` and already offers Resume.
+    ///
+    /// The name is settled by the caller, because a name freed while the agent
+    /// waited may have been taken by somebody hired since, and the partial
+    /// index is what would otherwise refuse the restore.
+    ///
+    /// Refused for a row that is not in the compost. That covers an agent
+    /// nobody deleted and one whose wait is over: the second has no memory, no
+    /// schedule and no machines left, so bringing it back would hand the
+    /// operator a name and a face wearing none of the work they wanted back.
+    pub fn restore_agent(&self, id: AgentId, name: &str) -> Result<AgentCard, StoreError> {
+        let conn = self.conn()?;
+        let changed = conn.execute(
+            "UPDATE agents SET lifecycle='paused', discarded_at=NULL, name=?2, updated_at=?3
+              WHERE id=?1 AND discarded_at IS NOT NULL",
+            params![id.to_string(), name, now_ms()],
+        )?;
+        if changed == 0 {
+            return Err(StoreError::AgentNotFound(id));
+        }
+        self.get_agent(id)?.ok_or(StoreError::AgentNotFound(id))
+    }
+
+    /// Ends the wait, leaving the agent terminated.
+    ///
+    /// Called once whatever the agent was holding has actually been destroyed,
+    /// so the row says what is true: terminated with no stamp is an agent whose
+    /// machines, memory, schedule and sign-ins are gone, which is every agent
+    /// deleted before the compost existed and every one whose thirty days have
+    /// run out.
+    pub fn forget_discard(&self, id: AgentId) -> Result<(), StoreError> {
+        let conn = self.conn()?;
+        conn.execute("UPDATE agents SET discarded_at=NULL WHERE id=?1", params![id.to_string()])?;
+        Ok(())
+    }
+
+    /// Whoever is in the compost, newest first.
+    ///
+    /// The order the panel draws them in: what you deleted a minute ago by
+    /// accident is what you came here for, and what has been in there for four
+    /// weeks is not.
+    pub fn discarded_agents(&self) -> Result<Vec<AgentCard>, StoreError> {
+        self.discards(None)
+    }
+
+    /// Whoever has been in there long enough. What the sweep acts on.
+    pub fn expired_discards(&self, cutoff: i64) -> Result<Vec<AgentCard>, StoreError> {
+        self.discards(Some(cutoff))
+    }
+
+    /// One query, because the sweep and the panel are the same read with and
+    /// without a deadline on it, and two would be two places for the compost to
+    /// mean something slightly different.
+    fn discards(&self, cutoff: Option<i64>) -> Result<Vec<AgentCard>, StoreError> {
+        let conn = self.conn()?;
+        let (clause, order) = match cutoff {
+            Some(_) => ("AND discarded_at <= ?1", "discarded_at"),
+            None => ("", "discarded_at DESC"),
+        };
+        let mut stmt = conn.prepare(&format!(
+            "SELECT {AGENT_COLUMNS} FROM agents
+               WHERE discarded_at IS NOT NULL {clause} ORDER BY {order}"
+        ))?;
+        let rows = match cutoff {
+            Some(at) => stmt.query_map(params![at], row_to_card)?,
+            None => stmt.query_map([], row_to_card)?,
+        };
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row??);
+        }
+        Ok(out)
+    }
+
     pub fn get_agent(&self, id: AgentId) -> Result<Option<AgentCard>, StoreError> {
         let conn = self.conn()?;
         conn.query_row(
-            "SELECT id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id,sandbox_id,sandbox_envd_token,sandbox_traffic_token,pinned,rail_order,browser_id,has_computer,has_browser,repository_id
-               FROM agents WHERE id=?1",
+            &format!("SELECT {AGENT_COLUMNS} FROM agents WHERE id=?1"),
             params![id.to_string()],
             row_to_card,
         )
@@ -410,10 +515,8 @@ impl Store {
     /// the sidebar itself.
     pub fn list_agents(&self) -> Result<Vec<AgentCard>, StoreError> {
         let conn = self.conn()?;
-        let mut stmt = conn.prepare(
-            "SELECT id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id,sandbox_id,sandbox_envd_token,sandbox_traffic_token,pinned,rail_order,browser_id,has_computer,has_browser,repository_id
-               FROM agents ORDER BY rowid",
-        )?;
+        let mut stmt =
+            conn.prepare(&format!("SELECT {AGENT_COLUMNS} FROM agents ORDER BY rowid"))?;
         let rows = stmt.query_map([], row_to_card)?;
         let mut out = Vec::new();
         for row in rows {
@@ -3121,10 +3224,10 @@ impl Store {
     /// exists, which is the failure the operator would then be shown.
     pub fn group_crew(&self, group: GroupId) -> Result<Vec<AgentCard>, StoreError> {
         let conn = self.conn()?;
-        let mut stmt = conn.prepare(
-            "SELECT id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id,sandbox_id,sandbox_envd_token,sandbox_traffic_token,pinned,rail_order,browser_id,has_computer,has_browser,repository_id
-               FROM agents WHERE group_id=?1 AND lifecycle <> 'terminated' ORDER BY rowid",
-        )?;
+        let mut stmt = conn.prepare(&format!(
+            "SELECT {AGENT_COLUMNS}
+               FROM agents WHERE group_id=?1 AND lifecycle <> 'terminated' ORDER BY rowid"
+        ))?;
         let rows = stmt.query_map(params![group.to_string()], row_to_card)?;
         let mut out = Vec::new();
         for row in rows {
@@ -3227,6 +3330,14 @@ fn participant_from_columns(kind: &str, agent: Option<String>) -> Result<Partici
 /// rather than being coerced into a rusqlite error with no context.
 type RowResult<T> = Result<Result<T, StoreError>, rusqlite::Error>;
 
+/// Every column [`row_to_card`] reads, in the order it reads them.
+///
+/// Spelled once because the reader is indexed by position: a column added to
+/// one of the five queries that share this mapper and not the others is four
+/// reads that silently take the wrong field, which is what a card carrying
+/// somebody else's sandbox token looks like on the way out.
+const AGENT_COLUMNS: &str = "id,name,avatar,color,model,system_prompt,skills,lifecycle,version,created_at,updated_at,group_id,sandbox_id,sandbox_envd_token,sandbox_traffic_token,pinned,rail_order,browser_id,has_computer,has_browser,repository_id,discarded_at";
+
 fn row_to_card(row: &Row<'_>) -> RowResult<AgentCard> {
     let id_raw: String = row.get(0)?;
     let skills_raw: String = row.get(6)?;
@@ -3273,6 +3384,7 @@ fn row_to_card(row: &Row<'_>) -> RowResult<AgentCard> {
             version: row.get(8)?,
             created_at: row.get(9)?,
             updated_at: row.get(10)?,
+            discarded_at: row.get(21)?,
         })
     })())
 }
@@ -3966,6 +4078,172 @@ mod tests {
         // And the value is still there, on the one path that is allowed to see it.
         let env = f.store.connector_env(agent.group_id).unwrap();
         assert_eq!(env.get("GITHUB_TOKEN").map(String::as_str), Some("ghp_hunter2"));
+    }
+
+    // ---- the compost -----------------------------------------------------
+
+    #[test]
+    fn a_discarded_agent_is_terminated_and_stamped() {
+        let f = fixture();
+        let agent = f.store.create_agent(&draft("Researcher")).unwrap();
+
+        let gone = f.store.discard_agent(agent.id, 1_000).unwrap();
+        assert_eq!(gone.lifecycle, Lifecycle::Terminated, "it has to be unreachable at once");
+        assert_eq!(gone.discarded_at, Some(1_000));
+        assert!(gone.discarded(), "and findable again, which is the whole of the compost");
+
+        // Every question the rest of the store asks about a deleted agent still
+        // gets the answer it has always got.
+        assert!(
+            f.store.group_crew(agent.group_id).unwrap().is_empty(),
+            "a composted agent must not be handed to a disband"
+        );
+    }
+
+    #[test]
+    fn a_discarded_agent_keeps_the_name_out_of_the_way() {
+        // The partial index covers live rows only, so throwing an agent out
+        // frees its name at once. That is what lets the crew hire a
+        // replacement, and it is why a restore has to settle the name again.
+        let f = fixture();
+        let agent = f.store.create_agent(&draft("Researcher")).unwrap();
+        f.store.discard_agent(agent.id, 1).unwrap();
+
+        let replacement = f.store.create_agent(&draft("Researcher")).unwrap();
+        assert_eq!(replacement.name, "Researcher");
+    }
+
+    #[test]
+    fn discarding_twice_does_not_buy_another_thirty_days() {
+        // A second click on a delete button, or a restore raced from another
+        // window. Re-stamping would restart a wait most of the way through, and
+        // the operator would find an agent they thought they had finished with
+        // back at the top of a list they had just emptied.
+        let f = fixture();
+        let agent = f.store.create_agent(&draft("Researcher")).unwrap();
+        f.store.discard_agent(agent.id, 1_000).unwrap();
+
+        let again = f.store.discard_agent(agent.id, 9_000);
+        assert!(matches!(again, Err(StoreError::AgentNotFound(_))), "got {again:?}");
+        assert_eq!(f.store.get_agent(agent.id).unwrap().unwrap().discarded_at, Some(1_000));
+    }
+
+    #[test]
+    fn a_restore_brings_an_agent_back_paused_and_unstamped() {
+        // Paused, not active: an agent restored three weeks on comes back to a
+        // schedule that has been coming due without it, and starting it is the
+        // operator's decision rather than a side effect of undoing a delete.
+        let f = fixture();
+        let agent = f.store.create_agent(&draft("Researcher")).unwrap();
+        f.store.discard_agent(agent.id, 1).unwrap();
+
+        let back = f.store.restore_agent(agent.id, "Researcher").unwrap();
+        assert_eq!(back.lifecycle, Lifecycle::Paused);
+        assert_eq!(back.discarded_at, None);
+        assert!(!back.discarded());
+        assert_eq!(
+            f.store.group_crew(agent.group_id).unwrap().len(),
+            1,
+            "and is in the crew again"
+        );
+    }
+
+    #[test]
+    fn a_restore_can_take_a_name_that_was_given_away() {
+        // The name was freed the moment the agent was thrown out, so the crew
+        // may be holding it. The caller settles it; what this asserts is that
+        // the store takes the settled one rather than refusing the restore.
+        let f = fixture();
+        let agent = f.store.create_agent(&draft("Researcher")).unwrap();
+        f.store.discard_agent(agent.id, 1).unwrap();
+        f.store.create_agent(&draft("Researcher")).unwrap();
+
+        let back = f.store.restore_agent(agent.id, "Researcher copy").unwrap();
+        assert_eq!(back.name, "Researcher copy");
+    }
+
+    #[test]
+    fn a_restore_is_refused_for_an_agent_whose_wait_is_over() {
+        // Two rows with no stamp on them: one nobody deleted, and one whose
+        // memory, schedule and machines are already gone. Neither has anything
+        // to bring back, so both are refused by the same clause.
+        let f = fixture();
+        let live = f.store.create_agent(&draft("Researcher")).unwrap();
+        let spent = f.store.create_agent(&draft("Scribe")).unwrap();
+        f.store.discard_agent(spent.id, 1).unwrap();
+        f.store.forget_discard(spent.id).unwrap();
+
+        for id in [live.id, spent.id] {
+            let refused = f.store.restore_agent(id, "Whoever");
+            assert!(matches!(refused, Err(StoreError::AgentNotFound(_))), "got {refused:?}");
+        }
+        assert_eq!(
+            f.store.get_agent(spent.id).unwrap().unwrap().lifecycle,
+            Lifecycle::Terminated,
+            "a refused restore must not move the row"
+        );
+    }
+
+    #[test]
+    fn the_compost_reads_newest_first_and_leaves_out_whoever_has_already_gone() {
+        let f = fixture();
+        let old = f.store.create_agent(&draft("Scribe")).unwrap();
+        let new = f.store.create_agent(&draft("Researcher")).unwrap();
+        let spent = f.store.create_agent(&draft("Ghost")).unwrap();
+        let live = f.store.create_agent(&draft("Manager")).unwrap();
+
+        f.store.discard_agent(old.id, 100).unwrap();
+        f.store.discard_agent(new.id, 900).unwrap();
+        f.store.discard_agent(spent.id, 50).unwrap();
+        f.store.forget_discard(spent.id).unwrap();
+
+        let names: Vec<String> =
+            f.store.discarded_agents().unwrap().into_iter().map(|c| c.name).collect();
+        assert_eq!(
+            names,
+            vec!["Researcher", "Scribe"],
+            "what was deleted a minute ago is what somebody came here for"
+        );
+        assert!(!names.contains(&live.name), "a live agent is not in the compost");
+    }
+
+    #[test]
+    fn only_agents_past_the_deadline_are_swept() {
+        let f = fixture();
+        let due = f.store.create_agent(&draft("Scribe")).unwrap();
+        let waiting = f.store.create_agent(&draft("Researcher")).unwrap();
+        f.store.discard_agent(due.id, 100).unwrap();
+        f.store.discard_agent(waiting.id, 900).unwrap();
+
+        let expired: Vec<String> =
+            f.store.expired_discards(500).unwrap().into_iter().map(|c| c.name).collect();
+        assert_eq!(expired, vec!["Scribe"]);
+
+        // The boundary is inclusive, or an agent stamped exactly on the cutoff
+        // waits another whole pass for no reason anybody could explain.
+        assert_eq!(f.store.expired_discards(900).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn a_discarded_agent_keeps_everything_a_restore_has_to_find() {
+        // The whole argument for the compost. Deleting used to take all of this
+        // on the click; now it is what waits, and a restore that came back with
+        // an agent that had forgotten its work would not be worth offering.
+        let f = fixture();
+        let agent = f.store.create_agent(&draft("Researcher")).unwrap();
+        f.store.append_working_note(agent.id, "waiting on the vendor", 5).unwrap();
+        f.store
+            .replace_signins(
+                agent.id,
+                Surface::Computer,
+                &[signin_at(agent.id, "Gmail", "mail.google.com", 1)],
+            )
+            .unwrap();
+
+        f.store.discard_agent(agent.id, 1).unwrap();
+
+        assert_eq!(f.store.working_notes(agent.id).unwrap().len(), 1);
+        assert_eq!(f.store.agent_signins(agent.id).unwrap().len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/domain/agent.rs
+++ b/src-tauri/src/domain/agent.rs
@@ -138,9 +138,36 @@ pub struct AgentCard {
     pub version: u32,
     pub created_at: i64,
     pub updated_at: i64,
+    /// When this agent was thrown out, while it can still be pulled back.
+    ///
+    /// Set only on a `Terminated` row, and only for as long as the wait lasts:
+    /// `None` is both an agent nobody has deleted and one whose thirty days
+    /// are up and whose machines, memory and schedule are already gone. The
+    /// lifecycle is what tells those two apart, which is why this is not a
+    /// state of its own. See [`COMPOST_DAYS`].
+    pub discarded_at: Option<i64>,
 }
 
+/// How long a deleted agent waits before it is gone for good.
+///
+/// Long enough that an operator who deleted the wrong row and did not notice
+/// until the next time they went looking still has it, and short enough that
+/// the compost is not a second roster nobody empties. The number is drawn in
+/// the panel, and `Compost.test.tsx` reads it out of this file rather than
+/// restating it, because a warning is read as a fact about what will happen.
+pub const COMPOST_DAYS: i64 = 30;
+
+/// The same wait, in the milliseconds every timestamp in this app is stamped
+/// with.
+pub const COMPOST_MS: i64 = COMPOST_DAYS * 24 * 60 * 60 * 1000;
+
 impl AgentCard {
+    /// Whether this agent is in the compost: deleted, and still able to come
+    /// back. Its machines, memory, schedule and sign-ins are all still there.
+    pub fn discarded(&self) -> bool {
+        self.discarded_at.is_some()
+    }
+
     /// The directory entry a peer sees. Deliberately excludes `system_prompt`:
     /// one agent should not be able to read another's instructions just by
     /// listing the directory.
@@ -482,6 +509,7 @@ mod tests {
             version: 1,
             created_at: 0,
             updated_at: 0,
+            discarded_at: None,
         };
         let json =
             serde_json::to_string(&card.directory_entry(vec!["Gmail as robert@x".into()])).unwrap();

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -324,7 +324,9 @@ enum Permission {
     Failed(String),
 }
 use crate::db::{Store, StoreError};
-use crate::domain::agent::{AgentCard, CleanDraft, DirectoryEntry, Lifecycle};
+use crate::domain::agent::{
+    copy_name, AgentCard, CleanDraft, DirectoryEntry, Lifecycle, COMPOST_MS,
+};
 use crate::domain::approval::{
     Approval, ApprovalState, Decision, DetailField, ProtectedAction, Request,
 };
@@ -447,6 +449,14 @@ const APPROVAL_WINDOW: Duration = Duration::from_secs(10 * 60);
 /// be rebuilt in memory at startup. The cost of the interval is lateness, and
 /// twenty seconds is under the resolution anything here can be scheduled at.
 const SCHEDULE_TICK: Duration = Duration::from_secs(20);
+
+/// How often the compost is checked for agents whose thirty days are up.
+///
+/// Hourly, because the deadline it enforces is measured in weeks. A sweep costs
+/// one indexless scan of a table with tens of rows in it, and a pass that finds
+/// something makes provider calls, so this is paced by what it is waiting for
+/// rather than by what it costs.
+const COMPOST_TICK: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Debug, thiserror::Error)]
 pub enum RuntimeError {
@@ -756,6 +766,223 @@ impl Runtime {
                 }
             }
         });
+    }
+
+    /// Throws an agent out, keeping everything it holds.
+    ///
+    /// What deleting an agent used to be is now two acts with thirty days
+    /// between them. This is the first: the row goes to `Terminated`, so the
+    /// agent is out of the rail, out of the directory and unreachable exactly
+    /// as a deleted one has always been, and its actor is dropped with whatever
+    /// was queued for it, because undelivered mail to a deleted mailbox has
+    /// nowhere to go. Its memory, its working notes, its schedule, its sign-ins
+    /// and every standing permission the operator gave it are untouched. See
+    /// [`Runtime::purge_agent`] for the half that waits.
+    ///
+    /// The machines are released rather than destroyed, which is the same
+    /// distinction *take it back* already draws. A sandbox is put to sleep and
+    /// keeps its disk, because that disk holds the accounts the operator signed
+    /// it in to and nothing else can sign them in again; a browser is closed,
+    /// which is what writes its cookies back to the profile. Both are what a
+    /// restore has to find.
+    ///
+    /// The row is stamped first. Nothing here is irreversible, so a provider
+    /// having a bad minute must not cost the operator the delete they asked
+    /// for, and a machine nobody reached sleeps on its own timeout anyway.
+    pub async fn discard_agent(&self, card: &AgentCard) -> Result<(), RuntimeError> {
+        let id = card.id;
+        self.inner.store.discard_agent(id, now_ms())?;
+        self.stop_agent(id);
+
+        if let Some(sandbox) = card.sandbox_id.as_ref() {
+            match crate::e2b::E2bClient::new(&self.config().e2b.api_key) {
+                Some(client) => {
+                    if let Err(err) = client.pause(sandbox).await {
+                        tracing::warn!(%err, %sandbox, "could not sleep a discarded agent's machine");
+                    }
+                }
+                None => tracing::warn!(%sandbox, "no key to sleep a discarded agent's machine"),
+            }
+        }
+
+        if let Some(browser) = card.browser_id.as_ref() {
+            match crate::kernel::KernelClient::new(&self.config().kernel.api_key) {
+                Some(client) => {
+                    if let Err(err) = client.delete(browser).await {
+                        tracing::warn!(%err, %browser, "could not close a discarded agent's browser");
+                    } else {
+                        // Recorded so nothing goes looking for a session that
+                        // has ended. The profile behind it stays: it is where
+                        // the cookies just went, and a restore opens onto it.
+                        let _ = self.inner.store.set_agent_browser(id, None);
+                    }
+                }
+                None => tracing::warn!(%browser, "no key to close a discarded agent's browser"),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Pulls one back out of the compost, stopped.
+    ///
+    /// Paused rather than active, because the wait is what makes it a different
+    /// question from unpausing: an agent restored after three weeks comes back
+    /// to a schedule that has been coming due every morning without it and to
+    /// peers that carried on. Starting it is one more click, on a row that is
+    /// already drawn as paused.
+    ///
+    /// The name is settled against whoever holds one now. A composted agent is
+    /// terminated, which is what frees its name for reuse, so the crew may have
+    /// hired somebody into it in the meantime and the restore would otherwise
+    /// die on a unique index. `copy_name` is the same rule a duplicate follows,
+    /// because one naming rule the operator can predict beats two.
+    pub fn restore_agent(&self, card: &AgentCard) -> Result<AgentCard, RuntimeError> {
+        let taken: Vec<String> = self
+            .inner
+            .store
+            .list_agents()?
+            .into_iter()
+            .filter(|c| c.group_id == card.group_id && c.lifecycle != Lifecycle::Terminated)
+            .map(|c| c.name)
+            .collect();
+        let free = !taken.iter().any(|held| held.trim().eq_ignore_ascii_case(card.name.trim()));
+        let name = if free { card.name.clone() } else { copy_name(&card.name, &taken) };
+
+        let restored = self.inner.store.restore_agent(card.id, &name)?;
+        self.start_agent(restored.id);
+        self.pause_agent(restored.id);
+        Ok(restored)
+    }
+
+    /// Everything one agent takes with it, in the order that leaves nothing
+    /// running and nothing billing.
+    ///
+    /// The other half of a delete, thirty days later, and what disbanding a
+    /// whole crew does immediately: those are the same act at different scales,
+    /// and a disband that only marked the rows would leave a group's worth of
+    /// sandboxes and browser profiles alive with nothing left on screen
+    /// pointing at them.
+    ///
+    /// A provider that refuses is logged and stepped over. The rows are the
+    /// record the operator sees, and stopping halfway through would leave an
+    /// agent still in the compost that has already lost its memory.
+    pub async fn purge_agent(&self, card: &AgentCard) -> Result<(), RuntimeError> {
+        let id = card.id;
+        // The machine goes first. A deleted agent cannot be asked to tidy up
+        // after itself, and a sandbox nobody holds a reference to keeps
+        // billing.
+        //
+        // A missing key means no machine was ever made through this build, so
+        // there is nothing to release.
+        if let (Some(sandbox), Some(client)) =
+            (card.sandbox_id.as_ref(), crate::e2b::E2bClient::new(&self.config().e2b.api_key))
+        {
+            if let Err(err) = client.kill(sandbox).await {
+                tracing::warn!(%err, %sandbox, "could not destroy the agent's computer");
+            }
+        }
+        // And its browser, which is a second provider with a second bill. The
+        // profile behind it goes too: it holds the cookies of accounts
+        // belonging to an agent that no longer exists, and a name is free to
+        // reuse the moment an agent is deleted, so whoever takes it next must
+        // not inherit its sessions.
+        if let Some(client) = crate::kernel::KernelClient::new(&self.config().kernel.api_key) {
+            if let Some(browser) = card.browser_id.as_ref() {
+                if let Err(err) = client.delete(browser).await {
+                    tracing::warn!(%err, %browser, "could not destroy the agent's browser");
+                }
+            }
+            // Attempted whether or not a browser was live, because the profile
+            // outlives every browser made against it and is the thing holding
+            // the cookies.
+            if let Err(err) = client.delete_profile(&id.to_string()).await {
+                tracing::warn!(%err, agent = %id, "could not destroy the agent's browser profile");
+            }
+        }
+
+        self.inner.store.set_lifecycle(id, Lifecycle::Terminated)?;
+        self.stop_agent(id);
+        // The transcript survives a deletion, but the agent's private memory is
+        // its own and goes with it.
+        self.inner.workspace.remove(id);
+        // Its schedule goes too, or it would keep coming due for an agent that
+        // can no longer act on it.
+        let _ = self.inner.store.delete_agent_routines(id);
+        // And what it was in the middle of, for the reason the memory above
+        // goes: it is the agent's own account of its work and belongs to
+        // nobody else. The row is only marked terminated rather than deleted,
+        // so the table's own cascade never fires and this is the whole cleanup.
+        let _ = self.inner.store.clear_working_notes(id);
+        // And what its browser was signed in to, which was cookies on the disk
+        // destroyed above. Left behind, the roster would keep telling the crew
+        // to ask this agent for an account nothing can reach any more.
+        let _ = self.inner.store.delete_agent_signins(id);
+        // Permission the operator gave this agent dies with it. A name is free
+        // to reuse the moment an agent is deleted, and whoever takes it next
+        // must not inherit a standing grant given to somebody else.
+        let _ = self.inner.store.delete_agent_approvals(id);
+        // And its place on any plugin the operator narrowed to named agents,
+        // for the same reason: a row naming an agent that no longer exists
+        // grants nothing and draws as nobody in the panel that lists them.
+        let _ = self.inner.store.delete_agent_plugin_access(id);
+        // And its reach into whatever the crew was working in. Same argument,
+        // and one more that only applies here: a repository is the operator's
+        // own source, so a retired agent must not leave one drawn as handed
+        // out.
+        let _ = self.inner.store.clear_agent_repository(id);
+        // Last, and only once the rest of it has actually gone: the stamp is
+        // what offers the operator a restore, and an agent still offered one
+        // after its memory has been deleted is an offer that cannot be kept.
+        let _ = self.inner.store.forget_discard(id);
+        Ok(())
+    }
+
+    /// Empties the compost of whatever has been in it long enough.
+    ///
+    /// Its own loop rather than a third statement in the scheduler's, because
+    /// the two are paced by different things. A routine is late by however long
+    /// the tick is, so that one is measured in seconds; a thirty-day deadline
+    /// is not made better by being met to the second, and this one makes
+    /// provider calls that a schedule sweep should never have to wait behind.
+    ///
+    /// Swept once before the first wait, so an app left closed for a month
+    /// empties on the next launch rather than an hour into it.
+    pub fn start_compost(&self) {
+        let runtime = self.clone();
+        self.inner.handle.spawn(async move {
+            loop {
+                runtime.sweep_compost().await;
+                tokio::time::sleep(COMPOST_TICK).await;
+            }
+        });
+    }
+
+    /// One pass: everything past its thirty days, gone for good.
+    ///
+    /// Split out of the loop for the reason [`Runtime::sweep_schedule`] is:
+    /// giving up on a pass must not also skip the wait.
+    pub async fn sweep_compost(&self) {
+        let cutoff = now_ms() - COMPOST_MS;
+        let expired = match self.inner.store.expired_discards(cutoff) {
+            Ok(expired) => expired,
+            Err(err) => {
+                tracing::warn!(%err, "could not read the compost; waiting for the next pass");
+                return;
+            }
+        };
+
+        for card in expired {
+            tracing::info!(
+                agent = %card.name,
+                "a discarded agent's thirty days are up; deleting it for good"
+            );
+            if let Err(err) = self.purge_agent(&card).await {
+                tracing::warn!(%err, agent = %card.name, "could not empty the compost of an agent");
+                continue;
+            }
+            self.emit(UiEvent::AgentsChanged);
+        }
     }
 
     /// Brings every non-terminated agent online. Called once at startup.
@@ -5390,14 +5617,21 @@ fn resolve_recipient<'a>(
 
 /// The sandboxes an agent could still be using.
 ///
-/// Only a live agent holds a claim. A deleted agent keeps its row so its
-/// transcript still reads, and that row keeps its sandbox id, but the agent can
-/// never act again. Counting it as a referrer let its machine shield itself
-/// from the sweep for as long as the row existed, which is forever.
+/// Only an agent that can still come back holds a claim. A deleted agent keeps
+/// its row so its transcript still reads, and that row keeps its sandbox id,
+/// but the agent can never act again. Counting it as a referrer let its machine
+/// shield itself from the sweep for as long as the row existed, which is
+/// forever.
+///
+/// An agent in the compost is the exception, and has to be. Its machine was put
+/// to sleep rather than destroyed, because the disk is where the operator's own
+/// sign-ins live and getting the agent back has to mean getting those back too.
+/// Swept, that machine would be killed within the minute and a restore three
+/// weeks later would hand back an agent signed in to nothing.
 fn claimed_sandboxes(cards: &[AgentCard]) -> std::collections::HashSet<String> {
     cards
         .iter()
-        .filter(|card| card.lifecycle != Lifecycle::Terminated)
+        .filter(|card| card.lifecycle != Lifecycle::Terminated || card.discarded())
         .filter_map(|card| card.sandbox_id.clone())
         .collect()
 }
@@ -5429,6 +5663,7 @@ mod tests {
             version: 1,
             created_at: 0,
             updated_at: 0,
+            discarded_at: None,
         }
     }
 

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -1086,6 +1086,7 @@ mod tests {
             version: 1,
             created_at: 0,
             updated_at: 0,
+            discarded_at: None,
         }
     }
 

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -18,7 +18,7 @@ use axum::Router;
 
 use guac_lib::config::{AppConfig, InferenceConfig};
 use guac_lib::db::Store;
-use guac_lib::domain::agent::Lifecycle;
+use guac_lib::domain::agent::{Lifecycle, COMPOST_MS};
 use guac_lib::domain::approval::{ApprovalState, Decision, ProtectedAction, Request};
 use guac_lib::domain::connector::CleanConnector;
 use guac_lib::domain::envelope::{Part, Participant, ToolOutcome};
@@ -3591,4 +3591,119 @@ async fn a_question_cannot_be_answered_with_a_verdict_and_a_permission_cannot_be
     h.runtime.answer_question(question, "Northwind").unwrap();
     h.runtime.stop_run(run);
     h.settle(run).await;
+}
+
+// ---- the compost ---------------------------------------------------------
+
+/// A crew whose model is never asked anything. The compost is entirely runtime
+/// machinery, so what the model would have said is beside the point.
+async fn quiet() -> Stub {
+    serve(|_| Script::Say("ok".into())).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_deleted_agent_keeps_its_memory_while_it_waits() {
+    // The whole argument for the compost. Deleting used to take the memory on
+    // the click, and a restore that came back with an agent that had forgotten
+    // its work would not be worth offering.
+    let stub = quiet().await;
+    let h = harness(&stub, &["Researcher"], GuardLimits::default());
+    let id = h.id("Researcher");
+    h.runtime.workspace().write(id, "Researcher", "The vendor answers on Tuesdays.").unwrap();
+
+    let card = h.runtime.store().get_agent(id).unwrap().unwrap();
+    h.runtime.discard_agent(&card).await.unwrap();
+
+    assert!(h.runtime.workspace().read(id).contains("Tuesdays"), "the memory has to wait with it");
+    assert!(h.runtime.store().get_agent(id).unwrap().unwrap().discarded());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_deleted_agent_cannot_be_messaged_and_comes_back_able_to_be() {
+    let stub = quiet().await;
+    let h = harness(&stub, &["Manager", "Researcher"], GuardLimits::default());
+    let id = h.id("Researcher");
+
+    let card = h.runtime.store().get_agent(id).unwrap().unwrap();
+    h.runtime.discard_agent(&card).await.unwrap();
+    assert!(
+        h.runtime.send_from_human(id, "still there?").is_err(),
+        "an agent in the compost is as unreachable as one that is gone"
+    );
+
+    let back = h.runtime.restore_agent(&card).unwrap();
+    assert_eq!(back.lifecycle, Lifecycle::Paused, "it comes back stopped, not working");
+    // Addressable again: paused queues rather than refuses, which is the
+    // difference between a restore and a resume.
+    let run = h.runtime.send_from_human(id, "welcome back").unwrap();
+    h.runtime.stop_run(run);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_restore_steps_around_a_name_the_crew_gave_away() {
+    // A composted agent frees its name at once, which is what lets the crew
+    // hire a replacement. Without settling it, the restore dies on the unique
+    // index and the operator is shown a database error for a button whose job
+    // is to succeed.
+    let stub = quiet().await;
+    let h = harness(&stub, &["Researcher"], GuardLimits::default());
+    let card = h.runtime.store().get_agent(h.id("Researcher")).unwrap().unwrap();
+
+    h.runtime.discard_agent(&card).await.unwrap();
+    h.runtime.store().create_agent(&draft("Researcher", &[])).unwrap();
+
+    let back = h.runtime.restore_agent(&card).unwrap();
+    assert_eq!(back.name, "Researcher copy");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn emptying_the_compost_takes_the_memory_and_leaves_the_transcript() {
+    let stub = quiet().await;
+    let h = harness(&stub, &["Researcher"], GuardLimits::default());
+    let id = h.id("Researcher");
+    h.runtime.workspace().write(id, "Researcher", "The vendor answers on Tuesdays.").unwrap();
+    let run = h.runtime.send_from_human(id, "hello").unwrap();
+    h.settle(run).await;
+
+    let card = h.runtime.store().get_agent(id).unwrap().unwrap();
+    h.runtime.discard_agent(&card).await.unwrap();
+    h.runtime.purge_agent(&card).await.unwrap();
+
+    assert!(h.runtime.workspace().read(id).is_empty(), "the memory goes with it");
+    assert!(
+        !h.runtime.store().get_agent(id).unwrap().unwrap().discarded(),
+        "and the offer of a restore goes with the memory, or it is an offer nothing can keep"
+    );
+    assert!(
+        !h.runtime.store().channel_messages(id, 50).unwrap().is_empty(),
+        "what it said stays readable: a delete must not punch holes in transcripts"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_sweep_takes_whoever_is_past_the_deadline_and_nobody_else() {
+    // The promise the panel draws a countdown against. Nothing else in the
+    // build empties the compost, so without this the feature is a list that
+    // grows forever and a memory that is never actually deleted.
+    let stub = quiet().await;
+    let h = harness(&stub, &["Researcher", "Scribe"], GuardLimits::default());
+    let (due, waiting) = (h.id("Researcher"), h.id("Scribe"));
+
+    for id in [due, waiting] {
+        h.runtime.workspace().write(id, "whoever", "something worth keeping").unwrap();
+    }
+    // Stamped through the store rather than through the runtime, because one of
+    // them has to be dated a month ago and that is the one thing a test cannot
+    // wait for. The stamp is all the sweep reads.
+    h.runtime.store().discard_agent(due, now_ms() - COMPOST_MS - 1).unwrap();
+    h.runtime.store().discard_agent(waiting, now_ms()).unwrap();
+
+    h.runtime.sweep_compost().await;
+
+    assert!(h.runtime.workspace().read(due).is_empty(), "its thirty days were up");
+    assert!(
+        h.runtime.workspace().read(waiting).contains("worth keeping"),
+        "and the other one has twenty-nine days left"
+    );
+    assert!(h.runtime.store().get_agent(waiting).unwrap().unwrap().discarded());
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -100,6 +100,7 @@ function agent(name: string, railOrder = 0): AgentCard {
     version: 1,
     createdAt: 1,
     updatedAt: 1,
+    discardedAt: null,
   };
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { AgentEditor } from "./components/AgentEditor";
 import { AgentMenu, type MenuTarget } from "./components/AgentMenu";
 import { Cafeteria } from "./components/Cafeteria";
 import { ChannelView } from "./components/ChannelView";
+import { Compost } from "./components/Compost";
 import { Desk } from "./components/Desk";
 import { GroupEditor } from "./components/GroupEditor";
 import { Inspector } from "./components/Inspector";
@@ -71,6 +72,7 @@ export default function App() {
   const [searching, setSearching] = useState(false);
   const [ready, setReady] = useState(false);
   const [showCafeteria, setShowCafeteria] = useState(false);
+  const [showCompost, setShowCompost] = useState(false);
 
   // The three shortcuts that work wherever the operator is, matched against
   // the same table the Shortcuts pane draws from, so a key listed there is a key
@@ -199,6 +201,7 @@ export default function App() {
       <Sidebar
         onEditAgent={(agent) => setEditing(agent)}
         onOpenCafeteria={() => setShowCafeteria(true)}
+        onOpenCompost={() => setShowCompost(true)}
         onEditGroup={(group) => setEditingGroup(group)}
         onOpenSettings={() => setShowSettings(true)}
         onOpenSearch={() => setSearching(true)}
@@ -305,6 +308,11 @@ export default function App() {
               await loadChannel(agent.id);
             })
           }
+          // Into the compost. The rail drops the row on the next roster read,
+          // and the pane is left where it was: what the agent said is still in
+          // every channel it said it in, and a view that emptied itself would
+          // read as the transcript having gone too.
+          onDelete={(agent) => void onAgent(() => api.deleteAgent(agent.id))}
         />
       )}
 
@@ -321,6 +329,7 @@ export default function App() {
         />
       )}
       {showCafeteria && <Cafeteria onClose={() => setShowCafeteria(false)} />}
+      {showCompost && <Compost onClose={() => setShowCompost(false)} />}
       {showSettings && (
         <SettingsDialog
           onClose={() => setShowSettings(null)}

--- a/src/components/ActivityFlow.test.tsx
+++ b/src/components/ActivityFlow.test.tsx
@@ -30,6 +30,7 @@ function card(id: string, name: string, color = "#c7d96b"): AgentCard {
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
   };
 }
 

--- a/src/components/AgentEditor.tsx
+++ b/src/components/AgentEditor.tsx
@@ -97,6 +97,13 @@ export function AgentEditor({ agent, onClose }: Props) {
     }
   };
 
+  /**
+   * Into the compost, where it waits thirty days.
+   *
+   * The same act the agent menu performs, worded the same way, because two
+   * surfaces that delete the same agent and describe it differently teach two
+   * different things about what a delete costs. See `lib/compost.ts`.
+   */
   const remove = async () => {
     if (!agent) return;
     setBusy(true);
@@ -288,7 +295,7 @@ export function AgentEditor({ agent, onClose }: Props) {
                   disabled={busy}
                   onClick={() => void remove()}
                 >
-                  Delete {agent.name}
+                  Delete {agent.name}, into the compost
                 </button>
                 <button
                   type="button"

--- a/src/components/AgentMenu.test.tsx
+++ b/src/components/AgentMenu.test.tsx
@@ -26,6 +26,7 @@ function card(over: Partial<AgentCard> = {}): AgentCard {
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
     ...over,
   };
 }
@@ -42,6 +43,7 @@ function open(agent: AgentCard, at = { x: 40, y: 40 }, groups: Group[] = []) {
     onTogglePause: vi.fn(),
     onDuplicate: vi.fn(),
     onClearHistory: vi.fn(),
+    onDelete: vi.fn(),
     onNudge: vi.fn(),
     onMoveToGroup: vi.fn(),
   };
@@ -60,6 +62,7 @@ describe("AgentMenu", () => {
       "Move down",
       "Duplicate",
       "Clear history…",
+      "Delete…",
     ]) {
       expect(screen.getByRole("button", { name })).toBeTruthy();
     }
@@ -145,6 +148,32 @@ describe("AgentMenu", () => {
     fireEvent.click(screen.getByRole("button", { name: "Delete history, keep memory" }));
     expect(handlers.onClearHistory).toHaveBeenCalledTimes(1);
     expect(handlers.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("asks twice before deleting an agent, and names it on the way", () => {
+    const handlers = open(card({ name: "Scribe" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete…" }));
+    expect(handlers.onDelete).not.toHaveBeenCalled();
+    expect(handlers.onClose).not.toHaveBeenCalled();
+
+    // The second wording says where it goes rather than that it is permanent,
+    // because it is not: this is the one destructive item in the menu that can
+    // be taken back, and an operator who thinks otherwise will not press it
+    // when they should.
+    fireEvent.click(screen.getByRole("button", { name: "Delete Scribe, into the compost" }));
+    expect(handlers.onDelete).toHaveBeenCalledTimes(1);
+    expect(handlers.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds one confirmation at a time", () => {
+    // Two items in this menu ask twice, and both used to read the same flag.
+    // Opening one of them armed the other, so an operator who went to clear a
+    // history found a delete button under their next click.
+    const handlers = open(card());
+    fireEvent.click(screen.getByRole("button", { name: "Clear history…" }));
+
+    expect(screen.getByRole("button", { name: "Delete…" })).toBeTruthy();
+    expect(handlers.onDelete).not.toHaveBeenCalled();
   });
 
   it("stays inside the window when opened near an edge", () => {

--- a/src/components/AgentMenu.tsx
+++ b/src/components/AgentMenu.tsx
@@ -19,6 +19,8 @@ interface Props {
   onTogglePause: (agent: AgentCard) => void;
   onDuplicate: (agent: AgentCard) => void;
   onClearHistory: (agent: AgentCard) => void;
+  /** Into the compost, where it waits thirty days. */
+  onDelete: (agent: AgentCard) => void;
   /** One row up or down: the drag, without a mouse. */
   onNudge: (agent: AgentCard, delta: -1 | 1) => void;
   onMoveToGroup: (agent: AgentCard, group: Group) => void;
@@ -53,6 +55,7 @@ export function AgentMenu({
   onTogglePause,
   onDuplicate,
   onClearHistory,
+  onDelete,
   onNudge,
   onMoveToGroup,
 }: Props) {
@@ -60,20 +63,25 @@ export function AgentMenu({
   const ref = useRef<HTMLDivElement>(null);
   const [at, setAt] = useState({ x: target.x, y: target.y, origin: "top left" });
   /**
-   * Clearing, asked twice, and the second wording says what survives.
+   * Which of the two destructive items is armed, and never both.
    *
+   * Each is asked twice, and each second wording says what actually happens.
    * In the menu rather than in the pane behind it: a confirmation drawn where
    * the click did not happen is a confirmation the operator has to go and find,
    * and this menu opens from two places that draw nothing in common.
    *
-   * It said "Delete this history", which is accurate and is not the question
-   * the operator is actually asking. An agent has two kinds of state and this
-   * touches one of them: the channel is what its turns read as conversation,
-   * and its memory is a separate file it wrote on purpose and would have to
-   * write again. Not saying so is why this went unused by an operator who
-   * needed it and would not risk finding out.
+   * Clearing said "Delete this history", which is accurate and is not the
+   * question the operator is actually asking. An agent has two kinds of state
+   * and this touches one of them: the channel is what its turns read as
+   * conversation, and its memory is a separate file it wrote on purpose and
+   * would have to write again. Not saying so is why this went unused by an
+   * operator who needed it and would not risk finding out.
+   *
+   * One value rather than a flag each, because two flags is a state where both
+   * are armed: opening one confirmation would leave a delete button under the
+   * next click of somebody who came here to clear a history.
    */
-  const [confirming, setConfirming] = useState(false);
+  const [confirming, setConfirming] = useState<"history" | "delete" | null>(null);
 
   // Measured after it is in the tree rather than guessed: the menu is opened
   // by a click that can land anywhere, and one hanging off the bottom of the
@@ -173,13 +181,27 @@ export function AgentMenu({
             </Fragment>
           ))}
         <hr className="menu__rule" />
-        {confirming ? (
+        {confirming === "history" ? (
           item("Delete history, keep memory", () => onClearHistory(agent), "danger")
         ) : (
-          // The only item that does not close the menu. Nothing has been
-          // decided yet, and the next click is the one that matters.
-          <button type="button" className="menu__item" onClick={() => setConfirming(true)}>
+          // The only kind of item that does not close the menu. Nothing has
+          // been decided yet, and the next click is the one that matters.
+          <button type="button" className="menu__item" onClick={() => setConfirming("history")}>
             Clear history…
+          </button>
+        )}
+        {/* Asked twice, and the second wording says where it goes rather than
+            that it is permanent, because it is not: this is the one destructive
+            item in the menu that can be taken back, and an operator who thinks
+            otherwise is one who will not press it when they should. What it
+            does not say is thirty days. The panel it lands in draws the clock,
+            and a number here would be a second place for that number to
+            drift. */}
+        {confirming === "delete" ? (
+          item(`Delete ${agent.name}, into the compost`, () => onDelete(agent), "danger")
+        ) : (
+          <button type="button" className="menu__item" onClick={() => setConfirming("delete")}>
+            Delete…
           </button>
         )}
       </div>

--- a/src/components/AgentRepositories.test.tsx
+++ b/src/components/AgentRepositories.test.tsx
@@ -37,6 +37,7 @@ const ADA: AgentCard = {
   version: 1,
   createdAt: 0,
   updatedAt: 0,
+  discardedAt: null,
 };
 
 function repository(over: Partial<Repository> = {}): Repository {

--- a/src/components/ApprovalRequest.test.tsx
+++ b/src/components/ApprovalRequest.test.tsx
@@ -36,6 +36,7 @@ const MANAGER: AgentCard = {
   version: 1,
   createdAt: 0,
   updatedAt: 0,
+  discardedAt: null,
 };
 
 const REQUEST: Extract<Part, { type: "approval" }> = {

--- a/src/components/BrowserScreen.test.tsx
+++ b/src/components/BrowserScreen.test.tsx
@@ -41,6 +41,7 @@ function card(id: string, name: string, given = true): AgentCard {
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
   };
 }
 

--- a/src/components/Cafeteria.test.tsx
+++ b/src/components/Cafeteria.test.tsx
@@ -60,6 +60,7 @@ function agent(name: string, groupId = KITCHEN): AgentCard {
     version: 1,
     createdAt: 1,
     updatedAt: 1,
+    discardedAt: null,
   };
 }
 

--- a/src/components/ChannelView.perf.test.tsx
+++ b/src/components/ChannelView.perf.test.tsx
@@ -69,6 +69,7 @@ function agent(id: string, name: string): AgentCard {
     railOrder: 0,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
     sandboxId: null,
     browserId: null,
     hasComputer: false,

--- a/src/components/ChannelView.test.tsx
+++ b/src/components/ChannelView.test.tsx
@@ -56,6 +56,7 @@ function card(id: string, name: string): AgentCard {
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
   };
 }
 

--- a/src/components/Composer.test.tsx
+++ b/src/components/Composer.test.tsx
@@ -60,6 +60,7 @@ function anAgent(name: string): AgentCard {
     railOrder: 0,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
     sandboxId: null,
     browserId: null,
     hasComputer: false,

--- a/src/components/Compost.test.tsx
+++ b/src/components/Compost.test.tsx
@@ -1,0 +1,177 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentCard } from "../lib/types";
+import { aGroup, DEFAULT_GROUP } from "../test-fixtures";
+
+/**
+ * The compost, over a mocked store.
+ *
+ * What is worth checking here is what a click actually sends, because the two
+ * buttons on a row do opposite things and one of them destroys a memory. The
+ * arithmetic behind the clock is `lib/compost`'s, and is tested there.
+ */
+
+const restoreAgent = vi.fn<(id: string) => Promise<AgentCard>>();
+const purgeAgent = vi.fn<(id: string) => Promise<void>>(async () => {});
+const select = vi.fn(async () => {});
+
+vi.mock("../lib/ipc", () => ({
+  api: {
+    restoreAgent: (id: string) => restoreAgent(id),
+    purgeAgent: (id: string) => purgeAgent(id),
+    listAgents: async () => [],
+    listGroups: async () => [],
+    listRepositories: async () => [],
+    channelMessages: async () => [],
+    conversationFlow: async () => [],
+  },
+}));
+
+const { Compost } = await import("./Compost");
+const { useStore } = await import("../lib/store");
+const { COMPOST_DAYS } = await import("../lib/compost");
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function agent(name: string, discardedAt: number | null): AgentCard {
+  return {
+    id: `id-${name}`,
+    groupId: DEFAULT_GROUP,
+    sandboxId: null,
+    browserId: null,
+    hasComputer: false,
+    hasBrowser: false,
+    repositoryId: null,
+    name,
+    avatar: "avocado",
+    color: "#c7d96b",
+    model: "",
+    systemPrompt: "",
+    skills: [],
+    lifecycle: discardedAt === null ? "active" : "terminated",
+    pinned: false,
+    railOrder: 0,
+    version: 1,
+    createdAt: 0,
+    updatedAt: 0,
+    discardedAt,
+  };
+}
+
+const onClose = vi.fn();
+
+function open(agents: AgentCard[]) {
+  useStore.setState({
+    agents,
+    groups: [aGroup({ name: "Kitchen" })],
+    activity: {},
+    lastActive: {},
+    selected: null,
+    select,
+  });
+  return render(<Compost onClose={onClose} />);
+}
+
+/** Deleted this many days ago. */
+const thrownOut = (name: string, daysAgo: number) => agent(name, Date.now() - daysAgo * DAY);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  restoreAgent.mockResolvedValue(agent("Scribe", null));
+});
+
+describe("the compost", () => {
+  it("lists whoever is in it, and nobody who is not", () => {
+    open([thrownOut("Scribe", 2), agent("Manager", null)]);
+
+    expect(screen.getByText("Scribe")).toBeTruthy();
+    expect(screen.queryByText("Manager")).toBeNull();
+  });
+
+  it("says what a restore would get back, once, at the top", () => {
+    // The one thing that is invisible everywhere else, on the one screen where
+    // somebody is deciding whether they meant it. Once rather than per row:
+    // the same sentence three times is wallpaper, and it would be read as
+    // three rows of gray beside the one number that differs.
+    const { container } = open([thrownOut("Scribe", 2), thrownOut("Paralegal", 4)]);
+
+    expect(
+      [...container.querySelectorAll(".dialog__lede")].filter((node) =>
+        /memory, their working notes, their schedule and their sign-ins/i.test(
+          node.textContent ?? "",
+        ),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("puts one back on a single click, and opens it", async () => {
+    restoreAgent.mockResolvedValue(agent("Scribe copy", null));
+    open([thrownOut("Scribe", 2)]);
+
+    fireEvent.click(screen.getByRole("button", { name: /put back/i }));
+
+    await waitFor(() => expect(restoreAgent).toHaveBeenCalledWith("id-Scribe"));
+    // Opened rather than only restored: the agent comes back paused and may
+    // come back renamed, so nothing about it would otherwise draw attention.
+    await waitFor(() => expect(select).toHaveBeenCalledWith("id-Scribe copy"));
+  });
+
+  it("asks twice before it deletes a memory, and the second wording says so", async () => {
+    open([thrownOut("Scribe", 2)]);
+
+    fireEvent.click(screen.getByRole("button", { name: /delete now/i }));
+    expect(purgeAgent).not.toHaveBeenCalled();
+
+    const confirm = screen.getByRole("button", { name: /delete the memory too/i });
+    fireEvent.click(confirm);
+    await waitFor(() => expect(purgeAgent).toHaveBeenCalledWith("id-Scribe"));
+  });
+
+  it("lets somebody out of the confirmation without deleting anything", () => {
+    open([thrownOut("Scribe", 2)]);
+
+    fireEvent.click(screen.getByRole("button", { name: /delete now/i }));
+    fireEvent.click(screen.getByRole("button", { name: /keep it/i }));
+
+    expect(purgeAgent).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: /put back/i })).toBeTruthy();
+  });
+
+  it("closes itself once there is nobody left in it", () => {
+    // Emptying it is the one reason to be here, and finishing is the answer.
+    // A panel that stays open drawing nothing is one the operator has to
+    // dismiss for no reason.
+    open([]);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("draws the wait the runtime actually enforces", () => {
+    // The one number in this file that is somebody else's. Read out of the
+    // Rust rather than trusted: this panel tells the operator when their
+    // agent's memory will be deleted, and nothing else in the build compares
+    // the two. Both sides compile, both sides pass, and the only symptom is a
+    // countdown that is not the one being counted down.
+    const rust = readFileSync(resolve(__dirname, "../../src-tauri/src/domain/agent.rs"), "utf8");
+    const declared = rust.match(/pub const COMPOST_DAYS: i64 = ([\d_]+)/);
+    expect(
+      declared,
+      "COMPOST_DAYS has been renamed or moved out of domain/agent.rs",
+    ).not.toBeNull();
+    expect(Number(declared![1]!.replaceAll("_", ""))).toBe(COMPOST_DAYS);
+  });
+
+  it("marks the last week and leaves the rest of the wait unmarked", () => {
+    const { container } = open([thrownOut("Going", COMPOST_DAYS - 2), thrownOut("Waiting", 1)]);
+
+    // Newest first, so the one with weeks to go is drawn above the one that is
+    // about to be swept. The mark is what says which is which.
+    const marked = [...container.querySelectorAll(".compost__clock")].map((node) =>
+      node.getAttribute("data-soon"),
+    );
+    expect(marked).toEqual([null, "true"]);
+  });
+});

--- a/src/components/Compost.tsx
+++ b/src/components/Compost.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { AgentAvatar } from "../avatars/AgentAvatar";
+import { COMPOST_DAYS, composted, goingSoon, timeLeft } from "../lib/compost";
+import { api } from "../lib/ipc";
+import { useStore } from "../lib/store";
+import { type AgentCard, type AgentId, errorMessage } from "../lib/types";
+
+interface Props {
+  onClose: () => void;
+}
+
+/**
+ * Where deleted agents go, and what it takes to get one back.
+ *
+ * The counterpart of the cafeteria, and drawn like one on purpose: the two
+ * surfaces are hiring and letting go, and an operator who has used one should
+ * recognize the other. Everything else about them is opposite. The cafeteria is
+ * a menu of agents nobody has met; this is a list of agents somebody worked
+ * with, each with a clock on it.
+ *
+ * What a delete actually costs is said once, in the head, and not on every row.
+ * It is the whole argument for the panel existing — a deleted agent used to
+ * lose its memory, its schedule, its sign-ins and its machine on the click, and
+ * none of that is visible at the moment of pressing delete — but it is the same
+ * sentence about every agent in the list, and the same sentence three times is
+ * wallpaper. Said once at the top it is read; repeated down the column it turns
+ * the clock, which is the one thing that differs per row, into more of the
+ * same gray text.
+ *
+ * Restoring is one click and deleting for good is two, which is the same
+ * asymmetry the agent menu draws. This is the only surface in the app that
+ * destroys a memory on a button, so the button says so before it does it.
+ */
+export function Compost({ onClose }: Props) {
+  const agents = useStore((s) => s.agents);
+  const groups = useStore((s) => s.groups);
+  const select = useStore((s) => s.select);
+  const refreshAgents = useStore((s) => s.refreshAgents);
+
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<AgentId | null>(null);
+  const [confirming, setConfirming] = useState<AgentId | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Read once, when the panel opens. A clock that ticks would redraw every row
+  // to move a number that changes once a day, and nothing here is worth
+  // watching happen: the sweep runs hourly and the panel is open for seconds.
+  const [now] = useState(() => Date.now());
+
+  useEffect(() => {
+    panelRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const rows = useMemo(() => composted(agents), [agents]);
+
+  // Closed when the last one is dealt with, rather than left drawing an empty
+  // panel the operator has to dismiss. Emptying the compost is the one reason
+  // to be here, and finishing it is the answer.
+  useEffect(() => {
+    if (rows.length === 0) onClose();
+  }, [rows.length, onClose]);
+
+  /**
+   * One row's button, whichever it was.
+   *
+   * The roster is re-read here rather than left to the runtime's own event,
+   * because both of these change which rows this panel draws and one of them
+   * closes it. Returns `null` when the call was refused, so a caller with
+   * something to do afterwards does not do it on a failure the operator is
+   * currently reading.
+   */
+  const act = async <T,>(agent: AgentCard, run: () => Promise<T>): Promise<T | null> => {
+    setBusy(agent.id);
+    setError(null);
+    try {
+      const done = await run();
+      await refreshAgents();
+      return done;
+    } catch (caught) {
+      setError(errorMessage(caught));
+      return null;
+    } finally {
+      setBusy(null);
+      setConfirming(null);
+    }
+  };
+
+  const restore = async (agent: AgentCard) => {
+    const back = await act(agent, () => api.restoreAgent(agent.id));
+    if (!back) return;
+    // Opening it is what makes the click look like it did something: the agent
+    // comes back paused, so nothing it does will draw attention to itself, and
+    // the name may have been settled on the way in.
+    await select(back.id);
+    onClose();
+  };
+
+  const row = (agent: AgentCard) => {
+    const crew = groups.find((group) => group.id === agent.groupId);
+    const soon = goingSoon(agent, now);
+    const working = busy === agent.id;
+
+    return (
+      <li key={agent.id} className="compost__row">
+        <span className="compost__face">
+          {/* Drawn as what it is: an agent that is not running. The same mark
+              the rail puts on a deleted row, so a face in here and a face in an
+              old transcript agree with each other. */}
+          <AgentAvatar
+            avatar={agent.avatar}
+            color={agent.color}
+            size="md"
+            seed={agent.id}
+            lifecycle="terminated"
+          />
+        </span>
+
+        <span className="compost__body">
+          <span className="compost__name">
+            {agent.name}
+            {crew && <span className="compost__crew">{crew.name}</span>}
+          </span>
+          <span className="compost__clock" data-soon={soon ? "true" : undefined}>
+            {timeLeft(agent, now)}
+          </span>
+        </span>
+
+        <span className="compost__actions">
+          {confirming === agent.id ? (
+            <>
+              <button
+                type="button"
+                className="btn btn--ghost"
+                disabled={working}
+                onClick={() => setConfirming(null)}
+              >
+                Keep it
+              </button>
+              <button
+                type="button"
+                className="btn btn--danger"
+                disabled={working}
+                onClick={() => void act(agent, () => api.purgeAgent(agent.id))}
+              >
+                {working ? "Deleting…" : "Delete the memory too"}
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                className="btn btn--ghost"
+                disabled={working}
+                onClick={() => setConfirming(agent.id)}
+              >
+                Delete now
+              </button>
+              <button
+                type="button"
+                className="btn btn--primary"
+                disabled={working}
+                onClick={() => void restore(agent)}
+              >
+                {working ? "Restoring…" : "Put back"}
+              </button>
+            </>
+          )}
+        </span>
+      </li>
+    );
+  };
+
+  return (
+    <div className="scrim">
+      <button type="button" className="scrim__close" aria-label="Close dialog" onClick={onClose} />
+      <div
+        className="dialog dialog--compost"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Compost"
+        tabIndex={-1}
+        ref={panelRef}
+      >
+        <div className="compost__head">
+          <h2 className="dialog__title">Compost</h2>
+          {/* The number comes from the constant the runtime enforces rather
+              than from this sentence, because this sentence is a promise about
+              when somebody's memory is deleted. */}
+          <p className="dialog__lede" style={{ margin: 0 }}>
+            Deleted agents wait {COMPOST_DAYS} days here, still holding everything they knew: their
+            memory, their working notes, their schedule and their sign-ins. Put one back and it
+            returns paused. Leave it and all of that goes with it.
+          </p>
+        </div>
+
+        <ul className="compost__list">{rows.map(row)}</ul>
+
+        {error && (
+          <div className="banner banner--error" style={{ margin: "0 1.35rem" }}>
+            <span>{error}</span>
+          </div>
+        )}
+
+        <div className="compost__foot">
+          <button type="button" className="btn" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ComputerScreen.test.tsx
+++ b/src/components/ComputerScreen.test.tsx
@@ -41,6 +41,7 @@ function card(id: string, name: string, given = true): AgentCard {
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
   };
 }
 

--- a/src/components/Desk.test.tsx
+++ b/src/components/Desk.test.tsx
@@ -42,6 +42,7 @@ function agent(name: string): AgentCard {
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
   };
 }
 

--- a/src/components/Inspector.test.tsx
+++ b/src/components/Inspector.test.tsx
@@ -46,6 +46,7 @@ function card(id: string, name: string): AgentCard {
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
   };
 }
 

--- a/src/components/MessageItem.test.tsx
+++ b/src/components/MessageItem.test.tsx
@@ -39,6 +39,7 @@ function card(id: string, name: string): AgentCard {
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
   };
 }
 

--- a/src/components/PluginList.test.tsx
+++ b/src/components/PluginList.test.tsx
@@ -159,6 +159,7 @@ function member(id: string, name: string): AgentCard {
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
   };
 }
 

--- a/src/components/QuestionRequest.test.tsx
+++ b/src/components/QuestionRequest.test.tsx
@@ -36,6 +36,7 @@ const ANALYST: AgentCard = {
   version: 1,
   createdAt: 0,
   updatedAt: 0,
+  discardedAt: null,
 };
 
 type QuestionPart = Extract<Part, { type: "question" }>;

--- a/src/components/RailRepositories.test.tsx
+++ b/src/components/RailRepositories.test.tsx
@@ -27,6 +27,7 @@ function member(id: string, name: string, repositoryId: string | null = null): A
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
   };
 }
 

--- a/src/components/RepositoryList.test.tsx
+++ b/src/components/RepositoryList.test.tsx
@@ -52,6 +52,7 @@ function member(id: string, name: string): AgentCard {
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
   };
 }
 

--- a/src/components/Search.test.tsx
+++ b/src/components/Search.test.tsx
@@ -55,6 +55,7 @@ function agent(name: string, extra: Partial<AgentCard> = {}): AgentCard {
     version: 1,
     createdAt: 1,
     updatedAt: 1,
+    discardedAt: null,
     ...extra,
   };
 }

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -51,6 +51,7 @@ function agent(name: string, over: Partial<AgentCard> = {}): AgentCard {
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
     ...over,
   };
 }
@@ -77,6 +78,7 @@ function draw(groups: Group[], agents: AgentCard[] = [], activity: Record<string
         onEditAgent={vi.fn()}
         onEditGroup={vi.fn()}
         onOpenCafeteria={vi.fn()}
+        onOpenCompost={vi.fn()}
         onOpenSettings={vi.fn()}
         onOpenSearch={vi.fn()}
         onNewAgent={onNewAgent}
@@ -576,6 +578,33 @@ describe("groups as places", () => {
     fireEvent.click(screen.getByLabelText("research, 1 agent"));
     await vi.waitFor(() => expect(useStore.getState().railGroup).toBe(RESEARCH));
     expect(useStore.getState().selected).toBe("Chief of research");
+  });
+
+  it("keeps the compost off the footer while it is empty", () => {
+    // What keeps the footer two rows for an operator who has never deleted
+    // anybody. Its counterpart below is how the compost is found by one who
+    // just has: the row turns up at the moment it has a reason to.
+    draw([group("everyone")], [agent("Manager")]);
+    expect(screen.queryByRole("button", { name: /compost/i })).toBeNull();
+  });
+
+  it("offers the compost, and its count, once somebody is in it", () => {
+    draw(
+      [group("everyone")],
+      [agent("Manager"), agent("Scribe", { lifecycle: "terminated", discardedAt: 1_000 })],
+    );
+
+    expect(screen.getByRole("button", { name: /compost/i }).textContent).toContain("1");
+    // And the agent is not in the rail itself, which is the whole point of
+    // having deleted it.
+    expect(screen.queryByText("Scribe")).toBeNull();
+  });
+
+  it("leaves an agent whose wait is already over out of the count", () => {
+    // Terminated with no stamp: deleted before the compost existed, or swept
+    // out of it. Counting one would offer a restore that cannot be kept.
+    draw([group("everyone")], [agent("Manager"), agent("Ghost", { lifecycle: "terminated" })]);
+    expect(screen.queryByRole("button", { name: /compost/i })).toBeNull();
   });
 
   it("moves an agent into the group whose circle it was dropped on", async () => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { AgentAvatar, type Look } from "../avatars/AgentAvatar";
 import { FLIGHT_MS, roleOf, usePulseChoreography } from "../lib/choreography";
+import { composted } from "../lib/compost";
 import { prefersReducedMotion } from "../lib/motion";
 import { type DropTarget, railOrder } from "../lib/rail";
 import { ACTIVITY_CHANNEL, useLiveAgents, useStore } from "../lib/store";
@@ -16,6 +17,7 @@ interface Props {
   onEditAgent: (agent: AgentCard) => void;
   onEditGroup: (group: Group) => void;
   onOpenCafeteria: () => void;
+  onOpenCompost: () => void;
   onOpenSettings: () => void;
   onOpenSearch: () => void;
   /** The plus beside the wordmark. App-level, not any one row's. */
@@ -55,6 +57,7 @@ export function Sidebar({
   onEditAgent,
   onEditGroup,
   onOpenCafeteria,
+  onOpenCompost,
   onOpenSettings,
   onOpenSearch,
   onNewAgent,
@@ -62,6 +65,10 @@ export function Sidebar({
   onOpenMenu,
 }: Props) {
   const agents = useLiveAgents();
+  // The whole roster, not the live half: what is in the compost is exactly what
+  // `useLiveAgents` filters out, and the footer row below is the only thing in
+  // the rail that asks about it.
+  const everyone = useStore((s) => s.agents);
   const groups = useStore((s) => s.groups);
   const repositories = useStore((s) => s.repositories);
   const building = useStore((s) => s.building);
@@ -415,6 +422,8 @@ export function Sidebar({
     </span>
   );
 
+  const inCompost = useMemo(() => composted(everyone), [everyone]);
+
   const held = drag ? agents.find((a) => a.id === drag.id) : undefined;
 
   return (
@@ -624,6 +633,22 @@ export function Sidebar({
             </span>
             Cafeteria
           </button>
+          {/* Drawn only while there is something in it, which is what keeps the
+              footer two rows for an operator who has never deleted anybody. It
+              is also how the compost is discovered: the row appears the moment
+              it has a reason to, which is the moment somebody has just deleted
+              an agent and might want it back. The count is on it because the
+              question this row answers from across the room is whether there is
+              anything in there at all. */}
+          {inCompost.length > 0 && (
+            <button type="button" className="btn btn--rail" onClick={onOpenCompost}>
+              <span aria-hidden="true" className="rail__hash">
+                ♻
+              </span>
+              Compost
+              <span className="rail__count">{inCompost.length}</span>
+            </button>
+          )}
           <button type="button" className="btn btn--rail" onClick={onOpenSettings}>
             <span aria-hidden="true" className="rail__hash">
               ⚙

--- a/src/components/SigninList.test.tsx
+++ b/src/components/SigninList.test.tsx
@@ -35,6 +35,7 @@ function card(over: Partial<AgentCard> = {}): AgentCard {
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
     ...over,
   };
 }

--- a/src/lib/compost.test.ts
+++ b/src/lib/compost.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { COMPOST_DAYS, composted, goingSoon, timeLeft } from "./compost";
+import type { AgentCard } from "./types";
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = 1_700_000_000_000;
+
+function agent(name: string, discardedAt: number | null): AgentCard {
+  return {
+    id: `id-${name}`,
+    groupId: "00000000-0000-4000-8000-000000000001",
+    sandboxId: null,
+    browserId: null,
+    hasComputer: false,
+    hasBrowser: false,
+    repositoryId: null,
+    name,
+    avatar: "avocado",
+    color: "#c7d96b",
+    model: "",
+    systemPrompt: "",
+    skills: [],
+    lifecycle: discardedAt === null ? "active" : "terminated",
+    pinned: false,
+    railOrder: 0,
+    version: 1,
+    createdAt: 0,
+    updatedAt: 0,
+    discardedAt,
+  };
+}
+
+/** Deleted this many days ago. */
+const thrownOut = (name: string, daysAgo: number) => agent(name, NOW - daysAgo * DAY);
+
+describe("who is in the compost", () => {
+  it("is whoever carries a stamp, and nobody else", () => {
+    const rows = composted([
+      agent("Manager", null),
+      thrownOut("Scribe", 1),
+      // Terminated with no stamp: deleted before the compost existed, or
+      // swept out of it. Its transcript still reads and its name is still
+      // drawn there, but there is nothing left to put back.
+      agent("Ghost", null),
+    ]);
+
+    expect(rows.map((row) => row.name)).toEqual(["Scribe"]);
+  });
+
+  it("is newest first, because that is what somebody came here for", () => {
+    const rows = composted([thrownOut("Old", 20), thrownOut("New", 1), thrownOut("Middle", 9)]);
+
+    expect(rows.map((row) => row.name)).toEqual(["New", "Middle", "Old"]);
+  });
+});
+
+describe("how long is left", () => {
+  it("counts down in days for most of the wait", () => {
+    expect(timeLeft(thrownOut("a", 0), NOW)).toBe(`${COMPOST_DAYS} days left`);
+    expect(timeLeft(thrownOut("a", 29), NOW)).toBe("1 day left");
+  });
+
+  it("drops to hours on the last day, which is when the unit starts to matter", () => {
+    // Rounded down on purpose. An agent with three hours left is not one that
+    // has a day, and telling somebody it does is the error that costs them the
+    // agent.
+    const threeHoursLeft = agent("a", NOW - COMPOST_DAYS * DAY + 3 * 60 * 60 * 1000);
+    expect(timeLeft(threeHoursLeft, NOW)).toBe("3 hours left");
+
+    const minutes = agent("a", NOW - COMPOST_DAYS * DAY + 90_000);
+    expect(timeLeft(minutes, NOW)).toBe("less than an hour left");
+  });
+
+  it("says the wait is over rather than counting backwards", () => {
+    // The sweep runs hourly, so a row can outlive its deadline by up to an
+    // hour. "-0 days left" for that hour reads as something broken.
+    expect(timeLeft(thrownOut("a", COMPOST_DAYS + 1), NOW)).toBe("going now");
+  });
+
+  it("says nothing at all about an agent that is not in there", () => {
+    expect(timeLeft(agent("Manager", null), NOW)).toBe("");
+  });
+});
+
+describe("what is about to go", () => {
+  it("is marked inside the last week and not before it", () => {
+    expect(goingSoon(thrownOut("a", COMPOST_DAYS - 6), NOW)).toBe(true);
+    expect(goingSoon(thrownOut("a", COMPOST_DAYS - 8), NOW)).toBe(false);
+  });
+
+  it("covers an agent already past its deadline", () => {
+    expect(goingSoon(thrownOut("a", COMPOST_DAYS + 1), NOW)).toBe(true);
+  });
+
+  it("is never true of an agent nobody deleted", () => {
+    expect(goingSoon(agent("Manager", null), NOW)).toBe(false);
+  });
+});

--- a/src/lib/compost.ts
+++ b/src/lib/compost.ts
@@ -1,0 +1,86 @@
+import type { AgentCard } from "./types";
+
+/**
+ * The compost: agents that were deleted and have not gone yet.
+ *
+ * Deleting an agent used to be one act, and it took the machines, the memory,
+ * the schedule, the sign-ins and every standing permission with it. All of that
+ * behind a menu item, on an agent that may have had six months of memory in it.
+ * So the destructive half waits: for thirty days the agent is out of the rail
+ * and unreachable, exactly as a deleted one has always been, and everything it
+ * held privately sits where it was.
+ *
+ * Nothing here decides anything. Which agents are in the compost, and for how
+ * long, is what the runtime wrote on the card; this is the two readings of it
+ * the panel and the rail need.
+ */
+
+/**
+ * How long an agent waits before it is gone for good.
+ *
+ * Pinned to the Rust constant by `Compost.test.tsx`, which reads both sources.
+ * The runtime is what actually deletes, and this number is drawn to the
+ * operator as a fact about when that happens: a mirror that has drifted is a
+ * promise the app does not keep. Same rule the memory cap follows.
+ */
+export const COMPOST_DAYS = 30;
+
+const DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Whoever is in the compost, newest first.
+ *
+ * The order matters more than it looks: what somebody deleted a minute ago by
+ * accident is what they came here for, and what has been in there for four
+ * weeks is not. Terminated agents with no stamp are not in this list and never
+ * come back into it — those are the ones whose wait is already over, and every
+ * transcript in the app still draws their names.
+ */
+export function composted(agents: AgentCard[]): AgentCard[] {
+  return agents
+    .filter((agent) => agent.discardedAt !== null && agent.discardedAt !== undefined)
+    .sort((a, b) => (b.discardedAt ?? 0) - (a.discardedAt ?? 0));
+}
+
+/**
+ * What is left of an agent's thirty days, in the coarsest unit still true.
+ *
+ * Days until the last one, then hours, because a deadline four weeks out and a
+ * deadline this afternoon are read differently and "1d" says both. Rounded
+ * down: an agent with a few hours left is on its last day, and telling somebody
+ * they have a day when they have three hours is the error that costs them the
+ * agent.
+ *
+ * Past the deadline it says the wait is over rather than counting negatives.
+ * The sweep runs hourly, so a row can outlive its deadline by up to an hour,
+ * and a panel drawing "-0d" for that hour reads as something broken.
+ */
+export function timeLeft(agent: AgentCard, now: number): string {
+  const at = agent.discardedAt;
+  if (at === null || at === undefined) return "";
+
+  const left = at + COMPOST_DAYS * DAY - now;
+  if (left <= 0) return "going now";
+
+  const days = Math.floor(left / DAY);
+  if (days >= 1) return `${days} ${days === 1 ? "day" : "days"} left`;
+
+  const hours = Math.floor(left / (60 * 60 * 1000));
+  if (hours >= 1) return `${hours} ${hours === 1 ? "hour" : "hours"} left`;
+  return "less than an hour left";
+}
+
+/**
+ * Whether an agent is close enough to going that the row should say so
+ * loudly.
+ *
+ * A week, because that is the horizon somebody who opens this panel once a
+ * fortnight can still act inside. Below it the row is marked; above it the
+ * count of days is all the warning that is warranted, and marking everything
+ * marks nothing.
+ */
+export function goingSoon(agent: AgentCard, now: number): boolean {
+  const at = agent.discardedAt;
+  if (at === null || at === undefined) return false;
+  return at + COMPOST_DAYS * DAY - now <= 7 * DAY;
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -353,7 +353,23 @@ export const api = {
 
   updateAgent: (id: AgentId, draft: AgentDraft) => invoke<AgentCard>("update_agent", { id, draft }),
 
+  /**
+   * Deletes an agent into the compost, where it waits thirty days.
+   *
+   * It is out of the rail and unreachable the moment this returns, exactly as a
+   * deleted agent has always been. What is different is that its memory, notes,
+   * schedule, sign-ins and machines are all still there until the wait is up.
+   */
   deleteAgent: (id: AgentId) => invoke<void>("delete_agent", { id }),
+
+  /**
+   * Pulls one back out, paused. The name may come back settled: a composted
+   * agent frees its name, so somebody hired since may be holding it.
+   */
+  restoreAgent: (id: AgentId) => invoke<AgentCard>("restore_agent", { id }),
+
+  /** Ends the wait now. Its memory, machines and schedule go for good. */
+  purgeAgent: (id: AgentId) => invoke<void>("purge_agent", { id }),
 
   /**
    * A second agent from the same card: the look, model, skills and

--- a/src/lib/rail.test.ts
+++ b/src/lib/rail.test.ts
@@ -24,6 +24,7 @@ function agent(name: string, over: Partial<AgentCard> = {}): AgentCard {
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
     ...over,
   };
 }

--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -28,6 +28,7 @@ function agent(name: string, extra: Partial<AgentCard> = {}): AgentCard {
     version: 1,
     createdAt: 1,
     updatedAt: 1,
+    discardedAt: null,
     ...extra,
   };
 }

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -63,6 +63,7 @@ const AGENTS: AgentCard[] = [
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
   },
   {
     id: "chef",
@@ -84,6 +85,7 @@ const AGENTS: AgentCard[] = [
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
   },
 ];
 

--- a/src/lib/transcript.test.ts
+++ b/src/lib/transcript.test.ts
@@ -24,6 +24,7 @@ function card(id: string, name: string): AgentCard {
     version: 1,
     createdAt: 0,
     updatedAt: 0,
+    discardedAt: null,
   };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -643,6 +643,14 @@ export interface AgentCard {
   version: number;
   createdAt: number;
   updatedAt: number;
+  /**
+   * When this agent was thrown out, while it can still be pulled back.
+   *
+   * Set only on a terminated row, and only while the wait lasts: `null` is both
+   * an agent nobody deleted and one whose thirty days are up and whose memory,
+   * machines and schedule are already gone. See `lib/compost.ts`.
+   */
+  discardedAt: number | null;
 }
 
 export interface AgentDraft {

--- a/src/styles.css
+++ b/src/styles.css
@@ -740,6 +740,17 @@ button {
    the rail is wide, so it took the group name's space on one line and a whole
    row of its own on two. It lives behind the gear, with the endpoint. */
 
+/* How many are in the compost, on the row that opens it. The one number in the
+   rail that is read from across the room, which is why it is beside the word
+   rather than only inside the panel. */
+.rail__count {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: var(--type-fine);
+  letter-spacing: var(--track-caps-wide);
+  color: var(--rail-muted);
+}
+
 .rail__gear {
   background: none;
   border: 0;
@@ -6102,6 +6113,120 @@ button {
 
 .cafeteria__spacer {
   margin-left: auto;
+}
+
+/* ==========================================================================
+   Compost
+
+   The cafeteria's shape, at the cafeteria's opposite end: a panel that owns its
+   height, a head and a foot pinned to it, one scrolling half. The two surfaces
+   are hiring and letting go, and somebody who has used one should recognize the
+   other on sight.
+
+   A list rather than a grid, and that is the difference that matters. The
+   cafeteria is a menu to browse, so its tiles are equals laid out in rows; this
+   is a queue of decisions, each with a clock on it, and a row that runs the
+   width of the panel is one that has room to say what is still inside the agent
+   before it asks whether to throw it away.
+   ========================================================================== */
+
+.dialog--compost:focus,
+.dialog--compost:focus-visible {
+  outline: none;
+}
+
+.dialog.dialog--compost {
+  width: min(38rem, 100%);
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 3rem);
+  padding: 0;
+}
+
+.compost__head {
+  padding: var(--space-7) var(--space-7) var(--space-6);
+  border-bottom: 1px solid var(--edge);
+  flex: none;
+}
+
+.compost__list {
+  overflow-y: auto;
+  flex: 1;
+  list-style: none;
+  margin: 0;
+  padding: var(--space-4) var(--space-7);
+}
+
+.compost__row {
+  display: grid;
+  grid-template-columns: 2.6rem 1fr auto;
+  align-items: center;
+  gap: var(--space-5);
+  padding: var(--space-5) 0;
+  border-bottom: 1px solid var(--edge);
+}
+
+.compost__row:last-child {
+  border-bottom: 0;
+}
+
+.compost__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.compost__name {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-4);
+  font-family: var(--font-display);
+  font-size: var(--type-ui);
+  font-weight: 600;
+  letter-spacing: var(--track-tight);
+  line-height: var(--lead-tight);
+  color: var(--ink);
+}
+
+.compost__crew {
+  font-family: var(--font-mono);
+  font-size: var(--type-mark);
+  font-weight: 400;
+  letter-spacing: var(--track-caps);
+  text-transform: uppercase;
+  color: var(--faint);
+}
+
+.compost__clock {
+  font-family: var(--font-mono);
+  font-size: var(--type-fine);
+  letter-spacing: var(--track-caps);
+  text-transform: uppercase;
+  color: var(--faint);
+}
+
+/* The last week, said in the one color this app uses for something about to go
+   wrong. Above a week the count of days is warning enough, and marking every
+   row marks none of them. */
+.compost__clock[data-soon="true"] {
+  color: var(--alarm);
+}
+
+.compost__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex: none;
+}
+
+.compost__foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-4);
+  padding: var(--space-6) var(--space-7);
+  border-top: 1px solid var(--edge);
+  flex: none;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
Deleting an agent used to be one irreversible act: the sandbox killed, the browser and its cookie profile destroyed, the memory it had spent months writing removed, and its schedule, working notes, sign-ins and standing permissions deleted, all behind one button with no way back. Now the destructive half waits thirty days in the compost, reached by right-clicking a row in the rail or from the agent editor, and emptied by an hourly sweep or by a second click in the panel.

It is a column and not a fourth lifecycle: a composted agent is `Terminated` with `discarded_at` set, so the fifteen queries asking `lifecycle <> 'terminated'` are all still right, including the partial index that frees the name. The machines are released rather than destroyed, since a sandbox's disk holds the accounts the operator signed it in to and closing a browser is what writes its cookies to the profile, which is also why `claimed_sandboxes` now counts a composted agent as holding its machine. A restore comes back paused, because thirty days of schedule have come due without it, and settles its name against a crew that may have hired into it.

Migration 41, `docs/WORKSPACE.md` for the reasoning, and 33 new tests including five in `cascade.rs` driving the real runtime and one pinning the panel's countdown to `COMPOST_DAYS` in the Rust.