### PR TITLE
feat: a coding job is told where it is standing before it is told what to do

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ repo: the frontend renders state and forwards intent.
 | Permission prompts, parked turns, acting in the operator's name | *A protected action parks the turn that asked for it* |
 | An agent writing code at all: the repository, the grant, the `code` tool, the job | `docs/CODING.md`, then `domain/repository.rs` and `Runtime::start_job` |
 | Which program writes the code, a spent plan, a harness that will not start | *There are two harnesses because a subscription is spent by one program* in `docs/CODING.md`, then `domain::repository::Harness` and `coding/mod.rs` |
+| What branch a coding job starts on, and what it is told about the tree | *A job is told where it is standing before it is told what to do* in `docs/CODING.md`, then `repo::footing` and the brief assembled in `Runtime::start_job` |
 | An argument either harness is started with, or how its stream is read | *One process lifecycle, two of what genuinely differs* in `docs/CODING.md`, then `coding/pi.rs` and `coding/claude_code.rs`, and run the live half of `tests/coding.rs` |
 | Anything an agent stops to ask a person: the desk, the queue, the two kinds of request, `ask_operator` | `docs/ATTENTION.md`, then `domain/approval.rs` and `Runtime::park` |
 | The crews' column, its badges, how a crew names itself, which crew the rail is inside | *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/presence.ts`, `src/components/GroupRail.tsx` and `src/components/OrbTag.tsx` |

--- a/docs/CODING.md
+++ b/docs/CODING.md
@@ -124,6 +124,65 @@ arguments, and a wrong guess there prints somebody's file contents into a
 channel. Anything not in a table draws no detail at all, which is what every MCP
 tool the operator has connected falls into.
 
+## A job is told where it is standing before it is told what to do
+
+A harness handed a brief starts editing where it is standing, and where it is
+standing is wherever the last job left the tree. Nothing prompts it to look at
+the branch first, and nothing else in the app will: a job that opens a pull
+request ends on the branch it made, the operator merges it, and every job after
+that starts on a feature branch whose work has already landed. Weeks of work can
+stack on top of it before anybody notices, and the transcript reads correctly
+throughout.
+
+So `repo::footing` reads the tree at the moment a job starts, and
+`Runtime::start_job` puts it in front of the brief: the branch, whether it is
+clean, whether it tracks anything, whether that branch is already contained in
+the default one, and whether a pull request is open for it. Then one rule the
+facts resolve to.
+
+The obvious fix is the other end, a standing rule in `APPENDED_PROMPT` about
+what a job leaves behind, and it does not hold. A job killed at the ceiling
+never runs its cleanup. A job that opened a pull request should still be on its
+branch. Cleanup at the end is a step that sometimes does not happen; the footing
+at the start always does.
+
+Both halves of the preamble are load-bearing, and this is the part to keep.
+Facts alone are not enough: a model handed a branch name and a count decides for
+itself what to do with them, and the decision it makes silently is to carry on
+where it is standing. A rule alone cannot be written safely, which is the
+sharper half. *Start from the default branch* over uncommitted work destroys it,
+and this is the operator's own machine rather than a sandbox. The facts are what
+let the rule be conditional, and uncommitted work is checked before anything
+else and overrides every other case: do not switch, do not stash, do not clean,
+work from here or stop and say why.
+
+Four details are not guesses.
+
+- **The merge test runs against `origin/main`, not `main`.** A branch merged
+  upstream has landed whether or not the local copy was ever pulled, and a local
+  default nobody has updated in a month calls every landed branch work in
+  flight. `default_branch` returns a name for the prose and a ref for the test,
+  because they are two different things.
+- **`origin/HEAD` first, `main` and `master` only after it.** The repository's
+  own answer beats a guess, and where nothing published one, the preamble says
+  so and asks the harness to decide rather than sending it to a branch that does
+  not exist.
+- **Every count is against the last fetch, and the preamble says so even when
+  they are zero.** Zero is where it misleads rather than where it is safe to
+  drop: a branch merged upstream an hour ago and never fetched reads here as
+  work in flight, level with its upstream. Fetching on the operator's behalf is
+  not this app's call. The harness is the thing standing in the directory with a
+  shell.
+- **A repository with no commits says so.** Git names an unborn HEAD after the
+  branch the first commit will create, so without it the preamble says *on
+  branch `main`* and *there is no `main`* two lines apart, and a model handed a
+  contradiction resolves it by guessing. A fresh `git init` is an ordinary thing
+  to link.
+
+Where the work lands is not decided here. That is already the brief's to say,
+and a standing rule that overrode it would be a second answer to a question that
+has one. What the footing settles is only where the work starts.
+
 ## A failed turn is not a job with nothing to do
 
 Both programs report a failed turn *inside* their stream and can still exit zero

--- a/src-tauri/src/repo.rs
+++ b/src-tauri/src/repo.rs
@@ -252,6 +252,362 @@ async fn open_pull_requests(path: &str) -> Option<u32> {
     Some(rows.len() as u32)
 }
 
+/// Where a coding job is about to start, and what that means for the branch.
+///
+/// Not [`RepoStatus`], and deliberately not folded into it. That one is drawn
+/// on the rail every thirty seconds and carries what fits on one line. This is
+/// read once, by a program that is about to write to the tree, and it exists to
+/// settle one question before the first edit: which branch this work starts on.
+///
+/// It has to be settled *before* the brief, because a harness handed a brief
+/// starts editing where it is standing. Nothing prompts it to look at the
+/// branch, and nothing else in the app will: a job that ends on the branch it
+/// made leaves the next job starting there, which is how a work tree ends up
+/// sitting on a feature branch that landed a month ago.
+///
+/// The alternative was a standing rule about what a job leaves behind, and it
+/// does not hold. A job killed at the ceiling never runs its cleanup, and a job
+/// that opened a pull request should still be on its branch. Cleanup at the end
+/// is a step that sometimes does not happen; the footing at the start always
+/// does.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Footing {
+    /// What git says about the tree. [`RepoStatus::pull_requests`] on it is not
+    /// read here: the count belongs to the rail, and what a job needs is the
+    /// one pull request whose head is this branch.
+    pub tree: RepoStatus,
+    /// The branch new work starts from, as this repository names it.
+    ///
+    /// `None` is a repository with no `origin/HEAD`, no `main` and no `master`,
+    /// which is somebody's own convention rather than a broken repository. The
+    /// brief says so and asks the harness to decide, because a name invented
+    /// here is a branch that does not exist.
+    pub default_branch: Option<String>,
+    /// Whether HEAD is already contained in the default branch.
+    ///
+    /// True on the default branch itself whenever it has nothing unpushed,
+    /// which is why [`Footing::rule`] asks where you are standing before it
+    /// asks this.
+    pub merged: bool,
+    /// An open pull request whose head is this branch.
+    pub pull_request: Option<u32>,
+    /// Whether nothing has been committed here yet.
+    ///
+    /// A fresh `git init` is an ordinary thing to link, and it is the one state
+    /// where the branch the tree reports is a branch that does not exist: git
+    /// names an unborn HEAD after the branch the first commit will create. Left
+    /// unsaid, the preamble reads as a contradiction, on branch `main` and
+    /// there is no `main`, and a model handed a contradiction resolves it by
+    /// guessing.
+    pub unborn: bool,
+}
+
+impl Footing {
+    /// What the harness reads in front of the brief.
+    ///
+    /// Facts, then the one rule they resolve to, and both halves are
+    /// load-bearing. Facts alone are not enough: a model handed a branch name
+    /// and a count decides for itself what to do with them, and the decision it
+    /// makes silently is to carry on where it is standing. A rule alone cannot
+    /// be written safely, which is the sharper half: *start from the default
+    /// branch* over uncommitted work destroys it, and this is the operator's
+    /// own machine rather than a sandbox. The facts are what make the rule
+    /// conditional, and the rule is what makes the facts act on anything.
+    pub fn brief(&self) -> String {
+        let mut out =
+            String::from("Where you are starting from, read from this work tree just now:\n");
+
+        if self.tree.detached {
+            out.push_str(&format!(
+                "- HEAD is detached at `{}`, not on a branch.\n",
+                self.tree.branch
+            ));
+        } else {
+            out.push_str(&format!("- On branch `{}`.\n", self.tree.branch));
+        }
+        if self.unborn {
+            out.push_str(&format!(
+                "- No commits yet: `{}` starts existing when something is committed to it.\n",
+                self.tree.branch
+            ));
+        }
+
+        out.push_str(&match self.tree.dirty {
+            0 => "- The tree is clean.\n".to_string(),
+            1 => "- 1 file is changed or untracked and not committed.\n".to_string(),
+            n => format!("- {n} files are changed or untracked and not committed.\n"),
+        });
+
+        if !self.tree.upstream {
+            out.push_str("- This branch tracks nothing on a remote.\n");
+        } else if self.tree.ahead == 0 && self.tree.behind == 0 {
+            out.push_str("- Level with its upstream.\n");
+        } else {
+            out.push_str(&format!(
+                "- {} not pushed, {} not pulled.\n",
+                commits(self.tree.ahead),
+                commits(self.tree.behind)
+            ));
+        }
+
+        if let Some(default) = &self.default_branch {
+            out.push_str(&format!("- The default branch here is `{default}`.\n"));
+        }
+        if let Some(number) = self.pull_request {
+            out.push_str(&format!("- Pull request #{number} is open for this branch.\n"));
+        }
+
+        // Said every time, including when the counts are zero, because zero is
+        // where it misleads: every number above and the merge test under it are
+        // measured against the last fetch, and a branch that landed upstream an
+        // hour ago reads here as work in flight. Fetching on the operator's
+        // behalf is not this app's call. The harness is the thing standing in
+        // the directory with a shell.
+        out.push_str(
+            "\nThese are measured against the last fetch rather than against the remote as it \
+             is now, so fetch before you rely on them.\n\n",
+        );
+
+        out.push_str(&self.rule());
+        // A brief and a preamble are both prose, and a harness given the two
+        // run together answers the preamble. One sentence is cheaper than
+        // finding out which it did.
+        out.push_str("\n\nWhat you have been asked to do follows.");
+        out
+    }
+
+    /// The one thing to do about all of that.
+    fn rule(&self) -> String {
+        // Uncommitted work is checked first and overrides every other case.
+        // The operator works in this directory too, and a rule that switched
+        // branches to be tidy would take an afternoon of theirs with it. This
+        // is the reason the facts are here at all: the same rule written
+        // unconditionally is the one that does the damage.
+        if self.tree.dirty > 0 {
+            return "There is uncommitted work in this tree and it may not be yours: this is the \
+                    operator's own machine and they work here too. Do not switch branches, \
+                    stash, reset or clean. Work from where you are, keep anything you did not \
+                    change out of your commits, and say what you found already changed. If this \
+                    brief cannot be done from here at all, stop and say so rather than clearing \
+                    the tree."
+                .to_string();
+        }
+
+        // After the dirty case, because a fresh `git init` with the operator's
+        // files already in it is both, and the rule that must not be lost is
+        // the one about their work. Before everything else, because there is no
+        // branch to go back to and no history to measure against.
+        if self.unborn {
+            return format!(
+                "This repository has no commits yet, so `{}` is not a branch you can leave and \
+                 come back to, and there is no history here to build on. Commit your work on it \
+                 rather than looking for another branch.",
+                self.tree.branch
+            );
+        }
+
+        // Before the default branch is looked at, because a detached HEAD is a
+        // state to get out of whether or not this repository publishes one, and
+        // the way out is the same either way.
+        if self.tree.detached {
+            let onto = match self.default_branch.as_deref() {
+                Some(default) => format!("a new one off `{default}` for new work"),
+                None => "a new one for new work".to_string(),
+            };
+            return format!(
+                "HEAD is detached, so a commit made here belongs to no branch and is easy to \
+                 lose. Put yourself on a branch before you change anything: {onto}, or the \
+                 branch this commit already belongs to if you are continuing something."
+            );
+        }
+
+        let Some(default) = self.default_branch.as_deref() else {
+            return "Nothing here names a default branch: there is no `origin/HEAD`, no `main` \
+                    and no `master`. Decide where this work belongs yourself, and say which \
+                    branch you put it on."
+                .to_string();
+        };
+
+        if self.tree.branch == default {
+            return format!(
+                "You are on `{default}`, the default branch. Bring it up to date before you \
+                 start. Where the work should land is the brief's to say; if it does not say, \
+                 put it on a branch of its own rather than committing here."
+            );
+        }
+
+        if self.merged {
+            return format!(
+                "`{}` is already contained in `{default}`: its work has landed and this is not \
+                 where new work goes. Unless the brief is explicitly about this branch, start \
+                 from `{default}` brought up to date and branch from there.",
+                self.tree.branch
+            );
+        }
+
+        let mut rule = format!(
+            "`{}` has commits `{default}` does not, so it is work in flight. Continue on it if \
+             this brief is about that work. If it is not, start from `{default}` brought up to \
+             date instead, so two unrelated changes do not arrive on one branch.",
+            self.tree.branch
+        );
+        if let Some(number) = self.pull_request {
+            rule.push_str(&format!(
+                " Pull request #{number} is open for it: push to this branch rather than opening \
+                 a second one."
+            ));
+        }
+        rule
+    }
+}
+
+/// A count of commits that reads as English at one.
+fn commits(count: u32) -> String {
+    match count {
+        1 => "1 commit".to_string(),
+        n => format!("{n} commits"),
+    }
+}
+
+/// Everything a job is told about the tree it is starting in.
+///
+/// `None` is the answer [`status`] gives for the same reason: this is not a
+/// directory git will talk about, which by the time a job starts means one that
+/// has been moved or deleted since it was linked. The job goes ahead without
+/// the preamble rather than being refused for it. The harness is standing in
+/// the directory and will find that out faster and say it better.
+pub async fn footing(path: &str) -> Option<Footing> {
+    let (tree, default) = tokio::join!(work_tree_status(path), default_branch(path));
+    let tree = tree?;
+
+    let (merged, pull_request, unborn) = tokio::join!(
+        async {
+            match &default {
+                Some((_, reference)) => contained_in(path, reference).await,
+                None => false,
+            }
+        },
+        async {
+            // Per branch rather than per repository, and only when there is a
+            // branch to ask about. The count the rail draws answers "is
+            // anything waiting for review"; what a job needs is whether the
+            // branch it is standing on already has one, which is the difference
+            // between pushing and opening a second.
+            if tree.detached {
+                None
+            } else {
+                open_pull_request(path, &tree.branch).await
+            }
+        },
+        // An unborn HEAD is the one thing `git status` reports by naming a
+        // branch that does not exist yet, and this is the cheapest question
+        // that tells the two apart.
+        async { !exists(path, "HEAD").await }
+    );
+
+    Some(Footing {
+        tree,
+        default_branch: default.map(|(name, _)| name),
+        merged,
+        pull_request,
+        unborn,
+    })
+}
+
+/// The branch new work starts from, by name and by the ref to measure against.
+///
+/// Two answers because they are two different things. The name is prose the
+/// harness reads and types. The ref is what the merge test runs against, and it
+/// is `origin/main` rather than `main`: a branch merged upstream has landed
+/// whether or not the local copy was ever pulled, and a local `main` nobody has
+/// updated in a month calls every landed branch work in flight.
+///
+/// `origin/HEAD` first, because it is the repository's own answer. The two
+/// names after it are a guess, reached only when nothing published one.
+async fn default_branch(path: &str) -> Option<(String, String)> {
+    let published = tokio::process::Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"])
+        .output()
+        .await
+        .ok();
+    if let Some(out) = published {
+        if out.status.success() {
+            let shown = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            // Always under `origin/`, because that is the ref that was asked
+            // for. Stripped by prefix rather than by the last separator, so a
+            // default branch called `release/next` keeps its own name.
+            if let Some(name) = shown.strip_prefix("origin/") {
+                if !name.is_empty() {
+                    return Some((name.to_string(), format!("refs/remotes/origin/{name}")));
+                }
+            }
+        }
+    }
+
+    for name in ["main", "master"] {
+        for reference in [format!("refs/remotes/origin/{name}"), format!("refs/heads/{name}")] {
+            if exists(path, &reference).await {
+                return Some((name.to_string(), reference));
+            }
+        }
+    }
+    None
+}
+
+async fn exists(path: &str, reference: &str) -> bool {
+    tokio::process::Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--verify", "--quiet", reference])
+        .output()
+        .await
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+/// Whether HEAD is already contained in this ref.
+///
+/// `merge-base --is-ancestor` rather than `branch --merged`, which answers with
+/// a list of names that would then have to be matched against the one this tree
+/// is on. Anything that is not a clean yes is a no: an unborn HEAD, a ref that
+/// has gone and a git that could not be run all mean this build cannot claim
+/// the work has landed, and claiming it wrongly sends a job away from the
+/// branch its work is on.
+async fn contained_in(path: &str, reference: &str) -> bool {
+    tokio::process::Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["merge-base", "--is-ancestor", "HEAD", reference])
+        .output()
+        .await
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+/// The open pull request whose head is this branch, asked of `gh`.
+///
+/// The same `None` discipline [`open_pull_requests`] has, for the same reason:
+/// every way of not knowing is one answer and it is not zero. The first row is
+/// taken because a branch carrying two open pull requests is somebody's own
+/// arrangement rather than something a job should reason about.
+async fn open_pull_request(path: &str, branch: &str) -> Option<u32> {
+    let out = tokio::process::Command::new("gh")
+        .current_dir(path)
+        .args([
+            "pr", "list", "--state", "open", "--head", branch, "--limit", "1", "--json", "number",
+        ])
+        .output()
+        .await
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let rows: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).ok()?;
+    rows.first()?.get("number")?.as_u64().map(|number| number as u32)
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -327,5 +683,246 @@ mod tests {
         let err = verify(file.to_str().unwrap()).await.unwrap_err();
         assert!(matches!(err, RepoError::NotADirectory(_)), "got {err:?}");
         let _ = tokio::fs::remove_file(&file).await;
+    }
+
+    // ---- the footing a job starts from -----------------------------------
+
+    /// A clean tree on a branch of its own, which every case below bends.
+    fn standing(branch: &str) -> Footing {
+        Footing {
+            tree: RepoStatus {
+                branch: branch.to_string(),
+                detached: false,
+                dirty: 0,
+                ahead: 0,
+                behind: 0,
+                upstream: true,
+                pull_requests: None,
+            },
+            default_branch: Some("main".to_string()),
+            merged: false,
+            pull_request: None,
+            unborn: false,
+        }
+    }
+
+    #[test]
+    fn a_branch_that_has_already_landed_sends_the_job_back_to_the_default() {
+        // The state this exists for: the last job opened a pull request, it was
+        // merged, and nobody put the tree back. Left alone, the next brief is
+        // built on top of a branch whose work is already in `main`.
+        let landed = Footing { merged: true, ..standing("feature/rail-badges") };
+        let brief = landed.brief();
+
+        assert!(brief.contains("already contained in `main`"), "{brief}");
+        assert!(brief.contains("start from `main`"), "{brief}");
+        assert!(brief.contains("branch from there"), "{brief}");
+    }
+
+    #[test]
+    fn uncommitted_work_is_never_cleared_to_get_to_a_branch() {
+        // The reason the state is read at all rather than the rule being
+        // written unconditionally. This is the operator's own machine: a job
+        // that checks out `main` to be tidy takes their afternoon with it.
+        let mut dirty = Footing { merged: true, ..standing("feature/x") };
+        dirty.tree.dirty = 4;
+        let brief = dirty.brief();
+
+        assert!(brief.contains("4 files are changed or untracked"), "{brief}");
+        assert!(brief.contains("Do not switch branches"), "{brief}");
+        assert!(brief.contains("stash, reset or clean"), "{brief}");
+        assert!(
+            !brief.contains("start from `main`"),
+            "a dirty tree is never sent to another branch: {brief}"
+        );
+    }
+
+    #[test]
+    fn a_branch_with_work_on_it_is_continued_and_its_pull_request_named() {
+        let flight = Footing { pull_request: Some(41), ..standing("feature/plugins") };
+        let brief = flight.brief();
+
+        assert!(brief.contains("work in flight"), "{brief}");
+        assert!(brief.contains("Continue on it"), "{brief}");
+        // Both halves matter: the fact, so it knows one exists, and the
+        // instruction, because the alternative it reaches for is a second one.
+        assert!(brief.contains("Pull request #41 is open for this branch"), "{brief}");
+        assert!(brief.contains("rather than opening a second one"), "{brief}");
+    }
+
+    #[test]
+    fn on_the_default_branch_the_brief_decides_where_the_work_lands() {
+        // Not an opinion about trunk-based development. Where the change goes
+        // is already the brief's to say, and a standing rule that overrode it
+        // would be a second answer to a question that has one.
+        let brief = standing("main").brief();
+
+        assert!(brief.contains("the default branch"), "{brief}");
+        assert!(brief.contains("brief's to say"), "{brief}");
+        assert!(brief.contains("branch of its own"), "{brief}");
+    }
+
+    #[test]
+    fn a_detached_head_is_put_on_a_branch_before_anything_is_written() {
+        let mut adrift = standing("x");
+        adrift.tree.branch = "9f3c1ab".into();
+        adrift.tree.detached = true;
+        let brief = adrift.brief();
+
+        assert!(brief.contains("HEAD is detached at `9f3c1ab`"), "{brief}");
+        assert!(brief.contains("belongs to no branch"), "{brief}");
+        assert!(brief.contains("off `main`"), "{brief}");
+    }
+
+    #[test]
+    fn a_repository_that_names_no_default_branch_asks_rather_than_inventing_one() {
+        // Somebody's own convention rather than a broken repository. A guessed
+        // name here is a branch that does not exist, and a job that spends its
+        // first minutes failing to check one out.
+        let unnamed = Footing { default_branch: None, ..standing("trunk") };
+        let brief = unnamed.brief();
+
+        assert!(brief.contains("Nothing here names a default branch"), "{brief}");
+        assert!(brief.contains("say which branch you put it on"), "{brief}");
+        // Naming the two it looked for is the explanation. What it must not do
+        // is send the job to one, which is a checkout that fails and a first
+        // minute spent on it.
+        assert!(!brief.contains("start from"), "sent to a branch that does not exist: {brief}");
+        assert!(!brief.contains("off `main`"), "sent to a branch that does not exist: {brief}");
+    }
+
+    #[test]
+    fn every_count_says_what_it_was_measured_against() {
+        // Zero is where this misleads rather than where it is safe to drop: a
+        // branch merged upstream an hour ago and never fetched reads here as
+        // work in flight, level with its upstream.
+        let brief = standing("feature/x").brief();
+        assert!(brief.contains("last fetch"), "{brief}");
+        assert!(brief.contains("What you have been asked to do follows"), "{brief}");
+    }
+
+    #[test]
+    fn a_single_commit_and_a_single_file_read_as_english() {
+        let mut one = standing("feature/x");
+        one.tree.dirty = 1;
+        one.tree.ahead = 1;
+        one.tree.behind = 1;
+        let brief = one.brief();
+        assert!(brief.contains("1 file is changed"), "{brief}");
+        assert!(brief.contains("1 commit not pushed, 1 commit not pulled"), "{brief}");
+    }
+
+    /// Git with an identity of its own, so the suite does not depend on what
+    /// the machine running it has configured and does not try to sign.
+    async fn run_git(root: &Path, args: &[&str]) {
+        let done = tokio::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args([
+                "-c",
+                "user.name=guac",
+                "-c",
+                "user.email=guac@example.com",
+                "-c",
+                "commit.gpgsign=false",
+            ])
+            .args(args)
+            .output()
+            .await
+            .expect("git has to be installed to run this suite");
+        assert!(done.status.success(), "git {args:?} failed: {done:?}");
+    }
+
+    /// A repository with a commit in it, because a merge test needs history and
+    /// a default branch needs a ref that exists.
+    async fn a_repository_with_history(name: &str, branch: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!("guac-hist-{name}-{}", std::process::id()));
+        let _ = tokio::fs::remove_dir_all(&root).await;
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        run_git(&root, &["init", "-b", branch]).await;
+        tokio::fs::write(root.join("a.txt"), b"one").await.unwrap();
+        run_git(&root, &["add", "."]).await;
+        run_git(&root, &["commit", "-m", "one"]).await;
+        tokio::fs::canonicalize(&root).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_branch_git_has_already_folded_in_is_read_as_landed() {
+        // Against real git rather than a fixture, for the reason the rest of
+        // this file is: the whole value of the answer is that it agrees with
+        // git, and a stub agrees with itself.
+        let root = a_repository_with_history("landed", "main").await;
+        let path = root.to_str().unwrap();
+
+        run_git(&root, &["checkout", "-b", "landed"]).await;
+        let standing = footing(path).await.expect("a repository with history has a footing");
+        assert_eq!(standing.default_branch.as_deref(), Some("main"));
+        assert!(standing.merged, "a branch carrying nothing has landed by definition");
+        assert!(standing.brief().contains("start from `main`"), "{}", standing.brief());
+
+        tokio::fs::write(root.join("b.txt"), b"two").await.unwrap();
+        run_git(&root, &["add", "."]).await;
+        run_git(&root, &["commit", "-m", "two"]).await;
+        let moved = footing(path).await.unwrap();
+        assert!(!moved.merged, "a commit the default does not have is work in flight");
+        assert!(moved.brief().contains("work in flight"), "{}", moved.brief());
+
+        let _ = tokio::fs::remove_dir_all(&root).await;
+    }
+
+    #[tokio::test]
+    async fn the_default_branch_is_the_one_the_remote_published() {
+        // Named `trunk` on purpose: neither fallback can find it, so this
+        // passing is `origin/HEAD` having been read and its prefix taken off
+        // correctly rather than a guess that happened to be right.
+        let root = a_repository_with_history("published", "trunk").await;
+        let path = root.to_str().unwrap();
+        let bare = std::env::temp_dir().join(format!("guac-bare-{}", std::process::id()));
+        let _ = tokio::fs::remove_dir_all(&bare).await;
+
+        run_git(&root, &["init", "--bare", bare.to_str().unwrap()]).await;
+        run_git(&root, &["remote", "add", "origin", bare.to_str().unwrap()]).await;
+        run_git(&root, &["push", "-u", "origin", "trunk"]).await;
+        run_git(&root, &["remote", "set-head", "origin", "trunk"]).await;
+
+        let standing = footing(path).await.unwrap();
+        assert_eq!(standing.default_branch.as_deref(), Some("trunk"), "{standing:?}");
+        assert!(standing.tree.upstream, "the push set one: {standing:?}");
+        assert!(
+            standing.brief().contains("You are on `trunk`, the default branch"),
+            "{}",
+            standing.brief()
+        );
+
+        let _ = tokio::fs::remove_dir_all(&root).await;
+        let _ = tokio::fs::remove_dir_all(&bare).await;
+    }
+
+    #[tokio::test]
+    async fn a_repository_with_no_commits_is_not_told_to_go_back_to_a_branch() {
+        // A fresh `git init` is an ordinary thing to link. Git names an unborn
+        // HEAD after the branch the first commit will create, so without this
+        // the preamble says `on branch main` and `there is no main` two lines
+        // apart, and sends the job looking for somewhere else to start.
+        let root = std::env::temp_dir().join(format!("guac-unborn-{}", std::process::id()));
+        let _ = tokio::fs::remove_dir_all(&root).await;
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        run_git(&root, &["init", "-b", "main"]).await;
+
+        let standing = footing(root.to_str().unwrap()).await.unwrap();
+        assert!(standing.unborn, "nothing has been committed: {standing:?}");
+        let brief = standing.brief();
+        assert!(brief.contains("No commits yet"), "{brief}");
+        assert!(brief.contains("Commit your work on it"), "{brief}");
+        assert!(!brief.contains("start from"), "there is nowhere to go back to: {brief}");
+
+        let _ = tokio::fs::remove_dir_all(&root).await;
+    }
+
+    #[tokio::test]
+    async fn a_directory_git_will_not_talk_about_has_no_footing() {
+        // A repository moved or deleted since it was linked. The job goes ahead
+        // without a preamble rather than being refused for one.
+        assert!(footing("/no/such/directory/anywhere").await.is_none());
     }
 }

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -1682,15 +1682,33 @@ impl Runtime {
         });
 
         tokio::spawn(async move {
-            // The operator's note rides in front of the brief rather than being
-            // left for the model to discover. It is the one thing they wrote to
-            // be read at exactly this moment, and the harness cannot see the
-            // conversation the note was attached to.
-            let brief = if note.trim().is_empty() {
-                task.clone()
-            } else {
-                format!("{}\n\nStanding instruction for this repository: {}", task, note.trim())
-            };
+            // Where the tree is standing, then the work, then the operator's
+            // note. All three are things the harness cannot see for itself and
+            // would not go looking for.
+            //
+            // The footing leads because it is read before the first edit or it
+            // is not read at all: a harness handed a brief starts working where
+            // it is standing, and where it is standing is wherever the last job
+            // left it. `repo::footing` is the argument. Read here rather than
+            // before the spawn because it is several subprocesses and one
+            // network round trip, and `start_job` has already returned to a
+            // turn that must not wait on any of it.
+            //
+            // The note is last because it is the one thing the operator wrote
+            // to be read at exactly this moment, and the harness cannot see the
+            // conversation it was attached to.
+            let mut brief = String::new();
+            if let Some(footing) = crate::repo::footing(&path).await {
+                brief.push_str(&footing.brief());
+                brief.push_str("\n\n");
+            }
+            brief.push_str(&task);
+            if !note.trim().is_empty() {
+                brief.push_str(&format!(
+                    "\n\nStanding instruction for this repository: {}",
+                    note.trim()
+                ));
+            }
 
             let watcher = runtime.clone();
             let outcome = crate::coding::run(harness, &path, &brief, move |progress| {

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -652,7 +652,11 @@ pub fn system_prompt(
               brief has to carry everything: what to change, how to tell it worked, and what to \
               do with the result.\n\
              - You have not read the code yourself. When the work comes back, report what the \
-              coding agent says it did rather than claiming to have checked it.\n",
+              coding agent says it did rather than claiming to have checked it.\n\
+             - The coding agent is told the state of the work tree as it starts: the branch, \
+              whether anything is uncommitted, and whether that branch has already been merged. \
+              So do not put branch instructions in the brief and do not guess at one. Say what \
+              the work is and where it should end up.\n",
             repository.own_line().trim_start_matches("- "),
         ));
     }

--- a/src-tauri/tests/coding.rs
+++ b/src-tauri/tests/coding.rs
@@ -110,6 +110,39 @@ fn a_repository(name: &str) -> PathBuf {
     std::fs::canonicalize(&root).unwrap()
 }
 
+/// Git with an identity of its own, so the suite does not depend on what the
+/// machine running it has configured and does not try to sign.
+fn git(root: &Path, args: &[&str]) {
+    let done = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args([
+            "-c",
+            "user.name=guac",
+            "-c",
+            "user.email=guac@example.com",
+            "-c",
+            "commit.gpgsign=false",
+        ])
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(done.status.success(), "git {args:?} failed: {done:?}");
+}
+
+/// A repository sitting where the last job left it: on a branch whose work is
+/// already in `main`. The state an operator finds weeks later and the reason
+/// a job is told its footing at all.
+fn a_repository_on_a_landed_branch(name: &str) -> PathBuf {
+    let root = a_repository(name);
+    git(&root, &["checkout", "-b", "main"]);
+    std::fs::write(root.join("a.txt"), "one").unwrap();
+    git(&root, &["add", "."]);
+    git(&root, &["commit", "-m", "one"]);
+    git(&root, &["checkout", "-b", "landed"]);
+    root
+}
+
 /// Every argument the stand-in in this repository was handed.
 fn argv_at(repository: &Path) -> Vec<String> {
     let raw = std::fs::read_to_string(repository.join(ARGV)).expect("the stand-in never ran");
@@ -312,7 +345,72 @@ async fn an_agent_is_told_what_the_harness_it_was_given_said() {
 
     let argv = argv_at(&repo);
     assert!(argv.contains(&"stream-json".to_string()), "the column was not read: {argv:?}");
-    assert!(argv.contains(&"fix the flaky test".to_string()), "{argv:?}");
+    // Contained rather than equal: the brief a job is started with carries the
+    // footing in front of it, which the test below is the test of.
+    assert!(argv.iter().any(|arg| arg.contains("fix the flaky test")), "{argv:?}");
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+/// A job is told where the tree is standing before it is told what to do.
+///
+/// This is the other seam nothing else in the repo can see. Drop the
+/// `repo::footing` read in `Runtime::start_job` and every suite still passes,
+/// while every job in every workspace goes on starting wherever the last one
+/// left the tree: a branch that was merged a month ago, silently, on top of
+/// work that has already landed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_job_is_told_which_branch_it_is_standing_on() {
+    stand_ins();
+    let repo = a_repository_on_a_landed_branch("footing");
+
+    let stub = serve(|body| {
+        if anyone_said(body, "has finished") {
+            Script::Say("The coding agent did the work.".into())
+        } else {
+            Script::Code("fix the flaky test".into())
+        }
+    })
+    .await;
+    let h = harness(&stub, &["Engineer"], GuardLimits::default());
+
+    let engineer = h.agent_named("Engineer").unwrap();
+    let linked = h
+        .runtime
+        .store()
+        .create_repository(&CleanRepository {
+            group_id: engineer.group_id,
+            name: "guaca".into(),
+            path: repo.to_string_lossy().to_string(),
+            note: "run ./scripts/ci.sh before you finish".into(),
+            harness: Which::Pi,
+        })
+        .unwrap();
+    h.runtime.store().set_agent_repository(engineer.id, Some(linked.id)).unwrap();
+
+    let run = h.runtime.send_from_human(h.id("Engineer"), "fix the flaky test").unwrap();
+    h.settle(run).await;
+    h.wait_until("the coding job is reported back", |h| {
+        h.channel_texts("Engineer").iter().any(|line| line.contains("did the work"))
+    })
+    .await;
+
+    let argv = argv_at(&repo);
+    let brief = argv
+        .iter()
+        .find(|arg| arg.contains("fix the flaky test"))
+        .unwrap_or_else(|| panic!("the brief never reached the program: {argv:?}"));
+
+    // The state, the rule it resolves to, the work, and the operator's note, in
+    // that order. The footing leads because it is read before the first edit or
+    // it is not read at all.
+    assert!(brief.contains("On branch `landed`"), "{brief}");
+    assert!(brief.contains("already contained in `main`"), "{brief}");
+    assert!(brief.contains("start from `main`"), "{brief}");
+    let state = brief.find("Where you are starting from").expect("no footing: {brief}");
+    let work = brief.find("fix the flaky test").unwrap();
+    let note = brief.find("Standing instruction").expect("the note still rides along");
+    assert!(state < work && work < note, "the three parts are out of order: {brief}");
+
     let _ = std::fs::remove_dir_all(&repo);
 }
 


### PR DESCRIPTION
A harness handed a brief starts editing where it is standing, and where it is standing is wherever the last job left the tree: a job that opens a pull request ends on the branch it made, the operator merges it, and every job after that builds on work that has already landed. `repo::footing` now reads the tree as a job starts and `Runtime::start_job` puts it in front of the brief (the branch, whether it is clean, whether it is already contained in the default branch, whether a pull request is open for it) followed by one rule those facts resolve to. Uncommitted work is checked before every other case, because "start from the default branch" over a dirty tree destroys the operator's own work, and this is their machine rather than a sandbox. The alternative, a standing rule about what a job leaves behind, does not hold: a job killed at the ceiling never runs its cleanup and a job that opened a pull request should still be on its branch. Ten tests in `repo.rs` cover the renderer and real git repositories, and `tests/coding.rs` drives a real `code` call against a repository sitting on a landed branch, which is the only test that fails if the footing read is dropped.