### PR TITLE
feat: a working turn is one line, and what it has done is behind the count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -579,6 +579,24 @@ the model takes a screenshot to see what `browse` did.
   so a round that turns out to be tool calls and nothing said leaves none
   behind, and it decides from what has been *drawn* rather than from what has
   been collected: a retry throws the bubble away and keeps the accumulator.
+- **The live trail is a count, and the chips behind it share the working's
+  slot.** Both look like the drawing being timid about what it has. Drawn open,
+  a long turn's whole record sits between the transcript and the composer,
+  seven kinds of work across four rows, reflowing every time a call comes back
+  and moving the box somebody is typing in; and stacked with the thinking, the
+  transcript gives up twice the height for a question asked once. Nothing is
+  lost: the transcript draws every chip from the same rules the moment the turn
+  ends. The two things that stay on the line are the two a count cannot carry —
+  a failure, which is the one part somebody may have to act on, and a
+  credential by name, which is their audit trail for their own tokens.
+- **A chip's label is never shrunk to make room for what came back.** Flex
+  shrinks in proportion to what each item asked for, so a refusal running to a
+  paragraph took the row and left the label as `U…`: a chip saying one
+  character about which call went wrong. A weighting is not the fix, at a
+  hundred to one it still cost the last letter. The label does not shrink, the
+  answer takes what is left, the chip clips the rest, and the refusal opens
+  underneath where a command opens. `styles.test.ts` is the gate, because no
+  DOM assertion sees a layout.
 - **Only the component drawing the live bubbles subscribes to `streams`.** One
   level higher, a single token re-renders every message in the transcript. The
   same split is why the line above the composer, the turn's chips and the open

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -518,6 +518,14 @@ Nothing new reaches the webview. A call's name and arguments are the model's own
 words and are the same bytes the transcript draws a minute later; a credential's
 value is in neither, for the reason it is in nothing (`docs/MACHINES.md`).
 
+What the operator sees of it while the turn runs is a count and not the record.
+The chips are the record and the transcript draws every one of them the moment
+the turn ends; drawn live and open they were the whole of a long turn stacked
+between the transcript and the composer, reflowing every time a call came back.
+So the line above the composer says `12 steps`, with a failure counted out
+loud and a credential named, and the chips are one click behind it. *A turn's
+own work is chips* in `docs/WORKSPACE.md` is where that is argued.
+
 ## Trust is a property of the envelope, and it is restated in words
 
 The survey's "tool poisoning" (MCP) and "task injection" (A2A) describe the same

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -76,6 +76,13 @@ is one the operator stops trusting the rest of. A memory that was cleared is the
 one call with no content and something to say anyway: what was thrown away is
 the whole of what happened, so it opens on that.
 
+**The two things worth a longer look share one slot.** The working the model
+has published and the chips for what it has done are both disclosures on that
+line, and they open into the same bounded panel above it rather than stacking.
+Stacked, the transcript gives up twice the height for a question asked once and
+the composer moves twice. `styles.test.ts` holds the two to one bound, because
+they are one place on screen that draws two things.
+
 **A memory rewrite opens as a diff, because the call is always the whole page.**
 `update_memory` replaces the file rather than appending to it, which is the right
 interface for an agent — it has to reconcile what it believed against what it
@@ -109,6 +116,26 @@ be, its portrait and name are at the top of the pane, and the rows this replaced
 put that name in front of every line. Same argument as *A channel names nobody*
 above, applied to the last place it had not reached.
 
+**A chip is never cut to make room for what came back.** Both are on the same
+line and only one of them yields, which is not the rule flex applies by
+default: it shrinks in proportion to what each item asked for, so a refused
+call whose reason ran to a paragraph asked for twenty times what its label did
+and took the row on the way to being clipped itself. The chip drew `U… a coding
+agent is already working in whizzworks-site, started by…`, which is one
+character about which call went wrong. A weighting is the near-miss worth
+naming and not the fix: at a hundred to one the label still gave up its last
+letter, because proportional is proportional however lopsided. So the label
+does not shrink at all, the answer takes whatever is left on the default every
+flex item has, and the chip clips anything that still will not fit.
+`styles.test.ts` holds it, because no DOM assertion sees a layout.
+
+**A refusal opens onto its reason.** It is written to be acted on and it runs
+to a paragraph, so the copy on the chip is a summary of something rather than
+the thing itself, and it is drawn where a command is drawn: whole, wrapped, and
+scrolled if it is long. Only where the call has nothing else to show — somebody
+opening a failed `run_command` came for the command. Open, the chip stops
+repeating the first line of what is directly underneath it.
+
 **The same chips are drawn while the turn is still making them**, above the
 composer rather than in the transcript, from `trail` in the store rather than
 from a message. Same rules, same file, same fold, and the same value: the
@@ -120,12 +147,31 @@ record it draws this from does not exist until the turn ends. It goes when the
 turn does. *A turn's own work is watched while it happens* in
 `docs/ARCHITECTURE.md` is why it is safe for it to be there at all.
 
+**Behind a count, though, and not in front of one.** Open, the live copy is the
+whole record of a long turn stacked between the transcript and the composer:
+seven kinds of work wrapped across four rows of gray monospace, reflowing every
+time a call comes back, with the box the operator is typing into moving
+underneath it. That is the shape a channel was collapsed to get away from,
+rebuilt in the one place nobody was looking at it. What it answers — "is this
+doing something sensible" — is a question asked a few times in ten minutes, not
+continuously, and the answer is permanent a minute later in the transcript. So
+the line carries `12 steps`, and the chips are one click behind it.
+
+Two things stay in front of the click, and each is on the line for a reason the
+count cannot cover. **A failure is counted separately and says so**, because it
+is the one part of the trail the operator may have to act on and a number that
+folded it in would report a turn that refused half its work as a turn that did
+it. **A credential is named**, not counted, for the reason it never joins a fold
+anywhere: it is the operator's audit trail for their own tokens. The value is
+not there and there is no field it could arrive in.
+
 **A call that has not come back is not a chip.** It has no outcome to draw one
-from, and it is what the line below the chips is for: `Running a command · 1m
-14s`, in the present tense, because a command still running is not a command
-that ran. That line is the one place `describe`'s vocabulary is not reused, and
-`callInFlight` is deliberately coarser than it. What is worth knowing while a
-call is in flight is which machine has not answered yet.
+from, and it is not counted either: it is what the line itself is for.
+`Running a command · 1m 14s`, in the present tense, because a command still
+running is not a command that ran. That line is the one place `describe`'s
+vocabulary is not reused, and `callInFlight` is deliberately coarser than it.
+What is worth knowing while a call is in flight is which machine has not
+answered yet.
 
 It has to have been in flight for a second first. A `directory` lookup answers
 in milliseconds, and a line that flashed its name for each of them would put

--- a/src/components/ChannelView.perf.test.tsx
+++ b/src/components/ChannelView.perf.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useStore } from "../lib/store";
@@ -205,7 +205,9 @@ describe("ChannelView under streaming load", () => {
     // The reason the line and the chips are two components. They sit next to
     // each other and change at wildly different rates: the line sixty times a
     // second, the chips a few times a minute. Written as one, every token
-    // re-rendered every chip the turn had made.
+    // re-rendered every chip the turn had made. The chips are behind the count
+    // on the line now, which makes the closed case free and leaves this one:
+    // an operator holding the panel open through a ten-minute turn.
     const id = "00000000-0000-4000-8000-0000000000d4";
     draw();
     await feed([
@@ -229,6 +231,11 @@ describe("ChannelView under streaming load", () => {
         },
       },
     ]);
+    // Nothing to re-render until somebody asks for it.
+    expect(rendersOfTrail).toBe(0);
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /1 step/ }));
+    });
     const chips = rendersOfTrail;
     expect(chips).toBeGreaterThan(0);
 

--- a/src/components/ChannelView.test.tsx
+++ b/src/components/ChannelView.test.tsx
@@ -2,7 +2,8 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ACTIVITY_CHANNEL, useStore } from "../lib/store";
-import type { Activity, AgentCard, Envelope, MessageId, Part } from "../lib/types";
+import type { LiveCall } from "../lib/trail";
+import type { Activity, AgentCard, Envelope, MessageId, Part, ToolOutcome } from "../lib/types";
 import { ChannelView } from "./ChannelView";
 
 /**
@@ -314,34 +315,129 @@ describe("while an agent is working", () => {
     expect(screen.queryByRole("button", { name: /working through/ })).toBeNull();
   });
 
-  it("draws the calls the turn has already made, as the transcript will", () => {
+  /** A call that has come back, as the runtime reports it. */
+  const finished = (
+    callId: string,
+    name: string,
+    args: object,
+    outcome: ToolOutcome,
+  ): LiveCall => ({
+    callId,
+    name,
+    arguments: args,
+    done: { type: "toolCall", name, arguments: args, outcome },
+    startedAt: 0,
+  });
+
+  const browsed = (callId: string) =>
+    finished(
+      callId,
+      "browse",
+      { action: "open", url: "https://www.cnn.com/world" },
+      {
+        status: "ok",
+        summary: "read cnn.com",
+      },
+    );
+
+  it("counts the calls the turn has made, and opens them as the transcript will", () => {
     // Until this, a turn's tool calls were invisible for as long as the turn
     // ran: a browsing turn spends most of its twenty-four rounds in the
-    // browser and the operator watching had one line of prose.
+    // browser and the operator watching had one line of prose. Open, they were
+    // the other extreme: the whole record of a long turn, wrapped across four
+    // rows and reflowing under the composer every time a call came back.
+    open([envelope({})]);
+    doing({ state: "thinking" });
+    act(() => useStore.setState({ trail: { [MANAGER]: [browsed("call_1")] } }));
+
+    expect(screen.queryByText("Opened cnn.com")).toBeNull();
+    const count = screen.getByRole("button", { name: /1 step/ });
+    fireEvent.click(count);
+    expect(screen.getByText("Opened cnn.com")).toBeTruthy();
+
+    // And the count is a count, not a name: a chip carrying the first of
+    // several kinds of work is a chip that is wrong about the rest.
+    act(() => useStore.setState({ trail: { [MANAGER]: [browsed("call_1"), browsed("call_2")] } }));
+    expect(document.querySelector(".working__steps")?.textContent).toContain("2 steps");
+  });
+
+  it("marks the count where something went wrong, and says how much", () => {
+    // The one thing on the trail the operator may have to act on. Everything
+    // else about the turn's work can wait behind the click; that it did not
+    // work cannot.
     open([envelope({})]);
     doing({ state: "thinking" });
     act(() =>
       useStore.setState({
         trail: {
           [MANAGER]: [
-            {
-              callId: "call_1",
-              name: "browse",
-              arguments: { action: "open", url: "https://www.cnn.com/world" },
-              done: {
-                type: "toolCall",
-                name: "browse",
-                arguments: { action: "open", url: "https://www.cnn.com/world" },
-                outcome: { status: "ok", summary: "read cnn.com" },
+            browsed("call_1"),
+            finished(
+              "call_2",
+              "run_command",
+              { command: "boom" },
+              {
+                status: "failed",
+                error: "no machine",
               },
-              startedAt: 0,
-            },
+            ),
           ],
         },
       }),
     );
 
-    expect(screen.getByText("Opened cnn.com")).toBeTruthy();
+    const count = screen.getByRole("button", { name: /2 steps, 1 failed/ });
+    expect(count.getAttribute("data-failed")).toBe("true");
+  });
+
+  it("keeps a spent credential on the line, never behind the click", () => {
+    // The operator's audit trail for their own tokens. A name is what tells
+    // two of them apart; the value is not here and there is no field it could
+    // arrive in.
+    open([envelope({})]);
+    doing({ state: "thinking" });
+    act(() =>
+      useStore.setState({
+        trail: {
+          [MANAGER]: [
+            finished(
+              "call_1",
+              "run_command",
+              { command: "curl" },
+              {
+                status: "ok",
+                summary: "used Mistral ($MISTRAL_API_KEY) · exit 0",
+              },
+            ),
+          ],
+        },
+      }),
+    );
+
+    expect(document.querySelector(".working__end .trail__spent")?.textContent).toBe(
+      "Mistral ($MISTRAL_API_KEY)",
+    );
+  });
+
+  it("gives the working and the calls one slot, so one closes the other", () => {
+    // Two disclosures stacking is the transcript giving up twice the height
+    // for a question asked once, and a composer that moves twice.
+    open([envelope({})]);
+    doing({ state: "thinking" });
+    act(() =>
+      useStore.setState({
+        reasoning: { [MANAGER]: "**Checking**\n\nthe totals agree." },
+        trail: { [MANAGER]: [browsed("call_1")] },
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /1 step/ }));
+    expect(document.querySelector(".steps")).toBeTruthy();
+    expect(document.querySelector(".thought")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Show what Manager is working through/ }));
+    expect(document.querySelector(".thought")).toBeTruthy();
+    expect(document.querySelector(".steps")).toBeNull();
   });
 
   it("says what it is waiting on, and how long it has been", () => {

--- a/src/components/ChannelView.tsx
+++ b/src/components/ChannelView.tsx
@@ -5,7 +5,14 @@ import { api } from "../lib/ipc";
 import { thoughtNow } from "../lib/reasoning";
 import { ACTIVITY_CHANNEL, type ChannelKey, useAgentLookup, useStore } from "../lib/store";
 import { elapsed, useNow } from "../lib/time";
-import { callInFlight, trailStep } from "../lib/trail";
+import {
+  callInFlight,
+  type LiveCall,
+  type Step,
+  tallyLabel,
+  tallyTrail,
+  trailStep,
+} from "../lib/trail";
 import { rowStandsFor, toPeer, transcriptRows } from "../lib/transcript";
 import {
   type Activity,
@@ -290,18 +297,30 @@ export function ChannelView({ channel, onOpenMenu }: Props) {
  * Everything about the turn that is still going, between the transcript and the
  * box you would type into.
  *
- * Three things, in the order they are read: what the model is working through,
- * when the operator has asked to see it; the calls this turn has already made;
- * and the line saying what it is doing now. Three components rather than one
- * because they change at wildly different rates. The line moves sixty times a
- * second and the chips a few times a minute, and a token arriving must not
- * re-render a chip for the same reason it must not re-render the transcript.
+ * **One line, and one slot above it.** The line says what the turn is doing
+ * now, what it has done and what it is spending, and it is the same height from
+ * the first token to the last. Behind it are two things worth a longer look —
+ * the working the model has published, and the calls it has already made — and
+ * they share one place to appear, so opening either moves the transcript by the
+ * same amount and opening the second does not stack on the first.
  *
- * This one holds only whether the working is open, which is the whole reason it
- * exists: the button is on the line and the panel is above the chips.
+ * It was three layers deep instead, and the middle one was the whole record of
+ * the turn drawn as it accumulated: a browsing turn's seven kinds of work
+ * wrapped across four rows of gray monospace, reflowing every time a call came
+ * back, with the composer moving underneath. That record is not lost by this
+ * and was never only here — the transcript draws every chip of it the moment
+ * the turn ends, from the same rules over the same values.
+ *
+ * Still three components rather than one, because they change at wildly
+ * different rates. The line moves sixty times a second and the chips a few
+ * times a minute, and a token arriving must not re-render a chip for the same
+ * reason it must not re-render the transcript.
+ *
+ * This one holds only which of the two is open, which is the whole reason it
+ * exists: both buttons are on the line and the panel is above it.
  */
 function TurnFooter({ agent, state }: { agent: AgentCard; state: Activity | undefined }) {
-  const [open, setOpen] = useState(false);
+  const [showing, setShowing] = useState<Showing | null>(null);
   const panel = useId();
 
   // Queued counts: the agent has work it has not read yet, and to the operator
@@ -313,19 +332,27 @@ function TurnFooter({ agent, state }: { agent: AgentCard; state: Activity | unde
   // standing decision to watch every turn's, and a panel that opened by itself
   // on the next one is the app deciding where the operator looks.
   useEffect(() => {
-    if (!working) setOpen(false);
+    if (!working) setShowing(null);
   }, [working]);
 
   if (!working) return null;
 
   return (
     <div className="turn">
-      {open && <ThoughtPanel id={panel} agent={agent.id} />}
-      <LiveTrail agent={agent.id} />
-      <WorkingNote agent={agent} panel={open ? panel : undefined} onToggle={() => setOpen(!open)} />
+      {showing === "working" && <ThoughtPanel id={panel} agent={agent.id} />}
+      {showing === "steps" && <StepsPanel id={panel} agent={agent.id} />}
+      <WorkingNote
+        agent={agent}
+        panel={panel}
+        showing={showing}
+        onToggle={(which) => setShowing((held) => (held === which ? null : which))}
+      />
     </div>
   );
 }
+
+/** Which of the line's two disclosures is in the slot above it, if either. */
+type Showing = "working" | "steps";
 
 /**
  * The whole of what the model has published this turn, when it is asked for.
@@ -369,7 +396,19 @@ function ThoughtPanel({ id, agent }: { id: string; agent: AgentId }) {
 }
 
 /**
- * What this turn has already done, while it is still doing it.
+ * A turn's finished calls, as the row draws them.
+ *
+ * A call still in flight is not one of them: it has no outcome to draw a chip
+ * from, and it is what the line above the composer is for.
+ */
+function liveSteps(calls: LiveCall[] | undefined): Step[] {
+  return (calls ?? []).flatMap((call, index) =>
+    call.done ? [trailStep(call.done, `${call.callId}-${index}`)] : [],
+  );
+}
+
+/**
+ * What this turn has already done, when the operator asks for it.
  *
  * The same chips the transcript will draw once the turn ends, from the same
  * rules, built from the calls the runtime reports as it makes them. Until this
@@ -378,19 +417,25 @@ function ThoughtPanel({ id, agent }: { id: string; agent: AgentId }) {
  * operator watching it had one line of prose and no way to tell work from a
  * hang. Prose is what a model says it is doing. This is what it did.
  *
- * A call still in flight is not here. It has no outcome to draw a chip from,
- * and it is the one thing the line below is for.
+ * Behind a click rather than in front of one, which is the one thing that
+ * changed: sitting open it is the whole of a long turn's record wrapped across
+ * four rows and reflowing under the composer, and what it answers — "is this
+ * doing something sensible" — is a question asked a few times in ten minutes
+ * rather than continuously. The count that says there is something to ask about
+ * is on the line, and it never wraps.
  */
-function LiveTrail({ agent }: { agent: AgentId }) {
+function StepsPanel({ id, agent }: { id: string; agent: AgentId }) {
   const calls = useStore((s) => s.trail[agent]);
-  const steps = (calls ?? []).flatMap((call, index) =>
-    call.done ? [trailStep(call.done, `${call.callId}-${index}`)] : [],
-  );
+  const steps = liveSteps(calls);
+  // Follows the end exactly as the working does and for the same reason: an
+  // operator reading back through what a turn has done must not be thrown to
+  // the floor by the next call coming back.
+  const { ref, follow } = useFollowBottom();
 
-  if (steps.length === 0) return null;
+  useLayoutEffect(follow, [follow, steps.length]);
 
   return (
-    <div className="turn__trail">
+    <div className="steps" id={id} ref={ref}>
       <TrailRow steps={steps} />
     </div>
   );
@@ -423,6 +468,14 @@ function LiveTrail({ agent }: { agent: AgentId }) {
  *   stays in the accessibility tree either way, which is why that is opacity
  *   rather than a mount.
  *
+ * At the end of it are the three things that are not the sentence: what the
+ * turn has spent, how much it has done, and the one control that stops it. The
+ * count is the whole of the trail while the turn runs and opens into the rest
+ * of it; the credentials are named rather than counted, because a name is the
+ * operator's audit trail for their own tokens and is not a thing to put behind
+ * a click; and Stop is always drawn, because it is the one thing on screen that
+ * costs money to leave alone.
+ *
  * Subscribed here rather than in the parent for the same reason `LiveStreams`
  * is: what it draws changes every sixteen milliseconds and everything around it
  * does not.
@@ -430,12 +483,15 @@ function LiveTrail({ agent }: { agent: AgentId }) {
 function WorkingNote({
   agent,
   panel,
+  showing,
   onToggle,
 }: {
   agent: AgentCard;
-  /** The open panel this line's button controls, or absent when it is shut. */
-  panel: string | undefined;
-  onToggle: () => void;
+  /** The one slot this line's two buttons open into. */
+  panel: string;
+  /** Which of them is open, if either. */
+  showing: Showing | null;
+  onToggle: (which: Showing) => void;
 }) {
   const held = useStore((s) => s.reasoning[agent.id]);
   const calls = useStore((s) => s.trail[agent.id]);
@@ -448,6 +504,10 @@ function WorkingNote({
   const now = useNow(1000);
 
   const thought = thoughtNow(held);
+  // Held against the trail rather than against the render: this component
+  // re-renders on every token of the model's working, and a tally rebuilt
+  // sixty times a second walks two dozen calls to arrive at the same number.
+  const tally = useMemo(() => tallyTrail(liveSteps(calls)), [calls]);
   // At most one: a turn makes its calls one at a time and waits for each.
   const waiting = calls?.find((call) => call.done === null && now - call.startedAt >= WAITED_MS);
   const saying = Boolean(waiting) || Boolean(thought.heading || thought.line);
@@ -491,42 +551,70 @@ function WorkingNote({
         <button
           type="button"
           className="working__label working__label--open"
-          aria-expanded={panel !== undefined}
-          aria-controls={panel}
-          aria-label={`${panel ? "Hide" : "Show"} what ${agent.name} is working through`}
-          onClick={onToggle}
+          aria-expanded={showing === "working"}
+          aria-controls={showing === "working" ? panel : undefined}
+          aria-label={`${showing === "working" ? "Hide" : "Show"} what ${agent.name} is working through`}
+          onClick={() => onToggle("working")}
         >
           {line}
         </button>
       ) : (
         <span className="working__label">{line}</span>
       )}
-      {run && (
-        // Stops the conversation, not the agent. A message that reached four
-        // agents is one run, and stopping only the one on screen would leave
-        // the other three working on the operator's bill: hence the wording,
-        // which is the same distinction the button actually makes.
-        <button
-          type="button"
-          className="btn btn--ghost btn--small working__stop"
-          disabled={stopping}
-          title="Stop this conversation and everything it set off"
-          onClick={async () => {
-            setStopping(true);
-            try {
-              // False means it had already finished, which needs no telling:
-              // the answer is on screen.
-              await api.stopRun(run);
-            } catch (error) {
-              setBanner({ tone: "error", text: errorMessage(error) });
-            } finally {
-              setStopping(false);
-            }
-          }}
-        >
-          Stop
-        </button>
-      )}
+      <div className="working__end">
+        {/* Named, never counted, and never behind the click beside it. The
+            value is not here and there is no field it could arrive in. */}
+        {tally.spent.map((credential) => (
+          <span className="trail__spent" key={credential}>
+            {credential}
+          </span>
+        ))}
+        {tally.done > 0 && (
+          // Drawn as one of the chips it opens, so the control and its contents
+          // read as one thing. Its own text is its name: "12 steps, 1 failed"
+          // is what somebody would say out loud about the button.
+          <button
+            type="button"
+            className="working__steps"
+            data-failed={tally.failed > 0 || undefined}
+            aria-expanded={showing === "steps"}
+            aria-controls={showing === "steps" ? panel : undefined}
+            title={`What ${agent.name} has done on this turn`}
+            onClick={() => onToggle("steps")}
+          >
+            <span className="working__caret" aria-hidden="true">
+              {showing === "steps" ? "▾" : "▸"}
+            </span>
+            {tallyLabel(tally)}
+          </button>
+        )}
+        {run && (
+          // Stops the conversation, not the agent. A message that reached four
+          // agents is one run, and stopping only the one on screen would leave
+          // the other three working on the operator's bill: hence the wording,
+          // which is the same distinction the button actually makes.
+          <button
+            type="button"
+            className="btn btn--ghost btn--small"
+            disabled={stopping}
+            title="Stop this conversation and everything it set off"
+            onClick={async () => {
+              setStopping(true);
+              try {
+                // False means it had already finished, which needs no telling:
+                // the answer is on screen.
+                await api.stopRun(run);
+              } catch (error) {
+                setBanner({ tone: "error", text: errorMessage(error) });
+              } finally {
+                setStopping(false);
+              }
+            }}
+          >
+            Stop
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/Trail.tsx
+++ b/src/components/Trail.tsx
@@ -7,6 +7,7 @@ import {
   type Step,
   saysMore,
   stepDiff,
+  stepReason,
   type TrailGroup,
   tellsMore,
 } from "../lib/trail";
@@ -88,6 +89,11 @@ function TrailChip({
   onToggle: () => void;
 }) {
   const only = group.steps.length === 1 ? group.steps[0]! : null;
+  // A refusal on the chip is a clipped copy of what the chip opens onto, which
+  // is the whole of it. Worth having shut, where it is the only thing saying
+  // what went wrong; a repeat of the paragraph directly under it once it is
+  // open.
+  const previewed = only && saysMore(only) && !(open && stepReason(only));
   const face = (
     <>
       <span className="trail__label">{group.label}</span>
@@ -95,7 +101,7 @@ function TrailChip({
           not already said. Several calls have several answers, and a chip
           quoting whichever happened to be first is a chip that is wrong about
           the rest. */}
-      {only && saysMore(only) && <span className="trail__said">{only.said}</span>}
+      {previewed && <span className="trail__said">{only.said}</span>}
       {group.spent.map((credential) => (
         <span className="trail__spent" key={credential}>
           {credential}
@@ -140,9 +146,13 @@ function TrailChip({
  * A call that overwrote something is drawn against what it overwrote instead,
  * however short it is: the whole reason to open a memory rewrite is to find out
  * what the agent changed its mind about, and the content alone never says.
+ *
+ * A call that went wrong and has nothing else to show is drawn as its reason,
+ * for the plainer reason that the reason is what happened.
  */
 function StepRow({ step }: { step: Step }) {
   const changed = stepDiff(step);
+  const reason = stepReason(step);
   // A url, a pair of coordinates or an element number is a few characters, and
   // a few characters in a block of their own is a gray rectangle drawn around
   // nothing. A command and a rewritten memory are the reason the block exists.
@@ -159,7 +169,11 @@ function StepRow({ step }: { step: Step }) {
             above the characters. How much of the page moved is the thing the
             operator came here to find out. */}
         {changed && <span className="trail__said">{diffSummary(changed)}</span>}
-        {step.said && tellsMore(step) && <span className="trail__said">{step.said}</span>}
+        {/* Not twice. A refusal drawn below is not also a clipped copy of
+            itself on the line above the block holding it. */}
+        {step.said && tellsMore(step) && !reason && (
+          <span className="trail__said">{step.said}</span>
+        )}
         {step.spent.map((credential) => (
           <span className="trail__spent" key={credential}>
             {credential}
@@ -167,6 +181,7 @@ function StepRow({ step }: { step: Step }) {
         ))}
       </div>
       {changed && <DiffBlock lines={changed} />}
+      {reason && <pre className="trail__target">{reason}</pre>}
       {!changed && step.target && !inline && <pre className="trail__target">{step.target}</pre>}
     </li>
   );

--- a/src/lib/trail.test.ts
+++ b/src/lib/trail.test.ts
@@ -7,6 +7,9 @@ import {
   readSpent,
   type Step,
   stepDiff,
+  stepReason,
+  tallyLabel,
+  tallyTrail,
   tellsMore,
   trailStep,
 } from "./trail";
@@ -355,5 +358,96 @@ describe("a progress note", () => {
       call("note_progress", { note: "waiting" }, { status: "failed", error: "database is locked" }),
     );
     expect(tellsMore(step!)).toBe(true);
+  });
+});
+
+describe("what the turn has done, on one line", () => {
+  it("counts the calls that came back, and says nothing about their kind", () => {
+    // The kinds are what the chips behind the count are for. A line naming the
+    // first of several is a line that is wrong about the rest.
+    const tally = tallyTrail(
+      steps(
+        call("browse", { action: "read" }),
+        call("run_command", { command: "ls" }, ok("exit 0")),
+      ),
+    );
+    expect(tally).toEqual({ done: 2, failed: 0, spent: [] });
+    expect(tallyLabel(tally)).toBe("2 steps");
+  });
+
+  it("says how many went wrong, because that is the part worth interrupting for", () => {
+    const tally = tallyTrail(
+      steps(
+        call("browse", { action: "read" }),
+        call("run_command", { command: "boom" }, { status: "failed", error: "no machine" }),
+        call(
+          "browse",
+          { action: "open", url: "https://example.com" },
+          {
+            status: "refused",
+            reason: "not given a browser",
+          },
+        ),
+      ),
+    );
+    expect(tally.failed).toBe(2);
+    expect(tallyLabel(tally)).toBe("3 steps, 2 failed");
+  });
+
+  it("counts one call as a step rather than as steps", () => {
+    expect(tallyLabel(tallyTrail(steps(call("directory", {}, ok("2 agent(s): Chef")))))).toBe(
+      "1 step",
+    );
+  });
+
+  it("names every credential the turn spent, once each", () => {
+    // The operator's audit trail for their own tokens, which is the one part
+    // of the trail that stays on the line while the turn runs. A name spent
+    // twice is one credential, not two.
+    const tally = tallyTrail(
+      steps(
+        call("run_command", { command: "one" }, ok("used Mistral ($MISTRAL_API_KEY) · exit 0")),
+        call("run_command", { command: "two" }, ok("used Mistral ($MISTRAL_API_KEY) · exit 0")),
+        call("run_command", { command: "three" }, ok("used Stripe ($STRIPE_KEY) · exit 0")),
+      ),
+    );
+    expect(tally.spent).toEqual(["Mistral ($MISTRAL_API_KEY)", "Stripe ($STRIPE_KEY)"]);
+  });
+});
+
+describe("a call that went wrong", () => {
+  it("opens on its reason, where the reason is the whole of what happened", () => {
+    // Clipped on the chip, because a refusal is written to be acted on and
+    // runs to a paragraph: `U… a coding agent is already working in…` is a row
+    // saying one character about which call it was.
+    const groups = foldTrail(
+      steps(
+        call(
+          "browse",
+          { action: "read" },
+          {
+            status: "refused",
+            reason:
+              "a coding agent is already working in whizzworks-site, started by Content Marketer.",
+          },
+        ),
+      ),
+    );
+    expect(hasDetail(groups[0]!)).toBe(true);
+    expect(stepReason(groups[0]!.steps[0]!)).toContain("already working in whizzworks-site");
+  });
+
+  it("opens on what it acted on where there is one, not on the reason", () => {
+    // Somebody opening a failed command came for the command.
+    const [step] = steps(
+      call("run_command", { command: "npm test" }, { status: "failed", error: "no machine" }),
+    );
+    expect(stepReason(step!)).toBeNull();
+    expect(step?.target).toBe("npm test");
+  });
+
+  it("says nothing extra about a call that worked", () => {
+    const [step] = steps(call("directory", {}, ok("2 agent(s): Chef, Scribe")));
+    expect(stepReason(step!)).toBeNull();
   });
 });

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -448,6 +448,56 @@ export function foldTrail(steps: Step[]): TrailGroup[] {
 }
 
 /**
+ * What a turn has done so far, as the one line that can stand for all of it.
+ *
+ * The chips are the record, and the transcript draws every one of them the
+ * moment the turn ends. While the turn is still running they are a wall: seven
+ * kinds of work wrapped across four rows directly above the composer, growing
+ * and reflowing every time a call comes back, with the box the operator is
+ * typing into moving underneath. What is worth knowing live is narrower than
+ * the record: that the work is moving, whether any of it went wrong, and what
+ * it is spending. The rest is one click away and permanent a minute later.
+ */
+export interface TrailTally {
+  /** Calls that have come back. A call still in flight is not one of them. */
+  done: number;
+  /** How many of those the runtime refused or that failed outright. */
+  failed: number;
+  /**
+   * Credentials spent, by name, first spend first.
+   *
+   * Never folded into a count and never behind a click, live or recorded: this
+   * is the operator's audit trail for their own tokens, and it is the one part
+   * of the trail that stays on the line while the turn runs.
+   */
+  spent: string[];
+}
+
+export function tallyTrail(steps: Step[]): TrailTally {
+  const spent = new Set<string>();
+  let failed = 0;
+  for (const step of steps) {
+    if (step.failed) failed += 1;
+    for (const credential of step.spent) spent.add(credential);
+  }
+  return { done: steps.length, failed, spent: [...spent] };
+}
+
+/**
+ * What the counter above the composer says.
+ *
+ * A count, because a turn's kinds of work are what the chips behind it are for
+ * and naming one of them here would be a chip that is wrong about the rest. A
+ * failure is the exception, and it is on the line rather than behind the click
+ * for the reason a failure never joins a burst: it is the one thing on the
+ * trail the operator may have to do something about.
+ */
+export function tallyLabel(tally: TrailTally): string {
+  const steps = tally.done === 1 ? "1 step" : `${tally.done} steps`;
+  return tally.failed > 0 ? `${steps}, ${tally.failed} failed` : steps;
+}
+
+/**
  * Tools whose summary is the call again, in the runtime's words.
  *
  * `browse` answers `read in the browser` beside a step that already says "Read
@@ -513,6 +563,23 @@ export function stepDiff(step: Step): DiffLine[] | null {
 }
 
 /**
+ * What a call that went wrong said, where the reason is the whole of it.
+ *
+ * A refusal is written to be acted on and runs to a paragraph, and a paragraph
+ * on a chip is a chip clipped at the pane: `U… a coding agent is already
+ * working in whizzworks-site, started by…`. So it comes off the head line and
+ * is drawn where a command is drawn — whole, wrapped, and scrolled if it runs
+ * long — and the clipped copy on the chip becomes a summary of something the
+ * operator can now open.
+ *
+ * Only where there is nothing else behind the call. A `run_command` that failed
+ * has its command to show, and that is what somebody opening it came for.
+ */
+export function stepReason(step: Step): string | null {
+  return step.failed && step.target === null && step.said.length > 0 ? step.said : null;
+}
+
+/**
  * Whether a chip has anything behind it.
  *
  * A directory lookup is one call with nothing to show but the sentence already
@@ -520,9 +587,16 @@ export function stepDiff(step: Step): DiffLine[] | null {
  * to distrust.
  *
  * A memory that was cleared has no content to show and is still worth opening:
- * what was thrown away is the whole of what happened.
+ * what was thrown away is the whole of what happened. So is a refusal with
+ * nothing but its reason, which is the one case where the sentence on the chip
+ * is a clipped copy rather than the whole thing.
  */
 export function hasDetail(group: TrailGroup): boolean {
   const only = group.steps[0]!;
-  return group.steps.length > 1 || only.target !== null || stepDiff(only) !== null;
+  return (
+    group.steps.length > 1 ||
+    only.target !== null ||
+    stepDiff(only) !== null ||
+    stepReason(only) !== null
+  );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -3107,6 +3107,11 @@ button {
   gap: var(--space-3);
   min-width: 0;
   max-width: 100%;
+  /* The one backstop under the rule that the label is never cut: a label wider
+     on its own than the pane is cut here rather than drawn over the message
+     beside it. Nothing real reaches it, and the alternative is a layout that
+     depends on nothing real ever reaching it. */
+  overflow: hidden;
   padding: var(--space-1) var(--space-2);
   margin: 0 calc(var(--space-2) * -1);
   border: 1px solid transparent;
@@ -3136,9 +3141,13 @@ button {
   color: var(--faint);
 }
 
+/* Never cut. Flex shrinks in proportion to what each item asked for, so a
+   refused call whose reason runs to a paragraph asked for twenty times what its
+   label did, took the row, and left the label as `U…`: a chip saying one
+   character about which call went wrong. What came back is the only thing on a
+   chip that yields, and the chip clips whatever is left over. */
 .trail__label {
-  overflow: hidden;
-  text-overflow: ellipsis;
+  flex-shrink: 0;
   white-space: nowrap;
 }
 
@@ -3569,18 +3578,23 @@ button {
    The turn that is still going
 
    Above the box you would type into, because that is where an operator waits.
-   Three layers, and the operator asked to see at most one of them: the working
-   the model has published, the calls this turn has already made, and the line
-   saying what it is doing now.
+   One line, and one slot above it. The line says what the turn is doing now,
+   what it has done and what it is spending, and it is the same height from the
+   first token to the last: the composer does not move while a turn runs.
 
-   Only the line is always there. The name on it is revealed on hover, because
-   whose channel this is has been established several times over by the time
-   you reach the bottom of it, so the resting state is one moving character.
+   Two things sit behind it and share the slot: the working the model has
+   published, and the chips for the calls it has already made. The chips used
+   to be a layer of their own, open, between the transcript and the line — a
+   long turn's whole record wrapping across four rows and reflowing every time a
+   call came back. One slot means opening either costs the transcript the same
+   height, and opening the second does not stack on the first.
 
-   A thought is not, and neither is a call that has not come back. Both are the
-   reason to look here at all, so both are shown without being asked for. One
-   line, clipped at the pane: it is replaced several times a second and
-   wrapping it would push the composer around the screen.
+   The name on the line is revealed on hover, because whose channel this is has
+   been established several times over by the time you reach the bottom of it,
+   so the resting state is one moving character. A thought is not, and neither
+   is a call that has not come back: both are the reason to look here at all.
+   One line, clipped at the pane, because it is replaced several times a second
+   and wrapping it would push the composer around the screen.
    ========================================================================== */
 
 .turn {
@@ -3590,32 +3604,45 @@ button {
   flex: none;
 }
 
-/* The same chips the transcript will draw, indented to the line below rather
-   than to a message body: there is no gutter down here for them to line up
-   under. Capped and scrolled, because opening one must not push the
-   conversation off the top of the pane. */
-.turn__trail {
-  max-height: 12rem;
+/* The slot. Whichever of the two is open takes the same bounds, so the
+   transcript above gives up the same height either way, and neither can push
+   the conversation off the top of the pane. */
+.thought,
+.steps {
+  max-height: 13rem;
   overflow-y: auto;
   flex: none;
-}
-
-.turn__trail .trail__chips {
-  padding-left: var(--space-8);
+  margin: 0 var(--column-inset) var(--space-3);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  background: var(--sunken);
 }
 
 /* The model's working, in full, when it has been asked for. Bounded so the
    transcript keeps most of the pane: this is a thing to glance into, and the
    answer it is on the way to is what the operator is actually waiting for. */
 .thought {
-  max-height: 13rem;
-  overflow-y: auto;
-  flex: none;
-  margin: 0 var(--column-inset) var(--space-3);
   padding: var(--space-4) var(--space-5);
-  border: 1px solid var(--edge);
-  border-radius: var(--radius-sm);
-  background: var(--sunken);
+}
+
+/* The same chips the transcript will draw, in a box of their own. The indents
+   they carry there are a message gutter to line up under, and there is no
+   gutter in here: left on, they draw the panel's contents as a column that
+   starts somewhere the panel has no edge. */
+.steps {
+  padding: var(--space-3) 0;
+}
+
+.steps .trail {
+  padding: 0 var(--space-5);
+}
+
+.steps .trail__chips {
+  padding-left: 0;
+}
+
+.steps .trail__steps {
+  margin-left: 0;
 }
 
 /* As the model wrote it. Wrapped rather than scrolled sideways, and not
@@ -3694,12 +3721,59 @@ button {
   color: var(--text);
 }
 
-/* Always visible, unlike the label beside it. A control that appears on hover
-   is a control nobody knows is there, and this is the one thing on screen that
-   costs money to leave alone. */
-.working__stop {
+/* Everything on the line that is not the line: what the turn has spent, how
+   much it has done, and the control that stops it. Pushed to the end as one
+   group, so the sentence in the middle is what gives up room in a narrow pane
+   and the three of them keep their order and their spacing whichever are
+   drawn.
+
+   All of it is always visible, unlike the label beside it. A control that
+   appears on hover is a control nobody knows is there, and one of these is the
+   thing on screen that costs money to leave alone. */
+.working__end {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
   margin-left: auto;
   flex: none;
+}
+
+/* What the turn has done, as one of the chips it opens: the control and its
+   contents are the same object at two sizes, rather than a button that happens
+   to reveal some chips. */
+.working__steps {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex: none;
+  padding: var(--space-1) var(--space-4);
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background: none;
+  font-family: var(--font-mono);
+  font-size: var(--type-fine);
+  letter-spacing: var(--track-flat);
+  color: var(--faint);
+  cursor: pointer;
+  transition: border-color var(--tempo-tap) var(--ease), color var(--tempo-tap) var(--ease), background-color var(--tempo-tap) var(--ease);
+}
+
+.working__steps:hover,
+.working__steps[aria-expanded="true"] {
+  background: var(--sunken);
+  border-color: var(--edge);
+  color: var(--text);
+}
+
+/* Something on this turn went wrong. The chip that says what is inside the
+   panel; this is the mark on the line that says to go and open it. */
+.working__steps[data-failed] {
+  color: var(--pit);
+}
+
+.working__caret {
+  flex: none;
+  line-height: var(--lead-flush);
 }
 
 /* Lighter than the answer it is on the way to, and italic so a glance can tell

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -192,6 +192,50 @@ describe("dialog modifiers", () => {
   });
 });
 
+describe("the trail above the composer", () => {
+  /**
+   * Which of the two things on a chip gives up room, and which keeps it.
+   *
+   * Flex shrinks in proportion to what each item asked for, so a refused call
+   * whose reason runs to a paragraph asked for twenty times what its label did
+   * and took the row on the way to being clipped itself: the chip drew
+   * `U… a coding agent is already working in whizzworks-site, started by…`,
+   * which is one character about which call it was. No DOM assertion sees it,
+   * because jsdom lays nothing out and both nodes are there either way.
+   *
+   * A weighting rather than a refusal is what this replaced, and it is the
+   * near-miss worth naming: at a hundred to one the label still gave up its
+   * last character, because proportional is proportional however lopsided.
+   */
+  it("cuts what came back before it cuts the label", () => {
+    const chip = getComputedStyle(nest("trail__chip"));
+    const label = getComputedStyle(nest("trail__chip", "trail__label"));
+
+    // The answer beside it takes the shrinking, on the default every flex item
+    // has and this one gives up.
+    expect(label.flexShrink).toBe("0");
+    // And what will not fit either way is cut by the chip rather than drawn
+    // across the message beside it.
+    expect(chip.overflow).toBe("hidden");
+  });
+
+  /**
+   * The working and the turn's calls are two disclosures sharing one slot.
+   *
+   * Stacked, they were the transcript giving up twice the height for a
+   * question asked once, and a composer that moved twice. The number is a
+   * decision and not asserted; that the two agree on it is the rule, because
+   * they are one place on screen that draws two things.
+   */
+  it("bounds both of the line's panels the same", () => {
+    const thought = getComputedStyle(nest("thought"));
+    const steps = getComputedStyle(nest("steps"));
+
+    expect(steps.maxHeight).toBe(thought.maxHeight);
+    expect(steps.margin).toBe(thought.margin);
+  });
+});
+
 describe("a message's clock", () => {
   /**
    * The clock is a lane, not something laid over the corner.


### PR DESCRIPTION
The strip above the composer drew a long turn's whole trail open between the transcript and the box: seven kinds of work across four rows of gray monospace, reflowing every time a call came back, with the working panel stacked beside it as a second layer. It is now one line of fixed height carrying a count, `31 steps, 1 failed`, and the chips share the working's one slot behind it; nothing is lost by that, because the transcript draws every chip from the same rules the moment the turn ends. A failure is counted out loud and a spent credential is named on the line, because a count cannot carry either. A chip's label is also no longer shrunk to make room for what came back, which had been drawing a refusal as `U… a coding agent is already working in…`, and a refusal now opens onto the whole of itself where a command opens. `styles.test.ts` gates both layout rules, since no DOM assertion sees a layout and neither is visible in review.