### PR TITLE
feat: what a model can be shown is asked of the endpoint, not assumed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ src-tauri/src/
     claude.rs         The third, which is a program rather than a protocol:
                       where a Claude subscription is spent, and why it has to be.
     catalog.rs        Which models OpenRouter sees doing which kind of work.
+    modality.rs       Whether a picture reaches the model that is answering.
   subscription.rs     Signing in to that subscription. A credential, not a wire.
   account.rs          The optional Guaca account. Nothing else depends on it.
   mcp.rs              The client end of MCP, in both of its protocol eras.
@@ -161,6 +162,7 @@ repo: the frontend renders state and forwards intent.
 | Settings, the surface, the scale, what may interrupt the operator | *Settings is nine places*, *The reading column has two surfaces* and *An interruption has to earn it* in `docs/WORKSPACE.md` |
 | The group editor: what a crew overrides and what it inherits | *A group's settings are the app's, with the crew's answer on top* in `docs/WORKSPACE.md`, then `src/components/GroupEditor.tsx` |
 | What model an agent is offered, and how its job is guessed at | *The model field suggests three, and is still a text box* in `docs/WORKSPACE.md`, then `src/lib/roles.ts` and `llm/catalog.rs`, whose twelve use cases have to agree |
+| Whether a model can be shown a picture: an attachment, a screen, what an agent is told it is | *What a model can be sent is asked of the endpoint, not assumed* in `docs/ARCHITECTURE.md`, then `llm/modality.rs` and the four places `Modalities` is spent from `Runtime::run_turn` |
 | A prompt, or anything that changes how much a crew talks | *Three test suites, asking different questions*, then run the live evals |
 | What a real crew of eight does with one directive, and what is different when you ask twice | *A crew is watched rather than asserted*, then `src-tauri/tests/crew.rs` |
 
@@ -449,6 +451,26 @@ the model takes a screenshot to see what `browse` did.
   subscription both report the equivalent API price. They agree with each other,
   and `Outcome::cost` claims no more than that; zero is absent rather than free,
   for the reason it always was.
+- **A model that cannot be shown a picture is one the endpoint said so about,
+  and nothing else.** An endpoint that publishes no modalities, and a model that
+  is not on its list, both mean what they always meant: send the picture. The
+  two errors are not equal. A wrong *it can see* is what every endpoint got
+  before this existed and costs one turn, refused with a message naming the
+  model; a wrong *it cannot see* takes `use_screen` off an agent that was using
+  it and stops delivering attachments, with nothing on screen saying why. So a
+  local server with no `architecture` on its model list changes nothing at all,
+  and only `input_modalities` without `image` in it subtracts anything.
+  `llm/modality.rs`.
+- **One value, settled once, spent in four places.** `Modalities` is resolved
+  at the top of `run_turn`: the prompt says what reaches this agent, `specs`
+  decides whether `use_screen` is offered, `deliver_files` decides what an
+  attached picture becomes, and `not_given` refuses a screen a model asked for
+  anyway. Three of four agreeing is worse than none: an agent told it is blind
+  and handed a screenshot concludes the delivery failed, and one served
+  `use_screen` gets a picture thrown away, which reads as a screen that came
+  back blank. The fourth is not belt and braces: a model naming a tool it was
+  never offered is ordinary, which is the same reason `Store::plugin_reach`
+  asks again on the call path.
 - **A double-clicked app does not have the operator's `PATH`.** `launchd` starts
   one from the Dock or the Finder with `/usr/bin:/bin:/usr/sbin:/sbin` and
   nothing else, so `claude` under `~/.local/bin` and `pi` and `gh` under
@@ -1199,4 +1221,15 @@ nothing.
 ```sh
 cargo test --manifest-path src-tauri/Cargo.toml --lib \
   llm::catalog::tests::every_use_case -- --ignored --nocapture
+```
+
+Whether a model can be shown a picture is read off the same vendor's catalog and
+has the same blind spot, so it has the same test: `architecture.input_modalities`
+renamed or dropped on OpenRouter's side turns every model into one nothing was
+published about, which looks exactly like the day before any of this existed and
+fails nothing offline. Also free.
+
+```sh
+cargo test --manifest-path src-tauri/Cargo.toml --lib \
+  llm::modality::tests::openrouter_still -- --ignored --nocapture
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -387,6 +387,67 @@ subscription cannot fund a third-party harness however the credential is
 obtained. Claude models reach Guaca the same way they always did: an API key, or
 OpenRouter, which is still the default. `docs/PROTOCOL.md` has the dates.
 
+## What a model can be sent is asked of the endpoint, not assumed
+
+The model is a text box. An operator types one slug this week and another next
+week, and the two do not have to be able to do the same things. The only thing
+every model can be relied on to take is text; everything else Guaca puts in
+front of one (an attached photograph, a picture of a machine's screen) is a
+capability of that particular model, and this app assumed it of all of them for
+as long as there was only one worth assuming.
+
+**Only what Guaca can send is worth asking about.** What a model accepts and
+what this app can produce are two lists, and the answer worth having is the
+intersection. Guaca produces exactly two things: text, and pictures. It records
+no audio and no video and has nothing to make either out of, so a model that
+would happily take a video still gets none, and its agent is told so rather than
+offering the operator something that cannot arrive. The other direction is a
+constant rather than a question: a reply is text. A transcript, a peer's inbox,
+an eval and this app's own record are all text, so a model that can draw a
+picture has nowhere to put one, and the way an agent shows something it drew is
+already a chart spec or a page it wrote. So there is one question, and
+`llm/modality.rs` answers only it: does a picture reach this model.
+
+**The answer comes from the endpoint, because that is the only place it is.**
+Not from a table of model names in this repo, which goes stale the week after it
+ships and is a lie about every model released since. Not from a checkbox in
+Settings either: an operator swapping a model changes one field, and a second
+field beside it that has to be changed in step is one that will not be.
+OpenRouter publishes `architecture.input_modalities` for every model it routes
+to, on the same `/models` any OpenAI-compatible endpoint answers, so the
+question is asked of whatever endpoint the turn is being paid through. Read once
+per endpoint and kept for six hours, for the reason a plugin's tool list is: it
+changes when a vendor ships, not when an agent thinks, and a round trip in front
+of every model call is one every agent in the crew pays. Both subscription
+providers are answered without asking anybody: their models are the vendor's
+rather than the operator's, and every model either of them hands a turn to takes
+pictures.
+
+**An endpoint that says nothing leaves everything as it was.** A local LM Studio
+answers `/models` with ids and no architecture, and a model that has never been
+near OpenRouter is not in its list at all. Both are answered the same way: the
+picture is sent, exactly as it was before any of this existed. The asymmetry is
+deliberate and it is the whole safety of the change. A wrong *it can see* is
+what happened on every endpoint before, and costs a turn that fails with an
+error naming the model. A wrong *it cannot see* takes `use_screen` off an agent
+that was using it and quietly stops delivering attachments, with nothing on
+screen saying why. Only an endpoint that has published a modality list without
+`image` in it is taken to have said no.
+
+**One answer, four things that have to agree.** The prompt says what reaches
+this agent, `tools::specs` decides whether `use_screen` is offered,
+`deliver_files` decides what an attached picture becomes, and `not_given`
+refuses a screen a model called for anyway. That fourth one is not belt and
+braces: a model naming a tool it was never offered is ordinary, and served it the
+machine is worked, the screen captured and the picture thrown away, which reads
+to the model as a screen that came back blank. Three of the four agreeing is worse than none,
+so the value is settled once at the top of `run_turn` and passed to all of them.
+`use_screen` is the only tool the answer reaches:
+its entire result is a picture, and the coordinates to click next are in it and
+nowhere else. The rest of the machine is untouched, because `run_command` reads
+back as text and `open_on_desktop` puts a program where the *operator* can watch
+it, which is worth doing whether or not the agent can see.
+
 ## A failed model call is retried before the operator hears about it
 
 `stream_with_retries` is the loop and `LlmError::is_transient` decides. Rate
@@ -688,10 +749,12 @@ activity view, so a proposal inlined into a message would be dragged through
 both, every time. Content addressing also makes the common case free: the same
 document sent to four agents and forwarded once is one file.
 
-**What reaches the model depends on the file.** A picture goes as a picture,
-down the same path as a screenshot from `use_screen`, because that is the one
-thing a model cannot be told about in words. Text is read into the prompt, cut
-at a limit that says it was cut. Anything else, a proposal in Word or a
+**What reaches the model depends on the file, and on the model.** A picture goes
+as a picture, down the same path as a screenshot from `use_screen`, because that
+is the one thing a model cannot be told about in words, unless the endpoint has
+said this model takes text only: then it goes down the third path below, and the
+agent is told in words that it has not seen it. Text is read into
+the prompt, cut at a limit that says it was cut. Anything else, a proposal in Word or a
 spreadsheet, is written to `~/inbox` on the agent's own machine and the agent is
 told the path. The host does not learn to parse PDF or docx: the agent has a
 Linux box and can install what it needs, which is the premise the rest of the

--- a/docs/MACHINES.md
+++ b/docs/MACHINES.md
@@ -94,6 +94,17 @@ the pointer is, and an action that hands work to the screen is given a moment to
 settle before the picture is taken. All three are in `e2b.rs` with the failure
 each one closes.
 
+A machine whose screen cannot be shown to the model is still a machine.
+`use_screen` is offered only when a picture reaches the model behind the turn,
+because its entire answer is one and the coordinates to click next are in it and
+nowhere else: offered to a model that cannot be sent a picture, it is a round
+trip that hands back nothing and a click aimed at a position nobody has seen.
+`run_command` and `open_on_desktop` are untouched, because a shell reads back as
+text and a program on the desktop is there for the *operator* to watch, and the
+prompt says which of the three this agent has. What decides that, and why an
+endpoint that publishes nothing leaves it exactly as it was, is *What a model
+can be sent is asked of the endpoint, not assumed* in `ARCHITECTURE.md`.
+
 ## The frame points at this app's page, not at noVNC's
 
 noVNC narrates its own transport. Every time it connects it slides a bar across

--- a/src-tauri/src/llm/mod.rs
+++ b/src-tauri/src/llm/mod.rs
@@ -1,6 +1,7 @@
 pub mod catalog;
 pub mod claude;
 pub mod codex;
+pub mod modality;
 pub mod openrouter;
 pub mod sse;
 pub mod tools;

--- a/src-tauri/src/llm/modality.rs
+++ b/src-tauri/src/llm/modality.rs
@@ -1,0 +1,551 @@
+//! What the model behind a turn can be sent, and what its agent is told it is.
+//!
+//! The model is a text box. An operator types one slug this week and another
+//! next week, and the two do not have to be able to do the same things: the
+//! only thing every one of them can be relied on to take is text. Everything
+//! else this app puts in front of a model (an attached photograph, a picture
+//! of a machine's screen) is a capability of that particular model, and
+//! Guaca assumed it of all of them for as long as there was only one worth
+//! assuming. A screenshot sent to a text-only model is a refusal from
+//! OpenRouter and a turn spent finding that out; `use_screen` offered to one is
+//! a tool whose entire answer is a picture that reaches nobody.
+//!
+//! ## Only what Guaca can send is worth asking about
+//!
+//! What a model accepts and what this app can produce are two lists, and the
+//! answer worth having is the intersection. Guaca produces exactly two things:
+//! text, and pictures: an attachment, or a screen. It records no audio and no
+//! video and has nothing to make either out of, so a model that would happily
+//! take a video still gets none, and its agent is told so rather than offering
+//! the operator something that cannot arrive.
+//!
+//! The other direction is a constant rather than a question. A reply is text.
+//! A transcript, a peer's inbox, an eval and this app's own record are all
+//! text, so a model that can draw a picture has nowhere to put one, and the way
+//! an agent shows something it drew is already a chart spec or a page it wrote.
+//! Nothing here is asked about output, and the prompt says the same thing in
+//! words: what you produce is text.
+//!
+//! So there is one question, and this module answers only it: does a picture
+//! reach this model.
+//!
+//! ## The answer comes from the endpoint, because it is the only place it is
+//!
+//! Not from a table of model names in this repo, which would be a build that
+//! goes stale the week after it ships and a lie about every model released
+//! since. Not from a checkbox in settings either: an operator swapping a model
+//! is changing one field, and a second field beside it that has to be changed
+//! in step is one that will not be.
+//!
+//! OpenRouter publishes `architecture.input_modalities` for every model it
+//! routes to, on the same `/models` any OpenAI-compatible endpoint answers, so
+//! the question is asked of whatever endpoint the turn is being paid through.
+//! Read once and kept, for the reason a plugin's tool list is: it changes when
+//! a vendor ships, not when an agent thinks, and a round trip in front of every
+//! model call to re-learn the same answer is one every agent in the crew pays.
+//!
+//! ## An endpoint that says nothing leaves everything as it was
+//!
+//! A local LM Studio answers `/models` with ids and no architecture, and a
+//! model that has never been near OpenRouter is not in its list at all. Both
+//! are answered here the same way: a picture is sent, exactly as it was before
+//! any of this existed.
+//!
+//! That asymmetry is deliberate and it is the whole safety of the change. A
+//! wrong "it can see" is what happens today, on every endpoint, and costs a
+//! turn that fails with an error naming the model. A wrong "it cannot see"
+//! takes `use_screen` off an agent that was using it and quietly stops
+//! delivering attachments, with nothing on screen saying why. Only an endpoint
+//! that has published a modality list without `image` in it is taken to have
+//! said no; nothing else is taken to have said anything.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use serde::Deserialize;
+
+use crate::config::{InferenceConfig, Provider};
+
+/// Long enough that a crew working all afternoon asks once, short enough that a
+/// model added this morning is not invisible until tomorrow. What is being
+/// cached moves when a vendor ships.
+const TTL: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// How long an endpoint that could not be asked is left alone.
+///
+/// Shorter than the TTL because nothing was learned, and not zero because the
+/// commonest reason to be here is an endpoint that is down, which is about to
+/// fail the model call too: paying for the same refused request in front of
+/// every turn adds a round trip to an outage.
+const COOLDOWN: Duration = Duration::from_secs(5 * 60);
+
+/// Long enough for a full catalog over a slow link, short enough that a hung
+/// endpoint does not hold a turn open. Nothing is blocked on the answer: a
+/// timeout is an endpoint that said nothing, which is the ordinary case.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// What Guaca will put in front of the model on this turn.
+///
+/// One field, because one of the two things this app can send is in question.
+/// Text is not a field: a model that cannot read text is not a model this app
+/// can use at all, and there is nothing to decide.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Modalities {
+    /// Whether a picture reaches the model as a picture.
+    ///
+    /// False makes three things true at once, and they have to stay in step: a
+    /// picture is not sent, `use_screen` is not offered, and the agent's prompt
+    /// says it cannot see. Two out of three is an agent told it is blind that
+    /// is still handed a screenshot, or one taking screenshots it will never be
+    /// shown.
+    pub image: bool,
+}
+
+impl Modalities {
+    /// A model that takes pictures, which is most of them and is what an
+    /// endpoint that publishes nothing is taken to mean.
+    pub fn seeing() -> Self {
+        Modalities { image: true }
+    }
+
+    /// A model the endpoint has said takes text and nothing else.
+    pub fn text_only() -> Self {
+        Modalities { image: false }
+    }
+}
+
+/// What each endpoint publishes about its own models, kept between turns.
+///
+/// Cheap to clone behind the `Arc` its owner holds. The mutex is taken to read
+/// or replace one endpoint's answer and never across a request, so two turns
+/// starting at once on a cold cache make two requests rather than one blocking
+/// the other. The same trade [`crate::llm::catalog::Catalog`] makes, for the
+/// same reason: the answer is idempotent and the lock is not worth holding
+/// across a network call.
+#[derive(Debug)]
+pub struct Registry {
+    http: reqwest::Client,
+    known: Mutex<HashMap<String, Known>>,
+}
+
+#[derive(Debug)]
+struct Known {
+    at: Instant,
+    /// [`TTL`] for an endpoint that answered, [`COOLDOWN`] for one that could
+    /// not be asked. Carried per entry rather than decided at the read, because
+    /// what expires is the attempt rather than the endpoint.
+    ttl: Duration,
+    /// Only the models the endpoint published a modality list for. A model that
+    /// is absent from this map is one nothing was said about, which is not the
+    /// same as one said to take text: see the module comment.
+    published: HashMap<String, Modalities>,
+}
+
+impl Registry {
+    pub fn new() -> Self {
+        Registry {
+            http: reqwest::Client::builder().timeout(HTTP_TIMEOUT).build().unwrap_or_default(),
+            known: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// What Guaca will send this model, settled before the turn is assembled.
+    ///
+    /// The two subscription providers are answered without a request. Their
+    /// models are the vendor's rather than the operator's (a ChatGPT plan runs
+    /// what the plan runs, and `claude` runs whatever it is configured to),
+    /// and every model either of them will hand a turn to takes pictures. There
+    /// is no endpoint to ask and no list to read: `codex.rs` and `claude.rs`
+    /// each already translate an image part into their own wire shape, which is
+    /// this same fact written once in each of them.
+    pub async fn of(&self, cfg: &InferenceConfig, model: &str) -> Modalities {
+        match cfg.provider {
+            Provider::Chatgpt | Provider::Claude => Modalities::seeing(),
+            Provider::Compatible => {
+                let answer =
+                    self.published(cfg, model.trim()).await.unwrap_or_else(Modalities::seeing);
+                // The one line that answers "why did my agent stop seeing
+                // screenshots". Everything else about this is silent, and the
+                // change it makes to a turn is three things not happening.
+                if !answer.image {
+                    tracing::debug!(
+                        model,
+                        endpoint = %cfg.base_url,
+                        "published as text only: no picture, no screen"
+                    );
+                }
+                answer
+            }
+        }
+    }
+
+    /// What this endpoint published for this model, or `None` for a model it
+    /// said nothing about.
+    async fn published(&self, cfg: &InferenceConfig, model: &str) -> Option<Modalities> {
+        let base = cfg.base_url.trim().trim_end_matches('/').to_string();
+        if base.is_empty() {
+            return None;
+        }
+        if let Some(remembered) = self.remembered(&base, model) {
+            return remembered;
+        }
+
+        let (published, ttl) = self.ask(cfg, &base).await;
+        let answer = published.get(model).copied();
+        self.known.lock().insert(base, Known { at: Instant::now(), ttl, published });
+        answer
+    }
+
+    /// `None` when this endpoint has not been asked lately. The nesting is the
+    /// distinction the module is about: `Some(None)` is an endpoint that was
+    /// asked and said nothing about this model, which is an answer and does not
+    /// want asking again.
+    fn remembered(&self, base: &str, model: &str) -> Option<Option<Modalities>> {
+        let held = self.known.lock();
+        let entry = held.get(base)?;
+        (entry.at.elapsed() < entry.ttl).then(|| entry.published.get(model).copied())
+    }
+
+    /// Reads the endpoint's model list, and how long to trust the reading.
+    ///
+    /// Never an error. Every way this can fail (no route, a refusal, a key
+    /// this endpoint wants for its catalog, a body in some other shape) is an
+    /// endpoint that published nothing, which is a state with a defined
+    /// meaning. Turning any of them into a failure would mean a turn that
+    /// cannot start because a nicety could not be looked up.
+    async fn ask(
+        &self,
+        cfg: &InferenceConfig,
+        base: &str,
+    ) -> (HashMap<String, Modalities>, Duration) {
+        let url = format!("{base}/models");
+        let mut request = self.http.get(&url);
+        // Sent when there is one, because a gateway in front of an endpoint
+        // refuses an unauthenticated catalog, and left off when there is not:
+        // a bare `Bearer` is a header some servers object to more than they
+        // object to no header at all.
+        let key = cfg.api_key.trim();
+        if !key.is_empty() {
+            request = request.bearer_auth(key);
+        }
+
+        let listing = match request.send().await {
+            Ok(response) if response.status().is_success() => response.json::<Listing>().await,
+            Ok(response) => {
+                tracing::debug!(%url, status = %response.status(), "endpoint published no model list");
+                return (HashMap::new(), COOLDOWN);
+            }
+            Err(err) => {
+                tracing::debug!(%url, %err, "could not read the endpoint's model list");
+                return (HashMap::new(), COOLDOWN);
+            }
+        };
+
+        match listing {
+            Ok(listing) => {
+                let published = listing.into_published();
+                tracing::debug!(%url, models = published.len(), "read what this endpoint's models take");
+                (published, TTL)
+            }
+            // A 200 in some other shape is an endpoint that does not publish
+            // this, not one that is broken: it answered.
+            Err(err) => {
+                tracing::debug!(%url, %err, "the endpoint's model list says nothing about modalities");
+                (HashMap::new(), TTL)
+            }
+        }
+    }
+}
+
+impl Default for Registry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---- the wire ------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct Listing {
+    #[serde(default)]
+    data: Vec<WireModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireModel {
+    #[serde(default)]
+    id: String,
+    /// OpenRouter's own addition to the OpenAI model object. Absent everywhere
+    /// else, which is what makes an endpoint's silence readable.
+    #[serde(default)]
+    architecture: Option<WireArchitecture>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireArchitecture {
+    /// `["text", "image", "file"]`, as the vendor spells them.
+    ///
+    /// `output_modalities` sits beside it on the wire and is deliberately not
+    /// read: see the module comment on why output is a constant here.
+    #[serde(default)]
+    input_modalities: Vec<String>,
+}
+
+impl Listing {
+    /// Every model the endpoint actually said something about.
+    ///
+    /// A row with an empty list is dropped rather than read as text-only. The
+    /// field defaults to empty when it is missing, so "published nothing" and
+    /// "published an empty list" arrive here as the same value, and the one
+    /// that is not a real answer is the one worth being wrong about.
+    fn into_published(self) -> HashMap<String, Modalities> {
+        self.data
+            .into_iter()
+            .filter_map(|model| {
+                let id = model.id.trim();
+                let takes = model.architecture?.input_modalities;
+                if id.is_empty() || takes.is_empty() {
+                    return None;
+                }
+                let image = takes.iter().any(|kind| kind.eq_ignore_ascii_case("image"));
+                Some((id.to_string(), Modalities { image }))
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use axum::response::IntoResponse;
+    use axum::routing::get;
+    use axum::Router;
+
+    /// An endpoint answering `/models` with whatever is handed in, and a count
+    /// of how many times it was asked.
+    async fn stub(
+        answer: impl Fn() -> axum::response::Response + Clone + Send + Sync + 'static,
+    ) -> (String, Arc<AtomicUsize>) {
+        let count = Arc::new(AtomicUsize::new(0));
+        let counter = count.clone();
+
+        let app = Router::new().route(
+            "/v1/models",
+            get(move || {
+                let answer = answer.clone();
+                let counter = counter.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    answer()
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        (format!("http://{addr}/v1"), count)
+    }
+
+    fn against(base: &str) -> InferenceConfig {
+        InferenceConfig {
+            provider: Provider::Compatible,
+            base_url: base.to_string(),
+            api_key: "sk-test".into(),
+            default_model: "vendor/seeing".into(),
+            ..Default::default()
+        }
+    }
+
+    /// Two models, one of each, in OpenRouter's own shape.
+    fn listing() -> axum::response::Response {
+        axum::Json(serde_json::json!({
+            "data": [
+                {
+                    "id": "vendor/seeing",
+                    "architecture": {
+                        "input_modalities": ["text", "image"],
+                        "output_modalities": ["text"],
+                    },
+                },
+                {
+                    "id": "vendor/reading",
+                    "architecture": {
+                        "input_modalities": ["text"],
+                        "output_modalities": ["text"],
+                    },
+                },
+            ]
+        }))
+        .into_response()
+    }
+
+    #[tokio::test]
+    async fn a_model_the_endpoint_says_takes_pictures_is_sent_them() {
+        let (base, _count) = stub(listing).await;
+
+        let seen = Registry::new().of(&against(&base), "vendor/seeing").await;
+
+        assert_eq!(seen, Modalities::seeing());
+    }
+
+    /// The one case any of this exists for.
+    #[tokio::test]
+    async fn a_model_published_as_text_only_is_not_sent_pictures() {
+        let (base, _count) = stub(listing).await;
+
+        let seen = Registry::new().of(&against(&base), "vendor/reading").await;
+
+        assert_eq!(seen, Modalities::text_only());
+    }
+
+    /// A local LM Studio answers with ids and nothing else. Reading that as
+    /// "takes text only" would take `use_screen` and every attachment away from
+    /// an operator running a vision model on their own machine, silently.
+    #[tokio::test]
+    async fn an_endpoint_that_publishes_no_modalities_changes_nothing() {
+        let (base, _count) = stub(|| {
+            axum::Json(serde_json::json!({
+                "data": [
+                    { "id": "vendor/reading", "object": "model", "owned_by": "somebody" },
+                    { "id": "vendor/empty", "architecture": { "input_modalities": [] } },
+                ]
+            }))
+            .into_response()
+        })
+        .await;
+        let registry = Registry::new();
+
+        for model in ["vendor/reading", "vendor/empty"] {
+            assert_eq!(registry.of(&against(&base), model).await, Modalities::seeing(), "{model}");
+        }
+    }
+
+    /// A model swapped to one this endpoint has never heard of. Not an error
+    /// and not an answer: the model call is where a name that is wrong is
+    /// reported, with a message naming it.
+    #[tokio::test]
+    async fn a_model_that_is_not_on_the_list_is_left_as_it_was() {
+        let (base, _count) = stub(listing).await;
+
+        let seen = Registry::new().of(&against(&base), "vendor/nobody-has-heard-of").await;
+
+        assert_eq!(seen, Modalities::seeing());
+    }
+
+    #[tokio::test]
+    async fn an_endpoint_with_no_such_route_is_asked_once_and_left_alone() {
+        // Nothing answers `/models` here, which is every OpenAI-compatible
+        // server that only implements the one endpoint this app calls.
+        let (base, count) = stub(|| axum::http::StatusCode::NOT_FOUND.into_response()).await;
+        let registry = Registry::new();
+
+        assert_eq!(registry.of(&against(&base), "vendor/reading").await, Modalities::seeing());
+        assert_eq!(registry.of(&against(&base), "vendor/reading").await, Modalities::seeing());
+
+        // The cooldown is the point: an endpoint that is down is about to fail
+        // the model call too, and a refused request in front of every turn adds
+        // a round trip to an outage.
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_endpoint_is_no_answer_rather_than_a_failure() {
+        // Nothing is listening here, and nothing ever will be.
+        let seen = Registry::new().of(&against("http://127.0.0.1:1/v1"), "vendor/reading").await;
+
+        assert_eq!(seen, Modalities::seeing());
+    }
+
+    /// A network round trip in front of every model call, paid by every agent
+    /// in the crew, to re-learn something that changes when a vendor ships.
+    #[tokio::test]
+    async fn one_endpoint_is_read_once_however_many_models_are_asked_about() {
+        let (base, count) = stub(listing).await;
+        let registry = Registry::new();
+
+        assert_eq!(registry.of(&against(&base), "vendor/seeing").await, Modalities::seeing());
+        assert_eq!(registry.of(&against(&base), "vendor/reading").await, Modalities::text_only());
+        assert_eq!(registry.of(&against(&base), "vendor/seeing").await, Modalities::seeing());
+
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+
+    /// Both subscription providers run the vendor's own models, and every one
+    /// of them takes pictures. There is no endpoint to ask, and asking the
+    /// operator's would answer for a model that is not paying for this turn.
+    #[tokio::test]
+    async fn a_subscription_is_answered_without_asking_anybody() {
+        let (base, count) = stub(listing).await;
+        let registry = Registry::new();
+
+        for provider in [Provider::Chatgpt, Provider::Claude] {
+            let cfg = InferenceConfig { provider, ..against(&base) };
+            // Named as the text-only model on purpose: the endpoint's list must
+            // not be consulted for a turn that endpoint is not paying for.
+            assert_eq!(registry.of(&cfg, "vendor/reading").await, Modalities::seeing());
+        }
+
+        assert_eq!(count.load(Ordering::SeqCst), 0);
+    }
+
+    /// The failure no stub can see.
+    ///
+    /// `architecture.input_modalities` is OpenRouter's own field, and every
+    /// test above is this build agreeing with itself about it. Renamed or
+    /// dropped on their side, every model becomes one nothing was published
+    /// about, which is a state that looks exactly like the day before this
+    /// existed: pictures sent to everything, `use_screen` offered to everything,
+    /// and no offline suite any the wiser. Same shape as the live halves of
+    /// `tests/plugins.rs` and [`crate::llm::catalog`].
+    ///
+    /// Asserted on the shape rather than on one slug, because a model delisted
+    /// by a vendor is not this build going stale. The one exception is the
+    /// model this app ships as its default: if that is gone, this repo has
+    /// something to change either way.
+    ///
+    /// Reaches the internet, authorizes nothing and spends nothing.
+    ///
+    ///   cargo test --manifest-path src-tauri/Cargo.toml --lib \
+    ///     llm::modality::tests::openrouter_still -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "reaches OpenRouter"]
+    async fn openrouter_still_publishes_what_each_of_its_models_takes() {
+        let cfg = InferenceConfig::default();
+        let (published, ttl) = Registry::new().ask(&cfg, cfg.base_url.trim_end_matches('/')).await;
+
+        assert!(!published.is_empty(), "OpenRouter published no modalities for any model");
+        assert_eq!(ttl, TTL, "an endpoint that answered is trusted for the full term");
+        // Both kinds have to be readable, or a field that has quietly become a
+        // constant reads as a catalog where everything can see.
+        assert!(published.values().any(|takes| takes.image), "nothing takes pictures");
+        assert!(published.values().any(|takes| !takes.image), "nothing is text only");
+
+        println!(
+            "{} models published, {} of them take pictures",
+            published.len(),
+            published.values().filter(|takes| takes.image).count()
+        );
+        assert_eq!(
+            published.get(crate::config::DEFAULT_MODEL),
+            Some(&Modalities::seeing()),
+            "the model every install starts on is not published as one that takes pictures"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_model_name_is_matched_however_it_was_typed_into_the_box() {
+        let (base, _count) = stub(listing).await;
+
+        let seen = Registry::new().of(&against(&base), "  vendor/reading  ").await;
+
+        assert_eq!(seen, Modalities::text_only());
+    }
+}

--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use crate::domain::envelope::Intent;
 use crate::domain::plugin::{PluginKind, PluginToolset};
 use crate::domain::routine::{Cadence, Trigger};
+use crate::llm::modality::Modalities;
 use crate::llm::openrouter::{ToolCall, ToolSpec};
 
 pub const DIRECTORY: &str = "directory";
@@ -180,11 +181,23 @@ pub fn plugin_specs(connected: &[PluginToolset]) -> Vec<ToolSpec> {
     out
 }
 
-pub fn specs(surfaces: Surfaces) -> Vec<ToolSpec> {
+/// The tools one agent is offered: what it has been given, narrowed to what the
+/// model behind it can be shown.
+///
+/// The second question only reaches one tool. `use_screen` answers every action
+/// with a picture of the screen, and that picture is the whole of what it
+/// returns: the coordinates to click next are in it and nowhere else. Offered
+/// to a model that cannot be sent one, it is a tool that costs a round trip to
+/// hand back nothing, and the model's next click is a guess at a position it
+/// has never seen. The rest of the computer is unaffected: `run_command` reads
+/// back as text, and `open_on_desktop` puts a program where the *operator* can
+/// watch it, which is a thing worth doing whether or not the agent can see.
+pub fn specs(surfaces: Surfaces, modalities: Modalities) -> Vec<ToolSpec> {
     all_specs(surfaces)
         .into_iter()
         .filter(|spec| match spec.name.as_str() {
-            RUN_COMMAND | OPEN_ON_DESKTOP | USE_SCREEN => surfaces.computer,
+            USE_SCREEN => surfaces.computer && modalities.image,
+            RUN_COMMAND | OPEN_ON_DESKTOP => surfaces.computer,
             BROWSE => surfaces.browser,
             CODE => surfaces.repository,
             REQUEST_PERMISSION => surfaces.computer || surfaces.browser,
@@ -1981,13 +1994,20 @@ mod tests {
     fn the_desktop_tool_names_a_browser_so_the_agent_knows_it_has_one() {
         // The failure this exists to stop: an agent with a working desktop
         // replying that it has no graphical browser.
-        let spec = specs(Surfaces::both()).into_iter().find(|s| s.name == OPEN_ON_DESKTOP).unwrap();
+        let spec = specs(Surfaces::both(), Modalities::seeing())
+            .into_iter()
+            .find(|s| s.name == OPEN_ON_DESKTOP)
+            .unwrap();
         assert!(spec.description.contains("google-chrome"), "{}", spec.description);
     }
 
     /// The one description under test, by name.
     fn description(name: &str) -> String {
-        specs(Surfaces::both()).into_iter().find(|s| s.name == name).unwrap().description
+        specs(Surfaces::both(), Modalities::seeing())
+            .into_iter()
+            .find(|s| s.name == name)
+            .unwrap()
+            .description
     }
 
     #[test]
@@ -2017,7 +2037,7 @@ mod tests {
             "an announcement is legitimate, so the rule has to leave room for one: {spec}"
         );
 
-        let to = specs(Surfaces::both())
+        let to = specs(Surfaces::both(), Modalities::seeing())
             .into_iter()
             .find(|s| s.name == SEND_MESSAGE)
             .unwrap()
@@ -2376,7 +2396,7 @@ mod tests {
         // turn to discover, and the agent reports the capability as broken
         // rather than absent.
         let names = |surfaces: Surfaces| -> Vec<String> {
-            specs(surfaces).into_iter().map(|spec| spec.name).collect()
+            specs(surfaces, Modalities::seeing()).into_iter().map(|spec| spec.name).collect()
         };
 
         let computer_only = names(Surfaces { computer: true, browser: false, repository: false });
@@ -2418,6 +2438,29 @@ mod tests {
         assert_eq!(names(Surfaces::both()).len(), all_specs(Surfaces::both()).len());
     }
 
+    /// The one tool the model's own modalities decide.
+    ///
+    /// `use_screen` hands back a picture and nothing else: what to click next
+    /// is in it, and a model that cannot be sent one would be clicking at
+    /// coordinates it has never seen. The rest of the machine is untouched,
+    /// because a shell reads back as text and a program opened on the desktop
+    /// is there for the operator to watch.
+    #[test]
+    fn a_screen_is_not_offered_to_a_model_that_cannot_be_shown_one() {
+        let blind: Vec<String> = specs(Surfaces::both(), Modalities::text_only())
+            .into_iter()
+            .map(|spec| spec.name)
+            .collect();
+
+        assert!(!blind.contains(&USE_SCREEN.to_string()), "{blind:?}");
+        assert!(blind.contains(&RUN_COMMAND.to_string()), "the shell still reads back: {blind:?}");
+        assert!(
+            blind.contains(&OPEN_ON_DESKTOP.to_string()),
+            "the operator can still watch the screen: {blind:?}"
+        );
+        assert!(blind.contains(&BROWSE.to_string()), "the browser answers in text: {blind:?}");
+    }
+
     #[test]
     fn the_code_tool_says_it_does_not_block_and_that_the_brief_is_everything() {
         // Two ways this gets used wrongly, and neither is obvious from the
@@ -2425,10 +2468,13 @@ mod tests {
         // backs up and whose routines are skipped for the length of a change to
         // a codebase. And the harness cannot see the conversation, so a task
         // saying "do what we discussed" is a task nobody can do.
-        let spec = specs(Surfaces { computer: false, browser: false, repository: true })
-            .into_iter()
-            .find(|spec| spec.name == CODE)
-            .unwrap();
+        let spec = specs(
+            Surfaces { computer: false, browser: false, repository: true },
+            Modalities::seeing(),
+        )
+        .into_iter()
+        .find(|spec| spec.name == CODE)
+        .unwrap();
         let text = spec.description.to_lowercase();
 
         assert!(text.contains("not when it is done"), "{text}");
@@ -2465,7 +2511,7 @@ mod tests {
         // The tool stays, because a file already in the channel is attachable
         // with no machine anywhere. What has to go is the half of its
         // description that is about a machine this agent does not have.
-        let without = specs(Surfaces::none())
+        let without = specs(Surfaces::none(), Modalities::seeing())
             .into_iter()
             .find(|spec| spec.name == ATTACH_FILE)
             .expect("a channel file needs no computer, so the tool stays");
@@ -2550,7 +2596,7 @@ mod tests {
 
     /// One tool's definition, with both places available.
     fn spec(name: &str) -> ToolSpec {
-        specs(Surfaces::both())
+        specs(Surfaces::both(), Modalities::seeing())
             .into_iter()
             .find(|spec| spec.name == name)
             .unwrap_or_else(|| panic!("no tool named {name}"))
@@ -2564,8 +2610,10 @@ mod tests {
         // asker could not take, and the grant landed on the wrong agent. A
         // permission obtained and then relayed is a peer's claim again, which
         // is the thing the agent holding the account was right to refuse.
-        let spec =
-            specs(Surfaces::both()).into_iter().find(|s| s.name == REQUEST_PERMISSION).unwrap();
+        let spec = specs(Surfaces::both(), Modalities::seeing())
+            .into_iter()
+            .find(|s| s.name == REQUEST_PERMISSION)
+            .unwrap();
         assert!(spec.description.contains("what you will do yourself"), "{}", spec.description);
         assert!(
             spec.description.contains("send it the work and let it ask"),
@@ -2669,7 +2717,7 @@ mod tests {
 
     #[test]
     fn every_tool_is_offered_with_a_strict_schema() {
-        let specs = specs(Surfaces::both());
+        let specs = specs(Surfaces::both(), Modalities::seeing());
         assert_eq!(
             specs.len(),
             15,
@@ -2693,7 +2741,10 @@ mod tests {
 
     #[test]
     fn send_message_description_tells_the_model_not_to_block() {
-        let spec = specs(Surfaces::both()).into_iter().find(|s| s.name == SEND_MESSAGE).unwrap();
+        let spec = specs(Surfaces::both(), Modalities::seeing())
+            .into_iter()
+            .find(|s| s.name == SEND_MESSAGE)
+            .unwrap();
         let text = spec.description.to_lowercase();
         assert!(text.contains("non-blocking") || text.contains("asynchronous"));
         assert!(text.contains("do not wait"), "blocking on a reply is the failure mode to prevent");
@@ -2770,7 +2821,10 @@ mod tests {
 
     #[test]
     fn the_send_message_schema_offers_intent_as_a_closed_choice() {
-        let spec = specs(Surfaces::both()).into_iter().find(|s| s.name == SEND_MESSAGE).unwrap();
+        let spec = specs(Surfaces::both(), Modalities::seeing())
+            .into_iter()
+            .find(|s| s.name == SEND_MESSAGE)
+            .unwrap();
         let intent = &spec.parameters["properties"]["intent"];
         assert_eq!(intent["enum"], serde_json::json!(["work", "courtesy"]));
         assert!(
@@ -3145,7 +3199,10 @@ mod tests {
     fn creating_an_agent_offers_no_choice_of_model() {
         // What a new agent costs to run is the operator's call, not a field a
         // model can set on its own behalf.
-        let spec = specs(Surfaces::both()).into_iter().find(|s| s.name == CREATE_AGENT).unwrap();
+        let spec = specs(Surfaces::both(), Modalities::seeing())
+            .into_iter()
+            .find(|s| s.name == CREATE_AGENT)
+            .unwrap();
         let properties = spec.parameters["properties"].as_object().unwrap();
         assert!(!properties.contains_key("model"), "{properties:?}");
         assert!(!properties.contains_key("group_id"), "an agent must not place one elsewhere");
@@ -3246,8 +3303,10 @@ mod tests {
         // Forwarding a file already in the channel is host-side and needs no
         // machine at all, and an operator with no provider configured is
         // exactly the person who still wants the document.
-        let offered: Vec<String> =
-            specs(Surfaces::none()).into_iter().map(|spec| spec.name).collect();
+        let offered: Vec<String> = specs(Surfaces::none(), Modalities::seeing())
+            .into_iter()
+            .map(|spec| spec.name)
+            .collect();
         assert!(offered.contains(&ATTACH_FILE.to_string()), "{offered:?}");
     }
 

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -344,6 +344,7 @@ use crate::domain::routine::{Routine, RunKind};
 use crate::domain::signin::{self, BrowserState, Signin, Surface};
 use crate::domain::worknote;
 use crate::files::FileStore;
+use crate::llm::modality::{self, Modalities};
 use crate::llm::openrouter::{ChatMessage, ChatRequest, LlmClient, LlmError, Token, ToolCall};
 use crate::llm::tools::{self, Delivery, ToolInvocation};
 use crate::plugins;
@@ -584,6 +585,14 @@ struct Inner {
     /// account makes that plugin refuse with a sentence rather than making the
     /// runtime behave differently. See `PluginKind::account_backed`.
     account: std::sync::OnceLock<Arc<crate::account::Account>>,
+    /// What each endpoint publishes about what its models can be sent.
+    ///
+    /// On the runtime rather than beside the model picker's catalog, because
+    /// unlike that one this is read on the turn path: what a model can be shown
+    /// decides what the prompt says, which tools are offered and what happens
+    /// to an attached picture. Read once per endpoint and kept, for the reason
+    /// a plugin's tool list is.
+    modalities: modality::Registry,
     /// Actor tasks currently running. Registration and the task are separate
     /// things, and a leaked task is invisible without counting it.
     live_actors: Arc<AtomicUsize>,
@@ -643,6 +652,7 @@ impl Runtime {
                 viewer_port: AtomicU16::new(0),
                 plugin_endpoints: std::sync::OnceLock::new(),
                 account: std::sync::OnceLock::new(),
+                modalities: modality::Registry::new(),
                 live_actors: Arc::new(AtomicUsize::new(0)),
                 events,
             }),
@@ -1220,15 +1230,43 @@ impl Runtime {
     /// spreadsheet, is written into `~/inbox` and the agent is told the path,
     /// because a Linux box with python on it knows more file formats than this
     /// runtime ever will.
+    ///
+    /// "Can read" is the model's answer and not this file type's. A picture
+    /// sent to a model that takes text only is refused by the endpoint, which
+    /// costs the whole turn rather than the attachment, so a model that cannot
+    /// be shown one is not shown one: the picture becomes the third case, on a
+    /// machine if there is one, and the agent is told in words what it has and
+    /// has not been given. Silently sending it anyway and letting the provider
+    /// object is the version of this that fails with an error naming neither
+    /// the file nor the reason.
     async fn deliver_files(
         &self,
         card: &AgentCard,
         batch: &[Envelope],
+        modalities: Modalities,
         messages: &mut Vec<ChatMessage>,
     ) {
         for envelope in batch {
             for file in prompt::attachments(envelope) {
-                let note = if file.is_image() {
+                let note = if file.is_image() && !modalities.image {
+                    match self.place(card, file).await {
+                        Ok(path) => format!(
+                            "The attached file {} is a picture, and pictures do not reach the \
+                             model you are running on: you have not seen it. It is on your \
+                             machine at {path}, which is the only way to get at what is in it. \
+                             Do not describe it from its name.",
+                            file.name
+                        ),
+                        Err(why) => format!(
+                            "The attached file {} is a picture, and pictures do not reach the \
+                             model you are running on: you have not seen it, and it could not be \
+                             put anywhere you could open it either ({why}). Say that plainly and \
+                             ask for what is in it in words, rather than describing a picture \
+                             from its name.",
+                            file.name
+                        ),
+                    }
+                } else if file.is_image() {
                     match self.inner.files.read(&file.digest) {
                         Ok(bytes) => {
                             let data =
@@ -2519,10 +2557,33 @@ impl Runtime {
             tracing::warn!(%err, "could not read what this agent is waiting on");
             Vec::new()
         });
+        // Settings resolve agent over group over app. An agent that names its own
+        // model keeps it; otherwise the group's choice applies; otherwise the
+        // app default. The endpoint resolves the same way, so one crew can run
+        // against a local server while another uses a hosted one.
+        //
+        // Read here rather than at the first model call, which is where it used
+        // to be: what the model can be sent decides what goes into the prompt
+        // and which tools are offered, and both of those are settled before a
+        // token is spent.
+        let config = self.config();
+        let inference = self.inference_for(&card, &config);
+        let model = if card.model.trim().is_empty() {
+            inference.default_model.clone()
+        } else {
+            card.model.clone()
+        };
+        // What Guaca will put in front of that model, decided once and used
+        // four times: the prompt says it, the tool list agrees with it,
+        // `deliver_files` obeys it, and `not_given` refuses a screen the model
+        // asked for anyway. Costs one request per endpoint per six hours, and
+        // an endpoint that says nothing leaves everything as it was.
+        let modalities = self.inner.modalities.of(&inference, &model).await;
+
         #[allow(unused_mut)]
         let mut messages = prompt::build_messages(
             &card,
-            &self.config().operator_name,
+            &config.operator_name,
             &roster,
             &credentials,
             &signins,
@@ -2537,11 +2598,12 @@ impl Runtime {
             &waiting_on,
             repository.as_ref(),
             surfaces,
+            modalities,
         );
         // After assembly, because what a file becomes depends on things the
-        // prompt cannot reach: bytes on disk, and a machine that may have to be
-        // started to hold them.
-        self.deliver_files(&card, &batch, &mut messages).await;
+        // prompt cannot reach: bytes on disk, a model that may not be able to
+        // see one, and a machine that may have to be started to hold them.
+        self.deliver_files(&card, &batch, modalities, &mut messages).await;
 
         // Where the finished message will land, and who it is for. Both are
         // known before the first token, so the UI never has to guess and then
@@ -2561,18 +2623,7 @@ impl Runtime {
         };
         stream.open(&*self.inner.events);
 
-        let config = self.config();
         let mut collected_text = String::new();
-        // Settings resolve agent over group over app. An agent that names its own
-        // model keeps it; otherwise the group's choice applies; otherwise the
-        // app default. The endpoint resolves the same way, so one crew can run
-        // against a local server while another uses a hosted one.
-        let inference = self.inference_for(&card, &config);
-        let model = if card.model.trim().is_empty() {
-            inference.default_model.clone()
-        } else {
-            card.model.clone()
-        };
 
         let mut tool_parts: Vec<Part> = Vec::new();
         // Peers written to through `send_message` during this turn.
@@ -2617,7 +2668,7 @@ impl Runtime {
                 // The crew's plugins after the app's own tools, in that order,
                 // so a provider that truncates a long list keeps the ones every
                 // agent needs to answer at all.
-                tools: tools::specs(surfaces)
+                tools: tools::specs(surfaces, modalities)
                     .into_iter()
                     .chain(tools::plugin_specs(&plugins))
                     .collect(),
@@ -2678,6 +2729,7 @@ impl Runtime {
                         &mut reading,
                         &mut attached,
                         call,
+                        modalities,
                         &named,
                     )
                     .await;
@@ -3080,6 +3132,11 @@ impl Runtime {
         // Files this turn has attached to the answer it has not written yet.
         attached: &mut Vec<Attachment>,
         call: &ToolCall,
+        // What the model behind this turn can be sent, settled once at the top
+        // of it. Passed rather than resolved again because it decides a refusal
+        // on this path, and a second reading could disagree with the tool list
+        // the model was offered.
+        modalities: Modalities,
         // The crew's servers, as the turn read them. Passed rather than read
         // again because a call to a server the operator added can only be
         // resolved against what this group has: its name and its address are on
@@ -3113,6 +3170,7 @@ impl Runtime {
                 attached,
                 call,
                 arguments,
+                modalities,
                 plugins,
             )
             .await;
@@ -3148,6 +3206,7 @@ impl Runtime {
         attached: &mut Vec<Attachment>,
         call: &ToolCall,
         arguments: serde_json::Value,
+        modalities: Modalities,
         plugins: &[PluginKind],
     ) -> (String, Part, Option<String>) {
         let invocation = match tools::parse(call, plugins) {
@@ -3169,7 +3228,7 @@ impl Runtime {
         // reaches a place this agent was not given, and this is the same rule
         // where a model that called it anyway meets it, exactly as
         // `ask_to_act` does one layer up.
-        if let Some(refusal) = self.not_given(card, &invocation) {
+        if let Some(refusal) = self.not_given(card, modalities, &invocation) {
             return (
                 refusal.clone(),
                 Part::tool_call(
@@ -3837,14 +3896,28 @@ impl Runtime {
         }
     }
 
-    /// A tool aimed at a place this agent has not been given.
+    /// A tool aimed at a place this agent has not been given, or at a screen
+    /// the model answering cannot be shown.
     ///
     /// A refusal rather than an error, and the difference is what the model
     /// does next. "Your computer is not available" reads as a machine that
     /// failed, which is a thing worth trying again in a minute; this says the
     /// access was never there, that only the operator can change it, and what
     /// to do with the rest of the turn.
-    fn not_given(&self, card: &AgentCard, invocation: &ToolInvocation) -> Option<String> {
+    ///
+    /// The screen is the one case where the agent has the place and still
+    /// cannot use it. `specs` leaves `use_screen` out when a picture would not
+    /// reach the model, and a model that names a tool it was never offered is
+    /// ordinary rather than exotic, so the same question is asked again here:
+    /// otherwise the machine is worked, the screen is captured and the picture
+    /// is thrown away, which reads to the model as a screen that came back
+    /// blank.
+    fn not_given(
+        &self,
+        card: &AgentCard,
+        modalities: Modalities,
+        invocation: &ToolInvocation,
+    ) -> Option<String> {
         let surfaces = self.surfaces_for(card);
         match invocation {
             ToolInvocation::RunCommand { .. }
@@ -3860,6 +3933,16 @@ impl Runtime {
                         .to_string(),
                 )
             }
+            // After the refusal above, because both can be true and "you have no
+            // computer" is the one with something the operator can do about it.
+            ToolInvocation::UseScreen { .. } if !modalities.image => Some(
+                "Refused: a picture cannot reach the model you are running on, so looking at \
+                 your screen would hand back nothing and nothing was done. Your machine still \
+                 works: use `run_command`, which answers in text, and `open_on_desktop` when the \
+                 point is for the operator to see something. Say plainly in your reply what \
+                 needed eyes on the screen."
+                    .to_string(),
+            ),
             ToolInvocation::Browse { .. } if !surfaces.browser => Some(
                 "Refused: you have no browser, so nothing was opened and no page was read. \
                  Nothing is broken and there is nothing to retry: you have not been given one, \

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -26,6 +26,7 @@ use crate::domain::repository::Repository;
 use crate::domain::routine::Routine;
 use crate::domain::signin::Signin;
 use crate::domain::worknote::{self, WorkingNote};
+use crate::llm::modality::Modalities;
 use crate::llm::openrouter::ChatMessage;
 use crate::llm::tools::Surfaces;
 
@@ -102,6 +103,13 @@ pub fn system_prompt(
     // describing a machine that is not configured is a promise the app cannot
     // keep, and an agent believing it spends a turn discovering otherwise.
     surfaces: Surfaces,
+    // What the model paying for this turn can actually be sent. Beside the
+    // surfaces rather than folded into them, because it is a different kind of
+    // fact: a surface is a place the operator gave this agent, and this is what
+    // the model in the box can take. They meet in one place, which is the
+    // screen: a machine whose screen cannot be shown to the model is still a
+    // machine.
+    modalities: Modalities,
 ) -> String {
     let mut out = String::new();
 
@@ -127,6 +135,44 @@ pub fn system_prompt(
         out.push('\n');
     }
 
+    // Before the places it works, because one of them depends on it. What an
+    // agent can be *sent* is a fact about the model in the box rather than
+    // about the workspace, and it is the one fact that changes under an agent
+    // without anything else about it changing: an operator swaps a model
+    // between two turns and the same agent stops being able to see. Said out
+    // loud for the same reason the surfaces are: told nothing, a model that
+    // cannot see a picture describes one anyway, from the file's name.
+    out.push_str("\n## What reaches you\n");
+    if modalities.image {
+        out.push_str(
+            "You read text, and you see pictures. A photograph or a screenshot in this \
+             conversation is really in front of you, so work from what is in it rather than \
+             asking what it shows.\n\n\
+             Nothing else arrives as itself. A sound or a video is a file you were sent, never \
+             something you have heard or watched: say so plainly rather than describing one.\n",
+        );
+    } else {
+        out.push_str(
+            "You read text, and only text. The model you are running on cannot be shown a \
+             picture, so a photograph or a screenshot in this conversation does not reach you: \
+             you are told what the file is called and that it arrived, and that is all you have \
+             of it. Never describe, quote or summarize a file whose contents you have not been \
+             given. Say you cannot see it, and ask for what is in it in words.\n\n\
+             A sound or a video is the same: a file you were sent, never something you have \
+             heard or watched.\n",
+        );
+    }
+    // Both cases, because it is the half that does not vary. An agent asked for
+    // a picture and told only what it can receive offers to make one.
+    out.push_str(if mode == ReplyMode::ToPeer {
+        "\nWhat you produce is text. You cannot draw, record or generate a picture, a sound or a \
+         video, so do not offer one.\n"
+    } else {
+        "\nWhat you produce is text. You cannot draw, record or generate a picture, a sound or a \
+         video, so do not offer one: when something is worth showing, the figures below are how \
+         you show it.\n"
+    });
+
     // Stated plainly and early, because an agent that is only handed a tool
     // schema does not connect it to what it can do: asked to check the weather,
     // one with a working machine still answered that it had no way to look
@@ -144,18 +190,33 @@ pub fn system_prompt(
              with a browser, a file manager and an editor installed, and the operator can watch \
              that screen and take control of it.\n\n\
              - `run_command` runs a shell command on it. The filesystem persists between turns \
-               and the internet works, so anything you do not already know you can go and find \
-               out rather than declining. Use it to fetch text, install what you need, and run \
-               code.\n\
+             and the internet works, so anything you do not already know you can go and find \
+             out rather than declining. Use it to fetch text, install what you need, and run \
+             code.\n\
              - `open_on_desktop` starts a program on the screen: an editor, a file manager, a \
-               document, or `google-chrome https://example.com`. The operator sees exactly what \
-               you opened.\n\
-             - `use_screen` is how you work that screen. Every action answers with a fresh \
-               picture of it, so you are always looking at the result of what you just did; \
-               `look` on its own is for when you have not seen it yet. Click, type, press keys, \
-               scroll and drag by the coordinates in the picture. This is how you use anything \
-               that is not a web page.\n",
+             document, or `google-chrome https://example.com`. The operator sees exactly what \
+             you opened.\n",
         );
+        // The screen is the one part of a machine that is only worth having if
+        // a picture of it reaches the model. Said either way rather than left
+        // out, because an agent told it has a desktop and offered no way to
+        // look at it calls for one by name and reports the machine as broken.
+        if modalities.image {
+            out.push_str(
+                "- `use_screen` is how you work that screen. Every action answers with a fresh \
+                 picture of it, so you are always looking at the result of what you just did; \
+                 `look` on its own is for when you have not seen it yet. Click, type, press \
+                 keys, scroll and drag by the coordinates in the picture. This is how you use \
+                 anything that is not a web page.\n",
+            );
+        } else {
+            out.push_str(
+                "\nYou cannot look at that screen yourself: a picture of it would not reach \
+                 you, so there is no tool for it and there is no point asking for one. Work the \
+                 machine with `run_command`, which answers in text, and use `open_on_desktop` \
+                 when the point is for the operator to watch something happen.\n",
+            );
+        }
         if surfaces.browser {
             out.push_str(
                 "\nThe browser on this machine's screen is not the browser `browse` uses. They \
@@ -895,6 +956,7 @@ pub fn build_messages(
     waiting_on: &[Outstanding],
     repository: Option<&Repository>,
     surfaces: Surfaces,
+    modalities: Modalities,
 ) -> Vec<ChatMessage> {
     let mut messages = vec![ChatMessage::system(system_prompt(
         card,
@@ -910,6 +972,7 @@ pub fn build_messages(
         waiting_on,
         repository,
         surfaces,
+        modalities,
     ))];
 
     for envelope in history {
@@ -960,6 +1023,7 @@ mod tests {
             &[],
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         )
     }
 
@@ -980,6 +1044,7 @@ mod tests {
             &[],
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         )
     }
 
@@ -1003,6 +1068,7 @@ mod tests {
             &[],
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         )
     }
 
@@ -1033,6 +1099,7 @@ mod tests {
             &[],
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         )
     }
 
@@ -1271,6 +1338,7 @@ mod tests {
             &[],
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         );
 
         assert!(prompt.contains("- LinkedIn"), "a detected session has to be named");
@@ -1329,6 +1397,7 @@ mod tests {
             &[],
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         );
 
         assert!(prompt.contains("- Neon — 2 tools, called as `neon__…`"), "{prompt}");
@@ -1363,6 +1432,7 @@ mod tests {
             &[],
             None,
             Surfaces::none(),
+            Modalities::seeing(),
         );
 
         assert!(prompt.contains("- Stripe — 1 tool, called as `stripe__…`"), "{prompt}");
@@ -1398,6 +1468,7 @@ mod tests {
             &[],
             None,
             Surfaces::none(),
+            Modalities::seeing(),
         );
 
         assert!(prompt.contains("Switched off by the operator"), "{prompt}");
@@ -1430,6 +1501,7 @@ mod tests {
             &[],
             None,
             Surfaces::none(),
+            Modalities::seeing(),
         );
 
         assert!(!prompt.contains("You are not signed in to anything"), "{prompt}");
@@ -1469,6 +1541,7 @@ mod tests {
             &[],
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         );
         assert!(prompt.contains("may also be signed in"), "a guess has to read as one");
         assert!(
@@ -1503,6 +1576,7 @@ mod tests {
             &[],
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         );
 
         assert!(prompt.contains("GITHUB_TOKEN"), "the name is what it needs");
@@ -1540,6 +1614,7 @@ mod tests {
             &[],
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         );
         assert!(prompt.contains("that session has ended"), "name what a login wall means");
         assert!(prompt.contains("do not ask anyone for a password"));
@@ -1572,6 +1647,7 @@ mod tests {
             &[],
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         );
         assert!(prompt.contains("- Researcher (web research) — signed in to LinkedIn"));
         assert!(
@@ -1890,6 +1966,7 @@ mod tests {
             &[],
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         );
         let assistant = messages
             .iter()
@@ -1987,6 +2064,7 @@ mod tests {
             &[],
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         );
         assert!(prompt.contains("Robert"), "the operator's name belongs in every prompt");
 
@@ -2005,6 +2083,7 @@ mod tests {
             &[],
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         );
         assert!(!anonymous.contains("is called"), "no name means no claim about one");
     }
@@ -2088,6 +2167,7 @@ mod tests {
             &waiting,
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         );
         let progress = section(&prompt, "## Your working notes");
 
@@ -2247,6 +2327,7 @@ mod tests {
             &[],
             None,
             Surfaces::none(),
+            Modalities::seeing(),
         );
         assert!(!neither.contains("## Your computer"), "{neither}");
         assert!(!neither.contains("## Your browser"), "{neither}");
@@ -2268,12 +2349,86 @@ mod tests {
             &[],
             None,
             Surfaces { computer: true, browser: false, repository: false },
+            Modalities::seeing(),
         );
         assert!(computer_only.contains("## Your computer"), "{computer_only}");
         assert!(!computer_only.contains("## Your browser"), "{computer_only}");
         // With no browser there is no second place to disclaim, and saying
         // there is would be the overclaim wearing a warning label.
         assert!(!computer_only.contains("not the browser `browse` uses"), "{computer_only}");
+    }
+
+    /// The prompt for an agent whose model can, or cannot, be shown a picture.
+    fn prompt_taking(modalities: Modalities, mode: ReplyMode) -> String {
+        system_prompt(
+            &card("Analyst"),
+            "",
+            &[],
+            &[],
+            &[],
+            &[],
+            "",
+            &[],
+            &[],
+            mode,
+            &[],
+            None,
+            Surfaces::both(),
+            modalities,
+        )
+    }
+
+    #[test]
+    fn an_agent_is_told_what_reaches_it_and_what_it_can_produce() {
+        let prompt = prompt_taking(Modalities::seeing(), ReplyMode::ToOperator);
+        let reaches = section(&prompt, "## What reaches you");
+
+        assert!(reaches.contains("you see pictures"), "{reaches}");
+        // The half that does not vary. Told only what it can receive, an agent
+        // asked for a picture offers to make one.
+        assert!(reaches.contains("What you produce is text"), "{reaches}");
+        // And what it cannot receive, or it describes a recording from the
+        // file's name rather than saying it never heard one.
+        assert!(reaches.contains("A sound or a video"), "{reaches}");
+
+        // Figures are how a reply shows something, and a peer is never told
+        // about them: pointing one at a section it does not have is an
+        // instruction it cannot follow.
+        let peer = prompt_taking(Modalities::seeing(), ReplyMode::ToPeer);
+        assert!(section(&peer, "## What reaches you").contains("What you produce is text"));
+        assert!(!section(&peer, "## What reaches you").contains("figures below"), "{peer}");
+    }
+
+    /// The case the whole thing exists for: an operator swaps the model in the
+    /// box for one that takes text only, and nothing else about the agent
+    /// changes.
+    #[test]
+    fn a_model_that_cannot_be_shown_a_picture_is_told_so_and_offered_no_screen() {
+        let prompt = prompt_taking(Modalities::text_only(), ReplyMode::ToOperator);
+        let reaches = section(&prompt, "## What reaches you");
+
+        assert!(reaches.contains("only text"), "{reaches}");
+        assert!(reaches.contains("does not reach you"), "{reaches}");
+        // The failure this closes. Handed a file it cannot open and told
+        // nothing, a model writes a confident description of a picture it has
+        // never seen, from the file's name.
+        assert!(reaches.contains("Never describe"), "{reaches}");
+        assert!(reaches.contains("ask for what is in it in words"), "{reaches}");
+
+        // The machine is still a machine. What goes is the one tool whose
+        // entire answer is a picture, and the section has to say so: an agent
+        // told it has a desktop and offered no way to look at it calls for one
+        // by name and reports the machine as broken.
+        let computer = section(&prompt, "## Your computer");
+        assert!(!computer.contains("`use_screen`"), "{computer}");
+        assert!(computer.contains("cannot look at that screen"), "{computer}");
+        assert!(computer.contains("`run_command`"), "the shell reads back as text: {computer}");
+        assert!(computer.contains("`open_on_desktop`"), "the operator can watch: {computer}");
+
+        // And a model that can see is still told how to work it, or the fix
+        // for one operator is a regression for everybody else.
+        let seeing = prompt_taking(Modalities::seeing(), ReplyMode::ToOperator);
+        assert!(section(&seeing, "## Your computer").contains("`use_screen`"), "{seeing}");
     }
 
     #[test]
@@ -2320,6 +2475,7 @@ mod tests {
             &[],
             None,
             Surfaces::none(),
+            Modalities::seeing(),
         );
         assert!(!nowhere.contains("request_permission"), "{nowhere}");
         // And the peer-claim paragraph still ends somewhere, rather than
@@ -2347,6 +2503,7 @@ mod tests {
             &[],
             None,
             Surfaces { computer: false, browser: true, repository: false },
+            Modalities::seeing(),
         );
         assert!(somewhere.contains("request_permission"), "{somewhere}");
         assert!(somewhere.contains("Declining is the correct response"), "{somewhere}");
@@ -2626,6 +2783,7 @@ mod tests {
             &waiting,
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         );
 
         // The heading, not the phrase. The memory section says "What you are
@@ -2657,6 +2815,7 @@ mod tests {
             &[],
             None,
             Surfaces::both(),
+            Modalities::seeing(),
         );
         assert!(!prompt.contains("## What you are waiting on"), "{prompt}");
     }

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -3069,6 +3069,53 @@ async fn a_computer_belongs_to_an_agent_the_operator_gave_one_to_and_not_to_the_
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_screen_is_neither_offered_nor_served_to_a_model_that_cannot_be_shown_one() {
+    // The agent has the machine. What it does not have is a model that can be
+    // sent a picture, and `use_screen` hands back nothing else: the coordinates
+    // to click next are in the picture and nowhere else. Both halves are
+    // tested, because a model names tools it was never offered and the tool
+    // list alone is decoration.
+    let listing = serde_json::json!({
+        "data": [{
+            "id": "test/model",
+            "architecture": { "input_modalities": ["text"], "output_modalities": ["text"] },
+        }]
+    });
+    let stub = serve_publishing(Some(listing), |body| {
+        if has_tool_result(body) {
+            Script::Say("I cannot look at that screen, so here is what I did instead.".into())
+        } else {
+            Script::Look
+        }
+    })
+    .await;
+
+    let h = harness_with_computer(&stub, &["Runner"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Runner"), "What is on the screen?").unwrap();
+    h.settle(run).await;
+
+    // Decided before the first token, which is the half that costs nothing.
+    let offered = tools_by_agent(&stub);
+    assert!(!offered["Runner"].contains(&"use_screen".to_string()), "{offered:?}");
+    // And the rest of the machine is untouched: a shell answers in text, and a
+    // program on the desktop is there for the operator to watch.
+    assert!(offered["Runner"].contains(&"run_command".to_string()), "{offered:?}");
+    assert!(offered["Runner"].contains(&"open_on_desktop".to_string()), "{offered:?}");
+
+    // The load-bearing half. Served, the machine would be worked, the screen
+    // captured and the picture thrown away, which reads to the model as a
+    // screen that came back blank.
+    let told = tool_results(&stub).join("\n");
+    assert!(told.contains("a picture cannot reach the model"), "{told}");
+    assert!(told.contains("`run_command`"), "a refusal needs a way forward: {told}");
+    assert!(
+        h.agent_named("Runner").unwrap().sandbox_id.is_none(),
+        "a refused call must not have rented a machine anyway"
+    );
+    h.expect_normal(run, "a refused tool call is an ordinary turn");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn a_browser_is_given_the_same_way_and_refused_the_same_way() {
     // The other place, and a separate decision: a crew where one agent reads
     // the web and nobody else leaves the workspace is the ordinary shape. The

--- a/src-tauri/tests/files.rs
+++ b/src-tauri/tests/files.rs
@@ -81,6 +81,44 @@ async fn a_picture_is_handed_over_as_a_picture() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_picture_is_not_sent_to_a_model_that_cannot_be_shown_one() {
+    // The other half of the test above, and the reason any of this is decided
+    // rather than assumed. An operator swaps the model in the box for one that
+    // takes text only; the picture would be refused by the endpoint, which
+    // costs the whole turn rather than the attachment. So it is not sent, and
+    // the agent is told in words what it is holding and what it is not.
+    let listing = serde_json::json!({
+        "data": [{
+            "id": "test/model",
+            "architecture": { "input_modalities": ["text"], "output_modalities": ["text"] },
+        }]
+    });
+    let stub = serve_publishing(Some(listing), |_| Script::Say("I cannot see it.".into())).await;
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+
+    let png: &[u8] = &[
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90,
+        0x77, 0x53, 0xde,
+    ];
+    let shot = h.runtime.files().put("chart.png", png).unwrap();
+    let run = h.runtime.send_from_human_with(h.id("Manager"), "What is this?", vec![shot]).unwrap();
+    h.settle(run).await;
+
+    let sent = prompts(&stub);
+    assert!(!sent.contains("image_url"), "the endpoint said it takes text only:\n{sent}");
+    assert!(!sent.contains("data:image/png;base64,"), "{sent}");
+    // Not silence. A model that finds no picture and no explanation talks about
+    // the file from its name, confidently, which is the failure this replaces.
+    assert!(sent.contains("chart.png"), "the agent has to know a file arrived:\n{sent}");
+    assert!(sent.contains("pictures do not reach the model"), "{sent}");
+    // And the prompt agrees with the delivery, rather than telling an agent it
+    // can see and then handing it nothing.
+    assert!(sent.contains("You read text, and only text"), "{sent}");
+    assert!(!sent.contains("use_screen"), "a screen it cannot be shown is not offered:\n{sent}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn a_picture_is_handed_over_once_and_never_again() {
     // A screenshot off a retina display is over a megabyte, and base64 is a
     // third bigger again. Attaching it to every turn that follows would make

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -96,6 +96,10 @@ pub enum Script {
     /// Emit a `run_command` tool call: a model reaching for a computer, whether
     /// or not it was offered one.
     Shell(String),
+    /// Emit a `use_screen` tool call that looks at the screen. The same reach
+    /// at the one place whose entire answer is a picture, which is what a model
+    /// running on an endpoint that takes text only must not be served.
+    Look,
     /// Emit a `code` tool call: a brief handed to whichever coding harness the
     /// agent's repository names.
     Code(String),
@@ -272,6 +276,16 @@ pub fn render(script: &Script) -> String {
                 serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
             ));
         }
+        Script::Look => {
+            let args = serde_json::json!({ "action": "look" }).to_string();
+            body.push_str(&frame(serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                {"index":0,"id":"call_screen","type":"function",
+                 "function":{"name":"use_screen","arguments": args}}
+            ]}}]})));
+            body.push_str(&frame(
+                serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
+            ));
+        }
         Script::Code(task) => {
             let args = serde_json::json!({ "task": task }).to_string();
             body.push_str(&frame(serde_json::json!({"choices":[{"delta":{"tool_calls":[
@@ -437,12 +451,38 @@ pub async fn serve<F>(decide: F) -> Stub
 where
     F: Fn(&serde_json::Value) -> Script + Clone + Send + Sync + 'static,
 {
+    // No `/v1/models` route, which is most OpenAI-compatible servers and is
+    // what every test in this repo but one runs against: an endpoint that
+    // publishes nothing about its models leaves everything exactly as it was.
+    serve_publishing(None, decide).await
+}
+
+/// The same endpoint, publishing what its models take.
+///
+/// OpenRouter's shape, which is where the field comes from. Only a test about
+/// modalities wants this: `listing` is the whole `/v1/models` body, so a test
+/// can say a model takes text and nothing else and watch a picture stop being
+/// sent to it.
+pub async fn serve_publishing<F>(listing: Option<serde_json::Value>, decide: F) -> Stub
+where
+    F: Fn(&serde_json::Value) -> Script + Clone + Send + Sync + 'static,
+{
     let calls = Arc::new(AtomicUsize::new(0));
     let transcript = Arc::new(parking_lot::Mutex::new(Vec::new()));
     let call_counter = calls.clone();
     let recorder = transcript.clone();
 
-    let app = Router::new().route(
+    let mut app = Router::new();
+    if let Some(listing) = listing {
+        app = app.route(
+            "/v1/models",
+            axum::routing::get(move || {
+                let listing = listing.clone();
+                async move { axum::Json(listing) }
+            }),
+        );
+    }
+    let app = app.route(
         "/v1/chat/completions",
         post(move |body: axum::extract::Json<serde_json::Value>| {
             let decide = decide.clone();


### PR DESCRIPTION
Whether a picture reaches the model was assumed of every model; now `llm/modality.rs` asks the endpoint the turn is paid through, reading OpenRouter's `architecture.input_modalities` off `/models` once per endpoint and keeping it, with both subscription providers answered without a request. An endpoint that publishes nothing, and a model that is not on its list, both leave everything exactly as it was: only a published list without `image` in it subtracts anything. That one answer is settled at the top of the turn and spent in four places that have to agree: the prompt says what reaches this agent and that its output is text, `specs` drops `use_screen`, `deliver_files` puts a picture on the machine and says in words that it was not seen, and `not_given` refuses a screen a model called for anyway. Covered by nine unit tests, two prompt tests, a tool-list test, end-to-end tests in `files.rs` and `cascade.rs`, and an `#[ignore]`d live check that OpenRouter still publishes the field (417 models today, 251 of which take pictures). This changes the system prompt, so the live evals want running before merge.