### PR TITLE
fix: an agent's menu keeps the crews beside it, not under it

### DIFF
--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -557,9 +557,8 @@ go away, it just stopped being the whole answer: it is what separates two lifted
 rows, and it is still the text in the right-hand column.
 
 `lib/rail.ts` holds all of it, and holds it as pure functions over a list, so the
-same rules order a section, decide where a drop lands, and decide what "one row
-up" means. The rail draws the arrangement itself while a drag is in progress,
-with nobody lifted. Dragging is arranging: a row dropped below a peer that is
+same rules order a section and decide where a drop lands. The rail draws the
+arrangement itself while a drag is in progress, with nobody lifted. Dragging is arranging: a row dropped below a peer that is
 only near the top because it happens to be mid-turn would land somewhere nobody
 aimed at, and the rail would look like it had ignored the gesture the moment that
 turn ended.
@@ -594,9 +593,15 @@ the same setting that stops `dragstart` firing inside the webview on some
 platforms. A rail that only rearranges on macOS is not a feature. A press
 becomes a drag after five pixels, because a row is a button first.
 
-Everything a drag does is also in the agent's menu: move up, move down, and move
-to a named group. A rail that can only be arranged by dragging cannot be arranged
-from a keyboard at all.
+The one thing a drag does that a hand on a trackpad should not have to aim for
+is crossing a crew boundary, so that is in the agent's menu, behind one row that
+opens the crews beside it. A row per crew was there first and is what the submenu
+replaced: the crews are the one part of that menu whose length nothing bounds, so
+a workspace with eight of them pushed clearing a history and deleting an agent
+off the bottom of the window, under the two items nobody wants to hunt for.
+Ordering within a crew has no menu item at all. "Move up" and "move down" were
+two rows spent on the gesture the rail already answers, in a menu where every
+other row is something a drag cannot do.
 
 ## A group is a place you can be inside
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,6 @@ export default function App() {
   const select = useStore((s) => s.select);
   const loadChannel = useStore((s) => s.loadChannel);
   const groups = useStore((s) => s.groups);
-  const nudgeAgent = useStore((s) => s.nudgeAgent);
   const dropAgent = useStore((s) => s.dropAgent);
   const prefs = useStore((s) => s.prefs);
 
@@ -282,10 +281,9 @@ export default function App() {
           onClose={() => setMenu(null)}
           onEditProfile={(agent) => setEditing(agent)}
           onTogglePin={(agent) => void onAgent(() => api.setAgentPinned(agent.id, !agent.pinned))}
-          // Both go through the store: it holds the roster and the activity the
-          // rail's order is computed from, so it is the only place that can say
-          // which row is above this one right now.
-          onNudge={(agent, delta) => void onAgent(() => nudgeAgent(agent.id, delta))}
+          // Through the store rather than the API: a move lands the agent at
+          // the end of a group it is not in yet, which is a placement only the
+          // roster the rail is drawn from can work out.
           onMoveToGroup={(agent, group) =>
             void onAgent(() => dropAgent(agent.id, { kind: "group", id: group.id }))
           }

--- a/src/components/AgentMenu.test.tsx
+++ b/src/components/AgentMenu.test.tsx
@@ -44,7 +44,6 @@ function open(agent: AgentCard, at = { x: 40, y: 40 }, groups: Group[] = []) {
     onDuplicate: vi.fn(),
     onClearHistory: vi.fn(),
     onDelete: vi.fn(),
-    onNudge: vi.fn(),
     onMoveToGroup: vi.fn(),
   };
   render(<AgentMenu target={{ agent, ...at }} groups={groups} {...handlers} />);
@@ -58,10 +57,8 @@ describe("AgentMenu", () => {
       "Pause",
       "Edit profile",
       "Pin to top",
-      "Move up",
-      "Move down",
       "Duplicate",
-      "Clear history…",
+      "Clear chat history…",
       "Delete…",
     ]) {
       expect(screen.getByRole("button", { name })).toBeTruthy();
@@ -88,26 +85,49 @@ describe("AgentMenu", () => {
     expect(screen.queryByRole("button", { name: "Pin to top" })).toBeNull();
   });
 
-  it("arranges the rail without a mouse", () => {
-    // A rail that can only be arranged by dragging cannot be arranged from a
-    // keyboard at all, and this menu is already where everything else lives.
-    const handlers = open(card());
-    fireEvent.click(screen.getByRole("button", { name: "Move up" }));
-    expect(handlers.onNudge).toHaveBeenCalledWith(expect.objectContaining({ id: "a1" }), -1);
-  });
-
-  it("offers the crews this agent is not in, and never the one it is", () => {
+  it("keeps the crews behind one row, and opens them beside it", () => {
+    // A row per crew is the one part of this menu whose length nothing bounds,
+    // and a workspace with eight of them pushed clearing a history and
+    // deleting an agent off the bottom of the window.
     const handlers = open(card(), { x: 40, y: 40 }, [
       group("g1", "everyone"),
       group("g2", "research"),
+      group("g3", "support"),
     ]);
 
-    expect(screen.queryByRole("button", { name: "Move to everyone" })).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Move to research" }));
+    const opener = screen.getByRole("button", { name: "Move to another group" });
+    expect(screen.queryByRole("button", { name: "research" })).toBeNull();
+    expect(opener.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.pointerEnter(opener);
+    expect(opener.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("menu", { name: "Move to another group" })).toBeTruthy();
+
+    // Never the crew it is already in: there is nothing for that row to do.
+    expect(screen.queryByRole("button", { name: "everyone" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "research" }));
     expect(handlers.onMoveToGroup).toHaveBeenCalledWith(
       expect.objectContaining({ id: "a1" }),
       expect.objectContaining({ id: "g2" }),
     );
+    expect(handlers.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the crews for a keyboard too, and closes when focus leaves them", () => {
+    open(card(), { x: 40, y: 40 }, [group("g1", "everyone"), group("g2", "research")]);
+
+    const opener = screen.getByRole("button", { name: "Move to another group" });
+    fireEvent.focus(opener);
+    const inside = screen.getByRole("button", { name: "research" });
+    expect(inside).toBeTruthy();
+
+    // A blur onto something inside the same box is a step within the submenu,
+    // not a departure from it: React reports one for every step either way.
+    fireEvent.blur(opener, { relatedTarget: inside });
+    expect(screen.getByRole("button", { name: "research" })).toBeTruthy();
+
+    fireEvent.blur(inside, { relatedTarget: document.body });
+    expect(screen.queryByRole("button", { name: "research" })).toBeNull();
   });
 
   it("says nothing about groups while there is only one", () => {
@@ -138,7 +158,7 @@ describe("AgentMenu", () => {
     // Closing on it would mean the decision is taken in a menu they have to
     // open again, having already seen the word "clear" act like a button.
     const handlers = open(card());
-    fireEvent.click(screen.getByRole("button", { name: "Clear history…" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear chat history…" }));
     expect(handlers.onClearHistory).not.toHaveBeenCalled();
     expect(handlers.onClose).not.toHaveBeenCalled();
 
@@ -170,7 +190,7 @@ describe("AgentMenu", () => {
     // Opening one of them armed the other, so an operator who went to clear a
     // history found a delete button under their next click.
     const handlers = open(card());
-    fireEvent.click(screen.getByRole("button", { name: "Clear history…" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear chat history…" }));
 
     expect(screen.getByRole("button", { name: "Delete…" })).toBeTruthy();
     expect(handlers.onDelete).not.toHaveBeenCalled();

--- a/src/components/AgentMenu.tsx
+++ b/src/components/AgentMenu.tsx
@@ -1,5 +1,5 @@
-import type { CSSProperties } from "react";
-import { Fragment, useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { CSSProperties, FocusEvent } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import type { AgentCard, Group } from "../lib/types";
 
@@ -21,8 +21,6 @@ interface Props {
   onClearHistory: (agent: AgentCard) => void;
   /** Into the compost, where it waits thirty days. */
   onDelete: (agent: AgentCard) => void;
-  /** One row up or down: the drag, without a mouse. */
-  onNudge: (agent: AgentCard, delta: -1 | 1) => void;
   onMoveToGroup: (agent: AgentCard, group: Group) => void;
 }
 
@@ -56,10 +54,10 @@ export function AgentMenu({
   onDuplicate,
   onClearHistory,
   onDelete,
-  onNudge,
   onMoveToGroup,
 }: Props) {
   const { agent } = target;
+  const elsewhere = groups.filter((group) => group.id !== agent.groupId);
   const ref = useRef<HTMLDivElement>(null);
   const [at, setAt] = useState({ x: target.x, y: target.y, origin: "top left" });
   /**
@@ -161,25 +159,18 @@ export function AgentMenu({
         {item(agent.lifecycle === "paused" ? "Resume" : "Pause", () => onTogglePause(agent))}
         {item("Edit profile", () => onEditProfile(agent))}
         {item(agent.pinned ? "Unpin" : "Pin to top", () => onTogglePin(agent))}
-        {/* The same two moves a drag makes, reachable without one. A rail that
-            can only be arranged by dragging cannot be arranged from a keyboard
-            at all, and this menu is already where everything else about an
-            agent lives. */}
-        {item("Move up", () => onNudge(agent, -1))}
-        {item("Move down", () => onNudge(agent, 1))}
         {item("Duplicate", () => onDuplicate(agent))}
         {/* Absent while there is one group, for the same reason the strip in
             the rail is: there is nowhere else to go. */}
-        {groups
-          .filter((group) => group.id !== agent.groupId)
-          .map((group) => (
-            // Keyed on the crew, not on its name: two crews may be called the
-            // same thing, and the row that moves an agent has to be the row
-            // for the crew it names.
-            <Fragment key={group.id}>
-              {item(`Move to ${group.name}`, () => onMoveToGroup(agent, group))}
-            </Fragment>
-          ))}
+        {elsewhere.length > 0 && (
+          <MoveToGroup
+            groups={elsewhere}
+            onPick={(group) => {
+              onMoveToGroup(agent, group);
+              onClose();
+            }}
+          />
+        )}
         <hr className="menu__rule" />
         {confirming === "history" ? (
           item("Delete history, keep memory", () => onClearHistory(agent), "danger")
@@ -187,7 +178,7 @@ export function AgentMenu({
           // The only kind of item that does not close the menu. Nothing has
           // been decided yet, and the next click is the one that matters.
           <button type="button" className="menu__item" onClick={() => setConfirming("history")}>
-            Clear history…
+            Clear chat history…
           </button>
         )}
         {/* Asked twice, and the second wording says where it goes rather than
@@ -206,5 +197,107 @@ export function AgentMenu({
         )}
       </div>
     </>
+  );
+}
+
+/**
+ * The crews this agent is not in, in a menu of their own to the side.
+ *
+ * A submenu rather than a row each, because the crews are the one part of this
+ * menu whose length nothing bounds: everything else is a verb on the agent and
+ * there are seven of them, while a workspace with eight crews pushed clearing a
+ * history and deleting an agent off the bottom of the window. The items are
+ * bare names because the row that opens them is the verb, and it is also the
+ * submenu's label, so a screen reader reads the sentence either way.
+ *
+ * Hover and focus open it, which are the same gesture from the two devices that
+ * can make it. Pointer and focus both leave through the wrapper rather than the
+ * row, so crossing into the submenu is not leaving.
+ */
+function MoveToGroup({ groups, onPick }: { groups: Group[]; onPick: (group: Group) => void }) {
+  const [open, setOpen] = useState(false);
+  const wrap = useRef<HTMLDivElement>(null);
+  const sub = useRef<HTMLDivElement>(null);
+  const [at, setAt] = useState({ side: "right", shift: 0, origin: "top left" });
+
+  // Measured for the same reason the menu is, from the row it hangs off rather
+  // than from itself: the menu it opens out of may already have been pulled
+  // back from the right edge, and a submenu drawn past that edge is a list of
+  // crews nothing can click.
+  useLayoutEffect(() => {
+    const node = sub.current;
+    const row = wrap.current;
+    if (!node || !row) return;
+    const box = node.getBoundingClientRect();
+    const from = row.getBoundingClientRect();
+    const side = from.right + box.width + MARGIN <= window.innerWidth ? "right" : "left";
+    // Never downward: the top of the submenu is the row that opened it, and the
+    // only reason to move is a list that would otherwise run off the bottom.
+    const shift = Math.min(0, window.innerHeight - MARGIN - (from.top + box.height));
+    setAt({
+      side,
+      shift,
+      origin: `${shift < 0 ? "bottom" : "top"} ${side === "right" ? "left" : "right"}`,
+    });
+  }, [open]);
+
+  return (
+    <div
+      className="menu__nest"
+      ref={wrap}
+      // A box to hang the submenu off and nothing else: the row is the control
+      // and the crews are the menu, and neither is this. The hover is on the
+      // box rather than on the row because crossing from one into the other has
+      // to not be a departure.
+      role="none"
+      onPointerEnter={() => setOpen(true)}
+      onPointerLeave={() => setOpen(false)}
+      onFocus={() => setOpen(true)}
+      onBlur={(event: FocusEvent<HTMLDivElement>) => {
+        // React reports a blur for every step between two children of one box,
+        // so where the focus went is what says whether it left at all.
+        if (!event.currentTarget.contains(event.relatedTarget)) setOpen(false);
+      }}
+    >
+      <button
+        type="button"
+        className="menu__item"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        // Opens rather than toggles. A click closing it leaves the pointer on
+        // the row that opens it, which is a state nothing can get out of
+        // without moving away and coming back.
+        onClick={() => setOpen(true)}
+      >
+        Move to another group
+        <span className="menu__more" aria-hidden="true">
+          ▸
+        </span>
+      </button>
+      {open && (
+        <div
+          className="menu__sub"
+          ref={sub}
+          role="menu"
+          aria-label="Move to another group"
+          data-side={at.side}
+          style={{ top: at.shift, "--pop-origin": at.origin } as CSSProperties}
+        >
+          {groups.map((group) => (
+            // Keyed on the crew, not on its name: two crews may be called the
+            // same thing, and the row that moves an agent has to be the row for
+            // the crew it names.
+            <button
+              key={group.id}
+              type="button"
+              className="menu__item"
+              onClick={() => onPick(group)}
+            >
+              {group.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/lib/rail.test.ts
+++ b/src/lib/rail.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { landsBefore, nudgeTarget, railOrder } from "./rail";
+import { landsBefore, railOrder } from "./rail";
 import type { Activity, AgentCard, AgentId } from "./types";
 
 function agent(name: string, over: Partial<AgentCard> = {}): AgentCard {
@@ -178,21 +178,5 @@ describe("where a dropped row lands", () => {
     const rows = crew();
     expect(landsBefore(rows, "Cook", "Cook")).toBeUndefined();
     expect(landsBefore(rows, "Cook", "Gone")).toBeUndefined();
-  });
-});
-
-describe("one row at a time", () => {
-  it("swaps with the row above or below", () => {
-    const rows = crew();
-    expect(nudgeTarget(rows, "Cook", -1)).toBe("Manager");
-    expect(nudgeTarget(rows, "Cook", 1)).toBeNull();
-    expect(nudgeTarget(rows, "Manager", 1)).toBe("Scribe");
-  });
-
-  it("says there is nowhere to go at either end", () => {
-    const rows = crew();
-    expect(nudgeTarget(rows, "Manager", -1)).toBeUndefined();
-    expect(nudgeTarget(rows, "Scribe", 1)).toBeUndefined();
-    expect(nudgeTarget(rows, "Nobody", -1)).toBeUndefined();
   });
 });

--- a/src/lib/rail.ts
+++ b/src/lib/rail.ts
@@ -149,19 +149,3 @@ export function landsBefore(
   if (from >= 0 && from < to) return order[to + 1]?.id ?? null;
   return onto;
 }
-
-/**
- * Where a row goes when the operator asks for it one place up or down, which is
- * the same move without a mouse. `undefined` means there is nowhere to go.
- */
-export function nudgeTarget(
-  order: AgentCard[],
-  id: AgentId,
-  delta: -1 | 1,
-): AgentId | null | undefined {
-  const at = order.findIndex((a) => a.id === id);
-  if (at < 0) return undefined;
-  const onto = order[at + delta];
-  if (!onto) return undefined;
-  return landsBefore(order, id, onto.id);
-}

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -600,62 +600,6 @@ describe("the channel open when the rail goes inside a crew", () => {
   });
 });
 
-describe("one row at a time", () => {
-  it("moves a row up past the one above it", async () => {
-    reset();
-    useStore.setState({
-      agents: [
-        { ...AGENTS[0]!, railOrder: 0 },
-        { ...AGENTS[1]!, railOrder: 1 },
-      ],
-    });
-
-    await useStore.getState().nudgeAgent("chef", -1);
-
-    const { moveAgent } = (await import("./ipc")).api as unknown as {
-      moveAgent: ReturnType<typeof vi.fn>;
-    };
-    expect(moveAgent).toHaveBeenCalledWith("chef", AGENTS[0]!.groupId, "manager");
-  });
-
-  it("orders from the arrangement and not from whoever is mid-turn", async () => {
-    // The keyboard path has to agree with the drag: both edit the arrangement,
-    // so neither may be measured against a rail with somebody lifted on top.
-    reset();
-    useStore.setState({
-      agents: [
-        { ...AGENTS[0]!, railOrder: 0 },
-        { ...AGENTS[1]!, railOrder: 1 },
-      ],
-      activity: { chef: { state: "thinking" } },
-    });
-
-    await useStore.getState().nudgeAgent("chef", -1);
-
-    const { moveAgent } = (await import("./ipc")).api as unknown as {
-      moveAgent: ReturnType<typeof vi.fn>;
-    };
-    expect(moveAgent).toHaveBeenCalledWith("chef", AGENTS[0]!.groupId, "manager");
-  });
-
-  it("asks for nothing at the end of a section", async () => {
-    reset();
-    useStore.setState({
-      agents: [
-        { ...AGENTS[0]!, railOrder: 0 },
-        { ...AGENTS[1]!, railOrder: 1 },
-      ],
-    });
-
-    const { moveAgent } = (await import("./ipc")).api as unknown as {
-      moveAgent: ReturnType<typeof vi.fn>;
-    };
-    moveAgent.mockClear();
-    await useStore.getState().nudgeAgent("manager", -1);
-    expect(moveAgent).not.toHaveBeenCalled();
-  });
-});
-
 describe("activity", () => {
   it("records the latest state per agent", () => {
     apply({ type: "activityChanged", agentId: "chef", activity: { state: "thinking" } });

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -11,7 +11,7 @@ import { create } from "zustand";
 
 import { api } from "./ipc";
 import { loadPrefs, type Prefs, savePrefs } from "./prefs";
-import { type DropTarget, landsBefore, nudgeTarget, railOrder } from "./rail";
+import { type DropTarget, landsBefore, railOrder } from "./rail";
 
 /**
  * How much of a running coding job's work is kept on screen.
@@ -280,8 +280,6 @@ interface State {
   moveAgent: (id: AgentId, at: Placement) => Promise<void>;
   /** One drop, resolved against the rules that drew the rail. */
   dropAgent: (id: AgentId, target: DropTarget) => Promise<void>;
-  /** The same move one row at a time, for an operator who is not dragging. */
-  nudgeAgent: (id: AgentId, delta: -1 | 1) => Promise<void>;
   loadChannel: (key: ChannelKey, through?: MessageId) => Promise<void>;
   /** Opens a message's channel with the message itself in the window. */
   openMessage: (channel: AgentId, message: MessageId) => Promise<void>;
@@ -630,34 +628,6 @@ export const useStore = create<State>((set, get) => ({
     const before = landsBefore(order, id, onto.id);
     if (before === undefined) return;
     await get().moveAgent(id, { groupId: onto.groupId, before, pinned: onto.pinned });
-  },
-
-  /**
-   * One row up or down, for an operator who is not holding a mouse.
-   *
-   * Ordered from the same function that draws the rail, and frozen, so this
-   * moves the row within the arrangement rather than within whatever the
-   * arrangement currently looks like with somebody mid-turn on top of it.
-   */
-  async nudgeAgent(id, delta) {
-    const state = get();
-    const agent = state.agents.find((a) => a.id === id);
-    if (!agent) return;
-
-    const live = state.agents.filter((a) => a.lifecycle !== "terminated");
-    // Within its own band, because that is the list the row is drawn in. A
-    // nudge across the boundary would ask for a place the bands then take back,
-    // and the row would sit exactly where it was with a write behind it.
-    const section = live.filter((a) => a.groupId === agent.groupId && a.pinned === agent.pinned);
-
-    const order = railOrder(section, {
-      activity: state.activity,
-      lastActive: state.lastActive,
-      frozen: true,
-    });
-    const before = nudgeTarget(order, id, delta);
-    if (before === undefined) return;
-    await get().moveAgent(id, { groupId: agent.groupId, before });
   },
 
   async loadChannel(key, through) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4739,6 +4739,7 @@ button {
 .dialog,
 .palette,
 .menu,
+.menu__sub,
 .orb__tag {
   animation: pop var(--tempo-enter) var(--ease) both;
   transform-origin: var(--pop-origin);
@@ -5695,6 +5696,53 @@ button {
 .menu__item:focus-visible {
   background: var(--sunken);
   outline: none;
+}
+
+/* The one item that opens a menu instead of doing something. Positioned, so
+   the crews hang off it rather than off the window: the menu itself is fixed
+   wherever the click landed, and the submenu's place is a fact about the row. */
+.menu__nest {
+  position: relative;
+}
+
+/* The row that leads somewhere is the one row that is not only a label, so it
+   is the one that lays itself out. The mark sits at the far edge with the whole
+   gap between it and the words, which is what says the row opens rather than
+   acts. */
+.menu__nest .menu__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.menu__more {
+  color: var(--faint);
+}
+
+.menu__sub {
+  position: absolute;
+  top: 0;
+  left: 100%;
+  z-index: 52;
+  min-width: 9rem;
+  /* A workspace can hold more crews than a window has room for, and a submenu
+     that runs off the bottom is the failure the parent menu measures to
+     avoid. Shifting up covers the rest; this covers a list longer than the
+     window. */
+  max-height: 60vh;
+  overflow-y: auto;
+  padding: var(--space-2);
+  background: var(--raised);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--lift-2);
+}
+
+/* The side is chosen after measuring, so a menu opened against the right edge
+   of the window puts its crews on the left. */
+.menu__sub[data-side="left"] {
+  left: auto;
+  right: 100%;
 }
 
 /* What the row makes, for the one menu whose items are not verbs on something


### PR DESCRIPTION
Move up and move down are gone: they were the drag written out as two rows, in a menu where every other row is something a drag cannot do, and `nudgeAgent` and `nudgeTarget` go with them rather than sit there uncalled. The crews are now behind one row that opens them to the side, because a row each is the one part of that menu whose length nothing bounds, and a workspace with eight of them pushed clearing a history and deleting an agent off the bottom of the window. The submenu is measured the way the menu itself is: flipped left against the right edge, shifted up rather than run off the bottom, opened by hover or focus and closed only when the pointer or focus leaves the box the row and the list share. Clear history now says clear chat history, which is what the armed wording has said all along. Checked on screen at three positions, and `pnpm check`, `typecheck`, `build` and all 1325 tests pass.