### PR TITLE
fix: an @ offers the crew you are talking to, and nobody else

### DIFF
--- a/src/components/ChannelView.tsx
+++ b/src/components/ChannelView.tsx
@@ -246,6 +246,7 @@ export function ChannelView({ channel, onOpenMenu }: Props) {
           {agent && <TurnFooter key={agent.id} agent={agent} state={activity[agent.id]} />}
           <Composer
             placeholder={`Message ${agent?.name ?? "agent"}`}
+            group={agent?.groupId ?? null}
             disabled={!agent || agent.lifecycle === "terminated"}
             disabledReason="This agent has been deleted."
             onSend={async (text, files) => {

--- a/src/components/Composer.test.tsx
+++ b/src/components/Composer.test.tsx
@@ -39,16 +39,24 @@ vi.mock("../lib/ipc", () => ({
   },
 }));
 
-/** The crew the box can complete against. Set per test where it matters. */
+/** Every live agent in the workspace, which is more than one crew. */
 let roster: AgentCard[] = [];
 
 vi.mock("../lib/store", () => ({ useLiveAgents: () => roster }));
 
+/** The crew whose channel is open in these tests. */
+const CREW = "00000000-0000-4000-8000-000000000001";
+/** Another one, whose names the box must never offer. */
+const ELSEWHERE = "00000000-0000-4000-8000-000000000002";
+
+/** Minted per card rather than per name: two crews can hold one name. */
+let minted = 0;
+
 /** An agent as the rail hands one over: only the fields the composer draws. */
-function anAgent(name: string): AgentCard {
+function anAgent(name: string, group = CREW): AgentCard {
   return {
-    id: `00000000-0000-4000-8000-${name.length.toString().padStart(12, "0")}`,
-    groupId: "00000000-0000-4000-8000-000000000001",
+    id: `00000000-0000-4000-8000-${(++minted).toString().padStart(12, "0")}`,
+    groupId: group,
     name,
     avatar: "plain",
     color: "#c7d96b",
@@ -79,7 +87,7 @@ describe("Composer", () => {
   });
 
   async function draw(onSend = vi.fn(async () => {})) {
-    render(<Composer placeholder="Message Manager" onSend={onSend} />);
+    render(<Composer placeholder="Message Manager" group={CREW} onSend={onSend} />);
     await waitFor(() => expect(dropped).not.toBeNull());
     return onSend;
   }
@@ -124,7 +132,7 @@ describe("Composer", () => {
     const onSend = vi.fn(async () => {
       throw new Error("that agent has been deleted");
     });
-    render(<Composer placeholder="Message Manager" onSend={onSend} />);
+    render(<Composer placeholder="Message Manager" group={CREW} onSend={onSend} />);
     await waitFor(() => expect(dropped).not.toBeNull());
 
     await drop(["/tmp/notes.md"]);
@@ -206,10 +214,33 @@ describe("a mention in the box", () => {
   /** The layer under the textarea, which is where a draft's mentions are drawn. */
   const painted = () => document.querySelector(".composer__mirror");
 
-  async function draw() {
-    render(<Composer placeholder="Message Manager" onSend={vi.fn(async () => {})} />);
+  async function draw(group: string | null = CREW) {
+    render(<Composer placeholder="Message Manager" group={group} onSend={vi.fn(async () => {})} />);
     await waitFor(() => expect(dropped).not.toBeNull());
   }
+
+  /** The names the typeahead is offering right now. */
+  const offered = () =>
+    [...document.querySelectorAll(".mentions__name")].map((item) => item.textContent);
+
+  it("offers the channel's own crew and nobody else", async () => {
+    // The workspace-wide list is what an operator sees after clearing a crew
+    // and hiring a new one: every agent they have ever had, on a menu where
+    // picking one writes a name `send_message` refuses as belonging to nobody.
+    roster = [anAgent("Critic"), anAgent("Scribe", ELSEWHERE)];
+    await draw();
+    await type("ask @");
+
+    expect(offered()).toEqual(["Critic"]);
+  });
+
+  it("offers nobody when the channel belongs to nobody", async () => {
+    roster = [anAgent("Critic")];
+    await draw(null);
+    await type("ask @");
+
+    expect(offered()).toEqual([]);
+  });
 
   it("marks a name the crew has, as it is typed", async () => {
     roster = [anAgent("Critic"), anAgent("Head Chef")];
@@ -245,6 +276,17 @@ describe("a mention in the box", () => {
     roster = [anAgent("Critic")];
     await draw();
     await type("mail bob@example.com about @lunch");
+
+    expect(painted()?.querySelectorAll(".mention")).toHaveLength(0);
+  });
+
+  it("marks nothing when the name belongs to another crew", async () => {
+    // The chip is the promise the menu made, one step later: drawing one
+    // around a name in a crew this channel cannot reach says the message is
+    // addressed to somebody it will never arrive at.
+    roster = [anAgent("Critic"), anAgent("Scribe", ELSEWHERE)];
+    await draw();
+    await type("ask @Scribe about it");
 
     expect(painted()?.querySelectorAll(".mention")).toHaveLength(0);
   });

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -5,16 +5,27 @@ import { fileUrl, previewKind, readableSize } from "../lib/files";
 import { api, onFileDrop } from "../lib/ipc";
 import { applyMention, matchMentions, mentionAt, splitMentions } from "../lib/mentions";
 import { useLiveAgents } from "../lib/store";
-import { type Attachment, errorMessage } from "../lib/types";
+import { type Attachment, errorMessage, type GroupId } from "../lib/types";
 
 interface Props {
   placeholder: string;
+  /**
+   * The crew this channel belongs to, or null when it belongs to nobody.
+   *
+   * What an `@` here is allowed to name. `send_message` resolves a recipient
+   * inside the sender's own group and refuses every name outside it, without
+   * saying whether that name belongs to anybody, so a completion offered from
+   * another crew is a delivery the runtime will not make. Two crews can also
+   * hold two agents with one name and one face, which the workspace-wide list
+   * offered twice with nothing on either row to say which was meant.
+   */
+  group: GroupId | null;
   disabled?: boolean;
   disabledReason?: string;
   onSend: (text: string, files: Attachment[]) => Promise<void>;
 }
 
-export function Composer({ placeholder, disabled, disabledReason, onSend }: Props) {
+export function Composer({ placeholder, group, disabled, disabledReason, onSend }: Props) {
   const [text, setText] = useState("");
   const [sending, setSending] = useState(false);
   const [caret, setCaret] = useState(0);
@@ -61,8 +72,12 @@ export function Composer({ placeholder, disabled, disabledReason, onSend }: Prop
     };
   }, [disabled]);
 
-  const agents = useLiveAgents();
-  const names = useMemo(() => agents.map((a) => a.name), [agents]);
+  const live = useLiveAgents();
+  const crew = useMemo(
+    () => (group ? live.filter((agent) => agent.groupId === group) : []),
+    [live, group],
+  );
+  const names = useMemo(() => crew.map((a) => a.name), [crew]);
   const query = dismissed ? null : mentionAt(text, caret);
   const matches = query ? matchMentions(names, query.term) : [];
   const showing = query !== null && matches.length > 0;
@@ -208,7 +223,7 @@ export function Composer({ placeholder, disabled, disabledReason, onSend }: Prop
         // the options are not themselves focusable.
         <div className="mentions" role="listbox" id="mention-list" aria-label="Agents">
           {matches.map((name, index) => {
-            const agent = agents.find((a) => a.name === name);
+            const agent = crew.find((a) => a.name === name);
             const active = index === selected;
             return (
               <div


### PR DESCRIPTION
The composer completed a mention against every live agent in the workspace, so an operator who cleared a crew and hired a new one pressed `@` and got a menu of every agent they had ever had. `send_message` resolves a recipient inside the sender's own group and refuses every name outside it, so those completions wrote names the runtime answers with `no agent named X`, and two crews each holding a Manager put that word on the menu twice with nothing on either row to say which was meant. Neither the compost nor a stale list was involved: `useLiveAgents` already filters exactly what `Lifecycle::is_discoverable` does, and the menu is a read of the store that every delete path invalidates. `Composer` now takes the channel's group and completes against that crew, with the menu's avatar lookup scoped alongside it. Three tests cover it, each of which fails without the change.