### PR TITLE
feat: a page an agent wrote can hand a value back, and Guaca is what carries it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ repo: the frontend renders state and forwards intent.
 | Charts, tables, a page an agent wrote: what a reply can be drawn as | *A reply can be a figure* in `docs/WORKSPACE.md`, then `src/lib/figure.ts` and `src/lib/chart.ts` |
 | A chart's colors, or how many series one may carry | *A chart's colors are the output of a check* in `docs/WORKSPACE.md`, then `src/lib/palette.ts` and the test beside it, which is the gate |
 | Running a model's own HTML, or anything about that origin | *A page an agent wrote runs somewhere else* in `docs/WORKSPACE.md`, then `src-tauri/src/artifact.rs` |
+| A page the operator can work, and what it may hand back | *A page can hand one value back* in `docs/WORKSPACE.md`, then `BRIDGE` in `src-tauri/src/artifact.rs` and `Answering` in `src/components/HtmlArtifact.tsx` |
 | A turn's tool calls in a channel: what folds, what a chip says, what opens | *A turn's own work is chips* in `docs/WORKSPACE.md`, then `src/lib/trail.ts` |
 | What an agent changed about its own memory, and where the version before it came from | *A memory rewrite opens as a diff* in `docs/WORKSPACE.md`, then `Workspace::write` and `src/lib/diff.ts` |
 | What an agent currently remembers, and editing it by hand | *An agent's memory is in the panel* in `docs/WORKSPACE.md`, then `src/components/Memory.tsx` and `src-tauri/src/workspace.rs` |
@@ -513,6 +514,23 @@ the model takes a screenshot to see what `browse` did.
   and its script would silently never run: an empty rectangle that passes every
   test, which is the same failure `FileCard` has a note about. So it gets an
   origin of its own, and the round trip through `frame_artifact` is what buys it.
+- **A page hands a value back and never a message, and the two clicks are the
+  lock.** `guaca.answer` posts to the window that framed the page, which is the
+  one channel an opaque origin has and the one the height reporter already used;
+  the renderer draws the value in Guaca's own chrome and waits for the operator.
+  Letting the page send directly is a page that sends again every time it is
+  scrolled past, because a transcript re-frames one whenever it draws it, and
+  every send is a turn nobody asked for and somebody paid for. The value is also
+  JSON and never a sentence, so nothing the page wrote can arrive as an
+  instruction in the operator's voice: `answerMessage` is the wording around it.
+  Same line `domain::approval` draws between a permission and a question.
+- **A page is framed once, whole; a chart is redrawn every token.** They look
+  like the same decision and are opposite ones. A chart is a pure function to
+  coordinates, so redrawing it is free and is what makes one assemble itself on
+  screen. A page is registered and then pointed at, so redrawing it is a reload:
+  a round trip per token, an entry per token in a store that holds two dozen, and
+  a frame that throws away whatever the operator had done in it. `live` on
+  `Markdown` is the whole mechanism, and `StreamingMessage` is its one caller.
 - **`allow-scripts` and `allow-same-origin` must never appear together.** On the
   frame or in `ARTIFACT_CSP`. Together they let the page remove its own sandbox
   attribute and reload out of the box, which is the whole lock. `default-src

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -396,7 +396,7 @@ server holds a copy of the last two dozen while a transcript is drawing them,
 and a restart re-registers whatever is on screen.
 
 **The page reports its own height, because nothing outside it can measure it.**
-A cross-origin frame cannot be read, so `artifact.rs` prepends a reporter that
+A cross-origin frame cannot be read, so `artifact.rs` prepends a bridge that
 posts its height on every change. Prepended rather than appended: a model's page
 is exactly where an unclosed tag lives, and an unclosed tag swallows everything
 after it. The parent trusts the message by the window that sent it and by
@@ -404,6 +404,65 @@ nothing else, because an opaque origin reports itself as `"null"` and checking
 the origin would either reject every real message or accept every forged one. It
 clamps what it is told, too: a page claiming a height of a hundred thousand has
 made itself the whole channel.
+
+**A page is framed once, whole, and not while the reply is still arriving.**
+This is where the two figures come apart. A chart is a pure function from a spec
+to coordinates, so redrawing it on every token is free and is what makes one
+assemble itself on screen; that is the feature. A page is drawn by registering a
+document and pointing a frame at the address that comes back, so the same
+treatment is a reload per token: a round trip each, a fresh entry each in a store
+that holds two dozen, and a frame that throws away whatever the operator had done
+in it every sixteen milliseconds. So a `html` fence in a live bubble says
+*Drawing…* until the reply settles. `live` is a prop on `Markdown`, set by the
+one component that draws a body still being written.
+
+## A page can hand one value back, and Guaca is what carries it
+
+A page that can be worked and cannot answer is a dead end. The operator picks one
+plan out of four, drags a range to $450K, ticks six of the nine rows, and none of
+it reaches the agent that drew the page: they are left retyping in the composer
+what they just expressed by clicking, which is the work the page was supposed to
+save.
+
+So the bridge defines one more thing, `guaca.answer(value)`, and it is not a hole
+in the paragraph above. It reaches no network. It posts to the window that framed
+it, which is the one channel an opaque origin has and the one the height reporter
+has always used, and **what happens next is Guaca's decision rather than the
+page's**: the renderer draws the value below the frame, in the app's own chrome,
+and waits. The page fills a form in. A person sends it.
+
+That ordering is the whole safety argument and it is not ceremony. A transcript
+re-frames a page whenever it draws one, so a page that could send by itself would
+send again every time it was scrolled past, and every send is a turn the operator
+did not ask for and does pay for. It is also the rule this app applies everywhere
+a model's words would travel under the operator's name: shown before they go,
+drawn as text, never as markup. Same line `domain::approval` draws between a
+permission and a question, one level out.
+
+**The page hands back a value, never a sentence.** `answerMessage` is Guaca's
+wording around the page's JSON, so nothing the page wrote can arrive as an
+instruction in the operator's voice. What is sent is an ordinary operator
+message: `Trust::Operator`, in the record, searchable, readable back by the agent
+that drew the page. It is theirs because they read the value in the strip and
+pressed the button, and what they are vouching for is a value they could see.
+
+The value crosses as JSON *text* rather than as a structured-cloned object,
+because the string is what is shown, what is capped and what is sent. A value
+that will not survive `JSON.stringify` fails inside the page, where the page is
+told about it by the `false` coming back, instead of arriving as something the
+app has to decide about. It is capped at 4,000 characters, with the refusal
+saying so: an answer is a choice, not a document.
+
+**Answering replaces, and never queues.** A page that calls `guaca.answer` on
+every drag of a slider is doing exactly the right thing, and what the operator
+sends is what the page last handed back, which is what they are looking at.
+
+**Nobody to answer means no strip at all.** `Answering` is a context that is null
+everywhere and provided by one surface: the channel, where the operator is one of
+the two participants and their next message has an obvious recipient. A page
+behind a search hit, inside a pair's thread or in a document preview draws and
+runs exactly as before; a Send button in those places would be a control that
+cannot say who it sends to.
 
 ## A transcript is a log, and says one thing out loud
 

--- a/src-tauri/src/artifact.rs
+++ b/src-tauri/src/artifact.rs
@@ -28,7 +28,7 @@
 //! argument for allowing this at all. A model's page is the least trustworthy
 //! content in the app: it was written by something that may have read a hostile
 //! web page earlier in the same turn. It may compute and it may draw, and it
-//! may not talk to anybody:
+//! may not reach anybody:
 //!
 //! - `default-src 'none'`: no fetch, no XHR, no websocket, no font, no
 //!   stylesheet and no image from anywhere. An `<img src="https://…/?data=">`
@@ -46,6 +46,32 @@
 //! `allow-scripts` without `allow-same-origin` is what makes the last one true,
 //! and the two must never be granted together: that combination lets the page
 //! remove its own sandbox attribute and reload itself out of the box.
+//!
+//! # It may hand one value back, and Guaca is what carries it
+//!
+//! A page that can be worked and cannot answer is a dead end. The operator
+//! picks one plan out of four, drags a range, ticks six of nine rows, and none
+//! of it can reach the agent that drew the page: they are left retyping in the
+//! composer what they just expressed by clicking. So [`BRIDGE`] defines
+//! `guaca.answer(value)`, and it is not a hole in the paragraph above.
+//!
+//! It reaches no network. It posts to the window that framed it, which is the
+//! one channel an opaque origin has and the one the height reporter has always
+//! used, and what happens next is the app's decision rather than the page's:
+//! the renderer draws the value in Guaca's own chrome, below the frame, and the
+//! operator presses the button. The page fills a form in. A person sends it.
+//!
+//! That ordering is the safety argument and it is not ceremony. A transcript
+//! re-frames a page whenever it draws one, so a page that could send by itself
+//! would send again every time it was scrolled past, and every send is a turn
+//! the operator did not ask for and does pay for. It is also the rule this app
+//! applies everywhere a model's words would go out under the operator's name:
+//! shown before they go, drawn as text, never as markup.
+//!
+//! JSON text rather than a structured-cloned value, because the string is what
+//! is shown, what is capped and what is sent. A value that would not survive
+//! `JSON.stringify` then fails inside the page, which is where the page can see
+//! it happen, instead of arriving as something the app has to decide about.
 //!
 //! Nothing here is persisted. The document itself already lives in the message
 //! that carried it, which is the record; this holds a copy only while a
@@ -230,31 +256,41 @@ fn requested(head: &[u8]) -> Option<String> {
     ok.then(|| id.to_ascii_lowercase())
 }
 
-/// The document, plus the one thing Guaca adds to it.
-///
-/// A frame on another origin cannot be measured from outside, so a page that
-/// says nothing about its own size is drawn at whatever height was guessed,
-/// which for a one-line diagram is a tall gray box and for a long one is a
-/// nested scrollbar. So the page is asked, and it answers on the only channel
-/// an opaque origin has.
+/// The document, plus the two things Guaca adds to it.
 ///
 /// Prepended, not appended: a document with an unclosed tag swallows anything
 /// after it, and a model's page is exactly where an unclosed tag lives. Ahead
 /// of `<!doctype>` it is still parsed and run, because the parser treats a
 /// stray script before the doctype as content and starts the document anyway.
+/// It is also what makes `guaca.answer` defined before the page's own script
+/// runs, rather than a function the page has to wait for.
 fn wrap(page: &str) -> String {
-    format!("{HEIGHT_REPORTER}{page}")
+    format!("{BRIDGE}{page}")
 }
 
-/// Tells whoever framed this how tall it turned out to be.
+/// Everything the page can say to the window that framed it.
 ///
-/// Reported on every change rather than once on load: a page that draws after
-/// a timer, or grows when something in it is clicked, has a different answer a
-/// second later. `postMessage` to `"*"` because the parent's origin is not
-/// something this document is allowed to know, and it does not need to: the
-/// parent identifies this frame by the window that sent the message, which is
-/// the check that actually holds.
-const HEIGHT_REPORTER: &str = r#"<script>
+/// Two messages, on the one channel an opaque origin has, and `postMessage` to
+/// `"*"` for both: the parent's origin is not something this document is
+/// allowed to know, and it does not need to be, because the parent identifies
+/// this frame by the window the message came from, which is the check that
+/// actually holds.
+///
+/// **The height**, because a frame on another origin cannot be measured from
+/// outside: a page that says nothing about its own size is drawn at whatever
+/// was guessed, which for a one-line diagram is a tall gray box and for a long
+/// one is a nested scrollbar. Reported on every change rather than once on
+/// load, since a page that draws after a timer, or grows when something in it
+/// is clicked, has a different answer a second later.
+///
+/// **The answer**, which is a value and never a send. `guaca.answer` posts and
+/// nothing else happens: whether that value ever becomes a message is the
+/// operator's decision, taken in Guaca's own chrome. See the note on this
+/// module for why that ordering is the whole of what makes this safe. It is
+/// serialized here rather than cloned, so a value that will not survive
+/// `JSON.stringify` fails in the page, where the page is told about it by the
+/// `false` coming back, instead of in the app.
+const BRIDGE: &str = r#"<script>
 (function () {
   var last = 0;
   function tell() {
@@ -274,6 +310,19 @@ const HEIGHT_REPORTER: &str = r#"<script>
       new ResizeObserver(tell).observe(document.documentElement);
     });
   }
+  window.guaca = {
+    answer: function (value) {
+      var said;
+      try {
+        said = JSON.stringify(value);
+      } catch (err) {
+        said = null;
+      }
+      if (typeof said !== "string") return false;
+      parent.postMessage({ guaca: "artifact-answer", value: said }, "*");
+      return true;
+    }
+  };
 })();
 </script>
 "#;
@@ -432,6 +481,9 @@ mod tests {
         // The page has to be able to report its own height, or a frame on
         // another origin is drawn at whatever was guessed.
         assert!(said.contains("artifact-height"), "{said}");
+        // And to hand a value back, or a page the operator can work is one
+        // whose working reaches nobody.
+        assert!(said.contains("artifact-answer"), "{said}");
     }
 
     #[tokio::test]
@@ -448,12 +500,31 @@ mod tests {
     }
 
     #[test]
-    fn puts_the_height_reporter_where_an_unclosed_tag_cannot_eat_it() {
+    fn puts_the_bridge_where_an_unclosed_tag_cannot_eat_it() {
         // A model's page is exactly where an unclosed tag lives, and anything
-        // after one is swallowed by it.
+        // after one is swallowed by it. It is also what makes `guaca.answer`
+        // defined before the page's own script asks for it.
         let wrapped = wrap("<!doctype html><p>hi");
         assert!(wrapped.starts_with("<script>"), "{wrapped}");
         assert!(wrapped.contains("artifact-height"));
+        assert!(wrapped.contains("window.guaca"));
         assert!(wrapped.ends_with("<!doctype html><p>hi"));
+    }
+
+    #[test]
+    fn the_answer_bridge_posts_a_value_and_never_a_message() {
+        // The distinction this whole feature rests on. A page hands a value to
+        // the window that framed it; whether that value ever becomes a message
+        // is decided in Guaca's own chrome, by the operator, and there is
+        // nothing in here that could take that step on its own.
+        assert!(BRIDGE.contains(r#"parent.postMessage({ guaca: "artifact-answer""#), "{BRIDGE}");
+        // Serialized in the page, so a value that cannot survive it fails
+        // where the page can be told about it rather than in the app.
+        assert!(BRIDGE.contains("JSON.stringify(value)"), "{BRIDGE}");
+        assert!(BRIDGE.contains("return false"), "{BRIDGE}");
+        // Nothing here may reach the network, which the policy already refuses
+        // and which nothing in the bridge should be asking for either.
+        assert!(!BRIDGE.contains("fetch("), "{BRIDGE}");
+        assert!(!BRIDGE.contains("XMLHttpRequest"), "{BRIDGE}");
     }
 }

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -719,15 +719,23 @@ pub fn system_prompt(
              - A scatter's `data` is `[x, y]` pairs.\n\
              - Guaca chooses the colors, the axes, the legend and the layout. Do not describe \
              them, and do not ask for them.\n\n\
-             An ```html fence is run as a page: a diagram, a layout, a small thing the operator \
-             can click. Its own markup, style and script, and it can reach nothing at all: no \
-             network, no remote image, no font. Everything it shows it has to contain or \
-             compute.\n\n\
+             An ```html fence is run as a page, on an origin of its own: a diagram, a layout, \
+             a comparison laid out as cards, a small thing the operator can work. Its own \
+             markup, style and script, and it can reach nothing at all: no network, no remote \
+             image, no font, no library. Everything it shows it has to contain or compute.\n\n\
+             A page can hand one value back. Call `guaca.answer(value)` with any JSON value and \
+             Guaca shows it to the operator underneath the page, with a button that sends it to \
+             you as their next message. The page cannot send anything by itself, so call it \
+             again on every change if that is easiest: what they send is whatever the page last \
+             handed back. Reach for a page over a question when what you need is a shape rather \
+             than a word: several things picked at once, a number chosen off a range, a table \
+             the operator edits. Hand back an object whose keys say what each value is.\n\n\
              Reach for a figure when the shape is the point: a trend, a comparison, a breakdown, \
-             a schedule. Do not draw a single number, or three of them; write those in a \
-             sentence, where they are read at a glance instead of measured off an axis. And \
-             write the sentence either way. A figure nobody says anything about leaves the \
-             operator to work out for themselves what you concluded.\n",
+             a schedule, a choice with more to it than a list of options. Do not draw a single \
+             number, or three of them; write those in a sentence, where they are read at a \
+             glance instead of measured off an axis. Most replies are prose and should stay \
+             prose. And write the sentence either way. A figure nobody says anything about \
+             leaves the operator to work out for themselves what you concluded.\n",
         );
     }
 
@@ -1179,9 +1187,13 @@ mod tests {
         assert!(prompt.contains("```chart"), "the chart fence is never mentioned");
         assert!(prompt.contains("bar, line, area, pie, donut, scatter"));
         assert!(prompt.contains("```html"));
+        // A page nobody can answer is a dead end, and a capability an agent is
+        // not told about is one nobody uses: both halves have to be said.
+        assert!(prompt.contains("guaca.answer(value)"), "the answer channel is never mentioned");
         // And the argument against overusing it, in the same breath. An agent
         // told only that it can draw charts draws one for three numbers.
         assert!(prompt.contains("Do not draw a single number"));
+        assert!(prompt.contains("Most replies are prose"));
     }
 
     #[test]
@@ -1190,6 +1202,9 @@ mod tests {
         // is tokens spent drawing something nobody will look at.
         let prompt = prompt_for(&card("Analyst"), &[], "", ReplyMode::ToPeer);
         assert!(!prompt.contains("```chart"), "the peer path carries the figure section");
+        // And a peer has no operator to hand a value back to, so a page it
+        // could answer with is a page nobody will ever press a button on.
+        assert!(!prompt.contains("guaca.answer"), "the peer path is offered the answer channel");
     }
 
     #[test]

--- a/src/components/ChannelView.tsx
+++ b/src/components/ChannelView.tsx
@@ -18,6 +18,7 @@ import {
 import { ActivityFlow } from "./ActivityFlow";
 import { CodingPanel } from "./CodingPanel";
 import { Composer } from "./Composer";
+import { Answering } from "./HtmlArtifact";
 import { MessageItem, StreamingMessage, WhenRow } from "./MessageItem";
 import { PairThread } from "./PairThread";
 import { TrailRow } from "./Trail";
@@ -60,6 +61,15 @@ export function ChannelView({ channel, onOpenMenu }: Props) {
 
   const isActivity = channel === ACTIVITY_CHANNEL;
   const agent = isActivity ? undefined : lookups.byId(channel);
+  // Held steady across renders: it is the value of a context read by every page
+  // in the transcript, and a fresh object each time would redraw all of them
+  // for every token that lands anywhere.
+  const answeringId = agent?.id;
+  const answeringName = agent?.name;
+  const answering = useMemo(
+    () => (answeringId && answeringName ? { id: answeringId, name: answeringName } : null),
+    [answeringId, answeringName],
+  );
 
   useLayoutEffect(follow, [follow, messages]);
 
@@ -184,49 +194,54 @@ export function ChannelView({ channel, onOpenMenu }: Props) {
           aria-live="off"
           aria-label={`Conversation with ${agent?.name ?? "this agent"}`}
         >
-          {messages === undefined ? (
-            <p className="hint" style={{ padding: "1rem 1.15rem" }}>
-              Loading…
-            </p>
-          ) : messages.length === 0 ? (
-            <div className="empty">
-              <p className="empty__body">No messages with {agent?.name ?? "this agent"} yet.</p>
-            </div>
-          ) : (
-            rows.map((row) => {
-              const stands = rowStandsFor(row);
-              return (
-                // Wrapped rather than marked on the entry itself: a row renders
-                // as several different shapes depending on who sent what to
-                // whom, and one of them is several rows.
-                <div
-                  key={row.key}
-                  data-message={stands.join(" ")}
-                  data-found={focused && stands.includes(focused) ? "true" : undefined}
-                >
-                  {row.kind === "peers" ? (
-                    <PeerBurstRow peers={row.peers} onOpen={setReading} />
-                  ) : row.kind === "refused" ? (
-                    <RefusedRow peer={row.peer} at={row.at} body={row.body} reason={row.reason} />
-                  ) : row.kind === "when" ? (
-                    <WhenRow at={row.at} />
-                  ) : (
-                    // Two participants, one of them named at the top of the
-                    // pane and the other reading this. Nothing here needs
-                    // telling whose words it is looking at.
-                    <MessageItem
-                      message={row.message}
-                      lookups={lookups}
-                      continued={row.continued}
-                      named={false}
-                    />
-                  )}
-                </div>
-              );
-            })
-          )}
+          {/* Who a page in this transcript may answer. Only here: the operator
+              is one of the two participants in a channel, so a value handed
+              back has an obvious next message and an obvious recipient. */}
+          <Answering.Provider value={answering}>
+            {messages === undefined ? (
+              <p className="hint" style={{ padding: "1rem 1.15rem" }}>
+                Loading…
+              </p>
+            ) : messages.length === 0 ? (
+              <div className="empty">
+                <p className="empty__body">No messages with {agent?.name ?? "this agent"} yet.</p>
+              </div>
+            ) : (
+              rows.map((row) => {
+                const stands = rowStandsFor(row);
+                return (
+                  // Wrapped rather than marked on the entry itself: a row renders
+                  // as several different shapes depending on who sent what to
+                  // whom, and one of them is several rows.
+                  <div
+                    key={row.key}
+                    data-message={stands.join(" ")}
+                    data-found={focused && stands.includes(focused) ? "true" : undefined}
+                  >
+                    {row.kind === "peers" ? (
+                      <PeerBurstRow peers={row.peers} onOpen={setReading} />
+                    ) : row.kind === "refused" ? (
+                      <RefusedRow peer={row.peer} at={row.at} body={row.body} reason={row.reason} />
+                    ) : row.kind === "when" ? (
+                      <WhenRow at={row.at} />
+                    ) : (
+                      // Two participants, one of them named at the top of the
+                      // pane and the other reading this. Nothing here needs
+                      // telling whose words it is looking at.
+                      <MessageItem
+                        message={row.message}
+                        lookups={lookups}
+                        continued={row.continued}
+                        named={false}
+                      />
+                    )}
+                  </div>
+                );
+              })
+            )}
 
-          <LiveStreams channel={channel} lookups={lookups} follow={follow} />
+            <LiveStreams channel={channel} lookups={lookups} follow={follow} />
+          </Answering.Provider>
         </div>
       )}
 

--- a/src/components/Figure.test.tsx
+++ b/src/components/Figure.test.tsx
@@ -1,13 +1,20 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const frameArtifact = vi.fn(async () => ({ port: 9999, id: "a".repeat(64) }));
+const sendMessage = vi.fn(async (_agentId: string, _text: string) => "run-1");
 vi.mock("../lib/ipc", () => ({
-  api: { frameArtifact: () => frameArtifact() },
+  api: {
+    frameArtifact: () => frameArtifact(),
+    sendMessage: (agentId: string, text: string) => sendMessage(agentId, text),
+  },
   openExternal: vi.fn(),
 }));
 
 const { Markdown } = await import("./Markdown");
+const { Answering, answerMessage } = await import("./HtmlArtifact");
 
 const fence = (language: string, body: unknown) =>
   `\`\`\`${language}\n${typeof body === "string" ? body : JSON.stringify(body)}\n\`\`\``;
@@ -177,6 +184,203 @@ describe("a page in a message", () => {
     const { container } = render(<Markdown>{fence("html", "<div>hi</div>")}</Markdown>);
     expect(container.querySelector(".md__pre")).toBeTruthy();
     expect(container.querySelector("iframe")).toBeNull();
+  });
+});
+
+describe("a page that hands a value back", () => {
+  const PAGE =
+    "<!doctype html><html><body><h1>Plan</h1><p>Something worth framing.</p></body></html>";
+  const TO = { id: "agent-1", name: "Analyst" };
+
+  beforeEach(() => {
+    sendMessage.mockClear();
+  });
+
+  /** Renders the page in a channel and answers from inside the frame. */
+  const answering = async (to: typeof TO | null = TO) => {
+    const view = render(
+      <Answering.Provider value={to}>
+        <Markdown>{fence("html", PAGE)}</Markdown>
+      </Answering.Provider>,
+    );
+    const frame = await waitFor(() => {
+      const found = view.container.querySelector("iframe");
+      if (!found) throw new Error("no frame yet");
+      return found as HTMLIFrameElement;
+    });
+    const say = (value: unknown) =>
+      act(() => {
+        // Exactly what the bridge in `artifact.rs` posts, and delivered from
+        // the frame's own window, which is the only thing the parent trusts.
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            source: frame.contentWindow,
+            data: { guaca: "artifact-answer", value },
+          }),
+        );
+      });
+    return { ...view, say };
+  };
+
+  it("shows what was handed back and sends nothing on its own", async () => {
+    // The whole safety argument. A transcript re-frames a page whenever it
+    // draws one, so a page that could send by itself would send again every
+    // time it was scrolled past, and each send is a turn nobody asked for.
+    const { say } = await answering();
+    say('{"plan":"pro","seats":12}');
+
+    expect(screen.getByText('{"plan":"pro","seats":12}')).toBeTruthy();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Send to Analyst" })).toBeTruthy();
+  });
+
+  it("sends it when the operator presses the button, and says so", async () => {
+    const { say } = await answering();
+    say('{"plan":"pro"}');
+
+    await act(async () => {
+      screen.getByRole("button", { name: "Send to Analyst" }).click();
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith("agent-1", answerMessage('{"plan":"pro"}'));
+    expect(screen.getByText("Sent to Analyst.")).toBeTruthy();
+  });
+
+  it("says why when the send is refused, and keeps the value on screen", async () => {
+    sendMessage.mockRejectedValueOnce(new Error("this agent has been deleted"));
+    const { say } = await answering();
+    say('{"plan":"pro"}');
+
+    await act(async () => {
+      screen.getByRole("button", { name: "Send to Analyst" }).click();
+    });
+
+    expect(screen.getByText("this agent has been deleted")).toBeTruthy();
+  });
+
+  it("keeps only the latest, because a page answering on every drag is right", async () => {
+    const { say } = await answering();
+    say('{"at":1}');
+    say('{"at":2}');
+
+    expect(screen.queryByText('{"at":1}')).toBeNull();
+    expect(screen.getByText('{"at":2}')).toBeTruthy();
+  });
+
+  it("refuses a document dressed as an answer, and names the cap", async () => {
+    const { say } = await answering();
+    say(JSON.stringify({ everything: "x".repeat(5000) }));
+
+    expect(screen.queryByRole("button", { name: "Send to Analyst" })).toBeNull();
+    expect(screen.getByText(/most Guaca will carry/)).toBeTruthy();
+  });
+
+  it("ignores anything that is not the string the bridge posts", async () => {
+    const { say } = await answering();
+    say({ plan: "pro" });
+
+    expect(screen.queryByText(/answer ready/)).toBeNull();
+  });
+
+  it("draws nothing where there is nobody to answer", async () => {
+    // A search hit, a pair's thread, a document preview. A Send button there
+    // is a control that cannot say who it sends to.
+    const { say } = await answering(null);
+    say('{"plan":"pro"}');
+
+    expect(screen.queryByText(/answer ready/)).toBeNull();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("fences the value clear of its own backticks", () => {
+    // A page about code hands back a snippet, and a fixed three would end the
+    // block in the middle of the value.
+    const message = answerMessage('{"snippet":"```js"}');
+    expect(message).toContain("````json");
+    expect(message.endsWith("````")).toBe(true);
+    // The plain case stays the plain case.
+    expect(answerMessage('{"plan":"pro"}')).toContain("```json");
+  });
+});
+
+/**
+ * The seam between the script `artifact.rs` prepends and the parent that reads
+ * it, checked by running the real one.
+ *
+ * Nothing else in the build can see this break. The Rust suite asserts what the
+ * bridge's text contains, the suite above asserts what the renderer accepts, and
+ * the two agree because the same literal is written in both places: renaming the
+ * message in Rust fails one test, and updating that test makes the build green
+ * with a page that can no longer answer. Same failure `ipc.contract.test.ts`
+ * exists for, so the same answer: read both sources and compare them.
+ */
+describe("the bridge the page is served with", () => {
+  /** The bridge's JavaScript, out of the Rust constant that carries it. */
+  const bridge = () => {
+    const rust = readFileSync(resolve(__dirname, "../../src-tauri/src/artifact.rs"), "utf8");
+    const held = rust.match(/const BRIDGE: &str = r#"([\s\S]*?)"#;/);
+    if (!held) throw new Error("could not find BRIDGE in artifact.rs");
+    const script = held[1]?.match(/<script>([\s\S]*)<\/script>/);
+    if (!script) throw new Error("BRIDGE is not a script");
+    return script[1] as string;
+  };
+
+  /** Runs it the way the page does, and collects what it posts to its parent. */
+  const running = () => {
+    const posted: unknown[] = [];
+    const page: Record<string, unknown> = {};
+    new Function("window", "document", "addEventListener", "parent", bridge())(page, {}, () => {}, {
+      postMessage: (said: unknown) => posted.push(said),
+    });
+    return { posted, guaca: page.guaca as { answer: (value: unknown) => boolean } };
+  };
+
+  it("defines the call the prompt tells an agent to make", () => {
+    expect(typeof running().guaca?.answer).toBe("function");
+  });
+
+  it("posts what the renderer is listening for, and the renderer draws it", async () => {
+    const { posted, guaca } = running();
+    expect(guaca.answer({ plan: "pro", seats: 12 })).toBe(true);
+    expect(posted).toEqual([{ guaca: "artifact-answer", value: '{"plan":"pro","seats":12}' }]);
+
+    // The same object, straight from the bridge into the component that reads
+    // it. Neither side is retyped here, which is the whole point.
+    const view = render(
+      <Answering.Provider value={{ id: "agent-1", name: "Analyst" }}>
+        <Markdown>
+          {fence(
+            "html",
+            "<!doctype html><html><body><h1>Plan</h1><p>Worth framing.</p></body></html>",
+          )}
+        </Markdown>
+      </Answering.Provider>,
+    );
+    const frame = await waitFor(() => {
+      const found = view.container.querySelector("iframe");
+      if (!found) throw new Error("no frame yet");
+      return found as HTMLIFrameElement;
+    });
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", { source: frame.contentWindow, data: posted[0] }),
+      );
+    });
+
+    expect(screen.getByText('{"plan":"pro","seats":12}')).toBeTruthy();
+  });
+
+  it("fails in the page, where the page can be told, rather than in the app", () => {
+    // A value that will not survive `JSON.stringify`. Arriving as something the
+    // app has to decide about is strictly worse than the page getting a false.
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const { posted, guaca } = running();
+
+    expect(guaca.answer(cyclic)).toBe(false);
+    expect(guaca.answer(() => {})).toBe(false);
+    expect(guaca.answer(undefined)).toBe(false);
+    expect(posted).toEqual([]);
   });
 });
 

--- a/src/components/HtmlArtifact.tsx
+++ b/src/components/HtmlArtifact.tsx
@@ -1,7 +1,19 @@
-import { useEffect, useRef, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 
 import { api } from "../lib/ipc";
-import { errorMessage } from "../lib/types";
+import { type AgentId, errorMessage } from "../lib/types";
+
+/**
+ * Who a page drawn here may answer, if anybody.
+ *
+ * Null by default and provided by exactly one surface: the channel, where the
+ * operator is one of the two participants and their next message has an
+ * obvious recipient. A page behind a search hit, inside a pair's thread or in a
+ * document preview has nobody, and a Send button in those places would be a
+ * control that cannot say who it sends to. Same discipline as `Roster`: the
+ * default is honest, so a surface that has not thought about it draws nothing.
+ */
+export const Answering = createContext<{ id: AgentId; name: string } | null>(null);
 
 /**
  * A page an agent wrote, running.
@@ -18,13 +30,21 @@ import { errorMessage } from "../lib/types";
  * `sandbox` attribute below is the second half of the same lock and its two
  * values must never gain `allow-same-origin`, which would let the page take the
  * sandbox off and reload out of it.
+ *
+ * The one thing it may hand back is a value, and this component is the reason
+ * that is not a hole in the paragraph above. `guaca.answer` posts; this draws
+ * what was posted, in Guaca's chrome, under the frame, and waits. Nothing goes
+ * anywhere until the operator presses a button that belongs to the app.
  */
 export function HtmlArtifact({ html, title }: { html: string; title: string }) {
   const frame = useRef<HTMLIFrameElement>(null);
+  const to = useContext(Answering);
   const [src, setSrc] = useState<string | null>(null);
   const [failed, setFailed] = useState<string | null>(null);
   const [height, setHeight] = useState(MIN_HEIGHT);
   const [full, setFull] = useState(false);
+  const [ready, setReady] = useState<Ready | null>(null);
+  const [sending, setSending] = useState(false);
 
   useEffect(() => {
     let live = true;
@@ -38,21 +58,49 @@ export function HtmlArtifact({ html, title }: { html: string; title: string }) {
     };
   }, [html]);
 
-  // A frame on another origin cannot be measured from outside, so the page is
-  // asked. The message is trusted by the window it came from and by nothing
-  // else: an opaque origin reports itself as "null", so checking the origin
-  // would either reject every real message or accept every forged one.
+  // Both of the things a page can say. Each is trusted by the window it came
+  // from and by nothing else: an opaque origin reports itself as "null", so
+  // checking the origin would either reject every real message or accept every
+  // forged one. Bound once, with no dependency on who is being answered: a page
+  // in a surface with nobody to answer still reports its height, and the value
+  // it posts is simply never drawn.
   useEffect(() => {
     const onMessage = (event: MessageEvent) => {
       if (event.source !== frame.current?.contentWindow) return;
       const said: unknown = event.data;
       if (typeof said !== "object" || said === null) return;
-      const { guaca, height: reported } = said as { guaca?: unknown; height?: unknown };
-      if (guaca !== "artifact-height" || typeof reported !== "number") return;
-      // Clamped rather than obeyed. A page that reports a height of a hundred
-      // thousand has made itself the whole channel, and one that reports zero
-      // has made itself invisible.
-      setHeight(Math.max(MIN_HEIGHT, Math.min(MAX_HEIGHT, Math.ceil(reported))));
+      const {
+        guaca,
+        height: reported,
+        value,
+      } = said as {
+        guaca?: unknown;
+        height?: unknown;
+        value?: unknown;
+      };
+
+      if (guaca === "artifact-height" && typeof reported === "number") {
+        // Clamped rather than obeyed. A page that reports a height of a hundred
+        // thousand has made itself the whole channel, and one that reports zero
+        // has made itself invisible.
+        setHeight(Math.max(MIN_HEIGHT, Math.min(MAX_HEIGHT, Math.ceil(reported))));
+        return;
+      }
+
+      if (guaca === "artifact-answer" && typeof value === "string") {
+        // Replaces whatever was there rather than queuing. A page that answers
+        // on every drag of a slider is doing the right thing, and what the
+        // operator sends is what the page last said, which is what they are
+        // looking at.
+        setReady(
+          value.length > MOST_ANSWER
+            ? {
+                kind: "refused",
+                why: `This page tried to hand back ${value.length.toLocaleString()} characters, and ${MOST_ANSWER.toLocaleString()} is the most Guaca will carry. An answer is a choice, not a document.`,
+              }
+            : { kind: "value", json: value },
+        );
+      }
     };
     window.addEventListener("message", onMessage);
     return () => window.removeEventListener("message", onMessage);
@@ -95,6 +143,29 @@ export function HtmlArtifact({ html, title }: { html: string; title: string }) {
     />
   );
 
+  // Drawn wherever the frame is. A page answered in the full view and shown the
+  // strip only on the card behind it is an operator pressing a button and
+  // watching nothing happen.
+  const answer = to && ready && (
+    <Answer
+      ready={ready}
+      to={to}
+      sending={sending}
+      onDismiss={() => setReady(null)}
+      onSend={async (json) => {
+        setSending(true);
+        try {
+          await api.sendMessage(to.id, answerMessage(json));
+          setReady({ kind: "sent" });
+        } catch (error) {
+          setReady({ kind: "refused", why: errorMessage(error) });
+        } finally {
+          setSending(false);
+        }
+      }}
+    />
+  );
+
   if (full) {
     return (
       <div className="scrim">
@@ -121,6 +192,7 @@ export function HtmlArtifact({ html, title }: { html: string; title: string }) {
           </div>
           <div className="file-view__body artifact__full">
             <div className="artifact">{page}</div>
+            {answer}
           </div>
         </div>
       </div>
@@ -128,21 +200,126 @@ export function HtmlArtifact({ html, title }: { html: string; title: string }) {
   }
 
   return (
-    <div className="artifact">
-      {src ? page : <p className="hint">Opening…</p>}
-      {/* A transcript is a conversation, so a page in one is bounded however
-          tall it says it is. The full view is where the reading happens, the
-          same way a document works. */}
-      <button
-        type="button"
-        className="btn btn--ghost btn--small artifact__open"
-        onClick={() => setFull(true)}
-      >
-        Open
-      </button>
+    <>
+      <div className="artifact">
+        {src ? page : <p className="hint">Opening…</p>}
+        {/* A transcript is a conversation, so a page in one is bounded however
+            tall it says it is. The full view is where the reading happens, the
+            same way a document works. */}
+        <button
+          type="button"
+          className="btn btn--ghost btn--small artifact__open"
+          onClick={() => setFull(true)}
+        >
+          Open
+        </button>
+      </div>
+      {answer}
+    </>
+  );
+}
+
+/** What a page has handed back, and what became of it. */
+type Ready = { kind: "value"; json: string } | { kind: "refused"; why: string } | { kind: "sent" };
+
+/**
+ * The strip under a page that has answered.
+ *
+ * Outside the frame, in the app's own chrome, and that is the entire point
+ * rather than a layout choice. The page draws the controls the operator works;
+ * Guaca draws the one that spends a turn. A page cannot press this, cannot
+ * style it, and cannot reach the document it is drawn in.
+ *
+ * The value is shown before it goes and shown as text. It is a model's own JSON
+ * about to travel to an agent under the operator's name, which is the shape
+ * this app treats most carefully everywhere else it occurs.
+ */
+function Answer({
+  ready,
+  to,
+  sending,
+  onSend,
+  onDismiss,
+}: {
+  ready: Ready;
+  to: { id: AgentId; name: string };
+  sending: boolean;
+  onSend: (json: string) => void;
+  onDismiss: () => void;
+}) {
+  if (ready.kind === "sent") {
+    return (
+      <div className="artifact__answer">
+        <p className="artifact__answer-note">Sent to {to.name}.</p>
+      </div>
+    );
+  }
+
+  if (ready.kind === "refused") {
+    return (
+      <div className="artifact__answer">
+        <p className="artifact__answer-note artifact__answer-note--fault">{ready.why}</p>
+        <div className="artifact__answer-acts">
+          <button type="button" className="btn btn--ghost btn--small" onClick={onDismiss}>
+            Dismiss
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="artifact__answer">
+      <p className="artifact__answer-note">
+        This page has an answer ready. Nothing goes to {to.name} until you send it.
+      </p>
+      <pre className="artifact__answer-value">{ready.json}</pre>
+      <div className="artifact__answer-acts">
+        <button
+          type="button"
+          className="btn btn--small"
+          disabled={sending}
+          onClick={() => onSend(ready.json)}
+        >
+          {sending ? "Sending…" : `Send to ${to.name}`}
+        </button>
+        <button type="button" className="btn btn--ghost btn--small" onClick={onDismiss}>
+          Dismiss
+        </button>
+      </div>
     </div>
   );
 }
+
+/**
+ * The message the agent actually receives.
+ *
+ * Guaca's sentence around the page's JSON, and the split is deliberate: a page
+ * hands back a value and never a sentence, so nothing it wrote can arrive as an
+ * instruction in the operator's voice. The operator read the value in the strip
+ * and pressed the button, so this is their message and it is `Trust::Operator`
+ * like any other; what they are vouching for is a value they could see.
+ *
+ * Fenced with a run one longer than the longest run in the value, which is
+ * CommonMark's own rule. A choice like `{"snippet": "```"}` is a perfectly
+ * ordinary thing for a page about code to hand back, and a fixed three would
+ * end the block in the middle of it.
+ */
+export function answerMessage(json: string): string {
+  const longest = Math.max(0, ...[...json.matchAll(/`+/g)].map((run) => run[0].length));
+  const rail = "`".repeat(Math.max(3, longest + 1));
+  return `From the page you drew:\n\n${rail}json\n${json}\n${rail}`;
+}
+
+/**
+ * The most JSON a page may hand back.
+ *
+ * An answer is what the operator chose, not what the page holds: a plan, a
+ * range, the six rows they ticked. Comfortably more than a long form's worth of
+ * values, and far less than a message anybody would read before sending, which
+ * is the thing the strip asks them to do.
+ */
+const MOST_ANSWER = 4000;
 
 /** Tall enough that a page still drawing does not read as a broken frame. */
 const MIN_HEIGHT = 120;

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -31,8 +31,12 @@ export const Roster = createContext<string[]>([]);
  * `rehype-raw` is added, and it is not. A fence tagged as a page is a different
  * thing entirely. It never becomes part of this document, and is run on an
  * origin of its own that can reach nothing. `artifact.rs` is the argument.
+ *
+ * `live` says this body is still being written, and only one caller sets it:
+ * the streaming bubble. It reaches exactly one decision, in {@link readFigure},
+ * which is whether a page is framed now or when the reply settles.
  */
-export function Markdown({ children }: { children: string }) {
+export function Markdown({ children, live = false }: { children: string; live?: boolean }) {
   const names = useContext(Roster);
   const plugins = useMemo(() => [remarkGfm, remarkMentions(names)], [names]);
 
@@ -74,7 +78,7 @@ export function Markdown({ children }: { children: string }) {
           pre: ({ children }) => {
             const fenced = asFence(children);
             if (fenced) {
-              const figure = readFigure(fenced.language, fenced.source);
+              const figure = readFigure(fenced.language, fenced.source, live);
               if (figure.kind !== "source") {
                 return <Figure figure={figure} source={fenced.source} />;
               }

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -337,7 +337,10 @@ export function StreamingMessage({ agent, text }: { agent: AgentCard | undefined
         />
       </div>
       <div className="msg__body md--streaming">
-        <Markdown>{text}</Markdown>
+        {/* Still being written, which is the one thing a body needs to know
+            about itself: a page is framed once, whole, rather than reloaded
+            on every token that lands. */}
+        <Markdown live>{text}</Markdown>
       </div>
     </article>
   );

--- a/src/lib/figure.test.ts
+++ b/src/lib/figure.test.ts
@@ -66,6 +66,37 @@ describe("an html fence", () => {
   });
 });
 
+describe("a fence in a reply that is still being written", () => {
+  const PAGE = "<!doctype html><html><body><h1>Plan</h1><p>Long enough to frame.</p></body></html>";
+
+  it("holds a page until the reply settles", () => {
+    // A page is drawn by registering a document and pointing a frame at the
+    // address that comes back, so drawing one per token is a reload per token:
+    // a round trip each, an entry each in a store that holds two dozen, and a
+    // frame that throws away whatever the operator did in it every sixteen
+    // milliseconds.
+    expect(readFigure("html", PAGE, true).kind).toBe("pending");
+    expect(readFigure("artifact", PAGE, true).kind).toBe("pending");
+    expect(readFigure("html", PAGE, false).kind).toBe("html");
+  });
+
+  it("says so the moment the fence opens, rather than flashing a code block", () => {
+    expect(readFigure("html", "", true).kind).toBe("pending");
+    expect(readFigure("html", "<!doc", true).kind).toBe("pending");
+  });
+
+  it("leaves a chart assembling itself, which is what it is for", () => {
+    // Pure function to coordinates, redrawn for free. This is the one figure
+    // where watching it arrive is the feature rather than the cost.
+    expect(readFigure("chart", SPEC, true).kind).toBe("chart");
+    expect(readFigure("chart", '{"type":"ba', true).kind).toBe("pending");
+  });
+
+  it("leaves every other fence exactly as it was", () => {
+    expect(readFigure("python", "print(1)", true).kind).toBe("source");
+  });
+});
+
 describe("telling a finished document from one still arriving", () => {
   it("counts braces and brackets", () => {
     expect(looksComplete("{}")).toBe(true);

--- a/src/lib/figure.ts
+++ b/src/lib/figure.ts
@@ -94,10 +94,24 @@ export function looksComplete(source: string): boolean {
  * refusal where the text used to be. What a *valid* refusal looks like is the
  * chart's own business: {@link readChart} returns the sentence, and the figure
  * draws it under the source so the agent can be told what to change.
+ *
+ * `live` is whether the message this fence is in is still being written, and
+ * it separates the two figures rather than gating both. A chart is drawn from
+ * a value by a pure function, so redrawing it every token is what makes one
+ * assemble itself on screen and costs nothing. A page is drawn by registering
+ * a document and pointing a frame at the address that comes back, so the same
+ * treatment is a reload per token: a round trip each, a new entry each in a
+ * store that holds two dozen, and a frame that throws away whatever the
+ * operator had done in it every sixteen milliseconds.
  */
-export function readFigure(language: string, source: string): Figure {
+export function readFigure(language: string, source: string, live = false): Figure {
   const tag = language.trim().toLowerCase();
   const body = source.trim();
+
+  // Before the emptiness check, so a page announces itself the moment its
+  // fence opens instead of flashing an empty code block first.
+  if (PAGE.has(tag) && live) return { kind: "pending" };
+
   if (body.length === 0) return { kind: "source" };
 
   if (CHART.has(tag)) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2542,6 +2542,52 @@ button {
   min-height: 60vh;
 }
 
+/* What a page handed back, waiting for a person.
+
+   Outside the frame and unmistakably Guaca's, which is the whole arrangement
+   rather than a layout preference: the page draws the controls the operator
+   works, and the app draws the one that spends a turn. Nothing in here can be
+   reached, styled or pressed by the document above it. */
+.artifact__answer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+  padding: var(--space-4);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  background: var(--sunken);
+}
+
+.artifact__answer-note {
+  margin: 0;
+  font-size: var(--type-aside);
+  color: var(--muted);
+}
+
+.artifact__answer-note--fault {
+  color: var(--alarm);
+}
+
+/* The value goes out under the operator's name, so it is shown before it goes
+   and shown as text. Monospace because it is JSON and reading it is the job. */
+.artifact__answer-value {
+  margin: 0;
+  padding: var(--space-3);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--type-fine);
+  color: var(--text);
+  background: var(--raised);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-xs);
+}
+
+.artifact__answer-acts {
+  display: flex;
+  gap: var(--space-3);
+}
+
 /* ==========================================================================
    Chips, controls, dialogs
    ========================================================================== */


### PR DESCRIPTION
A figure was a dead end. An agent could draw a chart, and it could write a page
that runs, but everything drawn was terminal: the operator picks one plan out of
four, drags a range, ticks six of nine rows, and none of it reaches the agent
that drew the page. They retype in the composer what they just expressed by
clicking, which is the work the page was there to save.

So the bridge `artifact.rs` prepends to every page defines one more thing,
`guaca.answer(value)`. It is not a hole in the policy. It reaches no network and
`ARTIFACT_CSP` is untouched: it posts to the window that framed it, which is the
one channel an opaque origin has and the one the height reporter has always
used.

What happens next is Guaca's decision rather than the page's. The renderer draws
the value below the frame, in the app's own chrome, and waits; the operator
presses the button. The page fills a form in and a person sends it. That
ordering is the whole safety argument and it is not ceremony: a transcript
re-frames a page whenever it draws one, so a page that could send by itself
would send again every time it was scrolled past, and every send is a turn
nobody asked for and somebody paid for.

The page hands back a value and never a sentence. `answerMessage` is Guaca's
wording around the page's JSON, so nothing the page wrote can arrive as an
instruction in the operator's voice, and what lands is an ordinary operator
message: `Trust::Operator`, in the record, searchable, readable back by the
agent that drew the page. No new `Part`, no new command, no runtime change at
all. The value crosses as JSON text rather than as a structured-cloned object,
because the string is what is shown, what is capped and what is sent, and one
that will not survive `JSON.stringify` then fails inside the page, where the
page is told about it. `Answering` is null everywhere and provided by the
channel alone, so a page behind a search hit or inside a pair's thread draws
exactly as it did: a Send button there is a control that cannot say who it
sends to.

A page is now framed once, whole. An `html` fence used to render mid-reply and
re-register on every token, which is a round trip each, an entry each in a store
that holds two dozen, and a frame throwing away whatever the operator had done
in it every sixteen milliseconds. A chart is a pure function to coordinates, so
it still redraws every token, which is what makes one assemble itself on screen.
`live` on `Markdown` is the whole mechanism and `StreamingMessage` is its one
caller.

One seam had no gate. The message shape was a literal in Rust and again in the
renderer, so renaming it in Rust fails the Rust test, and updating that test
makes the build green with a page that can no longer answer. `Figure.test.tsx`
now reads `BRIDGE` out of `artifact.rs`, runs the real script, and feeds what it
posts straight into the renderer, which is what `ipc.contract.test.ts` already
does for the command surface.

The prompt says all of this, with the argument against overusing it in the same
paragraph. A peer is told none of it, because a peer has no operator to press a
button. The live evals were not run: a prompt that makes agents reach for a page
where prose would do is exactly the failure CI cannot see.

