### PR TITLE
fix: the cafeteria hires into the crew you are standing in, not the first one

### DIFF
--- a/src/components/Cafeteria.test.tsx
+++ b/src/components/Cafeteria.test.tsx
@@ -66,8 +66,25 @@ function agent(name: string, groupId = KITCHEN): AgentCard {
 
 const onClose = vi.fn();
 
-function open(groups: Group[] = [group(KITCHEN, "Kitchen")], agents: AgentCard[] = []) {
-  useStore.setState({ agents, groups, activity: {}, lastActive: {}, selected: null });
+/** Where the operator is standing when they open the dialog. */
+interface Standing {
+  railGroup?: string | null;
+  selected?: string | null;
+}
+
+function open(
+  groups: Group[] = [group(KITCHEN, "Kitchen")],
+  agents: AgentCard[] = [],
+  standing: Standing = {},
+) {
+  useStore.setState({
+    agents,
+    groups,
+    activity: {},
+    lastActive: {},
+    selected: standing.selected ?? null,
+    railGroup: standing.railGroup ?? null,
+  });
   return render(<Cafeteria onClose={onClose} />);
 }
 
@@ -191,6 +208,18 @@ describe("who is already here", () => {
     expect(tile("Chief of Staff").textContent).not.toContain("on staff");
   });
 
+  it("does not count somebody in the compost", () => {
+    // A deleted agent is out of the crew the moment it goes in there, so the
+    // room it left is empty and the badge has to say so. Its name is free
+    // again too, which is what the hire is about to take.
+    open(
+      [group(KITCHEN, "Kitchen")],
+      [{ ...agent("Executive Assistant"), lifecycle: "terminated", discardedAt: 1_000 }],
+    );
+    expect(tile("Executive Assistant").textContent).not.toContain("on staff");
+    expect(screen.getByRole("button", { name: /starter crew/i })).toBeTruthy();
+  });
+
   it("still lets a second one be hired", async () => {
     // Deliberate: two researchers is a thing operators want. The runtime is
     // what settles the name.
@@ -214,5 +243,54 @@ describe("when a hire is refused", () => {
     expect(onClose).not.toHaveBeenCalled();
     expect(tile("Chief of Staff").getAttribute("aria-pressed")).toBe("true");
     expect(hireButton().disabled).toBe(false);
+  });
+});
+
+describe("where a hire lands", () => {
+  it("hires into the crew the rail is inside", async () => {
+    open(
+      [group(KITCHEN, "Kitchen"), group(GARDEN, "Garden")],
+      [agent("Executive Assistant", KITCHEN)],
+      { railGroup: GARDEN },
+    );
+
+    // Everything on screen has to be about the Garden, not about whichever
+    // group happens to be first: the badge, the starter crew, and the hire.
+    expect(tile("Executive Assistant").textContent).not.toContain("on staff");
+    expect(screen.getByRole("button", { name: /starter crew/i })).toBeTruthy();
+
+    fireEvent.click(tile("Executive Assistant"));
+    fireEvent.click(screen.getByRole("button", { name: /hire 1 into garden/i }));
+    await waitFor(() => expect(hireAgents).toHaveBeenCalledTimes(1));
+    expect(hireAgents.mock.calls[0]![0]).toBe(GARDEN);
+  });
+
+  it("follows the open channel when the rail is in the overview", () => {
+    // No group is focused, so the agent whose channel is open is what says
+    // which crew the operator is working with.
+    open(
+      [group(KITCHEN, "Kitchen"), group(GARDEN, "Garden")],
+      [agent("Executive Assistant", KITCHEN), agent("Paralegal", GARDEN)],
+      { selected: "id-Paralegal" },
+    );
+    expect(tile("Executive Assistant").textContent).not.toContain("on staff");
+    expect(screen.getByRole("button", { name: /hire 0 into garden|nobody picked/i })).toBeTruthy();
+    fireEvent.click(tile("Executive Assistant"));
+    expect(screen.getByRole("button", { name: /hire 1 into garden/i })).toBeTruthy();
+  });
+
+  it("falls back to the first group with nothing open", () => {
+    open([group(KITCHEN, "Kitchen"), group(GARDEN, "Garden")], [], {});
+    fireEvent.click(tile("Executive Assistant"));
+    expect(screen.getByRole("button", { name: /hire 1 into kitchen/i })).toBeTruthy();
+  });
+
+  it("keeps the crew it opened on when the activity board is what is open", () => {
+    open([group(KITCHEN, "Kitchen"), group(GARDEN, "Garden")], [], {
+      railGroup: GARDEN,
+      selected: "activity",
+    });
+    fireEvent.click(tile("Executive Assistant"));
+    expect(screen.getByRole("button", { name: /hire 1 into garden/i })).toBeTruthy();
   });
 });

--- a/src/components/Cafeteria.tsx
+++ b/src/components/Cafeteria.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { AgentAvatar } from "../avatars/AgentAvatar";
 import { HIREABLE, type Hireable, pick, STARTER_CREW, STATIONS, toDraft } from "../lib/cafeteria";
 import { api } from "../lib/ipc";
-import { useStore } from "../lib/store";
+import { ACTIVITY_CHANNEL, useStore } from "../lib/store";
 import { errorMessage, type GroupId } from "../lib/types";
 
 interface Props {
@@ -27,9 +27,34 @@ export function Cafeteria({ onClose }: Props) {
   const agents = useStore((s) => s.agents);
   const select = useStore((s) => s.select);
   const refreshAgents = useStore((s) => s.refreshAgents);
+  const railGroup = useStore((s) => s.railGroup);
+  const selected = useStore((s) => s.selected);
 
   const [picked, setPicked] = useState<Set<string>>(new Set());
-  const [groupId, setGroupId] = useState<GroupId | "">(() => groups[0]?.id ?? "");
+  /**
+   * The crew the operator is standing in, which is the one they came to hire
+   * into.
+   *
+   * Read once, when the dialog opens. Defaulting to the first group instead
+   * pointed everything below at somebody else's crew: an operator who had just
+   * emptied a group was told the preset they were about to hire was already
+   * "on staff", offered no starter crew for a room with nobody in it, and
+   * would have hired into a group they were not looking at. Three symptoms,
+   * one wrong id.
+   *
+   * The rail's focus is the answer when there is one, because that is the crew
+   * the rail is inside. With the rail in the overview the open channel is what
+   * says where the operator is, and `select` has already followed that agent
+   * into its crew. Neither, on a workspace with no channel open, falls back to
+   * the first group as before.
+   */
+  const [groupId, setGroupId] = useState<GroupId | "">(() => {
+    const open =
+      selected !== null && selected !== ACTIVITY_CHANNEL
+        ? agents.find((a) => a.id === selected)?.groupId
+        : undefined;
+    return railGroup ?? open ?? groups[0]?.id ?? "";
+  });
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
The cafeteria initialized its destination to `groups[0]`, which `list_groups` orders by `created_at`, so it was always the default group rather than the one the operator was looking at. That one id drives three things: the "on staff" badge, whether a starter crew is offered, and where the hire lands, so an operator who had just emptied a group was told the preset they were about to hire was already on staff, was offered no crew for a room with nobody in it, and would have hired somewhere they were not looking. It now reads where the operator is standing: the rail's focus when it is inside a crew, otherwise the open channel's agent, falling back to the first group as before when neither exists; the dropdown still overrides.

Four tests in `where a hire lands`, three of which fail without the change. The compost was never involved: `employed` has excluded terminated agents since it was written, and `does not count somebody in the compost` pins that so nothing starts counting them later.