### PR TITLE
fix: a note is written when the next turn needs it, and the panel shows four

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,6 +367,17 @@ the model takes a screenshot to see what `browse` did.
   operation these models are worst at: this is the one store that never asks.
   Adding a `revise` or a `clear` to the tool surface hands that decision straight
   back.
+- **A line an agent already holds is not stored twice, and its stamp does not
+  move.** The only brake a store that never asks the agent to prune can have.
+  *Still waiting on the legal read* on four turns is four of sixteen slots on
+  one fact, and told "noted" the agent learns that restating is how you say
+  something is still true. The repeat comes back with the age of the note that
+  already says it, which is what it was reaching for; refreshing the stamp
+  instead would hide staleness at the moment the age is worth reading. It is
+  still not a revision: nothing is edited and nothing is dropped, the second
+  write never happens. The same reasoning is why the tool and the prompt ask
+  whether the *next* turn would go wrong without the note, rather than saying
+  "note freely", which is what they said first and what filled the lists.
 - **Working notes are a table because an append is a read-modify-write.** An
   agent's stores are written from every thread it holds, so appending to a file
   loses notes under exactly the concurrency this app has. The insert and the

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -224,6 +224,34 @@ appended with `note_progress`, never revised. The agent is shown them with an
 age against each, which is what turns *waiting on the legal read* into something
 it can act on: the same line marked six days old says the thing is not coming.
 
+**A note is written when the next turn would go wrong without it.** That test,
+and not "note freely", which is what the tool and the prompt said first. It is
+true about what one note costs and it was read as a reason to write one: agents
+noted what they were about to do, what they had just said, and each step of a
+task they finished inside the same turn, so a list of sixteen ran on a turn
+narrating itself while what the agent was waiting on aged off the end of it.
+Cheap is a fact about the shape of the write, one line against memory's whole
+page, and it has to stay true or the impulse goes back to memory where it came
+from. It is not an invitation. The rule is now a question about the *next* turn
+— work you would repeat, something you would carry on waiting for, a decision
+you would make differently — with the three cases that produced the volume named
+as exclusions, because a model given only a positive rule reads every borderline
+call as inside it.
+
+**A line the agent already holds is not stored again.** The one mechanical
+brake, and the only one this store can have: it cannot ask the agent to prune,
+for the reason below. *Still waiting on the legal read*, noted on four turns, is
+four of sixteen slots spent on one fact and three notes that record nothing. The
+repeat is refused with the age of the note that already says it, which is both
+what the agent was reaching for and what it needs in order to chase or give up.
+The stamp is deliberately not moved forward: refreshing it would hide staleness
+at exactly the moment the age is worth reading. This is not a revision either,
+which is the rule the store does keep — nothing is edited and nothing is
+dropped, the second write simply never happens. The match is exact, per agent,
+and against the notes that survived the trim: a line that has aged out is one
+the agent can no longer see, so writing it again is recording rather than
+repeating.
+
 **The write rules are deliberately not symmetric.** Consolidating a memory after
 every interaction degrades it, and past a point below having no memory at all
 (arXiv 2605.12978); localized maintenance holds up better than global
@@ -240,6 +268,16 @@ edit or delete one. A stale note does not sit inert, it steers the next turn
 toward work that is already done (arXiv 2505.16067), and deciding what to drop
 is the operation these models are measurably worst at. This is the one store
 that never asks.
+
+**The panel draws the newest four and keeps the rest behind a button.** Its
+bound and the store's answer different questions: sixteen is what an agent may
+carry, four is what one section of a shared column can show. A note wraps to
+three lines in a sidebar that narrow, so a full list is a screen of text with
+the schedule and the memory below it, and the operator scrolls past what the
+agent is doing now to reach anything else. The newest are what stay, because
+the list reads oldest first and the tail is where the work got to; the button
+carries the count of what it hides, since a list of six and a list of sixteen
+are otherwise the same closed section.
 
 **The panel below the memory is read-only apart from Clear.** That asymmetry is
 the design and not an unfinished half of it. Memory is a page two parties

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -33,7 +33,7 @@ use crate::domain::search::{
 };
 use crate::domain::signin::{Signin, Surface};
 use crate::domain::usage::{Tokens, UsageEntry};
-use crate::domain::worknote::{WorkingNote, KEPT};
+use crate::domain::worknote::{Appended, WorkingNote, KEPT};
 
 pub type Conn = PooledConnection<SqliteConnectionManager>;
 
@@ -977,7 +977,8 @@ impl Store {
 
     // ---- working notes ---------------------------------------------------
 
-    /// Appends a note and drops whatever that pushed past `KEPT`.
+    /// Appends a note the agent does not already hold, and drops whatever that
+    /// pushed past `KEPT`.
     ///
     /// Both halves in one transaction, because the trim is not housekeeping
     /// that can run later: between the insert and the delete the agent is over
@@ -993,9 +994,27 @@ impl Store {
         agent: AgentId,
         body: &str,
         at: i64,
-    ) -> Result<(), StoreError> {
+    ) -> Result<Appended, StoreError> {
         let mut conn = self.conn()?;
         let tx = conn.transaction()?;
+        // A line the agent already holds is not stored again. Asked inside the
+        // same transaction as the insert for the reason the trim is: an agent
+        // writes from every thread it holds, and a check outside lets two turns
+        // land the same line twice. Only the rows that survived the trim are
+        // here to match against, which is the right set: a note that fell off
+        // the end is one the agent can no longer see, and writing it again is
+        // recording something rather than repeating it.
+        let held: Option<i64> = tx
+            .query_row(
+                "SELECT at FROM working_notes WHERE agent_id=?1 AND body=?2 ORDER BY id DESC \
+                 LIMIT 1",
+                params![agent.to_string(), body],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if let Some(at) = held {
+            return Ok(Appended::AlreadyHeld { at });
+        }
         tx.execute(
             "INSERT INTO working_notes (agent_id,at,body) VALUES (?1,?2,?3)",
             params![agent.to_string(), at, body],
@@ -1009,7 +1028,7 @@ impl Store {
             params![agent.to_string(), KEPT as i64],
         )?;
         tx.commit()?;
-        Ok(())
+        Ok(Appended::Stored)
     }
 
     /// An agent's working notes, oldest first.
@@ -7519,6 +7538,66 @@ mod tests {
             f.store.working_notes(agent.id).unwrap().into_iter().map(|n| n.body).collect();
         assert_eq!(bodies.first().unwrap(), "note 2");
         assert_eq!(bodies.last().unwrap(), &format!("note {}", KEPT + 1));
+    }
+
+    #[test]
+    fn a_line_the_agent_already_holds_is_not_stored_again() {
+        // The one mechanical brake on a list that fills with one fact. An agent
+        // saying "still waiting on Robert" for the fourth time is not recording
+        // anything, and acknowledging it teaches that repeating is how you say
+        // something is still true.
+        let f = fixture();
+        let agent = f.store.create_agent(&draft("Manager")).unwrap();
+        assert_eq!(
+            f.store.append_working_note(agent.id, "waiting on Robert", 1_000).unwrap(),
+            Appended::Stored
+        );
+        assert_eq!(
+            f.store.append_working_note(agent.id, "waiting on Robert", 9_000).unwrap(),
+            Appended::AlreadyHeld { at: 1_000 },
+            "the repeat has to come back with the stamp of the note that already says it"
+        );
+
+        let notes = f.store.working_notes(agent.id).unwrap();
+        assert_eq!(notes.len(), 1, "the repeat was stored anyway");
+        assert_eq!(
+            notes[0].at, 1_000,
+            "the stamp moved forward, which is the age hiding exactly when it matters"
+        );
+    }
+
+    #[test]
+    fn one_agents_note_does_not_block_anothers() {
+        // Two agents on one errand write the same line, and each is recording
+        // its own state. Deduping across the crew would leave the second with
+        // no note of work it is genuinely in the middle of.
+        let f = fixture();
+        let a = f.store.create_agent(&draft("Manager")).unwrap();
+        let b = f.store.create_agent(&draft("Chef")).unwrap();
+        f.store.append_working_note(a.id, "waiting on the vendor", 1_000).unwrap();
+
+        assert_eq!(
+            f.store.append_working_note(b.id, "waiting on the vendor", 1_000).unwrap(),
+            Appended::Stored
+        );
+    }
+
+    #[test]
+    fn a_note_that_has_already_fallen_off_the_end_can_be_written_again() {
+        // The match is against what the agent still holds, which is the set it
+        // can see. A line that aged out is one the next turn is not being told
+        // about, so writing it is recording something rather than repeating it.
+        let f = fixture();
+        let agent = f.store.create_agent(&draft("Manager")).unwrap();
+        f.store.append_working_note(agent.id, "the first thing", 1).unwrap();
+        for i in 0..KEPT {
+            f.store.append_working_note(agent.id, &format!("note {i}"), 1_000 + i as i64).unwrap();
+        }
+
+        assert_eq!(
+            f.store.append_working_note(agent.id, "the first thing", 9_000).unwrap(),
+            Appended::Stored
+        );
     }
 
     #[test]

--- a/src-tauri/src/domain/worknote.rs
+++ b/src-tauri/src/domain/worknote.rs
@@ -51,6 +51,28 @@ pub const KEPT: usize = 16;
 /// sixteen paragraphs is the page this store exists to stop being written.
 pub const MAX_NOTE: usize = 240;
 
+/// What became of a note the agent wrote.
+///
+/// A line the agent already holds is not stored a second time, and the agent is
+/// told so rather than told "noted". The difference is the whole point: an
+/// agent that gets an acknowledgment for restating a note learns that restating
+/// is how you say something is still true, and a bounded list then fills with
+/// one fact written six ways. It is not a revision either, which is the rule
+/// this store does keep: nothing is edited and nothing is dropped, the second
+/// write simply never happens.
+///
+/// The stamp carried here is the note's original one, and it is deliberately
+/// not moved forward. The age is what makes the list worth reading, so an agent
+/// that renotes what it noted three days ago must be told it has been three
+/// days, not handed a fresh clock that hides it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Appended {
+    /// The note is new and is now in the list.
+    Stored,
+    /// The agent already holds this exact line, written at this stamp.
+    AlreadyHeld { at: i64 },
+}
+
 /// One note, as it is stored and as it is read back.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -257,24 +257,40 @@ fn all_specs(surfaces: Surfaces) -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: NOTE_PROGRESS.to_string(),
-            // Deliberately cheap to reach for. This tool competes with
-            // `update_memory` for the same impulse, and it wins only if it is
-            // obviously the smaller thing to do: one line, no rewrite, nothing
-            // to reconcile. Anything that made an agent stop and think would
-            // send the thought back to memory, which is where it used to go.
-            description: "Note one line about what you are doing right now: what you have just \
-                          done, what you have handed over, what you are waiting on and from \
-                          whom. These are your working notes. You are shown them at the start of \
-                          every turn with how long ago each was written, which is how you know \
-                          whether you are still waiting or have been forgotten about. Use this \
-                          whenever the state of your work changes and you would otherwise lose \
-                          it: it is cheap, so note freely. Each note is added to the list; you \
-                          cannot edit or delete one, and the oldest drop off by themselves, so \
-                          write what is true now rather than trying to keep the list tidy. When \
-                          something you noted stops being true, note the new state and let the \
-                          old one age out. Keep it to a line. Durable facts about how you work \
-                          or what you have been told to prefer are memory, not progress, and go \
-                          in `update_memory`."
+            // Still the smaller thing to do than `update_memory`, which is what
+            // it has to be: the two compete for one impulse, and if writing a
+            // note made an agent stop and think the thought would go back into
+            // memory, which is where it used to go and the whole reason this
+            // store exists. Cheap is about the shape of the write — one line,
+            // no rewrite, nothing to reconcile — and this said so by inviting
+            // volume: "it is cheap, so note freely". Agents took the invitation
+            // and noted what they were about to do, what they had just said and
+            // each step of a task they finished in the same turn, which fills a
+            // list of sixteen with a turn's narration and pushes the four lines
+            // that were state off the end of it. So the invitation is replaced
+            // by a test the model can actually apply, which is about the next
+            // turn rather than about this one, and the cases that produced the
+            // volume are named as exclusions: a model given only a positive
+            // rule reads every borderline call as inside it.
+            description: "Note one line about where your work stands: what you handed over, what \
+                          you are waiting on and from whom, what you decided, what is still \
+                          open. These are your working notes, and you are shown them at the \
+                          start of every turn with how long ago each was written, which is how \
+                          you know whether you are still waiting or have been forgotten about. \
+                          Write one when a later turn would go wrong without it: work you would \
+                          repeat, something you would carry on waiting for, a decision you would \
+                          make differently. Nothing else belongs here. What you have just said \
+                          is already in the conversation you are shown; what you are about to do \
+                          is not progress; a step you will finish before this turn ends never \
+                          needed recording; and a message to a peer that has not come back is \
+                          worked out for you and listed separately. Most turns change nothing \
+                          about where the work stands and need no note. Each note is added to \
+                          the list; you cannot edit or delete one, and the oldest drop off by \
+                          themselves, so when something you noted stops being true, note the new \
+                          state and let the old one age out. Writing the same line again adds \
+                          nothing and does not refresh it. Keep it to a line. Durable facts \
+                          about how you work or what you have been told to prefer are memory, \
+                          not progress, and go in `update_memory`."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -3002,12 +3018,25 @@ mod tests {
     }
 
     #[test]
-    fn the_progress_tool_is_the_cheap_one_and_says_it_forgets_by_itself() {
+    fn the_progress_tool_says_when_a_note_is_worth_writing() {
         let text = spec(NOTE_PROGRESS).description.to_lowercase();
-        // Cheap to reach for, or the impulse goes back to memory where it came
-        // from. "Note freely" is doing more work here than any refusal could.
-        assert!(text.contains("note freely"), "{text}");
+        // The test is about the next turn, which is the only version of "is
+        // this worth a note" a model can actually answer while it is mid-turn.
+        assert!(text.contains("later turn would go wrong"), "{text}");
         assert!(text.contains("one line"), "{text}");
+
+        // And the cases that filled the list, named as exclusions. A model
+        // given only a positive rule reads every borderline call as inside it,
+        // and these three are what a narrating turn reaches for.
+        assert!(text.contains("already in the conversation"), "{text}");
+        assert!(text.contains("not progress"), "{text}");
+        assert!(text.contains("before this turn ends"), "{text}");
+
+        // The invitation this replaced. It is true about the cost of one note
+        // and was read as a reason to write one, and a crew took it: sixteen
+        // slots of a turn narrating itself, with what the agent was waiting on
+        // pushed off the end. Pinned so it cannot come back as a tidy-up.
+        assert!(!text.contains("note freely"), "the invitation is back: {text}");
 
         // That it forgets on its own is the sentence that stops an agent trying
         // to curate the list, which is the operation this store exists to avoid

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -3289,7 +3289,28 @@ impl Runtime {
             ToolInvocation::NoteProgress { note } => {
                 let (body, cut) = worknote::store_as(&note);
                 match self.inner.store.append_working_note(card.id, &body, now_ms()) {
-                    Ok(()) => {
+                    // A line the agent already holds. Told "noted" it learns
+                    // that restating a note is how you say something is still
+                    // true, and a list of sixteen fills with one fact. The age
+                    // of the note it already has is the whole answer: it is
+                    // what the repeat was reaching for, and it is also the
+                    // thing the agent needs in order to chase or give up.
+                    Ok(worknote::Appended::AlreadyHeld { at }) => {
+                        let summary = format!(
+                            "You noted that already, {}, and nothing was added. Note what has \
+                             changed since, or chase it if it has not moved.",
+                            worknote::how_long_ago(at, now_ms())
+                        );
+                        (
+                            summary.clone(),
+                            Part::tool_call(
+                                tools::NOTE_PROGRESS,
+                                arguments,
+                                ToolOutcome::Ok { summary },
+                            ),
+                        )
+                    }
+                    Ok(worknote::Appended::Stored) => {
                         self.emit(UiEvent::WorkingNotesChanged { agent_id: card.id });
                         // The count is the whole answer. It is how an agent
                         // learns the list is bounded without being lectured

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -449,16 +449,25 @@ pub fn system_prompt(
         out.push('\n');
     }
 
+    // The write rule here is a test about the *next* turn, and it is deliberately
+    // not an invitation. This section used to open with "note freely", which is
+    // true about the cost of one note and wrong about what to do with that: a
+    // crew took it and narrated itself, so a bounded list ran on what an agent
+    // was about to do while what it was waiting on aged off the end. Cheap is a
+    // fact about the write, not a reason to make one.
     out.push_str("\n## Your working notes\n");
     out.push_str(
         "Where your work stands, as lines you add with `note_progress`. This is the other half \
-         of what you carry between conversations, and it is the half that expires: what you have \
-         just done, what you have handed over, what you are waiting on and from whom.\n\n\
-         Note freely. A note is one line and costs nothing, and these are what stop you redoing \
-         work or waiting on something that already arrived. You cannot edit or delete one, and \
-         the oldest drop off by themselves once there are more than a page of them, so when \
-         something you noted stops being true, note the new state rather than trying to tidy the \
-         list.\n\n\
+         of what you carry between conversations, and it is the half that expires: where the \
+         work got to, what you are waiting on and from whom, and what is still open.\n\n\
+         Write one when a later turn would go wrong without it: work you would repeat, something \
+         you would carry on waiting for, a decision you would make differently. Most turns \
+         change nothing about where the work stands and need none. What you have just said is \
+         already in the conversation you are shown, and what you are about to do next is not \
+         progress. You cannot edit or delete a note, and the oldest drop off by themselves once \
+         there are more than a page of them, so when something you noted stops being true, note \
+         the new state rather than trying to tidy the list; writing the same line again adds \
+         nothing.\n\n\
          One thing needs no note: a message you sent a peer that has not come back is worked out \
          from your own sent messages and listed for you further down. Spend these on what nothing \
          else can see, which is everything off that path: what the operator owes you, what you \
@@ -2099,6 +2108,31 @@ mod tests {
         assert!(
             derived.contains("working notes above do not need to carry it"),
             "and the derived one has to say why the other is short: {derived}"
+        );
+    }
+
+    #[test]
+    fn the_progress_section_says_when_a_note_is_worth_writing() {
+        // This section used to say "note freely", which is true about what one
+        // note costs and was read as a reason to write one. A crew took it:
+        // agents noted what they were about to do and what they had just said,
+        // and a list of sixteen ran on a turn narrating itself while what the
+        // agent was waiting on aged off the end of it.
+        let prompt = prompt_for(&card("Manager"), &[], "", ReplyMode::ToOperator);
+        let progress = section(&prompt, "## Your working notes");
+
+        assert!(
+            progress.contains("later turn would go wrong"),
+            "the test has to be about the next turn, which is the one a model can apply: \
+             {progress}"
+        );
+        assert!(
+            progress.contains("not progress"),
+            "and the case that produced the volume has to be named: {progress}"
+        );
+        assert!(
+            !progress.contains("note freely"),
+            "the invitation is back in the prompt: {progress}"
         );
     }
 

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -586,6 +586,40 @@ async fn a_progress_note_tells_the_agent_how_many_it_now_holds() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn noting_the_same_line_twice_stores_it_once_and_says_how_old_the_first_is() {
+    // The one mechanical brake on a bounded list filling with a single fact.
+    // "Still waiting on the legal read", noted on four turns, is four of
+    // sixteen slots spent on one thing and three notes that record nothing.
+    // Acknowledging the repeat is what teaches an agent that restating is how
+    // you say something is still true, so it is not acknowledged: it is told
+    // how old the note it already has is, which is what it was reaching for and
+    // what it needs to decide whether to chase.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Say(serde_json::to_string(&body["messages"]).unwrap_or_default())
+        } else {
+            Script::Progress("waiting on the legal read".into())
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let first = h.runtime.send_from_human(h.id("Manager"), "chase the legal read").unwrap();
+    h.settle(first).await;
+    let second = h.runtime.send_from_human(h.id("Manager"), "any news?").unwrap();
+    h.settle(second).await;
+
+    let notes = h.runtime.store().working_notes(h.id("Manager")).unwrap();
+    assert_eq!(notes.len(), 1, "the repeat was stored as a second note");
+
+    let said = h.channel_texts("Manager").join("\n");
+    assert!(
+        said.contains("You noted that already"),
+        "the repeat came back as an ordinary note: {said}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn an_agent_can_write_its_memory_and_reads_it_back_next_turn() {
     // The write-manage-read loop, end to end: an agent records something on one
     // turn and finds it in its own prompt on the next.

--- a/src/components/WorkingNotes.test.tsx
+++ b/src/components/WorkingNotes.test.tsx
@@ -95,6 +95,45 @@ describe("WorkingNotes", () => {
     expect(agentWorkingNotes).toHaveBeenCalledTimes(1);
   });
 
+  it("draws the newest few and keeps the older ones behind a button", async () => {
+    // The panel shares one column with the agent's screen, its schedule and
+    // its memory. A full list of sixteen notes, each wrapping to three lines in
+    // a sidebar this narrow, is a screen of text everything else sits below.
+    // Which end is kept is the decision: the notes read oldest first, so the
+    // tail is where the work is now.
+    agentWorkingNotes.mockResolvedValue([
+      note(6 * DAY, "asked the paralegal for the read"),
+      note(5 * DAY, "chased the vendor"),
+      note(4 * DAY, "handed the scope over"),
+      note(3 * DAY, "started the summary"),
+      note(2 * DAY, "sent the summary to Robert"),
+      note(HOUR, "waiting on Robert"),
+    ]);
+    render(<WorkingNotes agentId="a1" />);
+
+    expect(await screen.findByText("waiting on Robert")).toBeTruthy();
+    expect(screen.getByText("handed the scope over")).toBeTruthy();
+    expect(screen.queryByText("asked the paralegal for the read")).toBeNull();
+
+    // The count is on the button because the alternative is an operator who
+    // cannot tell a list of six from a list of sixteen without opening it.
+    fireEvent.click(screen.getByRole("button", { name: "Show 2 older" }));
+
+    expect(screen.getByText("asked the paralegal for the read")).toBeTruthy();
+    expect(screen.getByText("chased the vendor")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show fewer" }));
+    expect(screen.queryByText("asked the paralegal for the read")).toBeNull();
+  });
+
+  it("offers nothing to open on a list that already fits", async () => {
+    agentWorkingNotes.mockResolvedValue([note(HOUR, "waiting on Robert")]);
+    render(<WorkingNotes agentId="a1" />);
+    await screen.findByText("waiting on Robert");
+
+    expect(screen.queryByRole("button", { name: /older/ })).toBeNull();
+  });
+
   it("offers no way to clear a list that is already empty", async () => {
     render(<WorkingNotes agentId="a1" />);
     await screen.findByText(/Nothing in flight/);

--- a/src/components/WorkingNotes.tsx
+++ b/src/components/WorkingNotes.tsx
@@ -29,6 +29,19 @@ export function ago(at: number, now: number): string {
   return "just now";
 }
 
+/**
+ * How many notes the panel draws before it is asked for the rest.
+ *
+ * The list is bounded at `KEPT` and not at this, and the two answer different
+ * questions. Sixteen is what an agent may carry; four is what the panel can
+ * show without becoming the column. A note runs to three wrapped lines in a
+ * sidebar this narrow, so a full list is a screen of text sitting above the
+ * schedule and the memory, and the operator scrolls past it to reach anything
+ * else. Four is where the section stops being a wall and still answers the
+ * question it is for, which is what this agent is in the middle of right now.
+ */
+const SHOWN = 4;
+
 interface Props {
   agentId: AgentId;
 }
@@ -52,6 +65,11 @@ export function WorkingNotes({ agentId }: Props) {
   const [notes, setNotes] = useState<WorkingNote[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  // Collapsed until asked. Not remembered across agents, because the inspector
+  // remounts this under each one and "opened for the agent I was reading" is
+  // not a preference about how the operator works, which is the bar the panel
+  // itself is remembered against.
+  const [all, setAll] = useState(false);
   // The agent appended one. Its own counter, because notes move far more often
   // than memory does and sharing one would refetch a page that has not changed.
   const changed = useStore((state) => state.workingNotesVersion[agentId] ?? 0);
@@ -86,6 +104,13 @@ export function WorkingNotes({ agentId }: Props) {
   // One clock for the whole list, taken at render. Per-row `Date.now()` would
   // let two notes written in the same second render a minute apart.
   const now = Date.now();
+  // The newest, and the older ones behind a button. Which end is cut is the
+  // decision: the notes read oldest first, so the tail is where the work is
+  // now, and a panel that showed the first four would answer with the state
+  // the agent has already moved on from.
+  const held = notes ?? [];
+  const hidden = all ? 0 : Math.max(0, held.length - SHOWN);
+  const drawn = hidden > 0 ? held.slice(hidden) : held;
 
   return (
     <section className="worknotes">
@@ -112,7 +137,22 @@ export function WorkingNotes({ agentId }: Props) {
         </p>
       ) : (
         <ol className="worknotes__list">
-          {notes.map((note) => (
+          {held.length > SHOWN && (
+            // Above the list because that is where the notes it hides are: they
+            // are the older ones, and a control under the list would point the
+            // operator the wrong way down it.
+            <li className="worknotes__rest">
+              <button
+                type="button"
+                className="worknotes__more"
+                aria-expanded={all}
+                onClick={() => setAll((open) => !open)}
+              >
+                {all ? "Show fewer" : `Show ${hidden} older`}
+              </button>
+            </li>
+          )}
+          {drawn.map((note) => (
             // Keyed on the stamp because it is unique: the runtime's clock is
             // strictly increasing, so two notes cannot share one. An index key
             // would redraw every row each time the oldest falls off the end.

--- a/src/styles.css
+++ b/src/styles.css
@@ -5148,6 +5148,22 @@ button {
   min-width: 0;
 }
 
+/* The older notes are behind this, so it sits above them and reads as the top
+   of the list rather than as a footer under it. */
+.worknotes__rest {
+  display: flex;
+}
+
+.worknotes__more {
+  padding: 0;
+  background: none;
+  border: 0;
+  color: var(--flesh);
+  font-size: var(--type-fine);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 .worknotes__age {
   flex: none;
   font-size: var(--type-meta);


### PR DESCRIPTION
The working notes tool and the prompt both said "it is cheap, so note freely", which is true about what one note costs and was read as a reason to write one: agents noted what they were about to do and each step of a task they finished inside the same turn, so a list of sixteen ran on a turn narrating itself while what the agent was waiting on aged off the end of it. Both now ask whether the next turn would go wrong without the note, and name the three cases that produced the volume as exclusions. A line the agent already holds is no longer stored a second time; the repeat comes back with the age of the note that already says it, and the stamp is not moved forward, because refreshing it would hide staleness at exactly the moment the age is worth reading. The panel draws the newest four and puts the rest behind a button carrying the count, since sixteen is what an agent may carry and four is what one section of a shared column can show. `KEPT` is unchanged at sixteen, and the live evals were not run: a prompt that changes how much a crew writes down is exactly the failure CI cannot see.
