### PR TITLE
fix: a working turn reads its inbox, and the coding job it started can reach it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ repo: the frontend renders state and forwards intent.
 | Changing | Read |
 |---|---|
 | Messaging, replies, cascades, hop limits, the guard | `runtime/guard.rs`, then *Cascades terminate because of one asymmetry* and *The five limits* in `docs/ARCHITECTURE.md` |
+| A message that arrives while an agent is already working, and the coding job whose answer could not reach the turn that started it | *A working turn reads its inbox, and only what it can answer where it stands* in `docs/ARCHITECTURE.md`, then `Runtime::take_in` and `Intake` |
 | What a turn is told it was asked for: `expects_reply`, `intent`, `ReplyMode` | *Cascades terminate because of one asymmetry*, and `runtime/prompt.rs`, which has to agree with it |
 | Streaming, retries, the budget, when a run settles | *A failed model call is retried*, *A thought is shown and never kept*, *The budget counts model calls* |
 | What a turn shows of itself while it runs: the thinking, the calls, the line above the composer | *A thought is shown and never kept* and *A turn's own work is watched while it happens*, then `src/lib/reasoning.ts` |
@@ -897,6 +898,32 @@ the model takes a screenshot to see what `browse` did.
   through. It is not a standing yes. It lives on the turn's `Reading`, reaches
   no table, and `Reading::took_in` drops it the moment the turn takes in a page
   from anywhere else.
+- **A turn reads its inbox between rounds, and reads nothing that would change
+  where its answer goes.** Those are one decision, not a rule with an exception
+  bolted on. The mode, the reply target, the placeholder's channel and `cause`
+  are all fixed before the first token and the UI has been drawing them since,
+  so what a running turn may take in is exactly what it could already answer
+  from where it stands: the operator and Guaca, into a turn that is writing to
+  this agent's own channel. `ToPeer` takes in nothing, because that turn's
+  answer is addressed to the agent that asked and an operator message read there
+  would be read and never answered. A peer's message waits for the same reason
+  from the other end: it is a hop with a reply owed, and answering it as a
+  footnote to somebody else's turn is not an answer. `Runtime::take_in`.
+- **A turn remembers what its own prompt already says, and intake renders
+  against that.** `deliver` writes to the store before the inbox, so a message
+  queued behind the one being answered is in the history the turn just read and
+  in the inbox at the same time. It is consumed, released and answered by this
+  turn either way; without the set it is also written into the prompt twice, and
+  an instruction a model reads twice is one it was told twice.
+- **`code` not blocking is what made a running turn need to read its inbox at
+  all.** The job's answer comes back as a fresh envelope on a run of its own, an
+  actor only examines the envelope it is holding, and the turn that asked was
+  therefore the one thing that could not receive it. `RepositoryBusy` then told
+  that agent to wait for the message its own turn was holding up, which is an
+  instruction nothing can follow: measured on a real crew, forty-five minutes
+  and forty-five model calls of a turn filling time, with three finished jobs
+  and an operator correction stacked behind it. Neither half was wrong on its
+  own, which is why it survived review twice.
 - **An envelope booked against a run is released by whatever consumes it.** A
   path that takes one without turning it into a turn leaves the run outstanding
   for the life of the process.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,6 +152,91 @@ what it already has. Waiting instead on "is anyone in this run still busy" was
 tried and was wrong: it made an agent sit through peers that had already
 answered and were finishing their own notes.
 
+## A working turn reads its inbox, and only what it can answer where it stands
+
+Batching decides what a turn starts with. This decides what it can still learn
+once it has started, and until it existed the answer was nothing: a turn was
+built from its batch and went deaf for as long as it ran. On a turn of three
+rounds nobody notices. On a turn of forty, which is what a crew with a raised
+`max_tool_rounds` and a coding job actually produces, it is the difference
+between an agent that can be corrected and one that cannot.
+
+Two things go wrong without it, and the second is a deadlock rather than a
+delay.
+
+**An operator cannot steer work they are watching.** They type a correction into
+the channel, it is delivered, the rail shows the agent working, and the message
+is read when the turn ends. The correction arrives after the thing it was meant
+to correct was finished and published.
+
+**A turn cannot receive the result of the job it started.** `code` does not
+block, deliberately: a coding job is a different unit of work with its own
+budget and its own forty-five minute ceiling, and a turn that waited for one
+would spend its own timeout doing nothing. So the harness's answer comes back as
+a fresh envelope on a run of its own. An actor only ever examines the envelope it
+is holding, so that answer could not reach the turn that asked for it. The agent
+would then call `code` again, and `RepositoryBusy` would tell it, correctly and
+uselessly, that *whoever asked for the first one gets a message when it
+finishes* — a message the turn being spoken to was itself the thing holding up.
+Measured on a real crew: forty-five minutes, forty-five model calls, twenty-two
+documents rewritten and thirty-one working notes, with three finished jobs and
+one operator correction stacked in an inbox nobody was free to read.
+
+`Runtime::take_in` runs at the top of every round, before the budget claims the
+step, and folds whatever has arrived into the conversation as one labeled user
+turn. `prompt::render_incoming` does the labeling, the same function the batch
+goes through, because a model that can tell `[OPERATOR]` from `[SYSTEM]` at the
+start of a turn has to be able to tell them apart in the middle of one, and a
+second way to write that label is a second thing for the injection tests to miss.
+
+**What arrives is context, and never a change of address.** Not the reply mode,
+not the reply target, not the channel the placeholder is already open in, not
+`cause`. All four are decided before the first token and the UI has been drawing
+them ever since; a turn that changed its mind about who it was answering would
+have to close a live bubble in one channel and open it in another, which is a
+worse thing to watch than a late reply.
+
+That constraint is what decides the rule, rather than the other way round. A
+turn in `ToPeer` takes in nothing at all: its answer is addressed to the agent
+that asked, so an operator message read there would be read and never answered.
+Every other mode writes into this agent's own channel to the operator, which is
+where a message from the operator or from Guaca would have been answered anyway,
+so taking one in changes what the turn knows and nothing about where it goes.
+
+Peers are refused from the other end for the same reason. A peer's message is a
+hop with a reply owed on it, and answering it as a footnote to somebody else's
+turn is not an answer. It waits and gets the turn it is owed, which is what the
+second cascade test asserts.
+
+**What the prompt already carries is taken in but not written again.**
+`deliver` writes to the store before it touches the inbox, so an envelope queued
+behind the one a turn is answering is already in the history that turn read while
+still sitting in the inbox waiting to be answered. Two operator lines typed a
+second apart are enough to reach it. Taken in without checking, the second line
+is written into the prompt twice, and a model reading one instruction twice is
+being told it was said twice. The turn keeps a set of the message ids its prompt
+already carries and intake renders against it, so such an envelope is still
+consumed, still released and still answered by this turn — it is only not
+repeated.
+
+**Each envelope is released against its own run as it is taken.** `Runtime::absorb`,
+which is `abandon`'s arithmetic under a different name because it is not the same
+fact: abandoning is work that will not happen, and this is work that just did
+inside somebody else's turn. The run that booked it has nothing further
+outstanding and settles there, which is what keeps `track_inflight` from
+reporting a run finished twice.
+
+**Nobody else's harness has this problem, and the reason is instructive.**
+Omnigent, which orchestrates Claude Code, Codex, Cursor and Pi behind one
+interface, runs `claude` as a real terminal under tmux and watches it through
+hooks and its session transcript. It never owns the agent loop, so it inherits
+Claude Code's own answer: a prompt typed while a turn is busy is recorded as a
+`queued_command` attachment and picked up at the next round rather than the next
+session, and omnigent's bridge parses those back into its transcript as user
+messages. Guaca keeps its own loop on purpose, for the reasons in
+`docs/PROTOCOL.md`, and the price of that decision is that the equivalent has to
+be built here. This is it.
+
 ## The five limits, and what each is for
 
 The guard is the backstop, not the mechanism. Each limit catches a different

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -2382,7 +2382,7 @@ impl Runtime {
 
     // ---- one agent turn --------------------------------------------------
 
-    async fn run_turn(&self, agent_id: AgentId, batch: Vec<Envelope>) {
+    async fn run_turn(&self, agent_id: AgentId, batch: Vec<Envelope>, intake: &mut Intake<'_>) {
         // Single-run by construction: the batch only ever drains envelopes
         // belonging to the same run as its first.
         let run_id = batch[0].run_id;
@@ -2415,7 +2415,7 @@ impl Runtime {
         // agent mid-task: an explicit instruction to send an email arrives with
         // no reply expected, so the turn was told nothing needed doing.
         let assigned = batch.iter().any(|e| e.intent.is_work());
-        let mode = match reply_target {
+        let mut mode = match reply_target {
             Some(Participant::Human) => ReplyMode::ToOperator,
             Some(Participant::Agent { .. }) => ReplyMode::ToPeer,
             // A routine coming due is the other way an agent is handed work
@@ -2484,6 +2484,15 @@ impl Runtime {
             // the model answer itself.
             .filter(|e| !batch.iter().any(|b| b.id == e.id))
             .collect::<Vec<_>>();
+
+        // Everything the prompt already carries, which is what stops a message
+        // this turn takes in later from being written into it twice. `deliver`
+        // writes to the store before it touches the inbox, so an envelope that
+        // was queued behind this turn's own batch when the turn started is
+        // already in the history that was just read while still sitting in the
+        // inbox waiting to be answered. Two operator lines typed a second apart
+        // are enough.
+        let mut rendered: HashSet<MessageId> = history.iter().map(|e| e.id).collect();
 
         let memory = self.inner.workspace.read(agent_id);
         // Read fresh alongside it, and a read that fails is an empty list
@@ -2651,6 +2660,27 @@ impl Runtime {
             if self.stopped(run_id) {
                 called_off = true;
                 break;
+            }
+
+            // Before the step is claimed, so what arrived is paid for by the
+            // call it is part of rather than by the one after it. A turn that
+            // is about to be cut off by the budget still reads its last
+            // message: taking it in costs nothing and releases the run holding
+            // it, and leaving it queued behind a turn that is ending buys
+            // nobody anything.
+            let arrived = self.take_in(mode, &names, &mut rendered, &mut messages, intake);
+            if !arrived.is_empty() {
+                self.deliver_files(&card, &arrived, modalities, &mut messages).await;
+                // Work taken in mid-turn carries the same obligation work in the
+                // batch does. `NoteOnly` tells an agent nothing is being asked
+                // of it and silence is usually right, which is true of what this
+                // turn woke up to and not of a finished coding job that landed
+                // while it ran. `Assigned` is the mode that says a note it never
+                // writes is a failure, and both write to the same place, so this
+                // moves nothing the UI has already drawn.
+                if mode == ReplyMode::NoteOnly && arrived.iter().any(|e| e.intent.is_work()) {
+                    mode = ReplyMode::Assigned;
+                }
             }
 
             // One claim per model call. Claiming per turn instead would let a
@@ -2917,6 +2947,109 @@ impl Runtime {
         }
 
         Err(last.expect("the loop only ends here after a failure"))
+    }
+
+    /// Takes in whatever arrived while this turn was working, as context.
+    ///
+    /// Called at the top of every round, so the model sees a correction or a
+    /// finished job on its next call rather than on its next turn. Without it a
+    /// long turn is deaf: an operator watching an agent work can type at it and
+    /// be read forty minutes later, and a `code` job's result can never reach
+    /// the turn that started it, because `code` does not block and its answer
+    /// comes back as an envelope the running actor is not free to look at. That
+    /// second one deadlocks: `RepositoryBusy` tells the agent to wait for a
+    /// message, and the turn doing the waiting is the thing holding it up.
+    ///
+    /// ## Context, and never a change of address
+    ///
+    /// What comes in is added to the conversation and changes nothing else. Not
+    /// the mode, not the reply target, not the channel the placeholder is
+    /// already open in, not `cause`. All four were decided before the first
+    /// token and the UI has been drawing them since; a turn that changed its
+    /// mind about who it was answering would have to close a live bubble in one
+    /// channel and open it in another, which is a worse thing to watch than a
+    /// late reply.
+    ///
+    /// That is also the whole reason `ToPeer` takes in nothing. Such a turn's
+    /// answer is addressed to the peer that asked, so an operator message read
+    /// there would be read and never answered. Every other mode writes into
+    /// this agent's own channel to the operator, which is where a message from
+    /// the operator or from Guaca would have been answered anyway.
+    ///
+    /// Peers are refused for the same reason from the other end: a peer's
+    /// message is a hop with a reply owed, and answering it as a footnote to
+    /// somebody else's turn is not an answer. It waits, exactly as it does now.
+    ///
+    /// Each envelope is released against its own run as it is taken, rather
+    /// than at the end of the turn with the batch. This turn is what consumed
+    /// it and no other turn is coming for it, so its run has nothing further
+    /// outstanding and settles here.
+    fn take_in(
+        &self,
+        mode: ReplyMode,
+        names: &NameTable,
+        // What the prompt already says, by message id. An envelope in here is
+        // one this turn is answering and has already been shown, not one to
+        // write out again.
+        rendered: &mut HashSet<MessageId>,
+        messages: &mut Vec<ChatMessage>,
+        intake: &mut Intake<'_>,
+    ) -> Vec<Envelope> {
+        if mode == ReplyMode::ToPeer {
+            return Vec::new();
+        }
+
+        let mut taken: Vec<Envelope> = Vec::new();
+        while taken.len() < MAX_BATCH {
+            let pulled = match intake.carry.pop_front() {
+                Some(held) => Some(held),
+                None => intake.rx.try_recv().ok(),
+            };
+            let Some(next) = pulled else { break };
+
+            // Order is the whole point of the holding queue, so the first one
+            // this turn cannot take ends the intake: anything behind it arrived
+            // later and has to stay there. A stopped run is left alone for the
+            // same reason it is left alone everywhere else — the actor's own
+            // boundary is where it gets its notice, and folding called-off work
+            // into a live turn is the one thing a stop exists to prevent.
+            let takeable = matches!(next.from, Participant::Human | Participant::System)
+                && !self.stopped(next.run_id);
+            if !takeable {
+                intake.carry.push_front(next);
+                break;
+            }
+
+            intake.depth.fetch_sub(1, Ordering::SeqCst);
+            self.absorb(next.run_id);
+            taken.push(next);
+        }
+
+        // One user turn for the lot, exactly as the batch collapses, and
+        // labeled by the same function. A model that can tell `[OPERATOR]` from
+        // `[SYSTEM]` at the top of a turn has to be able to tell them apart in
+        // the middle of one, and a second way of writing the label is a second
+        // thing for a prompt-injection test to miss.
+        let lines: Vec<String> = taken
+            .iter()
+            .filter(|e| rendered.insert(e.id))
+            .map(|e| prompt::render_incoming(e, names))
+            .collect();
+        if !lines.is_empty() {
+            messages.push(ChatMessage::user(lines.join("\n\n")));
+        }
+
+        taken
+    }
+
+    /// Releases an envelope a running turn took in, against the run that booked
+    /// it.
+    ///
+    /// The same arithmetic as [`Self::abandon`] and deliberately not the same
+    /// word. Abandoning is work that will not happen; this is work that just
+    /// did, inside somebody else's turn.
+    fn absorb(&self, run: RunId) {
+        self.track_inflight(run, -1);
     }
 
     fn finish_turn(&self, agent_id: AgentId, run_id: RunId, consumed: usize) {
@@ -5412,6 +5545,34 @@ impl Runtime {
     }
 }
 
+/// The inbox, reached from inside the turn that is already running.
+///
+/// A turn is started with a batch and, until this existed, could not see
+/// anything that arrived after it. That is right for a peer cascade and wrong
+/// for the two things a person does while watching an agent work: send it a
+/// correction, and start something whose result comes back as a message. A
+/// coding job is the second one, and it deadlocked on exactly this. `code` does
+/// not block, its result is delivered as a fresh envelope, and an actor only
+/// examines the envelope it is holding — so the turn that started the job could
+/// never receive it, and `RepositoryBusy` told the agent to wait for a message
+/// its own turn was the thing blocking.
+///
+/// Claude Code has the same problem and solves it a level down: a prompt typed
+/// while a turn is busy is recorded as a queued command and read at the next
+/// round rather than the next session. Guaca keeps its own loop, so it has to
+/// own the equivalent, and [`Runtime::take_in`] is it.
+///
+/// Borrowed rather than cloned because the receiver is the inbox. Two handles
+/// to it would be two readers of one queue, which is how an envelope goes to
+/// the wrong turn.
+struct Intake<'a> {
+    rx: &'a mut mpsc::UnboundedReceiver<Envelope>,
+    /// The actor's holding queue. Anything here arrived before whatever is
+    /// still in the channel, so it is read first and pushed back to the front.
+    carry: &'a mut VecDeque<Envelope>,
+    depth: &'a AtomicUsize,
+}
+
 async fn actor_loop(
     runtime: Runtime,
     id: AgentId,
@@ -5605,7 +5766,9 @@ async fn actor_loop(
             }
         }
 
-        runtime.run_turn(id, batch).await;
+        runtime
+            .run_turn(id, batch, &mut Intake { rx: &mut rx, carry: &mut carry, depth: &depth })
+            .await;
     }
 
     tracing::debug!(agent = %id.short(), "actor stopped");

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -929,7 +929,7 @@ fn body_with_files(envelope: &Envelope) -> String {
     body
 }
 
-fn render_incoming(envelope: &Envelope, names: &NameTable) -> String {
+pub(super) fn render_incoming(envelope: &Envelope, names: &NameTable) -> String {
     // Announced inside the labeled block, so a file from a peer inherits the
     // provenance of the message carrying it.
     let body = body_with_files(envelope);

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -104,6 +104,225 @@ async fn manager_introduces_itself_to_every_other_agent() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_message_that_arrives_mid_turn_reaches_the_turn_that_is_working() {
+    // The operator types a correction while an agent is working. Before the
+    // turn could see its own inbox, that correction waited for the turn to end,
+    // which on a long turn is forty minutes: the work it was meant to steer was
+    // finished and published first.
+    //
+    // The message is sent from inside the stub rather than from the test, so
+    // there is no race to lose. Answering the first model call is provably
+    // inside the turn, and provably before the round that follows it.
+    let hook: Arc<std::sync::OnceLock<(Runtime, guac_lib::domain::ids::AgentId)>> =
+        Arc::new(std::sync::OnceLock::new());
+    let typed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    let armed = hook.clone();
+    let once = typed.clone();
+    let stub = serve(move |body| {
+        if speaker(body) != "Writer" {
+            return Script::Say("ok".into());
+        }
+        if anyone_said(body, "Call it we") {
+            return Script::Say("Changed it to we.".into());
+        }
+        if !once.swap(true, Ordering::SeqCst) {
+            if let Some((runtime, writer)) = armed.get() {
+                runtime.send_from_human(*writer, "Stop writing I. Call it we.").unwrap();
+            }
+            return Script::Progress("drafting the post".into());
+        }
+        Script::Say("Draft done.".into())
+    })
+    .await;
+
+    let h = harness(&stub, &["Writer"], GuardLimits::default());
+    let writer = h.id("Writer");
+    let _ = hook.set((h.runtime.clone(), writer));
+
+    let run = h.runtime.send_from_human(writer, "Write the post.").unwrap();
+    h.settle(run).await;
+
+    let texts = h.channel_texts("Writer");
+    assert!(
+        texts.iter().any(|t| t.contains("Changed it to we")),
+        "the turn never read what the operator typed while it worked: {texts:?}"
+    );
+    // The discriminator. Left queued, the correction becomes a turn of its own
+    // and this line is what the working turn finishes with first.
+    assert!(
+        !texts.iter().any(|t| t.contains("Draft done")),
+        "the turn finished on its own answer and read the correction afterwards: {texts:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn work_that_lands_mid_turn_is_reported_even_when_the_turn_owed_nobody_words() {
+    // A turn woken by a peer's answer owes nobody words, which is `NoteOnly`,
+    // and `NoteOnly` tells an agent that silence is usually right. That is true
+    // of what it woke up to and false of work that lands while it runs, so
+    // anything taken in that carries work moves the turn to `Assigned`, where a
+    // note the agent never writes is reported rather than looking like an agent
+    // that quietly stopped. Both modes write to the same place, so nothing the
+    // UI has already drawn moves.
+    let hook: Arc<std::sync::OnceLock<(Runtime, guac_lib::domain::ids::AgentId)>> =
+        Arc::new(std::sync::OnceLock::new());
+
+    let armed = hook.clone();
+    let stub = serve(move |body| {
+        if speaker(body) == "Manager" {
+            // An answer, which is the one thing that never expects one back.
+            return Script::Say("Here is the answer.".into());
+        }
+        // The correction has been taken in. Say nothing at all, which is what
+        // `NoteOnly` invites and what must not pass unremarked now that work
+        // has landed in this turn.
+        if anyone_said(body, "fix the headline") {
+            return Script::Say(String::new());
+        }
+        // Woken by the Manager's answer: nobody is waiting on this agent's
+        // words. The operator types while it is working.
+        if reading_peer_replies(body) {
+            if let Some((runtime, writer)) = armed.get() {
+                runtime.send_from_human(*writer, "Also fix the headline.").unwrap();
+            }
+            return Script::Progress("tidying up".into());
+        }
+        if has_tool_result(body) {
+            return Script::Say("Asked.".into());
+        }
+        Script::SendTo { recipients: vec!["Manager".into()], text: "Quick question.".into() }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager", "Writer"], GuardLimits::default());
+    let _ = hook.set((h.runtime.clone(), h.id("Writer")));
+
+    let run =
+        h.runtime.send_from_human(h.id("Writer"), "Ask the Manager about the launch.").unwrap();
+    h.settle(run).await;
+
+    // A notice, not text: this is Guaca speaking into the Writer's channel,
+    // which is what `plain_text` filters out.
+    h.wait_until("the silent turn to be reported", |h| {
+        h.runtime
+            .store()
+            .channel_messages(h.id("Writer"), 50)
+            .unwrap()
+            .into_iter()
+            .flat_map(|e| e.parts)
+            .any(|part| {
+                matches!(part, Part::Notice { ref text, .. } if text.contains("without reporting anything"))
+            })
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_message_the_prompt_already_carries_is_taken_in_once() {
+    // `deliver` writes to the store before it touches the inbox, so a message
+    // queued behind the one a turn is answering is already in the history that
+    // turn reads while still sitting in the inbox waiting to be answered.
+    // Taken in without checking, it is written into the prompt twice, and a
+    // model reading the same instruction twice is being told it was said twice.
+    //
+    // Pausing is what makes the window certain rather than likely: both
+    // messages are provably in the store before the agent is free to read
+    // either.
+    let seen = Arc::new(AtomicUsize::new(0));
+    let counter = seen.clone();
+    let stub = serve(move |body| {
+        let times = body["messages"]
+            .as_array()
+            .map(|messages| {
+                messages
+                    .iter()
+                    .filter(|m| m["role"] != "system")
+                    .filter_map(|m| m["content"].as_str())
+                    .filter(|c| c.contains("Second thing"))
+                    .count()
+            })
+            .unwrap_or(0);
+        counter.fetch_max(times, Ordering::SeqCst);
+        Script::Say("Both noted.".into())
+    })
+    .await;
+
+    let h = harness(&stub, &["Writer"], GuardLimits::default());
+    let writer = h.id("Writer");
+
+    h.pause("Writer");
+    let run = h.runtime.send_from_human(writer, "First thing to do.").unwrap();
+    h.runtime.send_from_human(writer, "Second thing, while you are at it.").unwrap();
+    h.wait_until("both messages to be filed", |h| h.channel_texts("Writer").len() == 2).await;
+    h.resume("Writer");
+    h.settle(run).await;
+
+    assert_eq!(
+        seen.load(Ordering::SeqCst),
+        1,
+        "the second message reached the model more than once in the same call"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_turn_answering_a_peer_leaves_the_operator_a_turn_of_their_own() {
+    // The other half of the rule, and the reason it is not "read everything".
+    // A turn in `ToPeer` is addressed to the agent that asked, so an operator
+    // message folded into it would be read and never answered. It waits, and
+    // gets the turn it is owed.
+    let hook: Arc<std::sync::OnceLock<(Runtime, guac_lib::domain::ids::AgentId)>> =
+        Arc::new(std::sync::OnceLock::new());
+    let typed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    let armed = hook.clone();
+    let once = typed.clone();
+    let stub = serve(move |body| {
+        let who = speaker(body);
+        if who == "Manager" {
+            return if has_tool_result(body) {
+                Script::Say("Asked.".into())
+            } else {
+                Script::Instruct {
+                    recipients: vec!["Writer".into()],
+                    text: "Draft the announcement.".into(),
+                }
+            };
+        }
+        if anyone_said(body, "Call it we") {
+            return Script::Say("Noted for next time: we.".into());
+        }
+        if !once.swap(true, Ordering::SeqCst) {
+            if let Some((runtime, writer)) = armed.get() {
+                runtime.send_from_human(*writer, "Stop writing I. Call it we.").unwrap();
+            }
+            return Script::Progress("drafting".into());
+        }
+        Script::Say("Here is the announcement.".into())
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager", "Writer"], GuardLimits::default());
+    let _ = hook.set((h.runtime.clone(), h.id("Writer")));
+
+    let run = h.runtime.send_from_human(h.id("Manager"), "Get the announcement drafted.").unwrap();
+    h.settle(run).await;
+
+    // The peer got its answer, undiluted.
+    let manager = h.channel_texts("Manager");
+    assert!(
+        manager.iter().any(|t| t.contains("Here is the announcement")),
+        "the peer that asked never got its answer: {manager:?}"
+    );
+
+    // And the operator got theirs, in a turn of its own.
+    h.wait_until("the operator's message to be answered", |h| {
+        h.channel_texts("Writer").iter().any(|t| t.contains("Noted for next time"))
+    })
+    .await;
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 6)]
 async fn replies_queued_together_are_read_in_a_single_turn() {
     // Batching is what stops four replies from costing four Manager turns.


### PR DESCRIPTION
A turn was built from its batch and went deaf for as long as it ran, so an operator watching an agent work could type a correction and be read forty minutes later, and a turn could never receive the result of the `code` job it started: that job does not block on purpose, its answer comes back as a fresh envelope on a run of its own, and an actor only examines the envelope it is holding, so `RepositoryBusy` told the agent to wait for a message the turn being spoken to was itself holding up. `Runtime::take_in` now runs at the top of every round and folds what has arrived into the conversation as one labeled user turn, through the same `render_incoming` the batch goes through.

What arrives is context and never a change of address: not the mode, not the reply target, not the channel the placeholder is already open in, not `cause`, all four having been decided before the first token. That constraint is what decides the rule rather than the other way round, so a `ToPeer` turn takes in nothing and a peer's message waits for the turn it is owed. Two things the shape forces: the turn keeps the set of message ids its prompt already carries, because `deliver` writes to the store before the inbox and two operator lines a second apart are enough to put one in both at once; and work taken into a `NoteOnly` turn moves it to `Assigned`, where a note the agent never writes is reported rather than looking like an agent that stopped.

Four cascade tests, each checked to fail without the change; full `./scripts/ci.sh` and the trajectory suite pass. The live evals were not run, so a prompt-level judgement on the new mid-turn block is still outstanding.