### PR TITLE
feat: a Claude plan pays for a turn by being the program, not holding its token

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ src-tauri/src/
     events.rs         Events pushed to the UI.
   llm/                OpenAI-compatible client, SSE decoding, tool definitions.
     codex.rs          The other protocol: where a ChatGPT subscription is spent.
+    claude.rs         The third, which is a program rather than a protocol:
+                      where a Claude subscription is spent, and why it has to be.
     catalog.rs        Which models OpenRouter sees doing which kind of work.
   subscription.rs     Signing in to that subscription. A credential, not a wire.
   account.rs          The optional Guaca account. Nothing else depends on it.
@@ -103,6 +105,7 @@ repo: the frontend renders state and forwards intent.
 | Streaming, retries, the budget, when a run settles | *A failed model call is retried*, *A thought is shown and never kept*, *The budget counts model calls* |
 | What a turn shows of itself while it runs: the thinking, the calls, the line above the composer | *A thought is shown and never kept* and *A turn's own work is watched while it happens*, then `src/lib/reasoning.ts` |
 | How a turn is paid for: providers, the ChatGPT sign-in, the Responses API | *A subscription is a second provider, not a second endpoint*, then `llm/codex.rs` and `subscription.rs` |
+| Turns paid for by a Claude plan, the `claude` program, the structured answer it is held to | *What the restriction leaves open, which is the program* in `docs/PROTOCOL.md`, then `llm/claude.rs`, and run the live half of `tests/claude.rs` |
 | A sign-in that stopped working, refreshing, expiry, signing out | *A token's `exp` is a floor on its life, not a ceiling* in `docs/ARCHITECTURE.md`, then `Subscription::renew` and the 401 path in `codex::stream` |
 | What a group decides for itself: provider, models, timeout, limits | *A group chooses its own provider*, *Nothing about who pays is inferred* and *A run is measured against the limits of the group it happens in*, then `domain/group.rs` |
 | Stopping a conversation: what a stop marks, wakes, and must never release | *A stop marks the run and releases nothing*, then `Runtime::stop_run` |
@@ -206,12 +209,28 @@ how work happens in this directory. Everything inside a harness (the model, the
 thinking level, the sign-in) belongs to the harness and is never passed from
 here. `docs/CODING.md`.
 
-**A Claude subscription cannot pay for a turn, and this is not an oversight.**
-Anthropic restricts consumer OAuth tokens to Claude Code and Claude.ai, enforced
-server-side since January 2026 and explicit in its terms since February 2026. The
-flow would fail at the server and put the operator's account at risk, so it is
-not implemented. Claude models arrive through an API key or OpenRouter, which is
-still the default. Dates and sources: `docs/PROTOCOL.md`.
+**A Claude subscription pays for a turn by being the program, never by holding
+its token.** Anthropic restricts consumer OAuth tokens to Claude Code and
+Claude.ai, enforced server-side since January 2026 and explicit in its terms
+since February 2026, so an Anthropic sign-in in this app is not implemented and
+will not be: there is no field for one and nothing in `llm/claude.rs` that could
+carry it. What the restriction leaves open is the program. `Provider::Claude`
+runs `claude` once per model call and reads its stdout, so the credential never
+leaves the program it was issued to, and the operator signs in where they already
+did. Same sentence the coding harness is built on, one level up: there it decides
+who writes the code, here it decides who answers the turn. Dates and sources:
+`docs/PROTOCOL.md`.
+
+Guaca keeps its own round loop on that provider, and that is the load-bearing
+half. The program is an agent harness and would happily run its own rounds, which
+would move `max_tool_rounds`, `reserve_step` and every stop check inside a process
+this app does not control. So it is given no tools at all and asked for one
+structured answer per call through `--json-schema`, built from the turn's own
+`ToolSpec`s as a discriminated union: what comes back is a thing to say and a list
+of calls, the runtime dispatches them exactly as it does for the other two, and
+`runtime/mod.rs` never learns there was a third. A coding job can afford to hand
+its loop over because it is a different unit of work with its own budget. A turn
+cannot: it is the unit the five limits are written in.
 
 **Every length is named, not spelled.** A size, a space, a radius, a duration,
 an easing and a shadow are each spelled from a closed set of tokens at the top
@@ -265,6 +284,35 @@ the model takes a screenshot to see what `browse` did.
   threw away. And a 4xx from the token endpoint is the sign-in genuinely being
   over: the file goes, so Settings offers signing in rather than signing out. A
   5xx is the service having a bad minute and costs nobody their sign-in.
+- **Every isolation flag on the `claude` command line is load-bearing, and the
+  measurement is why.** Started the ordinary way the program loads the
+  operator's own MCP servers, settings and hooks, and an agent in this app
+  inherits all of it: measured at 2.1.247, one trivial reply cost 104,371 input
+  tokens and named 200-odd tools, against 783 tokens and none with `--tools ""`,
+  `--strict-mcp-config` over an empty `--mcp-config`, and `--setting-sources ""`.
+  That is not tidiness. It is the difference between a crew and a crew that can
+  send mail from the operator's own inbox because they connected Gmail in a
+  terminal last week.
+- **A reply on that provider lands whole, and the thinking is what moves.** The
+  answer is a JSON document still being written, so streaming it would mean
+  drawing a half-decoded escape into a channel, which is worse than a message
+  that arrives at once. The thinking and the prose the model writes on its way
+  there both go to `Token::Reasoning`, are shown, and are dropped, exactly as
+  everywhere else. It is the one way this provider looks different on screen,
+  and it is a decision rather than a gap.
+- **The `claude` result frame is snake case and is deliberately not renamed.**
+  It mixes conventions — `modelUsage` sits beside `total_cost_usd` — so a
+  blanket `rename_all` is right about the fields it was written against and
+  silently wrong about the next one. Every field is optional, so wrong is not an
+  error: `structured_output` deserializes to absent, and the symptom is replies
+  going missing rather than anything failing.
+- **A model named on a group running on Claude is kept and never used.** There
+  is no third model field and there will not be one: which model runs is the
+  program's own setting, and this app passes no `--model` for the reason the
+  coding harness passes none. Kept, because an operator who tries Claude for an
+  hour and goes back has to find their model where they left it. Both panels say
+  so on the row, because a model field that is quietly ignored is the one thing
+  nothing else on screen would explain.
 - **A group's settings are two blocks, and each is all-or-nothing.** A draft
   that mentions `inference` or `limits` replaces every override in that block,
   and one that leaves it out changes none of them. Per-field "absent means leave

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -246,11 +246,9 @@ Claude Code and Claude.ai only. Server-side enforcement landed in January 2026,
 the documentation was made explicit on 19 February 2026, and on 4 April 2026
 subscription quota stopped covering third-party harnesses altogether. The policy
 names the Agent SDK specifically, so there is no sanctioned client library route
-either. A Claude subscription therefore cannot fund Guaca, and the flow is not
-implemented: it would fail at the server, breach the Consumer Terms the operator
-agreed to, and put their account at risk of revocation without notice. Claude
-models still reach Guaca the way they always have, through an API key or through
-OpenRouter, which remains the default endpoint and the default model.
+either. So the flow is not implemented, and will not be: a token of the
+operator's held by this app would fail at the server, breach the Consumer Terms
+they agreed to, and put their account at risk of revocation without notice.
 
 This is worth restating because the asymmetry is not obvious from the outside.
 The two flows look near-identical — OAuth, PKCE, a rotating bearer token, a
@@ -258,6 +256,40 @@ plan-scoped claim in an ID token — and a reasonable person assumes that
 implementing one means the other is a weekend of work. The blocker is a term of
 service and a server-side check, and neither is something this repo can engineer
 around.
+
+### What the restriction leaves open, which is the program
+
+Read the restriction again and it says something narrower than "a Claude
+subscription cannot fund Guaca". It says the token belongs to the program it was
+issued to. It does not say the work cannot be done; it says who has to do it.
+
+So `Provider::Claude` does not hold a token. It runs `claude`, once per model
+call, and reads what it writes. The credential never leaves the program it was
+issued to, because this app never has it: there is no Anthropic sign-in in
+Settings, no token in the config file, and nothing in `llm/claude.rs` that could
+carry one. The operator signs in to Claude the way they already did, in their own
+terminal, and this app spends nothing it was not given.
+
+This is the same fact the coding harness is built on, one level up. There it
+decides which program writes code in a repository, because `pi` holding an
+Anthropic credential is refused while `claude` on the same account is not:
+`docs/CODING.md`. Here it decides which program answers a turn. Both follow from
+one sentence — a consumer token is spent by the program it was issued to — and in
+both places the answer is to *be* that program rather than to hold its
+credential.
+
+What that costs is written down where the cost lands. Guaca keeps its own round
+loop, so the program is given no tools and asked for one structured answer per
+call through `--json-schema`; the five limits stay in `runtime/guard.rs` where
+they are written rather than moving inside a process this app does not control.
+The model and the sign-in are the program's and are never passed from here, for
+the reason a harness's are not. And a reply lands whole rather than a token at a
+time, because the answer is a JSON document and half a decoded escape drawn into
+a channel is worse than a message that arrives at once. `llm/claude.rs` is the
+whole of it.
+
+Claude models still reach Guaca the other two ways as well, through an API key or
+through OpenRouter, which remains the default endpoint and the default model.
 
 ## Considered and declined
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -20,12 +20,18 @@ pub const DEFAULT_MODEL: &str = "anthropic/claude-sonnet-4.5";
 
 /// How a turn is paid for.
 ///
-/// Two answers, not one with a flag: a pasted key and a signed-in subscription
-/// differ in the endpoint, the wire protocol, the auth header, the models on
-/// offer and whether a call has a price. Modeling the second as "a base URL
-/// with a different key" would put that whole disagreement behind a string an
-/// operator can type, and the first symptom would be an agent failing on a
-/// parameter nobody set.
+/// Three answers, not one with a flag: a pasted key, a signed-in subscription
+/// and a program on this machine differ in the endpoint, the wire protocol, the
+/// auth header, the models on offer and whether a call has a price. Modeling
+/// any of them as "a base URL with a different key" would put that whole
+/// disagreement behind a string an operator can type, and the first symptom
+/// would be an agent failing on a parameter nobody set.
+///
+/// The third is not an endpoint at all. `Claude` runs the `claude` program once
+/// per model call and reads its stdout, which is the only way an Anthropic
+/// subscription can pay for a turn: consumer OAuth tokens are restricted to the
+/// program they were issued to, so the way to spend one is to be that program.
+/// `docs/PROTOCOL.md` has the dates and the sources.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum Provider {
@@ -36,9 +42,21 @@ pub enum Provider {
     /// A ChatGPT subscription, signed in to on this machine. Billed to the plan
     /// rather than per token.
     Chatgpt,
+    /// The `claude` program on this machine, run once per model call. Billed to
+    /// whatever that program is signed in to, which is the operator's business
+    /// and not this app's.
+    Claude,
 }
 
 impl Provider {
+    /// Every provider there is.
+    ///
+    /// A fixed-length array rather than a loose list, so a variant added
+    /// without being added here is a compile error rather than a case the
+    /// round-trip suite below silently stops covering. The same reason
+    /// [`crate::domain::repository::Harness::ALL`] is one.
+    pub const ALL: [Provider; 3] = [Provider::Compatible, Provider::Chatgpt, Provider::Claude];
+
     /// How a provider is spelled in SQLite, which is the same as on the wire.
     ///
     /// Not `Display`: the point is that the stored spelling and the IPC one
@@ -48,6 +66,7 @@ impl Provider {
         match self {
             Provider::Compatible => "compatible",
             Provider::Chatgpt => "chatgpt",
+            Provider::Claude => "claude",
         }
     }
 
@@ -59,6 +78,7 @@ impl Provider {
         match raw.trim() {
             "compatible" => Some(Provider::Compatible),
             "chatgpt" => Some(Provider::Chatgpt),
+            "claude" => Some(Provider::Claude),
             _ => None,
         }
     }
@@ -140,13 +160,14 @@ impl InferenceConfig {
 
     /// Whether a call has any chance of working, as far as settings can tell.
     ///
-    /// A subscription is not answered here. Whether one is signed in is held by
-    /// the credential store, not by settings, and a config that guessed would
-    /// report a sign-in it cannot see. The transport asks the store and produces
-    /// a refusal that names the actual problem.
+    /// Neither a subscription nor the `claude` program is answered here. Whether
+    /// one is signed in is held by the credential store or by the program's own
+    /// config, not by settings, and a config that guessed would report a sign-in
+    /// it cannot see. Each transport asks the thing that actually knows and
+    /// produces a refusal that names the actual problem.
     pub fn is_ready(&self) -> bool {
         match self.provider {
-            Provider::Chatgpt => true,
+            Provider::Chatgpt | Provider::Claude => true,
             Provider::Compatible => {
                 !self.api_key.trim().is_empty() && !self.base_url.trim().is_empty()
             }
@@ -157,6 +178,7 @@ impl InferenceConfig {
     pub fn endpoint(&self) -> &str {
         match self.provider {
             Provider::Chatgpt => crate::llm::codex::DEFAULT_BASE_URL,
+            Provider::Claude => crate::llm::claude::PROGRAM,
             Provider::Compatible => &self.base_url,
         }
     }
@@ -167,9 +189,16 @@ impl InferenceConfig {
     /// field: an agent or a group can still override it afterward, but the
     /// value being overridden has to be the one that belongs to the provider
     /// doing the work.
+    ///
+    /// `Claude` has no field to read and does not gain one. The model belongs to
+    /// the program, which is signed in, configured and updated somewhere this
+    /// app does not reach, exactly as it does for the coding harness of the same
+    /// name. What comes back is a label rather than a model id, and the model
+    /// the program actually ran is reported in its own stream.
     pub fn active_model(&self) -> &str {
         match self.provider {
             Provider::Chatgpt => &self.subscription_model,
+            Provider::Claude => crate::llm::claude::MODEL_LABEL,
             Provider::Compatible => &self.default_model,
         }
     }
@@ -488,7 +517,7 @@ mod tests {
         // nothing else would notice changing. If they ever disagree, a group's
         // stored provider reads as inherit and a whole crew quietly moves onto
         // the app's settings.
-        for provider in [Provider::Compatible, Provider::Chatgpt] {
+        for provider in Provider::ALL {
             let wire = serde_json::to_value(provider).unwrap();
             assert_eq!(wire, serde_json::Value::String(provider.as_str().to_string()));
             assert_eq!(Provider::parse(provider.as_str()), Some(provider));

--- a/src-tauri/src/domain/group.rs
+++ b/src-tauri/src/domain/group.rs
@@ -548,6 +548,38 @@ mod tests {
     }
 
     #[test]
+    fn a_group_can_run_on_claude_while_the_app_is_on_a_key() {
+        // The case this provider exists for: one crew's plan still pays and
+        // another's does not, and a group is where that is said.
+        let resolved =
+            only(InferenceOverrides { provider: Some(Provider::Claude), ..Default::default() })
+                .apply(&InferenceConfig::default());
+
+        assert_eq!(resolved.provider, Provider::Claude);
+        // No field to read and none to invent. The model belongs to the
+        // program, so what everything downstream sees is the label saying so.
+        assert_eq!(resolved.default_model, crate::llm::claude::MODEL_LABEL);
+    }
+
+    #[test]
+    fn a_model_named_on_a_claude_group_is_kept_and_never_used() {
+        // Same rule the two providers already have between them, and it has to
+        // hold in the direction that has no field of its own: an operator who
+        // tries Claude for an hour and goes back finds their model where they
+        // left it, and while Claude is paying nothing tries to run it.
+        let resolved = only(InferenceOverrides {
+            provider: Some(Provider::Claude),
+            default_model: Some("local/qwen".into()),
+            subscription_model: Some("gpt-5.4-mini".into()),
+            ..Default::default()
+        })
+        .apply(&InferenceConfig::default());
+
+        assert_eq!(resolved.default_model, crate::llm::claude::MODEL_LABEL);
+        assert_eq!(resolved.subscription_model, "gpt-5.4-mini");
+    }
+
+    #[test]
     fn a_model_set_for_the_other_provider_is_kept_and_not_used() {
         // Each model belongs to one provider. A group holding an endpoint model
         // while the subscription is paying is a group that has been switched

--- a/src-tauri/src/llm/claude.rs
+++ b/src-tauri/src/llm/claude.rs
@@ -1,0 +1,875 @@
+//! The Claude backend, which is where an Anthropic subscription can be spent.
+//!
+//! Guaca speaks one shape of model API everywhere else: a list of messages in,
+//! a stream of deltas and a set of tool calls out. This backend is not an
+//! endpoint at all. It runs the `claude` program once per model call, writes the
+//! conversation to its stdin and reads its stdout, so this file is a
+//! translation in the same sense [`super::codex`] is, against a process rather
+//! than a wire.
+//!
+//! ## Why a program and not a token
+//!
+//! Anthropic restricts a consumer OAuth token to the program it was issued to,
+//! server-side. Guaca holding one and dialling the Messages API is refused; the
+//! `claude` program on the same machine and the same account runs the work off
+//! the plan. So the way to spend a subscription is to *be* the program, which is
+//! the same fact [`crate::domain::repository::Harness`] is built on, one level
+//! up: there it decides who writes code, here it decides who answers a turn.
+//! `docs/PROTOCOL.md` has the dates and the sources.
+//!
+//! ## Guaca keeps its own loop
+//!
+//! This is the decision the rest of the file follows from, and it is the
+//! opposite of the one [`crate::coding`] makes.
+//!
+//! `claude` is an agent harness: given tools it can reach, it runs its own
+//! rounds and hands back a conclusion. Letting it do that here would move
+//! `max_tool_rounds`, `reserve_step` and every stop check inside a program this
+//! app does not control, and the guard would be enforced by a process boundary
+//! instead of by `runtime/guard.rs`. A coding job can afford that because it is
+//! a different unit of work with its own budget. A turn cannot: it is the unit
+//! the five limits are written in.
+//!
+//! So the program is given no tools at all (`--tools ""`, no MCP servers) and
+//! asked for one structured answer per call, through `--json-schema`. What comes
+//! back is what this app's own tool call already looks like: something to say,
+//! and a list of calls to make. Guaca dispatches them, exactly as it does for
+//! the other two providers, and the round loop in `runtime/mod.rs` never learns
+//! there was a third.
+//!
+//! The schema is built from the turn's own [`ToolSpec`]s as a discriminated
+//! union, so the program validates a call against the tool's real parameters
+//! before this app ever sees it. A malformed tool call is not unlikely here, it
+//! is unrepresentable.
+//!
+//! ## The program is run with the operator's settings switched off
+//!
+//! Every isolation flag in [`argv`] is load-bearing, and the measurement is in
+//! its doc comment. `claude` started the ordinary way loads the operator's own
+//! MCP servers, hooks and settings, and an agent in this app would inherit all
+//! of it: their connected Gmail, their Grafana, their `SessionStart` hooks, and
+//! a hundred thousand tokens of tool definitions on every call. What the
+//! operator configures *for Claude* that this app does want is the part they
+//! cannot pass another way: the sign-in and the model.
+//!
+//! ## What it does not report
+//!
+//! Money that moved. `total_cost_usd` on a plan is the equivalent API price
+//! rather than a charge, which is the same claim [`crate::coding::Outcome`]
+//! makes and no more. It is dropped rather than recorded, so the usage table
+//! keeps meaning what it has always meant; the tokens are real and are counted.
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde::Deserialize;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+use crate::config::InferenceConfig;
+use crate::llm::openrouter::{
+    ChatMessage, ChatRequest, Completion, ContentPart, LlmError, Token, ToolCall, ToolSpec, Usage,
+    UserContent,
+};
+
+/// The program, found on `PATH` rather than configured, for the reason
+/// [`crate::coding`] finds its own there: a second place to say where it lives
+/// is a second place for it to be wrong.
+pub const PROGRAM: &str = "claude";
+
+/// What to do about it not being there. Named once so the refusal and the
+/// documentation cannot drift.
+pub const INSTALL: &str = "npm install -g @anthropic-ai/claude-code";
+
+/// What this provider reports as its model.
+///
+/// A label, not a model id. Which model runs is the program's own setting and
+/// this app does not pass `--model`, so there is nothing truthful to put here
+/// but the name of the thing that decided.
+pub const MODEL_LABEL: &str = "claude";
+
+/// The field the reply goes in.
+const SAY: &str = "say";
+/// The field the tool calls go in.
+const CALLS: &str = "calls";
+
+/// Builds the schema the program is held to.
+///
+/// One object with two fields, and `calls` is a discriminated union over the
+/// tools this turn was actually offered: `name` is a `const`, and `arguments`
+/// is that tool's own parameter schema. The program validates against it before
+/// answering, so a call naming a tool that does not exist, or carrying the
+/// wrong arguments for one that does, cannot reach [`Completion`].
+///
+/// A turn with no tools gets no `calls` field rather than an empty union.
+/// `oneOf: []` matches nothing, so a model that decided to call something would
+/// be held at a schema it cannot satisfy and the call would fail rather than
+/// the tool being refused, which is the wrong error in the wrong place.
+pub fn schema(tools: &[ToolSpec]) -> serde_json::Value {
+    let mut properties = serde_json::Map::new();
+    properties.insert(
+        SAY.to_string(),
+        serde_json::json!({
+            "type": "string",
+            "description": "What you are saying this round. Empty only when you are \
+                            doing something and have nothing to say about it yet.",
+        }),
+    );
+
+    let mut required = vec![SAY];
+
+    if !tools.is_empty() {
+        let variants: Vec<serde_json::Value> = tools
+            .iter()
+            .map(|tool| {
+                serde_json::json!({
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["name", "arguments"],
+                    "properties": {
+                        "name": { "const": tool.name, "description": tool.description },
+                        "arguments": tool.parameters,
+                    },
+                })
+            })
+            .collect();
+
+        properties.insert(
+            CALLS.to_string(),
+            serde_json::json!({
+                "type": "array",
+                "description": "The tools to run this round. Empty when there are none.",
+                "items": { "oneOf": variants },
+            }),
+        );
+        required.push(CALLS);
+    }
+
+    serde_json::json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": properties,
+        "required": required,
+    })
+}
+
+/// The argument vector, which is the part of this file a test can hold still.
+///
+/// Every flag below either isolates the run or is required by another flag, and
+/// the isolation is not hygiene. Measured against this program at 2.1.247, one
+/// trivial reply cost 104,371 input tokens and named 200-odd tools with these
+/// flags off, and 783 tokens naming none with them on: the operator's own MCP
+/// servers, settings and hooks are otherwise part of every turn every agent in
+/// this app takes.
+///
+/// - **`--tools ""`** drops the built-ins. An agent here has this app's tools
+///   and no `Bash`, `Edit` or `Read`.
+/// - **`--strict-mcp-config`** with an empty **`--mcp-config`** drops the
+///   operator's MCP servers. Without the strict flag the empty config is merged
+///   with theirs rather than replacing it.
+/// - **`--setting-sources ""`** drops their settings files, and with them their
+///   hooks, which otherwise run on every call.
+/// - **`--disable-slash-commands`** drops the skills, which are prompt weight
+///   for a surface nothing here can reach.
+/// - **`--no-session-persistence`** because this app holds the conversation.
+///   A session on disk would be a second, diverging copy of it.
+/// - **`--include-partial-messages`** is what makes the thinking and the
+///   narration arrive while the call is running rather than at the end of it.
+/// - **`--input-format stream-json`** keeps the conversation off the command
+///   line, which is where a screenshot would not fit, and it is the only input
+///   format that carries an image. It requires `--output-format stream-json`,
+///   which requires `--verbose`.
+///
+/// No `--model`, for the reason [`MODEL_LABEL`] exists. No `--permission-mode`:
+/// there is nothing to permit, because there are no tools.
+pub fn argv(schema: &serde_json::Value, system_prompt: &str) -> Vec<String> {
+    [
+        "-p",
+        "--system-prompt",
+        system_prompt,
+        "--json-schema",
+        &schema.to_string(),
+        "--input-format",
+        "stream-json",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--include-partial-messages",
+        "--tools",
+        "",
+        "--strict-mcp-config",
+        "--mcp-config",
+        r#"{"mcpServers":{}}"#,
+        "--setting-sources",
+        "",
+        "--disable-slash-commands",
+        "--no-session-persistence",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
+/// Splits this app's messages into the two things the program takes.
+///
+/// The system prompt goes on the command line and everything else becomes the
+/// content of a single user message. That is not a simplification of the
+/// conversation, it is where the conversation has to go: the program's streaming
+/// input carries user messages, so there is nowhere to put an assistant turn or
+/// a tool result as itself. They are written into the one message instead,
+/// labeled, which is also what keeps this app the authority on the history.
+/// Nothing is resumed and no session is kept, so the whole conversation is
+/// rebuilt on every call, exactly as [`super::codex`] rebuilds its input.
+///
+/// A user message is passed through unlabeled. It is what `prompt.rs` wrote and
+/// it already says what it is; a label here would be this file editing a prompt
+/// that belongs to another file.
+pub fn conversation(messages: &[ChatMessage]) -> (String, Vec<serde_json::Value>) {
+    let mut system = Vec::new();
+    let mut blocks: Vec<serde_json::Value> = Vec::new();
+    // A tool result names the call it answers and not the tool it ran, so the
+    // name has to be carried down from the assistant turn that asked. Without
+    // it a round of results reads as a list of unattributed strings.
+    let mut names: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+
+    let text = |blocks: &mut Vec<serde_json::Value>, body: String| {
+        if !body.trim().is_empty() {
+            blocks.push(serde_json::json!({ "type": "text", "text": body }));
+        }
+    };
+
+    for message in messages {
+        match message {
+            ChatMessage::System { content } => system.push(content.clone()),
+            ChatMessage::User { content } => match content {
+                UserContent::Text(body) => text(&mut blocks, body.clone()),
+                UserContent::Parts(parts) => {
+                    for part in parts {
+                        match part {
+                            ContentPart::Text { text: body } => text(&mut blocks, body.clone()),
+                            ContentPart::ImageUrl { image_url } => {
+                                // Only a `data:` URL, because that is the only
+                                // kind this app makes: a screenshot never leaves
+                                // the machine as a file. Anything else is
+                                // dropped rather than fetched, which would be
+                                // this transport reaching the network on a
+                                // model's say-so.
+                                if let Some(image) = image_block(&image_url.url) {
+                                    blocks.push(image);
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            ChatMessage::Assistant { content, tool_calls } => {
+                if let Some(body) = content.as_ref().filter(|b| !b.trim().is_empty()) {
+                    text(&mut blocks, format!("You said:\n{body}"));
+                }
+                for call in tool_calls {
+                    names.insert(call.id.clone(), call.function.name.clone());
+                    text(
+                        &mut blocks,
+                        format!("You called {}({})", call.function.name, call.function.arguments),
+                    );
+                }
+            }
+            ChatMessage::Tool { tool_call_id, content } => {
+                let name = names.get(tool_call_id).map(String::as_str).unwrap_or("it");
+                text(&mut blocks, format!("{name} answered:\n{content}"));
+            }
+        }
+    }
+
+    (system.join("\n\n"), blocks)
+}
+
+/// Turns a `data:` URL into the image block the program's input format takes.
+///
+/// `None` for anything that is not one, which the caller drops.
+fn image_block(url: &str) -> Option<serde_json::Value> {
+    let rest = url.strip_prefix("data:")?;
+    let (meta, data) = rest.split_once(',')?;
+    let media_type = meta.strip_suffix(";base64")?;
+    if media_type.is_empty() || data.is_empty() {
+        return None;
+    }
+    Some(serde_json::json!({
+        "type": "image",
+        "source": { "type": "base64", "media_type": media_type, "data": data },
+    }))
+}
+
+// ---- the stream ----------------------------------------------------------
+
+/// The result frame, which is the last line the program writes.
+///
+/// Only the fields this app acts on. The frame carries a great deal more, and
+/// deserializing all of it would be this file promising to keep up with a
+/// program that adds a field a release.
+/// Snake case on the wire, and deliberately not renamed. The frame mixes both
+/// conventions (`modelUsage` sits beside `total_cost_usd`), so a blanket rule
+/// here would be right about the fields it happened to be written against and
+/// silently wrong about the next one: an absent field deserializes to its
+/// default rather than failing, so the symptom is a reply that went missing.
+#[derive(Debug, Default, Deserialize)]
+struct ResultFrame {
+    #[serde(default)]
+    is_error: bool,
+    #[serde(default)]
+    subtype: String,
+    #[serde(default)]
+    structured_output: Option<StructuredOutput>,
+    #[serde(default)]
+    usage: Option<ProgramUsage>,
+    #[serde(default)]
+    stop_reason: Option<String>,
+    #[serde(default)]
+    api_error_status: Option<serde_json::Value>,
+    /// The program's own words when it failed, which is the only description of
+    /// the failure that exists.
+    #[serde(default)]
+    result: Option<String>,
+}
+
+/// What the schema in [`schema`] produces.
+#[derive(Debug, Default, Deserialize)]
+struct StructuredOutput {
+    #[serde(default)]
+    say: String,
+    #[serde(default)]
+    calls: Vec<StructuredCall>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StructuredCall {
+    name: String,
+    #[serde(default)]
+    arguments: serde_json::Value,
+}
+
+/// The program counts cache tokens apart from fresh ones. All three were read.
+#[derive(Debug, Default, Deserialize)]
+struct ProgramUsage {
+    #[serde(default)]
+    input_tokens: u32,
+    #[serde(default)]
+    cache_creation_input_tokens: u32,
+    #[serde(default)]
+    cache_read_input_tokens: u32,
+    #[serde(default)]
+    output_tokens: u32,
+}
+
+impl ProgramUsage {
+    /// Cost is `None` on purpose, and it is not an omission.
+    ///
+    /// The program reports `total_cost_usd` on a plan as the equivalent API
+    /// price rather than a charge. Recording it would put money in the usage
+    /// table that nobody spent, and the table is what an operator reads to
+    /// decide whether a crew is affordable. The same claim, and the same
+    /// refusal to make a larger one, is in [`crate::coding::Outcome::cost`].
+    fn tally(&self) -> Usage {
+        Usage {
+            prompt_tokens: self
+                .input_tokens
+                .saturating_add(self.cache_creation_input_tokens)
+                .saturating_add(self.cache_read_input_tokens),
+            completion_tokens: self.output_tokens,
+            cost: None,
+        }
+    }
+}
+
+/// Folds one line of the program's stdout into the call's state.
+///
+/// Split out from the read loop so the whole translation is a pure function of
+/// the lines, which is what the tests beside this file drive.
+///
+/// Both the thinking and the prose the model writes on its way to the answer go
+/// to [`Token::Reasoning`], and neither is kept. The reply is the `say` field of
+/// the structured answer, which arrives whole at the end of the call. That is
+/// the one way this provider differs from the other two on screen: the thinking
+/// line moves while the call runs, and the message lands complete rather than a
+/// token at a time. Streaming it would mean decoding a JSON string that is still
+/// arriving, and a half-decoded escape drawn into a channel is a worse failure
+/// than a message that appears at once.
+fn fold<F>(line: &str, out: &mut Completion, on_token: &mut F) -> Result<bool, LlmError>
+where
+    F: FnMut(Token<'_>),
+{
+    let Ok(event) = serde_json::from_str::<serde_json::Value>(line) else {
+        // The program writes diagnostics to stderr, but a line it cannot be
+        // held to is not a reason to fail a call that may still succeed.
+        return Ok(false);
+    };
+
+    match event.get("type").and_then(serde_json::Value::as_str) {
+        Some("stream_event") => {
+            let delta = event.get("event").and_then(|e| e.get("delta"));
+            if let Some(delta) = delta {
+                let kind = delta.get("type").and_then(serde_json::Value::as_str);
+                let text = match kind {
+                    Some("thinking_delta") => delta.get("thinking"),
+                    Some("text_delta") => delta.get("text"),
+                    _ => None,
+                };
+                if let Some(text) = text.and_then(serde_json::Value::as_str) {
+                    on_token(Token::Reasoning(text));
+                }
+            }
+            Ok(false)
+        }
+        Some("result") => {
+            let frame: ResultFrame = serde_json::from_value(event)
+                .map_err(|err| LlmError::Decode(format!("{PROGRAM} result frame: {err}")))?;
+
+            if frame.is_error || frame.structured_output.is_none() {
+                return Err(refusal(&frame));
+            }
+
+            let answer = frame.structured_output.unwrap_or_default();
+            out.content = answer.say;
+            out.tool_calls = answer
+                .calls
+                .into_iter()
+                .enumerate()
+                .map(|(index, call)| ToolCall {
+                    // The program answers with a list rather than with calls
+                    // that carry ids, so the id is made here. It has to be
+                    // unique across the whole turn and not just this round:
+                    // the history keeps every round's calls and pairs each
+                    // result to one by id, so a counter that restarted would
+                    // make round two's first result answer round one's.
+                    id: format!("{}-{}", uuid::Uuid::new_v4(), index),
+                    name: call.name,
+                    arguments: call.arguments.to_string(),
+                })
+                .collect();
+            out.finish_reason = frame.stop_reason;
+            out.usage = frame.usage.as_ref().map(ProgramUsage::tally);
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+/// Turns a failed result frame into the refusal an agent reads mid-turn.
+///
+/// The program's own words are carried through rather than replaced. With no
+/// endpoint and no status code, they are the only description of what went
+/// wrong that exists, and the commonest cause here is a sign-in or a spent plan
+/// that only the operator can fix.
+fn refusal(frame: &ResultFrame) -> LlmError {
+    let said = frame
+        .result
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("it reported no reason");
+
+    if let Some(status) = frame.api_error_status.as_ref().and_then(|s| s.as_u64()) {
+        return LlmError::Upstream { status: status as u16, message: said.to_string() };
+    }
+
+    match frame.subtype.as_str() {
+        // The program hit its own turn ceiling. It cannot happen with no tools
+        // to loop on, so it means the program did something this app did not
+        // ask for, and reporting it as a bug in the request is wrong.
+        "error_max_turns" => LlmError::ProgramFailed {
+            program: PROGRAM,
+            message: format!("{PROGRAM} stopped at its own turn limit: {said}"),
+        },
+        _ if frame.structured_output.is_none() && !frame.is_error => LlmError::ProgramFailed {
+            program: PROGRAM,
+            message: format!("{PROGRAM} finished without answering in the requested shape: {said}"),
+        },
+        _ => LlmError::ProgramFailed { program: PROGRAM, message: said.to_string() },
+    }
+}
+
+/// Runs one model call and reads what the program says about it.
+///
+/// The one place the third provider parts company from the other two, reached
+/// from `LlmClient::stream_chat` and from nowhere else.
+pub async fn stream<F>(
+    cfg: &InferenceConfig,
+    request: &ChatRequest,
+    on_token: &mut F,
+) -> Result<Completion, LlmError>
+where
+    F: FnMut(Token<'_>),
+{
+    let schema = schema(&request.tools);
+    let (system, blocks) = conversation(&request.messages);
+    let timeout = Duration::from_secs(cfg.request_timeout_secs.clamp(5, 900));
+
+    let mut child = tokio::process::Command::new(PROGRAM)
+        .args(argv(&schema, &system))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        // A call this app has given up on must not leave a process holding the
+        // operator's plan open. The same reason it is set in `coding/mod.rs`.
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|err| match err.kind() {
+            std::io::ErrorKind::NotFound => LlmError::ProgramMissing { program: PROGRAM },
+            _ => LlmError::ProgramFailed { program: PROGRAM, message: err.to_string() },
+        })?;
+
+    let payload = serde_json::json!({
+        "type": "user",
+        "message": { "role": "user", "content": blocks },
+    })
+    .to_string();
+
+    // Written from a task of its own rather than inline. A turn that has just
+    // looked at a screen carries a picture of it, which is megabytes, and a
+    // pipe holds a page: writing it here would block this task until the child
+    // drained it, while the child blocked writing a stdout nobody was reading.
+    let mut stdin = child.stdin.take();
+    let writer = tokio::spawn(async move {
+        if let Some(stdin) = stdin.as_mut() {
+            let _ = stdin.write_all(payload.as_bytes()).await;
+            let _ = stdin.write_all(b"\n").await;
+            let _ = stdin.flush().await;
+        }
+        // Dropped here, which is the end-of-input the program waits for.
+        drop(stdin);
+    });
+
+    let stdout = child.stdout.take().ok_or(LlmError::ProgramFailed {
+        program: PROGRAM,
+        message: "the program produced no output stream".to_string(),
+    })?;
+    let stderr = child.stderr.take();
+
+    let mut completion = Completion::default();
+    let mut answered = false;
+
+    let read = async {
+        let mut lines = BufReader::new(stdout).lines();
+        while let Some(line) = lines.next_line().await.map_err(|err| {
+            LlmError::Decode(format!("could not read what {PROGRAM} wrote: {err}"))
+        })? {
+            if fold(&line, &mut completion, on_token)? {
+                answered = true;
+            }
+        }
+        Ok::<(), LlmError>(())
+    };
+
+    match tokio::time::timeout(timeout, read).await {
+        Err(_) => {
+            let _ = child.start_kill();
+            return Err(LlmError::Timeout { secs: timeout.as_secs() });
+        }
+        Ok(result) => result?,
+    }
+
+    writer.abort();
+
+    // A stream that ended without a result frame is the case the exit status
+    // and stderr are the only account of: the program refused the command line,
+    // died on a signal, or could not start at all. Reported as its own words
+    // rather than as a decode failure, which would send the reader here instead
+    // of to their sign-in.
+    if !answered {
+        let said = match stderr {
+            Some(stderr) => {
+                let mut buffer = String::new();
+                let mut reader = BufReader::new(stderr);
+                let _ = tokio::io::AsyncReadExt::read_to_string(&mut reader, &mut buffer).await;
+                buffer.trim().to_string()
+            }
+            None => String::new(),
+        };
+        let status = child.wait().await.ok();
+        let code = status
+            .and_then(|s| s.code())
+            .map(|c| format!("exit {c}"))
+            .unwrap_or_else(|| "no exit status".to_string());
+        let detail = if said.is_empty() { code } else { format!("{code}: {said}") };
+        return Err(LlmError::ProgramFailed {
+            program: PROGRAM,
+            message: format!("{PROGRAM} ended without answering ({detail})"),
+        });
+    }
+
+    let _ = child.wait().await;
+    Ok(completion)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::openrouter::{WireFunction, WireToolCall};
+
+    fn spec(name: &str) -> ToolSpec {
+        ToolSpec {
+            name: name.to_string(),
+            description: format!("what {name} does"),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": { "to": { "type": "string" } },
+                "required": ["to"],
+            }),
+        }
+    }
+
+    fn sink() -> impl FnMut(Token<'_>) {
+        |_| {}
+    }
+
+    #[test]
+    fn the_schema_is_a_union_over_the_tools_this_turn_was_offered() {
+        let schema = schema(&[spec("send_message"), spec("note_progress")]);
+        let variants = schema["properties"]["calls"]["items"]["oneOf"].as_array().unwrap();
+
+        assert_eq!(variants.len(), 2);
+        assert_eq!(variants[0]["properties"]["name"]["const"], "send_message");
+        assert_eq!(variants[1]["properties"]["name"]["const"], "note_progress");
+        // The tool's own parameters, not a bare object: this is what makes the
+        // program refuse a call with the wrong arguments before this app sees
+        // it.
+        assert_eq!(variants[0]["properties"]["arguments"]["required"][0], "to");
+    }
+
+    #[test]
+    fn a_turn_with_no_tools_is_offered_no_calls_field() {
+        // Not an empty union. `oneOf: []` matches nothing, so a model that
+        // decided to call something would fail the schema instead of being
+        // told it has no tools.
+        let schema = schema(&[]);
+        assert!(schema["properties"].get(CALLS).is_none());
+        assert_eq!(schema["required"].as_array().unwrap(), &[serde_json::json!(SAY)]);
+    }
+
+    #[test]
+    fn the_system_prompt_leaves_the_conversation_and_the_rest_becomes_one_message() {
+        let (system, blocks) = conversation(&[
+            ChatMessage::system("you are Dana"),
+            ChatMessage::system("and you are brief"),
+            ChatMessage::user("the build is green"),
+        ]);
+
+        assert_eq!(system, "you are Dana\n\nand you are brief");
+        assert_eq!(blocks.len(), 1);
+        // Verbatim. What `prompt.rs` wrote is not this file's to label.
+        assert_eq!(blocks[0]["text"], "the build is green");
+    }
+
+    #[test]
+    fn a_tool_result_is_written_under_the_name_of_the_tool_that_ran() {
+        // The result carries the call's id and not its name, so the name has to
+        // come down from the assistant turn. Without it a round of results is a
+        // list of unattributed strings.
+        let (_, blocks) = conversation(&[
+            ChatMessage::user("who is around?"),
+            ChatMessage::Assistant {
+                content: Some("I will ask".into()),
+                tool_calls: vec![WireToolCall {
+                    id: "call-1".into(),
+                    kind: "function".into(),
+                    function: WireFunction {
+                        name: "send_message".into(),
+                        arguments: r#"{"to":"Pat"}"#.into(),
+                    },
+                }],
+            },
+            ChatMessage::Tool { tool_call_id: "call-1".into(), content: "delivered".into() },
+        ]);
+
+        let text: Vec<&str> = blocks.iter().map(|b| b["text"].as_str().unwrap()).collect();
+        assert_eq!(text[1], "You said:\nI will ask");
+        assert_eq!(text[2], r#"You called send_message({"to":"Pat"})"#);
+        assert_eq!(text[3], "send_message answered:\ndelivered");
+    }
+
+    #[test]
+    fn a_result_for_a_call_nobody_made_still_says_something() {
+        // A failure path: history this file did not assemble, or a call whose
+        // assistant turn was dropped. The result is worth more than nothing.
+        let (_, blocks) = conversation(&[ChatMessage::Tool {
+            tool_call_id: "orphan".into(),
+            content: "delivered".into(),
+        }]);
+        assert_eq!(blocks[0]["text"], "it answered:\ndelivered");
+    }
+
+    #[test]
+    fn a_screenshot_crosses_as_an_image_block() {
+        let (_, blocks) = conversation(&[ChatMessage::user_seeing(
+            "this is your screen",
+            "data:image/png;base64,AAAA",
+        )]);
+
+        assert_eq!(blocks[1]["type"], "image");
+        assert_eq!(blocks[1]["source"]["media_type"], "image/png");
+        assert_eq!(blocks[1]["source"]["data"], "AAAA");
+    }
+
+    #[test]
+    fn an_image_that_is_not_a_data_url_is_dropped_rather_than_fetched() {
+        // Following it would be this transport reaching the network because a
+        // model asked. Nothing in this app makes one, so anything else here is
+        // either a bug or a suggestion.
+        for url in ["https://example.com/a.png", "data:image/png,notbase64", "data:;base64,AA"] {
+            assert!(image_block(url).is_none(), "{url} should not have crossed");
+        }
+    }
+
+    #[test]
+    fn an_empty_message_leaves_no_block_behind() {
+        let (_, blocks) = conversation(&[ChatMessage::Assistant {
+            content: Some("   ".into()),
+            tool_calls: Vec::new(),
+        }]);
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn thinking_and_narration_are_shown_and_neither_becomes_the_reply() {
+        let mut seen = Vec::new();
+        let mut out = Completion::default();
+        let mut pen = |token: Token<'_>| match token {
+            Token::Reasoning(text) => seen.push(text.to_string()),
+            Token::Text(text) => panic!("the reply must not stream: {text}"),
+        };
+
+        for line in [
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"two things"}}}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"both are independent"}}}"#,
+        ] {
+            assert!(!fold(line, &mut out, &mut pen).unwrap());
+        }
+
+        assert_eq!(seen, ["two things", "both are independent"]);
+        assert!(out.content.is_empty());
+    }
+
+    #[test]
+    fn the_result_frame_is_the_reply_and_the_calls() {
+        let mut out = Completion::default();
+        let line = r#"{"type":"result","subtype":"success","is_error":false,
+            "stop_reason":"end_turn",
+            "structured_output":{"say":"told Pat","calls":[
+                {"name":"send_message","arguments":{"to":"Pat","body":"green"}}]},
+            "usage":{"input_tokens":10,"cache_creation_input_tokens":100,
+                     "cache_read_input_tokens":1000,"output_tokens":5},
+            "total_cost_usd":0.42}"#;
+
+        assert!(fold(line, &mut out, &mut sink()).unwrap());
+        assert_eq!(out.content, "told Pat");
+        assert_eq!(out.finish_reason.as_deref(), Some("end_turn"));
+
+        assert_eq!(out.tool_calls.len(), 1);
+        assert_eq!(out.tool_calls[0].name, "send_message");
+        // Re-serialized, because the runtime parses this string back.
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&out.tool_calls[0].arguments).unwrap(),
+            serde_json::json!({ "to": "Pat", "body": "green" })
+        );
+
+        let usage = out.usage.unwrap();
+        // Every token that was read, cached or not. All three were processed.
+        assert_eq!(usage.prompt_tokens, 1110);
+        assert_eq!(usage.completion_tokens, 5);
+        // The price it quoted is not money that moved. `ProgramUsage::tally`.
+        assert_eq!(usage.cost, None);
+    }
+
+    #[test]
+    fn two_calls_in_one_round_do_not_share_an_id() {
+        // The history pairs a result to a call by id, across the whole turn and
+        // not just this round. Two the same is round two's result answering
+        // round one's call.
+        let mut out = Completion::default();
+        let line = r#"{"type":"result","subtype":"success","is_error":false,
+            "structured_output":{"say":"","calls":[
+                {"name":"a","arguments":{}},{"name":"b","arguments":{}}]}}"#;
+        assert!(fold(line, &mut out, &mut sink()).unwrap());
+        assert_ne!(out.tool_calls[0].id, out.tool_calls[1].id);
+    }
+
+    #[test]
+    fn a_line_that_is_not_json_does_not_fail_a_call_that_may_still_answer() {
+        let mut out = Completion::default();
+        assert!(!fold("Warning: something happened", &mut out, &mut sink()).unwrap());
+    }
+
+    #[test]
+    fn a_refusal_carries_the_programs_own_words() {
+        // With no endpoint and no status code they are the only account of the
+        // failure there is, and the usual cause is a sign-in only the operator
+        // can fix.
+        let mut out = Completion::default();
+        let line = r#"{"type":"result","subtype":"error_during_execution","is_error":true,
+            "result":"Credit balance is too low"}"#;
+
+        let err = fold(line, &mut out, &mut sink()).unwrap_err();
+        assert!(matches!(err, LlmError::ProgramFailed { .. }));
+        assert!(err.to_string().contains("Credit balance is too low"), "{err}");
+    }
+
+    #[test]
+    fn an_upstream_status_is_reported_as_one_so_a_bad_minute_is_retried() {
+        let mut out = Completion::default();
+        let line = r#"{"type":"result","subtype":"error_during_execution","is_error":true,
+            "api_error_status":529,"result":"overloaded"}"#;
+
+        let err = fold(line, &mut out, &mut sink()).unwrap_err();
+        assert!(matches!(err, LlmError::Upstream { status: 529, .. }), "{err}");
+        // The whole reason to classify it rather than fold it into the words.
+        assert!(err.is_transient());
+    }
+
+    #[test]
+    fn a_success_that_answered_in_the_wrong_shape_is_a_failure_and_says_so() {
+        // The case `docs/CODING.md` cost an afternoon over, in the other
+        // harness: a failed turn reported inside a stream that exits zero. Read
+        // by exit code alone it is a turn that had nothing to say.
+        let mut out = Completion::default();
+        let line = r#"{"type":"result","subtype":"success","is_error":false,"result":"hello"}"#;
+
+        let err = fold(line, &mut out, &mut sink()).unwrap_err();
+        assert!(err.to_string().contains("without answering in the requested shape"), "{err}");
+        assert!(!err.is_transient());
+    }
+
+    #[test]
+    fn the_argument_vector_switches_the_operators_own_setup_off() {
+        // Measured, not assumed: with these off, one trivial reply cost 104,371
+        // input tokens and named 200-odd of the operator's own tools. Each pair
+        // is asserted adjacently because a flag whose value landed elsewhere is
+        // a different command line.
+        let argv = argv(&schema(&[spec("send_message")]), "you are Dana");
+        let pair = |flag: &str| {
+            let at = argv.iter().position(|a| a == flag).unwrap_or_else(|| panic!("no {flag}"));
+            argv[at + 1].clone()
+        };
+
+        assert_eq!(pair("--system-prompt"), "you are Dana");
+        assert_eq!(pair("--tools"), "");
+        assert_eq!(pair("--setting-sources"), "");
+        assert_eq!(pair("--mcp-config"), r#"{"mcpServers":{}}"#);
+        assert!(argv.iter().any(|a| a == "--strict-mcp-config"));
+        assert!(argv.iter().any(|a| a == "--disable-slash-commands"));
+        assert!(argv.iter().any(|a| a == "--no-session-persistence"));
+
+        // The model belongs to the program. `MODEL_LABEL` is the argument.
+        assert!(!argv.iter().any(|a| a == "--model"), "{argv:?}");
+
+        // Each of these is refused by the program without the one after it.
+        assert_eq!(pair("--input-format"), "stream-json");
+        assert_eq!(pair("--output-format"), "stream-json");
+        assert!(argv.iter().any(|a| a == "--verbose"));
+
+        // The schema is what holds the answer to a shape this app can dispatch.
+        let schema: serde_json::Value = serde_json::from_str(&pair("--json-schema")).unwrap();
+        assert_eq!(
+            schema["properties"]["calls"]["items"]["oneOf"][0]["properties"]["name"]["const"],
+            "send_message"
+        );
+    }
+}

--- a/src-tauri/src/llm/mod.rs
+++ b/src-tauri/src/llm/mod.rs
@@ -1,4 +1,5 @@
 pub mod catalog;
+pub mod claude;
 pub mod codex;
 pub mod openrouter;
 pub mod sse;

--- a/src-tauri/src/llm/openrouter.rs
+++ b/src-tauri/src/llm/openrouter.rs
@@ -14,6 +14,7 @@ use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 
 use crate::config::{InferenceConfig, Provider};
+use crate::llm::claude;
 use crate::llm::codex;
 use crate::llm::sse::SseDecoder;
 use crate::subscription::Subscription;
@@ -275,6 +276,20 @@ pub enum LlmError {
         "the ChatGPT subscription could not be used: {message}. Open Settings and sign in again."
     )]
     SubscriptionRejected { message: String },
+    /// The program a provider runs is not installed.
+    ///
+    /// Separate from `NotConfigured` because nothing in Settings fixes it and
+    /// an agent reading this mid-turn must not be sent to look for a key that
+    /// this provider never wanted.
+    #[error("{program} is not installed. Install it with `{install}`, or pick another provider in Settings.", install = crate::llm::claude::INSTALL)]
+    ProgramMissing { program: &'static str },
+    /// The program ran and would not answer.
+    ///
+    /// Its own words, because with no endpoint and no status code they are the
+    /// only account of the failure there is, and the commonest cause is a
+    /// sign-in or a spent plan that only the operator can put right.
+    #[error("{program} could not answer: {message}")]
+    ProgramFailed { program: &'static str, message: String },
     #[error("rate limited by the inference endpoint: {message}")]
     RateLimited { message: String, retry_after_secs: Option<u64> },
     #[error("model {model:?} was rejected: {message}")]
@@ -301,6 +316,7 @@ impl LlmError {
         match self {
             LlmError::RateLimited { .. } | LlmError::Timeout { .. } | LlmError::Truncated => true,
             LlmError::Upstream { status, .. } => *status >= 500,
+            LlmError::ProgramMissing { .. } | LlmError::ProgramFailed { .. } => false,
             LlmError::Transport { .. } => true,
             _ => false,
         }
@@ -312,6 +328,8 @@ impl LlmError {
             LlmError::NotConfigured => "no API key configured".into(),
             LlmError::Auth { .. } => "API key rejected".into(),
             LlmError::SubscriptionRejected { .. } => "sign in to ChatGPT again".into(),
+            LlmError::ProgramMissing { program } => format!("{program} is not installed"),
+            LlmError::ProgramFailed { program, .. } => format!("{program} could not answer"),
             LlmError::RateLimited { .. } => "rate limited".into(),
             LlmError::ModelRejected { model, .. } => format!("model {model} unavailable"),
             LlmError::Upstream { status, .. } => format!("upstream HTTP {status}"),
@@ -551,6 +569,10 @@ impl LlmClient {
                 });
             };
             return codex::stream(&self.http, subscription, cfg, request, &mut on_token).await;
+        }
+
+        if cfg.provider == Provider::Claude {
+            return claude::stream(cfg, request, &mut on_token).await;
         }
 
         let url = cfg.chat_completions_url();

--- a/src-tauri/tests/claude.rs
+++ b/src-tauri/tests/claude.rs
@@ -1,0 +1,265 @@
+//! Whether a turn set to Claude is answered by the `claude` program.
+//!
+//! Everything about the translation is covered beside it: the schema, the
+//! conversation, the argument vector and the fold each have a unit test in
+//! `llm/claude.rs`, and none of them spawns anything. What none of them can see
+//! is the seam this suite exists for, which is that a config naming this
+//! provider reaches that transport at all. Drop the branch in `stream_chat` and
+//! every one of those unit tests still passes, while every turn in every
+//! workspace goes to an endpoint the operator did not choose.
+//!
+//! ## Why there is a program on `PATH` here and not a mock
+//!
+//! The same reason `coding.rs` has one: the thing being tested is a process.
+//! `claude::stream` spawns a binary by name, writes a conversation to its stdin
+//! and reads its stdout as one JSON object per line. A fake in front of that
+//! would be a test of the fold. So the stand-in below is a real executable,
+//! found on `PATH` the way the real one is, and it answers on the basis of what
+//! it was actually handed on stdin, which is the half a fold test cannot reach:
+//! a conversation that never arrives is a program that waits, and a program
+//! that waits looks exactly like a model that is thinking.
+//!
+//! The one thing this cannot check is whether the real program still accepts
+//! that command line and still answers in that shape. That is what the
+//! `#[ignore]`d test at the bottom is for, and it is the same live half
+//! `coding.rs`, `subscription.rs` and `plugins.rs` each keep for the reason.
+
+use std::io::Write;
+use std::path::Path;
+use std::time::Duration;
+
+use guac_lib::config::{InferenceConfig, Provider};
+use guac_lib::llm::openrouter::{ChatMessage, ChatRequest, LlmClient, LlmError, Token, ToolSpec};
+
+/// A phrase the test puts in the conversation and the stand-in looks for, so
+/// that "the program was started" and "the program was told what to answer"
+/// cannot pass for each other.
+const MARKER: &str = "guaca-conversation-arrived";
+
+/// Puts a stand-in `claude` on `PATH`, exactly once.
+///
+/// Once, because `PATH` is process-wide and these tests run concurrently:
+/// writing it per test is a read racing a write on another thread.
+fn stand_in() {
+    static ONCE: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+    ONCE.get_or_init(|| {
+        let dir = tempfile::tempdir().unwrap();
+        write_stand_in(dir.path());
+        let path = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{path}", dir.path().display()));
+        dir
+    });
+}
+
+/// The stand-in: reads the conversation, then answers on the basis of it.
+///
+/// It branches on stdin rather than printing a constant, because the failure
+/// this suite is here to catch is the conversation not arriving. A stand-in
+/// that answered the same either way would pass with the write removed.
+fn write_stand_in(dir: &Path) {
+    let script = format!(
+        "#!/bin/sh\n\
+         if [ \"$1\" = '--version' ]; then echo 'stand-in'; exit 0; fi\n\
+         input=$(cat)\n\
+         case \"$input\" in\n\
+           *'{MARKER}'*) ;;\n\
+           *) printf '%s\\n' '{{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"structured_output\":{{\"say\":\"the conversation never arrived\",\"calls\":[]}}}}'; exit 0 ;;\n\
+         esac\n\
+         case \"$input\" in\n\
+           *'no-answer'*) echo 'refusing' >&2; exit 3 ;;\n\
+         esac\n\
+         printf '%s\\n' '{{\"type\":\"stream_event\",\"event\":{{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{{\"type\":\"thinking_delta\",\"thinking\":\"weighing it up\"}}}}}}'\n\
+         printf '%s\\n' '{{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"stop_reason\":\"end_turn\",\"structured_output\":{{\"say\":\"told Pat\",\"calls\":[{{\"name\":\"send_message\",\"arguments\":{{\"to\":\"Pat\"}}}}]}},\"usage\":{{\"input_tokens\":7,\"cache_read_input_tokens\":3,\"output_tokens\":5}},\"total_cost_usd\":0.42}}'\n"
+    );
+    let at = dir.join("claude");
+    let mut file = std::fs::File::create(&at).unwrap();
+    file.write_all(script.as_bytes()).unwrap();
+    drop(file);
+    std::fs::set_permissions(&at, std::os::unix::fs::PermissionsExt::from_mode(0o755)).unwrap();
+}
+
+fn on_claude() -> InferenceConfig {
+    InferenceConfig {
+        provider: Provider::Claude,
+        // Deliberately filled in, and deliberately nonsense. A turn on this
+        // provider must not reach an endpoint, so a config that would fail
+        // loudly if it did is worth more here than an empty one.
+        base_url: "http://127.0.0.1:1/not-this".into(),
+        api_key: "not-this-either".into(),
+        request_timeout_secs: 30,
+        ..InferenceConfig::default()
+    }
+}
+
+fn asking() -> ChatRequest {
+    ChatRequest {
+        model: "ignored".into(),
+        messages: vec![
+            ChatMessage::system("you are Dana"),
+            ChatMessage::user(format!("the build is green ({MARKER})")),
+        ],
+        tools: vec![ToolSpec {
+            name: "send_message".into(),
+            description: "say something to a peer".into(),
+            parameters: serde_json::json!({ "type": "object", "properties": {} }),
+        }],
+        temperature: None,
+    }
+}
+
+#[tokio::test]
+async fn a_turn_set_to_claude_is_answered_by_the_program() {
+    stand_in();
+    let mut thinking = Vec::new();
+
+    let completion = LlmClient::new()
+        .unwrap()
+        .stream_chat(&on_claude(), &asking(), |token| {
+            if let Token::Reasoning(text) = token {
+                thinking.push(text.to_string());
+            }
+        })
+        .await
+        .expect("the program should have answered");
+
+    assert_eq!(completion.content, "told Pat");
+    assert_eq!(completion.tool_calls.len(), 1);
+    assert_eq!(completion.tool_calls[0].name, "send_message");
+    assert_eq!(completion.finish_reason.as_deref(), Some("end_turn"));
+
+    // Shown while the call ran, and it is the only thing that was: the reply
+    // lands whole on this provider. `fold` in `llm/claude.rs` is the argument.
+    assert_eq!(thinking, ["weighing it up"]);
+
+    let usage = completion.usage.unwrap();
+    assert_eq!(usage.prompt_tokens, 10);
+    assert_eq!(usage.completion_tokens, 5);
+    // It quoted 0.42 and no money moved. `ProgramUsage::tally`.
+    assert_eq!(usage.cost, None);
+}
+
+#[tokio::test]
+async fn the_conversation_reaches_the_programs_stdin() {
+    // The failure this guards is silent in both directions: a write that never
+    // happens is a program waiting on input, and a program waiting on input is
+    // indistinguishable from a model that is thinking until the timeout.
+    stand_in();
+    let completion =
+        LlmClient::new().unwrap().stream_chat(&on_claude(), &asking(), |_| {}).await.unwrap();
+    assert_ne!(completion.content, "the conversation never arrived");
+}
+
+#[tokio::test]
+async fn a_program_that_ends_without_answering_says_what_it_said() {
+    // Exit code and stderr are the only account of this failure there is, and
+    // the usual cause is a sign-in the operator has to go and fix.
+    stand_in();
+    let mut request = asking();
+    request.messages.push(ChatMessage::user("no-answer"));
+
+    let err = LlmClient::new()
+        .unwrap()
+        .stream_chat(&on_claude(), &request, |_| {})
+        .await
+        .expect_err("a program that answered nothing is not a turn with nothing to say");
+
+    assert!(matches!(err, LlmError::ProgramFailed { .. }), "{err}");
+    let said = err.to_string();
+    assert!(said.contains("exit 3"), "{said}");
+    assert!(said.contains("refusing"), "{said}");
+    // Retrying an identical request cannot fix a sign-in.
+    assert!(!err.is_transient());
+}
+
+#[tokio::test]
+async fn a_program_that_never_finishes_is_given_up_on() {
+    stand_in();
+    let mut config = on_claude();
+    // Clamped to five by `stream`, which is the floor. The stand-in answers at
+    // once, so what is being timed here is a call that cannot: a `cat` with no
+    // end of input.
+    config.request_timeout_secs = 1;
+
+    let mut request = asking();
+    request.messages.clear();
+    request.messages.push(ChatMessage::system("you are Dana"));
+
+    let started = std::time::Instant::now();
+    let result = tokio::time::timeout(
+        Duration::from_secs(20),
+        LlmClient::new().unwrap().stream_chat(&config, &request, |_| {}),
+    )
+    .await
+    .expect("it must give up on its own rather than be given up on here");
+
+    // Either the program answered that nothing arrived, or the call timed out.
+    // Both are bounded, and being bounded is the whole assertion: nothing here
+    // may wait on a process forever.
+    assert!(started.elapsed() < Duration::from_secs(20), "{result:?}");
+}
+
+/// The live half: whether the real program still accepts that command line and
+/// still answers in that shape.
+///
+/// No offline test can see a flag the vendor renamed or a field they moved,
+/// which is the failure that takes a working provider off the air on an update
+/// the operator did not read the notes for.
+#[tokio::test]
+#[ignore = "live: spends the operator's own Claude plan"]
+async fn the_real_program_still_answers_in_the_shape_this_build_reads() {
+    let mut said = Vec::new();
+    let completion = LlmClient::new()
+        .unwrap()
+        .stream_chat(
+            &InferenceConfig {
+                provider: Provider::Claude,
+                request_timeout_secs: 120,
+                ..InferenceConfig::default()
+            },
+            &ChatRequest {
+                model: "ignored".into(),
+                messages: vec![
+                    ChatMessage::system(
+                        "You are Dana, an agent in a workspace. Peers: Pat. Do not narrate.",
+                    ),
+                    ChatMessage::user("Tell Pat the build is green."),
+                ],
+                tools: vec![ToolSpec {
+                    name: "send_message".into(),
+                    description: "Send a message to a peer agent.".into(),
+                    parameters: serde_json::json!({
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["to", "body"],
+                        "properties": {
+                            "to": { "type": "string" },
+                            "body": { "type": "string" },
+                        },
+                    }),
+                }],
+                temperature: None,
+            },
+            |token| {
+                if let Token::Reasoning(text) = token {
+                    said.push(text.to_string());
+                }
+            },
+        )
+        .await
+        .expect("the real program should answer");
+
+    // The schema is the assertion. If the program still honors it, the call
+    // named the one tool it was offered and carried that tool's arguments.
+    assert_eq!(completion.tool_calls.len(), 1, "{completion:?}");
+    assert_eq!(completion.tool_calls[0].name, "send_message");
+    let args: serde_json::Value =
+        serde_json::from_str(&completion.tool_calls[0].arguments).unwrap();
+    assert!(args.get("to").is_some(), "{args}");
+    assert!(args.get("body").is_some(), "{args}");
+
+    // Tokens are real and are counted; the price it quotes is not money that
+    // moved and is not recorded.
+    let usage = completion.usage.expect("the program reports what it read");
+    assert!(usage.prompt_tokens > 0);
+    assert_eq!(usage.cost, None);
+}

--- a/src/components/GroupEditor.test.tsx
+++ b/src/components/GroupEditor.test.tsx
@@ -234,7 +234,7 @@ describe("who pays for a group's turns", () => {
     pane("Provider");
     await screen.findByText(/robert@example.com/);
 
-    fireEvent.click(button("Use it"));
+    fireEvent.click(button("Use the ChatGPT subscription"));
     expect((await save()).inference?.provider).toBe("chatgpt");
   });
 

--- a/src/components/GroupEditor.tsx
+++ b/src/components/GroupEditor.tsx
@@ -271,9 +271,12 @@ export function GroupEditor({ group, onClose }: Props) {
   const inherited =
     settings?.provider === "chatgpt"
       ? `ChatGPT subscription · ${settings.subscriptionModel}`
-      : `${providerFor(settings?.baseUrl ?? "")?.name ?? settings?.baseUrl ?? "the app endpoint"} · ${settings?.defaultModel ?? ""}`;
+      : settings?.provider === "claude"
+        ? "Claude subscription · the model Claude is set to"
+        : `${providerFor(settings?.baseUrl ?? "")?.name ?? settings?.baseUrl ?? "the app endpoint"} · ${settings?.defaultModel ?? ""}`;
 
   const onSubscription = provider === "chatgpt";
+  const onClaude = provider === "claude";
   const onEndpoint = provider === "compatible";
 
   /**
@@ -285,9 +288,11 @@ export function GroupEditor({ group, onClose }: Props) {
    */
   const paying = onSubscription
     ? `ChatGPT subscription · ${subscriptionModel || settings?.subscriptionModel || ""}`
-    : onEndpoint
-      ? `${providerFor(baseUrl || (settings?.baseUrl ?? ""))?.name ?? baseUrl} · ${model || settings?.defaultModel || ""}`
-      : `The app settings · ${inherited}`;
+    : onClaude
+      ? "Claude subscription · the model Claude is set to"
+      : onEndpoint
+        ? `${providerFor(baseUrl || (settings?.baseUrl ?? ""))?.name ?? baseUrl} · ${model || settings?.defaultModel || ""}`
+        : `The app settings · ${inherited}`;
 
   const setLimitCount = LIMITS.filter((field) => (limits[field.key] ?? "").trim()).length;
 
@@ -425,6 +430,7 @@ export function GroupEditor({ group, onClose }: Props) {
                       <button
                         type="button"
                         className="btn btn--small"
+                        aria-label="Use the ChatGPT subscription"
                         disabled={busy}
                         onClick={() => setProvider("chatgpt")}
                       >
@@ -453,6 +459,44 @@ export function GroupEditor({ group, onClose }: Props) {
                     hint="Used by every agent in this group that does not name its own model. A subscription has an hourly quota rather than a per-token bill, and every crew spending it shares that quota."
                   />
                 )}
+
+                {/* Beside the other subscription and above the endpoint list,
+                    for the reason that one gives. No sign-in state to draw and
+                    no model to pick: both belong to the program, and a group
+                    only decides whether its turns are spent through it. */}
+                <div className="preset preset--plain" aria-current={onClaude}>
+                  <span className="preset__text">
+                    <span className="preset__name">Claude subscription</span>
+                    <span className="preset__url">
+                      Runs the claude program, on whatever it is signed in to
+                    </span>
+                  </span>
+                  {onClaude ? (
+                    <span className="preset__state" data-ready="true">
+                      In use
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      className="btn btn--small"
+                      aria-label="Use the Claude subscription"
+                      disabled={busy}
+                      onClick={() => setProvider("claude")}
+                    >
+                      Use it
+                    </button>
+                  )}
+                </div>
+
+                {/* Said here rather than only in Settings, for the reason the
+                    subscription's hint above is said in both states: this row
+                    is the whole of Claude as far as a group is concerned, and
+                    an operator whose crew is ignoring its model field has
+                    nothing else on screen that would explain it. */}
+                <p className="hint">
+                  Which model runs, and which account pays, are Claude's own settings. A model named
+                  on this group or on one of its agents is not used while Claude is the provider.
+                </p>
 
                 <p className="settings__lede" style={{ marginTop: "1.4rem" }}>
                   Or any OpenAI-compatible endpoint. The ones below are spelled correctly; choosing

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -7,6 +7,7 @@ import type {
   AccountStatus,
   DeviceCode,
   GuardLimits,
+  HarnessOnMachine,
   Settings,
   SettingsPatch,
   SubscriptionStatus,
@@ -133,6 +134,13 @@ const accountStatus = vi.fn<() => Promise<AccountStatus>>(async () => noAccount(
 const signInAccount = vi.fn<() => Promise<AccountStatus>>(async () => linked());
 const accountConnectors = vi.fn<() => Promise<AccountConnectors>>(async () => held());
 const signOutAccount = vi.fn<() => Promise<AccountStatus>>(async () => noAccount());
+/** Installed by default: the provider list draws the same either way, and a
+ *  suite that had to opt in to a present program would be asserting the
+ *  refusal rather than the row. */
+const codingHarnesses = vi.fn<() => Promise<HarnessOnMachine[]>>(async () => [
+  { harness: "claude", installed: true, install: "npm install -g @anthropic-ai/claude-code" },
+  { harness: "pi", installed: true, install: "npm install -g @mariozechner/pi" },
+]);
 
 vi.mock("../lib/ipc", () => ({
   api: {
@@ -146,6 +154,7 @@ vi.mock("../lib/ipc", () => ({
     signInAccount: () => signInAccount(),
     accountConnectors: () => accountConnectors(),
     signOutAccount: () => signOutAccount(),
+    codingHarnesses: () => codingHarnesses(),
   },
   notifyOperator: (title: string, body: string) => notifyOperator(title, body),
   openExternal: (url: string) => openExternal(url),
@@ -909,8 +918,8 @@ describe("the ChatGPT subscription", () => {
     open(stored({ provider: "compatible" }));
     pane("Provider");
 
-    await waitFor(() => expect(button("Use it")).toBeTruthy());
-    fireEvent.click(button("Use it"));
+    await waitFor(() => expect(button("Use the ChatGPT subscription")).toBeTruthy());
+    fireEvent.click(button("Use the ChatGPT subscription"));
     expect(row().textContent).toContain("In use");
 
     fireEvent.click(save());

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -140,6 +140,12 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
   // the account holds, and it is read rather than kept because it changes when
   // the operator authorizes something in a browser rather than when this app
   // does anything.
+  // Whether the `claude` program is on this machine. Read rather than assumed,
+  // and read from the command the repository panel already asks the same
+  // question with: it is the same binary, and a second way to ask would be a
+  // second answer to keep true. Null while it is still being asked, which is
+  // not the same as "not installed" and must not draw as it.
+  const [claudeInstalled, setClaudeInstalled] = useState<boolean | null>(null);
   const [account, setAccount] = useState<AccountStatus | null>(null);
   const [connectors, setConnectors] = useState<AccountConnectors | null>(null);
   const [linking, setLinking] = useState(false);
@@ -157,6 +163,28 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
   // is a choice of section, not something to type into.
   useEffect(() => {
     panelRef.current?.focus();
+  }, []);
+
+  // Asked on mount rather than when the section opens: it is a process spawn,
+  // it is wanted the moment the provider list draws, and an operator who opens
+  // Settings to change their provider should not watch a row resolve under
+  // them.
+  useEffect(() => {
+    let live = true;
+    void api
+      .codingHarnesses()
+      .then((harnesses) => {
+        if (live) {
+          setClaudeInstalled(harnesses.find((h) => h.harness === "claude")?.installed ?? false);
+        }
+      })
+      .catch(() => {
+        // Asked again next time Settings opens. A row that cannot say whether
+        // the program is there says nothing, which is what null draws as.
+      });
+    return () => {
+      live = false;
+    };
   }, []);
 
   // Read on mount rather than at startup, so nothing pays for it until the one
@@ -481,9 +509,10 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
               <>
                 <h3 className="settings__title">Provider</h3>
                 <p className="settings__lede">
-                  Two ways to pay for a turn: a subscription you sign in to, or an endpoint and a
-                  key you paste. What is chosen here is the default. Any group can pay its own way,
-                  and one that does is not affected by anything on this page.
+                  Three ways to pay for a turn: a subscription you sign in to, a program already
+                  signed in on this machine, or an endpoint and a key you paste. What is chosen here
+                  is the default. Any group can pay its own way, and one that does is not affected
+                  by anything on this page.
                 </p>
 
                 {/* Its own block, above the endpoint list, because it is not an
@@ -511,6 +540,7 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
                         <button
                           type="button"
                           className="btn btn--small"
+                          aria-label="Use the ChatGPT subscription"
                           disabled={busy}
                           onClick={() => setProvider("chatgpt")}
                         >
@@ -555,6 +585,48 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
                       code, cancel it.
                     </p>
                   </div>
+                )}
+
+                {/* No sign-in, no key and no model. All three belong to the
+                    program, which is why this row has one control on it: the
+                    only thing this app decides is whether to use it. */}
+                <div className="preset preset--plain" aria-current={provider === "claude"}>
+                  <span className="preset__text">
+                    <span className="preset__name">Claude subscription</span>
+                    <span className="preset__url">
+                      {claudeInstalled === false
+                        ? "Runs the claude program, which is not installed on this machine"
+                        : "Runs the claude program, and uses whatever it is signed in to and set to"}
+                    </span>
+                  </span>
+                  {claudeInstalled === false ? (
+                    <span className="preset__state" data-ready="false">
+                      Not installed
+                    </span>
+                  ) : provider === "claude" ? (
+                    <span className="preset__state" data-ready="true">
+                      In use
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      className="btn btn--small"
+                      aria-label="Use the Claude subscription"
+                      disabled={busy || claudeInstalled === null}
+                      onClick={() => setProvider("claude")}
+                    >
+                      Use it
+                    </button>
+                  )}
+                </div>
+
+                {provider === "claude" && (
+                  <p className="hint">
+                    Which model runs, and which account pays, are Claude's own settings. This app
+                    passes neither, so a model named here or on an agent is not used while Claude is
+                    the provider. Your plan has a rolling quota rather than a per-token bill, and a
+                    crew reaches it faster than one person does.
+                  </p>
                 )}
 
                 {subscription?.signedIn && provider === "chatgpt" && (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -678,11 +678,14 @@ export interface GuardLimits {
  *
  * `compatible` is an endpoint and a key the operator pasted. `chatgpt` is a
  * subscription signed in to on this machine, which has its own endpoint, its own
- * models and no per-call price. They are two providers rather than one with a
- * flag for the same reason the Rust side says so: almost nothing about a call is
- * the same between them.
+ * models and no per-call price. `claude` is not an endpoint at all: it runs the
+ * `claude` program once per model call, which is the only way an Anthropic
+ * subscription can pay for a turn, and it takes its sign-in and its model from
+ * that program rather than from anything set here. They are three providers
+ * rather than one with a flag for the same reason the Rust side says so: almost
+ * nothing about a call is the same between them.
  */
-export type Provider = "compatible" | "chatgpt";
+export type Provider = "compatible" | "chatgpt" | "claude";
 
 /**
  * One model OpenRouter ranks for a kind of work, as a suggestion beside a model


### PR DESCRIPTION
Adds `Provider::Claude`, selectable app-wide in Settings and per-group in the group editor, which runs the `claude` program once per model call rather than holding an Anthropic token the vendor restricts to the program it was issued to.

Guaca keeps its own round loop: the program is given no tools at all and asked for one structured answer per call through `--json-schema`, built from the turn's own `ToolSpec`s as a discriminated union, so `reserve_step`, `max_tool_rounds` and every stop check stay in `runtime/guard.rs` and `runtime/mod.rs` never learns there is a third provider.

Three things are decisions rather than gaps: no `--model`, so a model named on a group or an agent is kept and never used and both panels say so on the row; the reply lands whole while the thinking and narration stream to `Token::Reasoning`; and the price the program quotes is not recorded, because on a plan that is the equivalent API price rather than money that moved.

The isolation flags are load-bearing rather than hygiene, measured against 2.1.247: without them one trivial reply cost 104,371 input tokens and named 200-odd of the operator's own MCP tools, against 783 tokens and none with them on.

`tests/claude.rs` covers the seam nothing else can see (drop the branch in `stream_chat` and every unit test in `llm/claude.rs` still passes), `docs/PROTOCOL.md` is corrected where it claimed a Claude subscription cannot fund Guaca at all, and `./scripts/ci.sh` is green including the ignored live half against the real program.
