### PR TITLE
fix: a right-click on the rail leaves no word highlighted behind it

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -576,6 +576,8 @@ button {
   background: var(--grail-ground);
   border-right: 1px solid var(--rail-edge);
   color: var(--rail-text);
+  /* Not selectable, for the reason the rail is not. */
+  user-select: none;
   /* The window's own buttons float over the top left corner, which is now this
      column rather than the rail. The first circle starts under them. */
   padding: var(--space-8) 0 var(--space-4);
@@ -624,6 +626,17 @@ button {
 .rail {
   --flesh: #4e6b16;
   --flesh-soft: #eef2d8;
+
+  /* A right-click leaves nothing highlighted behind it. WebKit selects the word
+     under the pointer before it dispatches `contextmenu`, for the menu it is
+     about to draw, so a row that answers with a menu of its own cannot undo
+     that by preventing a default which has already happened: the agent's name
+     is left selected underneath the menu, and stays selected after it closes.
+     Everywhere else in the column, where `main.tsx` refuses the menu outright,
+     the highlight is the whole of what the right-click did. The rail is
+     controls rather than prose, so none of it is selectable, which is also what
+     a drag across it wanted. The reading column is prose and keeps both. */
+  user-select: none;
 
   width: var(--rail-w);
   background: var(--rail-ground);
@@ -1033,11 +1046,10 @@ button {
    land. See lib/rail.ts.
    ========================================================================== */
 
-/* A rail being rearranged is not a rail being read. Selection is off for the
-   whole of it: the gesture starts on a row whose name is selectable text, and a
-   half-highlighted name left behind reads as something having gone wrong. */
+/* The fist is on the whole column rather than on the row that was picked up:
+   the pointer leaves that row almost immediately, and a cursor that turns back
+   into an arrow over the gap between two rows says the drag ended. */
 .rail[data-dragging="true"] {
-  user-select: none;
   cursor: grabbing;
 }
 

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -147,6 +147,22 @@ describe("the dark columns", () => {
   });
 });
 
+describe("the navigation columns", () => {
+  /**
+   * A right-click on either of them has to leave nothing highlighted behind.
+   * WebKit selects the word under the pointer before it dispatches
+   * `contextmenu`, for the menu it is about to draw, so the row that answers
+   * with a menu of its own cannot undo that by preventing a default which has
+   * already happened. Neither column is selectable instead, and the assertion
+   * is here rather than in a DOM test because jsdom has no native selection to
+   * make: the declaration is the whole of the fix, so the declaration is what
+   * is read.
+   */
+  it.each(["rail", "grail"])("select nothing under a right-click (.%s)", (column) => {
+    expect(getComputedStyle(nest(column)).userSelect).toBe("none");
+  });
+});
+
 describe("dialog modifiers", () => {
   /**
    * A modifier declared above `.dialog` silently loses to it.


### PR DESCRIPTION
Right-clicking an agent sometimes left the agent's name highlighted, because on macOS WebKit selects the word under the pointer before it dispatches `contextmenu`, and the row's `preventDefault` suppresses the menu it was made for without undoing a selection that already happened. The same artifact is everywhere in both navigation columns, where `main.tsx` refuses the webview's menu outright and the stray highlight is the whole of what a right-click does. Both columns are controls rather than prose, so neither is selectable now: that covers the double-click that opens a profile editor too, and makes the `user-select` in `.rail[data-dragging]` redundant, so that rule now says only what a drag does to the cursor. `styles.test.ts` is the gate, since jsdom has no native selection to assert from the other end and the declaration is the whole of the fix. `./scripts/ci.sh web` passes; the Rust half reads none of this and was not run, and the real window cannot be right-clicked from a shell, so it is worth one click to confirm.