### PR TITLE
feat: memory is the last section in the inspector, not the first

### DIFF
--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -50,12 +50,20 @@ function remembered(): boolean {
  * edited rarely and all at once, which is what a dialog is for; these are
  * glanced at constantly.
  *
- * Memory is first, and what the agent is in the middle of is directly under
- * it: they are the two halves of what an agent carries between conversations,
- * and read apart neither says what it means. Those two are also the only
- * sections with something to show on every agent, since a screen is usually an
- * offer rather than a picture and a new agent keeps no routines. Memory is
- * capped in height, so a long one cannot push a live desktop off the panel.
+ * The order is what is worth glancing at, most first. A screen is a picture of
+ * something happening right now, so the two of them lead; then the working
+ * notes, which are what the agent is in the middle of; then the schedule it
+ * keeps. Memory is last because it is the one section that is a text box: it
+ * is read closely rather than glanced at, edited deliberately, and at the top
+ * it spent the panel's vertical budget on a page nobody was looking at while
+ * the live desktop under it sat below the fold. Its height cap stays for the
+ * same reason it was added, one section further down.
+ *
+ * Memory and the working notes are still the two halves of what an agent
+ * carries between conversations, and they are still the only sections with
+ * something to show on every agent, since a screen is usually an offer rather
+ * than a picture and a new agent keeps no routines. Separating them costs the
+ * reading that puts them side by side; each says which the other is.
  */
 export function Inspector({ agent, onEditProfile }: Props) {
   const [open, setOpen] = useState(remembered);
@@ -171,11 +179,11 @@ export function Inspector({ agent, onEditProfile }: Props) {
             its polling still running, every switch added another, and only
             closing the panel cleared them. */}
         <div className="inspector__level" hidden={routine !== null} key={agent.id}>
-          <Memory agentId={agent.id} />
-          <WorkingNotes agentId={agent.id} />
-          <ComputerScreen agent={agent} />
           <BrowserScreen agent={agent} />
+          <ComputerScreen agent={agent} />
+          <WorkingNotes agentId={agent.id} />
           <RoutineList agentId={agent.id} onOpen={setRoutine} />
+          <Memory agentId={agent.id} />
         </div>
 
         {routine !== null && (

--- a/src/components/Memory.tsx
+++ b/src/components/Memory.tsx
@@ -242,7 +242,7 @@ export function Memory({ agentId }: Props) {
         <p className="memory__note">
           The agent writes here with <code>update_memory</code> when it learns something durable,
           and is shown it at the start of every turn. Where its work stands goes in the working
-          notes below instead. Seed a persona if you like.
+          notes above instead. Seed a persona if you like.
         </p>
       )}
 

--- a/src/components/WorkingNotes.tsx
+++ b/src/components/WorkingNotes.tsx
@@ -34,10 +34,10 @@ interface Props {
 }
 
 /**
- * What an agent is in the middle of, under what it knows.
+ * What an agent is in the middle of, over what it knows.
  *
  * Read-only apart from one button, and that asymmetry against the memory panel
- * above it is the design rather than an unfinished half of it. Memory is a page
+ * below it is the design rather than an unfinished half of it. Memory is a page
  * two parties maintain, which is why it needs a draft, a held incoming version
  * and two ways out. This is the agent's own account of its work: the operator
  * either believes it or declares the work done, and there is no third thing to


### PR DESCRIPTION
The agent panel is ordered by what is worth glancing at: browser, computer screen, working notes, routines, memory. Memory goes last because it is the one section that is a text box, read closely rather than glanced at, and at the top it spent the panel's vertical budget on a page nobody was looking at while a live desktop sat below the fold. Its height cap stays for the reason it was added.

Two sentences were positional and would have been wrong after the move: the working-notes header said memory was above it, and the memory panel's empty state told the operator that where work stands goes in the notes below. Both flipped, and the second is copy the operator reads.