### PR TITLE
fix: a turn paid for by a Claude plan does not ask for the operator's photos

### DIFF
--- a/src-tauri/src/llm/claude.rs
+++ b/src-tauri/src/llm/claude.rs
@@ -52,6 +52,31 @@
 //! operator configures *for Claude* that this app does want is the part they
 //! cannot pass another way: the sign-in and the model.
 //!
+//! ## The program is started in an empty directory this app owns
+//!
+//! A child process inherits its parent's working directory, and a
+//! double-clicked app's is `/`: `launchd` starts one there, which is the same
+//! finding [`crate::programs`] is built on, from the other end. `claude` takes
+//! the directory it is started in as the project it is working on and asks the
+//! operating system what it may reach inside it. Started in `/` that question
+//! covers every protected folder on the machine, and macOS answers a child's
+//! request in the name of the *responsible* process rather than the child, so
+//! the operator is asked whether **Guaca** may read their photos, their music
+//! library, their Desktop and their Downloads, once per model call, about
+//! folders this app has never read and has no tool that could.
+//!
+//! Measured on 2026-08-27 against 2.1.247: one turn produced
+//! `kTCCServiceMediaLibrary`, `kTCCServicePhotos`,
+//! `kTCCServiceSystemPolicyDesktopFolder`,
+//! `kTCCServiceSystemPolicyDownloadsFolder` and a refused
+//! `kTCCServiceSystemPolicyAllFiles`, each logged by `tccd` as
+//! `responsible=com.madebywelch.guac, accessing=com.anthropic.claude-code`.
+//! [`scratch`] is what takes the disk back out of that question. It is not
+//! tidiness: a permission dialog naming this app for something it does not do
+//! is one an operator either denies, and then distrusts the app, or accepts,
+//! and then has granted a real reach to a program that asked under a borrowed
+//! name.
+//!
 //! ## What it does not report
 //!
 //! Money that moved. `total_cost_usd` on a plan is the equivalent API price
@@ -59,6 +84,7 @@
 //! makes and no more. It is dropped rather than recorded, so the usage table
 //! keeps meaning what it has always meant; the tokens are real and are counted.
 
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;
 
@@ -487,6 +513,23 @@ fn refusal(frame: &ResultFrame) -> LlmError {
     }
 }
 
+/// The directory the program is started in, made if it is not there yet.
+///
+/// Empty, this app's, and about nothing. The module docs have the argument for
+/// why it is not the one this process happens to be standing in.
+///
+/// `None` is the whole error handling and it means inherit, which is where this
+/// started and is no worse than it was. Answering with a path that is not on
+/// disk would be worse than either: [`std::process::Command::spawn`] reports a
+/// missing working directory as `NotFound`, which the caller below maps to
+/// [`LlmError::ProgramMissing`], and the operator is told to install a program
+/// they already have.
+fn scratch() -> Option<PathBuf> {
+    let at = std::env::temp_dir().join("guaca-claude");
+    std::fs::create_dir_all(&at).ok()?;
+    Some(at)
+}
+
 /// Runs one model call and reads what the program says about it.
 ///
 /// The one place the third provider parts company from the other two, reached
@@ -503,7 +546,13 @@ where
     let (system, blocks) = conversation(&request.messages);
     let timeout = Duration::from_secs(cfg.request_timeout_secs.clamp(5, 900));
 
-    let mut child = tokio::process::Command::new(PROGRAM)
+    let mut command = tokio::process::Command::new(PROGRAM);
+    // Set rather than inherited, and the module docs say what inheriting costs.
+    if let Some(at) = scratch() {
+        command.current_dir(at);
+    }
+
+    let mut child = command
         .args(argv(&schema, &system))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/src-tauri/tests/claude.rs
+++ b/src-tauri/tests/claude.rs
@@ -25,7 +25,7 @@
 //! `coding.rs`, `subscription.rs` and `plugins.rs` each keep for the reason.
 
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use guac_lib::config::{InferenceConfig, Provider};
@@ -36,11 +36,13 @@ use guac_lib::llm::openrouter::{ChatMessage, ChatRequest, LlmClient, LlmError, T
 /// cannot pass for each other.
 const MARKER: &str = "guaca-conversation-arrived";
 
-/// Puts a stand-in `claude` on `PATH`, exactly once.
+/// Puts a stand-in `claude` on `PATH`, exactly once, and says where it is.
 ///
 /// Once, because `PATH` is process-wide and these tests run concurrently:
-/// writing it per test is a read racing a write on another thread.
-fn stand_in() {
+/// writing it per test is a read racing a write on another thread. The path
+/// comes back because what the stand-in records about its own start is written
+/// beside it.
+fn stand_in() -> PathBuf {
     static ONCE: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
     ONCE.get_or_init(|| {
         let dir = tempfile::tempdir().unwrap();
@@ -48,7 +50,9 @@ fn stand_in() {
         let path = std::env::var("PATH").unwrap_or_default();
         std::env::set_var("PATH", format!("{}:{path}", dir.path().display()));
         dir
-    });
+    })
+    .path()
+    .to_path_buf()
 }
 
 /// The stand-in: reads the conversation, then answers on the basis of it.
@@ -57,8 +61,15 @@ fn stand_in() {
 /// this suite is here to catch is the conversation not arriving. A stand-in
 /// that answered the same either way would pass with the write removed.
 fn write_stand_in(dir: &Path) {
+    // Where it was started, recorded before anything else. The path is absolute
+    // so that reading it back does not depend on where it was started, and
+    // `pwd -P` resolves symlinks because the answer is compared against a
+    // canonical path: on this platform the temporary directory is reached
+    // through one.
+    let record = dir.join("cwd");
     let script = format!(
         "#!/bin/sh\n\
+         pwd -P > '{cwd}'\n\
          if [ \"$1\" = '--version' ]; then echo 'stand-in'; exit 0; fi\n\
          input=$(cat)\n\
          case \"$input\" in\n\
@@ -69,7 +80,8 @@ fn write_stand_in(dir: &Path) {
            *'no-answer'*) echo 'refusing' >&2; exit 3 ;;\n\
          esac\n\
          printf '%s\\n' '{{\"type\":\"stream_event\",\"event\":{{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{{\"type\":\"thinking_delta\",\"thinking\":\"weighing it up\"}}}}}}'\n\
-         printf '%s\\n' '{{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"stop_reason\":\"end_turn\",\"structured_output\":{{\"say\":\"told Pat\",\"calls\":[{{\"name\":\"send_message\",\"arguments\":{{\"to\":\"Pat\"}}}}]}},\"usage\":{{\"input_tokens\":7,\"cache_read_input_tokens\":3,\"output_tokens\":5}},\"total_cost_usd\":0.42}}'\n"
+         printf '%s\\n' '{{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"stop_reason\":\"end_turn\",\"structured_output\":{{\"say\":\"told Pat\",\"calls\":[{{\"name\":\"send_message\",\"arguments\":{{\"to\":\"Pat\"}}}}]}},\"usage\":{{\"input_tokens\":7,\"cache_read_input_tokens\":3,\"output_tokens\":5}},\"total_cost_usd\":0.42}}'\n",
+        cwd = record.display()
     );
     let at = dir.join("claude");
     let mut file = std::fs::File::create(&at).unwrap();
@@ -196,6 +208,40 @@ async fn a_program_that_never_finishes_is_given_up_on() {
     // Both are bounded, and being bounded is the whole assertion: nothing here
     // may wait on a process forever.
     assert!(started.elapsed() < Duration::from_secs(20), "{result:?}");
+}
+
+#[tokio::test]
+async fn the_program_is_started_somewhere_this_app_owns() {
+    // Not where this process happens to be standing. A double-clicked app is
+    // started in `/` by `launchd` and a child inherits that, and `claude` takes
+    // the directory it is started in as the project it is working on: from `/`
+    // it asks the operating system what it may reach across the whole disk, and
+    // macOS puts that question to the operator in the name of the *responsible*
+    // process, which is this app. Measured on 2026-08-27 against 2.1.247, one
+    // turn asked for the photo library, the music library, the Desktop and the
+    // Downloads folder, and for full disk access, each dialog naming Guaca.
+    // `llm/claude.rs` has the log lines.
+    let beside = stand_in();
+    LlmClient::new().unwrap().stream_chat(&on_claude(), &asking(), |_| {}).await.unwrap();
+
+    let recorded = std::fs::read_to_string(beside.join("cwd"))
+        .expect("the stand-in records where it was started");
+    let started_in = Path::new(recorded.trim());
+
+    assert_ne!(started_in, Path::new("/"), "started in the root of the disk");
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = std::fs::canonicalize(home).unwrap();
+        assert_ne!(started_in, home, "started in the operator's home directory");
+    }
+
+    // Canonical on both sides: the temporary directory is reached through a
+    // symlink on macOS, and the two spellings of it are not equal as strings.
+    let scratch = std::fs::canonicalize(std::env::temp_dir()).unwrap();
+    assert!(
+        started_in.starts_with(&scratch),
+        "started outside this app's own scratch space: {}",
+        started_in.display()
+    );
 }
 
 /// The live half: whether the real program still accepts that command line and


### PR DESCRIPTION
`llm/claude.rs` spawned `claude` with no working directory, so it inherited this process's, which for a double-clicked app is `/` because that is where `launchd` starts one. `claude` takes the directory it is started in as the project it is working on and asks the operating system what it may reach inside it, and macOS puts a child's request to the operator in the name of the responsible process, so a turn on a group set to Claude asked whether Guaca could read the operator's photo library, music library, Desktop and Downloads, once per model call, about folders this app has never read and has no tool that could. Measured on 2026-08-27 against 2.1.247, one turn produced `kTCCServiceMediaLibrary`, `kTCCServicePhotos`, `kTCCServiceSystemPolicyDesktopFolder`, `kTCCServiceSystemPolicyDownloadsFolder` and a refused `kTCCServiceSystemPolicyAllFiles`, each logged by `tccd` as `responsible=com.madebywelch.guac, accessing=com.anthropic.claude-code`. `scratch` makes an empty directory of this app's own and the program is started there; `None` means inherit, because handing `spawn` a path that is not on disk is reported as `NotFound` and mapped to `ProgramMissing`, which tells the operator to install a program they already have. `coding/mod.rs` already sets its own, to the repository the operator picked, and is unchanged. The stand-in in `tests/claude.rs` now records where it was started and one test asserts that is not `/`, not the operator's home, and inside this app's own scratch space; drop the `current_dir` and every other test in the repo still passes.