### PR TITLE
fix: a Save is drawn while something is waiting for it, and not otherwise

### DIFF
--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -805,6 +805,19 @@ would be a permission the operator believes they granted. The reasoning is in
 a plugin is currently offered to, including the honest one for a plugin
 narrowed to nobody, which is otherwise indistinguishable from a working row.
 
+The foot follows from that. A Save under a panel that has already written what it
+was told is a button offering to save work that is saved, beside a Cancel
+implying it could be taken back, and both sit there at the moment the operator is
+deciding whether the plugin they just connected went through. So the Save is
+drawn while something is genuinely waiting for it — a name, a provider, a limit,
+a key that was typed — and the button next to it says Close rather than Cancel
+when there is nothing to cancel. It is read across the whole dialog rather than
+the open section, for the reason the state lives in the shell: an endpoint typed
+on Provider is still unsaved while the operator is on Plugins, and a Save that
+went missing on the way past is how it would get lost. A group that does not
+exist yet is always waiting, because there is nothing to compare it with and
+Create is the only way out that leaves one behind.
+
 Three rows say who pays, and the first is "follow the app settings", which is
 where every group starts. The second is the ChatGPT subscription, and the group
 editor cannot sign in: there is one sign-in on this machine, it is performed in
@@ -1048,11 +1061,36 @@ to live somewhere else or not exist. `docs/ACCOUNT.md` is the long version.
 Every value lives in the shell rather than in the pane that draws it, and that is
 not tidiness. The shell is unmounted when the dialog closes, so a pane holding
 its own state would discard it on every section change: typing an endpoint,
-glancing at Limits and coming back would silently lose the endpoint. Save and
-Test stay in the foot for the same reason they used to be at the bottom of the
-one column — they act on the whole panel, not on the section that happens to be
-open — and Save still does not close, because the point of Test is to press it
-next.
+glancing at Limits and coming back would silently lose the endpoint. Save stays
+in the foot for the same reason it used to be at the bottom of the one column —
+it acts on the whole panel, not on the section that happens to be open — and it
+still does not close, because the point of Test is to press it next. Test is not
+beside it: it reads the endpoint, the key and the model, acts on none of the
+other eight sections, and sits in the pane those three are in.
+
+What the foot does not do is offer a Save when nothing is waiting for one. Five
+of the nine panes stage nothing at all: Appearance and Notifications are kept the
+moment they are clicked, Account acts at once, and Shortcuts and About are only
+there to be read. A Save pinned there regardless spent most of its life under a
+pane it could not affect, saying "not saved yet" over settings that were already
+on disk. So it is drawn while the panel differs from what is stored, and the
+whole panel is what is compared: an endpoint typed on Provider keeps the Save
+reachable from Shortcuts, which is what stops the rule from turning "there is
+nothing to save here" into a way to lose an edit.
+
+A key is the one field that cannot take part in that comparison, because a stored
+one is never read back. So a key box counts as an edit whenever it holds
+anything, spaces excepted, which is the same rule that keeps it out of the patch.
+
+Which is why a save puts every box that stages something back to blank. Blank is
+their resting state: each one means "keep what is stored" and each has a
+placeholder saying what that is, read from what the save returned. A key left on
+screen afterward is indistinguishable from an edit nobody saved, which is how the
+E2B key kept the Save up offering to send itself again. The three durations are
+worse than that, because the runtime clamps them: a box still reading 2000 sits
+under "Saved." claiming a machine sleeps after thirty-three hours when what was
+stored was twenty-four. It is the same read-back the limits have always had,
+finally applied to the fields beside them.
 
 Two things open onto a named section rather than onto the top. The banner that
 says there is no API key opens Provider, because landing on General with the key

--- a/src/components/GroupEditor.test.tsx
+++ b/src/components/GroupEditor.test.tsx
@@ -140,6 +140,10 @@ beforeEach(() => {
 describe("what a group sends", () => {
   it("says inherit as null rather than as an empty string", async () => {
     open();
+    // One field is touched because the Save is only drawn while something is
+    // waiting for it. Everything else opens inheriting and is left that way,
+    // which is the state this is about.
+    type(/Name/, "Kitchenette");
     const draft = await save();
 
     expect(draft.inference).toEqual({
@@ -163,6 +167,8 @@ describe("what a group sends", () => {
     // never touched must not mention it at all: the field shows a hint, and a
     // hint written back is not a key.
     open(aGroup({ id: KITCHEN, name: "Kitchen", apiKeySet: true, apiKeyHint: "...9999" }));
+    // Renaming a crew is the everyday save that must not take the key with it.
+    type(/Name/, "Kitchenette");
     expect("apiKey" in (await save())).toBe(false);
   });
 
@@ -324,6 +330,52 @@ describe("what the operator is shown", () => {
   it("refuses to save a group with no name", () => {
     open(null);
     expect(button("Create").disabled).toBe(true);
+  });
+});
+
+describe("the Save in the foot", () => {
+  const saveButton = () => screen.queryByRole("button", { name: "Save" });
+
+  it("is not there until something is waiting for it", () => {
+    open();
+    expect(saveButton()).toBeNull();
+    type(/Name/, "Kitchenette");
+    expect(saveButton()).toBeTruthy();
+  });
+
+  it("says Close rather than Cancel while there is nothing to cancel", () => {
+    open();
+    expect(button("Close")).toBeTruthy();
+    type(/Name/, "Kitchenette");
+    expect(button("Cancel")).toBeTruthy();
+  });
+
+  it("offers nothing on the panes that save as the operator goes", async () => {
+    // A plugin is signed in and a repository is linked at the moment it is
+    // done. A Save under either offered to save work that was already saved,
+    // beside a Cancel implying it could be taken back.
+    open();
+    pane("Repositories");
+    expect(await screen.findByText("Link a repository")).toBeTruthy();
+    expect(saveButton()).toBeNull();
+  });
+
+  it("is still reachable from a pane that stages nothing", async () => {
+    // Every pane's state is held by the shell, so a rename is still unsaved
+    // from Repositories. A Save that went missing on the way past is how it
+    // would get lost.
+    open();
+    type(/Name/, "Kitchenette");
+    pane("Repositories");
+    expect(await screen.findByText("Link a repository")).toBeTruthy();
+    expect(saveButton()).toBeTruthy();
+  });
+
+  it("is always there for a group that does not exist yet", () => {
+    // Nothing to compare a new group with, and Create is the only way out of
+    // the dialog that leaves one behind.
+    open(null);
+    expect(button("Create")).toBeTruthy();
   });
 });
 

--- a/src/components/GroupEditor.tsx
+++ b/src/components/GroupEditor.tsx
@@ -151,6 +151,34 @@ export function GroupEditor({ group, onClose }: Props) {
     },
   });
 
+  /**
+   * Whether anything here is waiting to be saved.
+   *
+   * Read across every pane, because the shell holds all of their state: an
+   * endpoint typed on Provider and left there while the operator signs a plugin
+   * in is still unsaved, and a Save that went missing on the way past is how it
+   * would get lost.
+   *
+   * What it buys is a foot that offers nothing on the two panes that stage
+   * nothing. A plugin is signed in and a repository is linked at the moment the
+   * operator does it, so a Save under either was a button offering to save work
+   * that had already been saved, beside a Cancel implying it could be taken
+   * back. A group that does not exist yet is always waiting: there is nothing
+   * to compare it with, and Create is the only way out that leaves one behind.
+   */
+  const dirty =
+    !group ||
+    name !== group.name ||
+    provider !== (group.inference.provider ?? INHERIT) ||
+    baseUrl !== (group.inference.baseUrl ?? "") ||
+    model !== (group.inference.defaultModel ?? "") ||
+    subscriptionModel !== (group.inference.subscriptionModel ?? "") ||
+    timeout !== asText(group.inference.requestTimeoutSecs) ||
+    // Typed at all, including typed and then emptied, which is the one
+    // instruction that puts a group back on the app's key.
+    apiKey !== null ||
+    LIMITS.some((field) => limits[field.key] !== asText(group.limits[field.key]));
+
   /** Live agents. Terminated ones are not in the count and are not deleted twice. */
   const crew = group?.agentCount ?? 0;
 
@@ -709,17 +737,23 @@ export function GroupEditor({ group, onClose }: Props) {
               </button>
             ))}
           <span style={{ flex: 1 }} />
+          {/* Cancel only while there is something to cancel. With nothing
+              staged this button closes a dialog, and saying otherwise invites
+              the operator to think the plugin they just signed in goes with
+              it. */}
           <button type="button" className="btn" onClick={onClose}>
-            Cancel
+            {dirty ? "Cancel" : "Close"}
           </button>
-          <button
-            type="button"
-            className="btn btn--primary"
-            disabled={busy || !name.trim()}
-            onClick={() => void save()}
-          >
-            {group ? "Save" : "Create"}
-          </button>
+          {dirty && (
+            <button
+              type="button"
+              className="btn btn--primary"
+              disabled={busy || !name.trim()}
+              onClick={() => void save()}
+            >
+              {group ? "Save" : "Create"}
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -296,8 +296,11 @@ describe("when the runtime refuses", () => {
           settle = resolve;
         }),
     );
-    // On Provider so both of the buttons a press could double up are on screen.
+    // On Provider so both of the buttons a press could double up are on screen,
+    // and with the endpoint typed into because the Save is only drawn while
+    // something is waiting for it.
     open(stored(), DEFAULT_PREFS, "provider");
+    type(/^Inference endpoint/, "http://localhost:1234/v1");
     fireEvent.click(save());
 
     // Two config writes racing each other is the failure this prevents, and the
@@ -315,6 +318,10 @@ describe("when the runtime refuses", () => {
 describe("what a save sends", () => {
   it("leaves a blank key, timer and timeout out of the patch entirely", async () => {
     open();
+    // The name is touched and nothing else is, because the Save is only drawn
+    // while something is waiting for it. Every box below opens blank and is
+    // left blank, which is the state this is about.
+    type(/^Your name/, "Robert W");
     fireEvent.click(save());
 
     await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
@@ -328,7 +335,7 @@ describe("what a save sends", () => {
     expect("browserIdleMinutes" in patch).toBe(false);
     expect("requestTimeoutSecs" in patch).toBe(false);
     expect(patch).toEqual({
-      operatorName: "Robert",
+      operatorName: "Robert W",
       // Both models go every time, and so does the provider. Each model belongs
       // to one provider, so sending only the active one would leave the other
       // to be overwritten by whatever the next save happened to be looking at.
@@ -350,6 +357,10 @@ describe("what a save sends", () => {
     pane("Machines");
     type(/^E2B API key/, " ");
     type(/^Kernel API key/, "   ");
+    // Spaces are not an edit either, by the same rule that keeps them out of
+    // the patch, so the Save is reached through a field that is one.
+    pane("General");
+    type(/^Your name/, "Robert W");
     fireEvent.click(save());
 
     await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
@@ -475,35 +486,116 @@ describe("what a save sends", () => {
     expect(sentPatch().browserIdleMinutes).toBe(5);
   });
 
-  it("clears the API key box afterward and leaves every other box alone", async () => {
+  it("puts every staged box back to blank, saying what was actually stored", async () => {
     open();
     pane("Provider");
     type(/^API key/, "sk-or-v1-typed");
     type(/^Give up on a call after/, "30");
     pane("Machines");
     type(/^E2B API key/, "e2b_typed");
-    type(/^Sleep computers after/, "45");
+    // Past the ceiling the runtime clamps to, which is the case a box left
+    // reading what was typed gets wrong.
+    type(/^Sleep computers after/, "2000");
 
-    updateSettings.mockResolvedValue(stored({ apiKeySet: true, apiKeyHint: "…yped" }));
+    updateSettings.mockResolvedValue(
+      stored({ apiKeySet: true, apiKeyHint: "…yped", computerIdleMinutes: 1440 }),
+    );
     fireEvent.click(save());
     await waitFor(() => expect(screen.getByText("Saved.")).toBeTruthy());
 
-    // The asymmetry is asserted as it stands: one secret is dropped from the
-    // webview and the other is left on screen.
-    expect(field(/^E2B API key/).value).toBe("e2b_typed");
-    expect(field(/^Sleep computers after/).value).toBe("45");
+    // Blank is the resting state of every box that stages something, and the
+    // placeholder beside each one is read from what came back. Left as it was
+    // typed, a key is indistinguishable from an edit nobody saved and a
+    // duration is a number under "Saved." that the runtime did not store.
+    expect(field(/^E2B API key/).value).toBe("");
+    expect(field(/^Sleep computers after/).value).toBe("");
+    expect(field(/^Sleep computers after/).placeholder).toBe("1440 minutes");
     pane("Provider");
     expect(field(/^API key/).value).toBe("");
-    expect(field(/^Give up on a call after/).value).toBe("30");
+    expect(field(/^API key/).placeholder).toBe("Stored …yped");
+    expect(field(/^Give up on a call after/).value).toBe("");
   });
 
   it("stays open on a save, because saving is not finishing", async () => {
     open();
+    type(/^Your name/, "Robert W");
     fireEvent.click(save());
     await waitFor(() => expect(screen.getByText("Saved.")).toBeTruthy());
     expect(banner().className).toContain("banner--ok");
     expect(onClose).not.toHaveBeenCalled();
     expect(useStore.getState().settings?.operatorName).toBe("Robert");
+  });
+});
+
+describe("the Save in the foot", () => {
+  const saveButton = () => screen.queryByRole("button", { name: "Save" });
+
+  it("is not there until something is waiting for it", () => {
+    open();
+    expect(saveButton()).toBeNull();
+    type(/^Your name/, "Robert W");
+    expect(saveButton()).toBeTruthy();
+  });
+
+  it("offers nothing on the panes that write as they are clicked", () => {
+    // Appearance and Notifications are kept the moment they are pressed, and a
+    // Save under them said the opposite about settings that were already saved.
+    open(stored(), DEFAULT_PREFS, "appearance");
+    fireEvent.click(screen.getByRole("button", { name: "Reading surface: Ink" }));
+    expect(saveButton()).toBeNull();
+
+    pane("Notifications");
+    fireEvent.click(switchOn("Notify me at all"));
+    expect(saveButton()).toBeNull();
+  });
+
+  it("offers nothing on the panes there is nothing to save on", () => {
+    open(stored(), DEFAULT_PREFS, "shortcuts");
+    expect(saveButton()).toBeNull();
+    pane("About");
+    expect(saveButton()).toBeNull();
+  });
+
+  it("is still reachable from a pane that stages nothing", () => {
+    // Every pane's state is held by the shell, so an endpoint typed on Provider
+    // is still unsaved from Shortcuts. A Save that went missing on the way past
+    // is how it would get lost.
+    open();
+    pane("Provider");
+    type(/^Inference endpoint/, "http://localhost:1234/v1");
+    pane("Shortcuts");
+    expect(saveButton()).toBeTruthy();
+  });
+
+  it("goes once what was typed has been saved", async () => {
+    open();
+    type(/^Your name/, "Robert W");
+    updateSettings.mockResolvedValue(stored({ operatorName: "Robert W" }));
+
+    fireEvent.click(save());
+    await waitFor(() => expect(screen.getByText("Saved.")).toBeTruthy());
+    expect(saveButton()).toBeNull();
+  });
+
+  it("stays after a refusal, because the edit is still unsaved", async () => {
+    updateSettings.mockRejectedValue({ kind: "config", message: "config.json is read-only" });
+    open();
+    type(/^Your name/, "Robert W");
+
+    fireEvent.click(save());
+    await waitFor(() => expect(screen.getByText(/config\.json is read-only/i)).toBeTruthy());
+    expect(saveButton()).toBeTruthy();
+  });
+
+  it("does not count a duration retyped as what is already stored", () => {
+    // The box is blank while it inherits and the placeholder says what that is,
+    // so typing the number back in changes nothing and offers nothing.
+    open();
+    pane("Machines");
+    type(/^Sleep computers after/, "15");
+    expect(saveButton()).toBeNull();
+    type(/^Sleep computers after/, "45");
+    expect(saveButton()).toBeTruthy();
   });
 });
 
@@ -808,10 +900,24 @@ describe("the ChatGPT subscription", () => {
     expect(row().textContent).toContain("robert@example.com");
     expect(row().textContent).toContain("Pro");
 
-    // And the save that follows carries it.
+    // And the save that follows carries it, which is what the message says.
+    expect(banner().textContent).toContain("Save to start using it");
     fireEvent.click(save());
     await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
     expect(sentPatch().provider).toBe("chatgpt");
+  });
+
+  it("does not send an operator to a Save that is not there", async () => {
+    // A sign-in that stopped working leaves the provider where it was, so
+    // signing back in changes nothing: there is no Save, and a message naming
+    // one sends the operator looking for a button that is not on screen.
+    open(stored({ provider: "chatgpt" }));
+    pane("Provider");
+    fireEvent.click(button("Sign in"));
+
+    await waitFor(() => expect(screen.getByText(/Signed in as robert@example\.com/)).toBeTruthy());
+    expect(banner().textContent).not.toContain("Save to start using it");
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
   });
 
   it("says so when the plan signed in to cannot run Codex", async () => {
@@ -878,6 +984,10 @@ describe("the ChatGPT subscription", () => {
     open(stored({ provider: "chatgpt" }));
     pane("Provider");
     await waitFor(() => expect(field(/^Model/)).toBeTruthy());
+    // Saved for a reason that has nothing to do with either model, which is the
+    // case where one of them going missing would not be noticed.
+    pane("General");
+    type(/^Your name/, "Robert W");
 
     fireEvent.click(save());
     await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -7,10 +7,16 @@
  * changed section, and typing an endpoint, glancing at Limits and coming back
  * would silently lose the endpoint.
  *
- * Save and Test stay in the foot, outside the scrolling half, for the same
- * reason they used to be at the bottom of one column: they act on everything,
- * not on the section that happens to be open. Test deliberately sends what is
- * on screen rather than what is stored, and Save deliberately does not close.
+ * Save stays in the foot, outside the scrolling half, for the same reason it
+ * used to be at the bottom of one column: it acts on everything, not on the
+ * section that happens to be open. It is drawn only while something is waiting
+ * for it, which is what keeps that from being a lie. Five of the nine panes
+ * stage nothing at all — Appearance and Notifications write as they are
+ * clicked, Account acts at once, Shortcuts and About are read-only — so a Save
+ * pinned there regardless spent most of its life offering to save settings that
+ * were already saved, which reads as the opposite. Test is in the Provider pane
+ * because it reads that pane and acts on none of the others, and it deliberately
+ * sends what is on screen rather than what is stored. Save does not close.
  */
 
 import { useEffect, useRef, useState } from "react";
@@ -91,6 +97,15 @@ const NOTIFY_COPY: Record<NotifyKind, { label: string; hint: string }> = {
     hint: "The model call failed after its retries. Same channel rule as above.",
   },
 };
+
+/**
+ * A duration box, which is blank while it is inheriting what is stored.
+ *
+ * So an edit is a number that is not the stored one, and retyping what the
+ * placeholder already says is not one.
+ */
+const differs = (text: string, stored: number | undefined) =>
+  text.trim() !== "" && Number(text) !== stored;
 
 export function SettingsDialog({ onClose, section: opening }: Props) {
   const settings = useStore((s) => s.settings);
@@ -196,6 +211,33 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
     ...(timeout.trim() ? { requestTimeoutSecs: Number(timeout) } : {}),
   });
 
+  /**
+   * Whether anything on this dialog is waiting to be saved.
+   *
+   * Read across every pane rather than the open one, because the shell holds
+   * all of their state: an endpoint typed on Provider and left there while the
+   * operator reads Limits is still unsaved, and a Save that went missing on the
+   * way past is how it would get lost.
+   *
+   * A key is compared with blank rather than with what is stored, because what
+   * is stored cannot be read back. A blank box is not an edit, and a box of
+   * spaces is not one either: that is exactly what `patch` omits.
+   */
+  const dirty =
+    operatorName !== (settings?.operatorName ?? "") ||
+    provider !== (settings?.provider ?? "compatible") ||
+    baseUrl !== (settings?.baseUrl ?? "") ||
+    model !== (settings?.defaultModel ?? "") ||
+    subscriptionModel !== (settings?.subscriptionModel ?? "") ||
+    stealth !== (settings?.browserStealth ?? false) ||
+    apiKey.trim() !== "" ||
+    e2bKey.trim() !== "" ||
+    kernelKey.trim() !== "" ||
+    differs(idleMinutes, settings?.computerIdleMinutes) ||
+    differs(browserIdleMinutes, settings?.browserIdleMinutes) ||
+    differs(timeout, settings?.requestTimeoutSecs) ||
+    LIMITS.some((field) => limits[field.key] !== settings?.limits[field.key]);
+
   const save = async () => {
     setBusy(true);
     setStatus(null);
@@ -208,8 +250,21 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
       // 16. Saying "Saved." over a box still reading 40 tells the operator
       // something untrue about what is running.
       setLimits(next.limits);
+      // And every box that stages something goes back to blank, which is the
+      // same argument one field further. A key box left holding a key the
+      // runtime already has is indistinguishable from an edit nobody saved, and
+      // a duration box is worse than that: those three are clamped on the way
+      // in, so a box still reading 2000 sits under "Saved." claiming a machine
+      // sleeps after thirty-three hours when the runtime stored twenty-four.
+      // Blank is these boxes' resting state and the placeholder beside each one
+      // is read from what came back, so what is on screen after this is what is
+      // running.
       setApiKey("");
+      setE2bKey("");
       setKernelKey("");
+      setIdleMinutes("");
+      setBrowserIdleMinutes("");
+      setTimeoutSecs("");
       setStatus({ tone: "ok", text: "Saved." });
     } catch (error) {
       setStatus({ tone: "error", text: errorMessage(error) });
@@ -385,7 +440,13 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
       setStatus({
         tone: next.includesCodex ? "ok" : "error",
         text: next.includesCodex
-          ? `Signed in as ${next.email || "your ChatGPT account"}. Save to start using it.`
+          ? // The second sentence only where there is a Save to press. An
+            // operator whose sign-in expired is already on the subscription, so
+            // signing back in leaves nothing waiting to be saved and the button
+            // is not drawn: sending them to it would be sending them nowhere.
+            `Signed in as ${next.email || "your ChatGPT account"}.${
+              settings?.provider === "chatgpt" ? "" : " Save to start using it."
+            }`
           : `Signed in as ${next.email || "your ChatGPT account"}, but a ${planLabel(next.plan)} plan does not include Codex. Use an API key instead.`,
       });
     } catch (error) {
@@ -1148,14 +1209,16 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
           <button type="button" className="btn" onClick={onClose}>
             Close
           </button>
-          <button
-            type="button"
-            className="btn btn--primary"
-            disabled={busy}
-            onClick={() => void save()}
-          >
-            Save
-          </button>
+          {dirty && (
+            <button
+              type="button"
+              className="btn btn--primary"
+              disabled={busy}
+              onClick={() => void save()}
+            >
+              Save
+            </button>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Settings pinned a Save in the foot under all nine panes and the group editor under all five, but five of the nine and two of the five stage nothing: Appearance and Notifications are kept the moment they are clicked, Account signs in and out at once, Shortcuts and About are there to be read, and Plugins and Repositories write as the operator goes. It is now drawn while the panel differs from what is stored, read across the whole dialog rather than the open section so an endpoint typed on Provider is still saveable from Shortcuts, and the group editor's other button says Close rather than Cancel when there is nothing to cancel. The comparison turned up two bugs: the E2B key box was never cleared after a save, so it kept the Save up offering to send a key that had just been sent, and the three duration boxes kept what was typed while `update_settings` clamps every one of them, so a box reading 2000 sat under "Saved." against a stored 1440. Every box that stages something now goes back to blank with its placeholder read from what came back, which is the read-back the limits have always had applied to the fields beside them. The ChatGPT sign-in also stops saying "Save to start using it" when signing back in stages nothing and there is no button to send anyone to.