### PR TITLE
fix: a stop drops the model call it landed in, not just the ones after it

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -337,14 +337,31 @@ be:
   turn — would reach the reply with the mode it started in and write to the peer
   that was waiting. One lock read per turn closes it.
 
-A stop does not interrupt the model call in flight. The streaming client has no
-cancellation handle, so the turn that is talking finishes talking and stops
-before it would have called again. That is also what keeps the accounting
-honest: a call that was paid for is a call that completed. The same reasoning is
-why a stop is not looked at inside the retry loop either, which is the one place
-it costs something: a step is claimed for the whole call before the first
-attempt, so abandoning it between attempts would leave the run reporting a step
-against no call. A stop landing during a backoff waits it out.
+**The model call in flight is dropped, and that is the fifth place.** The four
+boundaries above are all places a turn passes between calls, and a turn spends
+most of a long minute inside one. Waiting for it to come back was defensible
+while every provider was an endpoint that answers in seconds. It stopped being
+defensible when one of them became a program: a call on the Claude provider is a
+whole `claude` run, which thinks for as long as it wants and holds the operator's
+plan for all of it, so a stop that waited was a button that did nothing for
+minutes. `Runtime::until_stopped` races the call, and the backoff between
+attempts with it, against the agent's own `resume` — the signal `stop_run`
+already wakes on every inbox.
+
+Dropping the future is the whole of the cancellation, and no backend needed a
+line for it. A `reqwest` response closes its connection when it goes; `llm/claude.rs`
+spawns its child with `kill_on_drop`, so the program dies with the call and the
+plan stops being spent on an answer nobody will read.
+
+What that costs is one line of accounting. A step is claimed before the call,
+because the run's bill has to name calls that were really made, and `trajectory.rs`
+reads that bill as `steps == calls + failures`: a call that answered reports
+usage, a call that failed every attempt writes a notice, and both are visible
+from outside. An abandoned call is in neither bucket, so `RunState::release_step`
+gives its step back at the point the turn gives up on it. Without that, every
+stop that landed mid-call would read as a budget that miscounted. It cannot be
+used to dodge the ceiling: a run only reaches it on the way out, and the turn
+that released breaks out of its round loop on the same stop.
 
 A stopped turn keeps its words and sends them nowhere. It reports as a note, so
 whatever it managed to say lands in its own channel where the operator can read

--- a/src-tauri/src/llm/claude.rs
+++ b/src-tauri/src/llm/claude.rs
@@ -558,7 +558,11 @@ where
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         // A call this app has given up on must not leave a process holding the
-        // operator's plan open. The same reason it is set in `coding/mod.rs`.
+        // operator's plan open. The same reason it is set in `coding/mod.rs`,
+        // and it is load-bearing rather than tidy here: this is the whole of
+        // what a stop does to a call in flight. `Runtime::until_stopped` drops
+        // the future, the drop takes the child with it, and the plan stops being
+        // spent on an answer nobody is going to read.
         .kill_on_drop(true)
         .spawn()
         .map_err(|err| match err.kind() {

--- a/src-tauri/src/runtime/guard.rs
+++ b/src-tauri/src/runtime/guard.rs
@@ -284,6 +284,25 @@ impl RunState {
         true
     }
 
+    /// Gives back the step claimed for a call the operator's stop cut short.
+    ///
+    /// The one caller is the model call a stop abandoned, and it exists because
+    /// of how the bill is read rather than to be generous about the ceiling.
+    /// `trajectory.rs` checks a run's steps against `calls + failures`: a
+    /// completed call reports usage and a call that failed every attempt writes
+    /// a notice, so both buckets are visible from outside. A call dropped
+    /// mid-flight is in neither, and a step left claimed for it makes every
+    /// stopped run read as a budget that miscounted.
+    ///
+    /// It cannot be spent against the ceiling, because a run only reaches here
+    /// on its way out: the turn that released breaks out of its round loop on
+    /// the same stop, and every other boundary is already refusing work for the
+    /// run. Nothing claims again after this.
+    pub fn release_step(&mut self) {
+        self.last_touched = now_ms();
+        self.steps_used = self.steps_used.saturating_sub(1);
+    }
+
     /// Evaluates one proposed send and, when allowed, records it.
     ///
     /// Recording on allow is what makes the per-pair and dedup limits real, so
@@ -552,6 +571,31 @@ mod tests {
         assert!(state.reserve_step());
         assert!(!state.reserve_step(), "fourth turn must be denied");
         assert_eq!(state.steps_remaining(), 0);
+    }
+
+    #[test]
+    fn a_call_the_operator_cut_short_gives_its_step_back() {
+        // The bill is read as `steps == calls + failures`. An abandoned call is
+        // in neither bucket, so a step left claimed for it is a run that looks
+        // like it billed for a call nothing can find.
+        let mut state = RunState::new(GuardLimits { max_steps_per_run: 3, ..permissive() });
+        assert!(state.reserve_step());
+        assert!(state.reserve_step());
+        state.release_step();
+        assert_eq!(state.steps_used(), 1, "only the call that answered is on the bill");
+        assert_eq!(state.steps_remaining(), 2);
+    }
+
+    #[test]
+    fn releasing_a_step_that_was_never_claimed_does_nothing() {
+        // Nothing calls it that way today, and a wrap to u32::MAX would be a
+        // run whose budget can never be spent rather than a panic anybody sees.
+        let mut state = RunState::new(GuardLimits { max_steps_per_run: 2, ..permissive() });
+        state.release_step();
+        assert_eq!(state.steps_used(), 0);
+        assert!(state.reserve_step());
+        assert!(state.reserve_step());
+        assert!(!state.reserve_step(), "the ceiling still holds");
     }
 
     #[test]

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -511,7 +511,10 @@ struct Inbox {
     /// Queue depth, so the sidebar can show a backlog without draining it.
     depth: Arc<AtomicUsize>,
     /// Woken when a paused agent is resumed, or when a run it may be holding is
-    /// stopped.
+    /// stopped. Both a parked actor and a model call this agent has in flight
+    /// wait on it, so it is a nudge to go and look rather than a message: every
+    /// waiter re-reads what it was waiting for and goes back to waiting if the
+    /// answer was not for it.
     resume: Arc<Notify>,
 }
 
@@ -2113,11 +2116,12 @@ impl Runtime {
     /// going to lift. Everything else is either running, and will reach a
     /// boundary on its own, or queued, and will reach one when it is read.
     ///
-    /// A stop does not interrupt the model call in flight. There is no
-    /// cancellation handle on the streaming client, so the turn that is talking
-    /// finishes talking and stops before it would have called again. That is
-    /// the honest boundary and it is also the one that keeps the budget
-    /// truthful: a call that was paid for is a call that completed.
+    /// The model call in flight is dropped rather than waited out, which is
+    /// what the wake above buys on top of the mark. See [`Self::until_stopped`]:
+    /// on the Claude provider a call is a whole `claude` run and waiting for one
+    /// made this button do nothing for minutes. The step claimed for that call
+    /// is given back where it was claimed, so the run's bill still names only
+    /// calls it was answered by.
     ///
     /// False when the run has nothing outstanding, which is every run that has
     /// already finished. That is not an error, and it deliberately writes
@@ -2708,7 +2712,18 @@ impl Runtime {
             let completion = self.stream_with_retries(&inference, &request, &mut stream).await;
 
             let completion = match completion {
-                Ok(completion) => completion,
+                Ok(Some(completion)) => completion,
+                // The operator stopped the run while this call was in the air,
+                // so it was dropped rather than waited out. The step goes back
+                // here, next to where it was claimed: the abandoned call
+                // reported no usage and raised no error, so it is in neither
+                // bucket the run's bill is read as and a step left standing for
+                // it makes every stopped run look like a budget that miscounted.
+                Ok(None) => {
+                    self.inner.guard.lock().run_within(run_id, limits).release_step();
+                    called_off = true;
+                    break;
+                }
                 Err(err) => {
                     failure = Some(err);
                     break;
@@ -2836,9 +2851,9 @@ impl Runtime {
             tool_parts.push(Part::Notice {
                 kind: NoticeKind::GuardStop,
                 text: format!(
-                    "You stopped this conversation. {} finished the model call it was already in \
-                     and started nothing else, and nothing was sent on. Send it again if you want \
-                     it finished.",
+                    "You stopped this conversation. {} dropped the model call it was in, started \
+                     nothing else, and nothing was sent on. Send it again if you want it \
+                     finished.",
                     card.name
                 ),
             });
@@ -2880,23 +2895,25 @@ impl Runtime {
     /// One model call, attempted more than once when the failure is the kind
     /// that fixes itself.
     ///
-    /// The budget is not touched here. A call is one call however many times
-    /// the network dropped it, and reserving a step per attempt would bill a
-    /// run for requests that never reached a provider.
+    /// `None` is the operator stopping the run mid-call: the attempt in flight
+    /// was dropped, nothing was counted and nothing failed. The caller gives the
+    /// step back, which is the only place the budget has to know this happened.
     ///
-    /// A stop is not looked at here either, and that is the one place it costs
-    /// something. A step is claimed for the whole call before this is entered,
-    /// so abandoning it partway through would leave the run reporting a step
-    /// against no call and the two would disagree for the rest of its life. A
-    /// stop that lands during a backoff therefore waits it out — up to
-    /// `MAX_RETRY_AFTER` when a provider asked for that long — and is noticed
-    /// at the boundary after the call returns.
+    /// The budget is not touched here otherwise. A call is one call however many
+    /// times the network dropped it, and reserving a step per attempt would bill
+    /// a run for requests that never reached a provider.
+    ///
+    /// Both awaits in here are raced against the stop, and the backoff is not an
+    /// afterthought: a provider that asked for a minute would otherwise hold a
+    /// called-off run for `MAX_RETRY_AFTER` doing nothing, which reads exactly
+    /// like the hang this whole path is here to end.
     async fn stream_with_retries(
         &self,
         inference: &InferenceConfig,
         request: &ChatRequest,
         stream: &mut Stream,
-    ) -> Result<crate::llm::openrouter::Completion, LlmError> {
+    ) -> Result<Option<crate::llm::openrouter::Completion>, LlmError> {
+        let (run_id, agent_id) = (stream.run_id, stream.agent_id);
         let mut last: Option<LlmError> = None;
 
         for attempt in 0..CALL_ATTEMPTS {
@@ -2915,7 +2932,9 @@ impl Runtime {
                     wait_ms = wait.as_millis() as u64,
                     "retrying a model call"
                 );
-                tokio::time::sleep(wait).await;
+                if self.until_stopped(run_id, agent_id, tokio::time::sleep(wait)).await.is_none() {
+                    return Ok(None);
+                }
                 // Anything already on screen belongs to the attempt that broke.
                 stream.reopen(&*self.inner.events);
             }
@@ -2932,21 +2951,76 @@ impl Runtime {
             // several agents answering at once it stopped painting at all,
             // which read as the app freezing and the text arriving in a lump.
             let mut pen = Pen::new(self.inner.events.clone(), message_id, channel_id, lead);
-            let result =
-                self.inner.llm.stream_chat(inference, request, |token| pen.write(token)).await;
+            let call = self.inner.llm.stream_chat(inference, request, |token| pen.write(token));
+            let result = self.until_stopped(run_id, agent_id, call).await;
+            // Before the answer is looked at, and before the return below, so
+            // whatever the abandoned attempt drew is committed while the
+            // placeholder is still open. The turn closes it on its way out.
             pen.flush();
 
             match result {
-                Ok(completion) => return Ok(completion),
-                Err(err) if err.is_transient() => last = Some(err),
+                None => return Ok(None),
+                Some(Ok(completion)) => return Ok(Some(completion)),
+                Some(Err(err)) if err.is_transient() => last = Some(err),
                 // A rejected key or an unknown model answers the same way every
                 // time. Retrying it wastes the operator's time to reach the
                 // message they needed to read immediately.
-                Err(err) => return Err(err),
+                Some(Err(err)) => return Err(err),
             }
         }
 
         Err(last.expect("the loop only ends here after a failure"))
+    }
+
+    /// Awaits one piece of a model call, and gives up on it the moment the
+    /// operator stops the run. `None` when the stop won.
+    ///
+    /// Dropping the future is the whole of the cancellation, and every backend
+    /// behind `stream_chat` already cleans itself up that way: an HTTP response
+    /// closes its connection, and `llm::claude` spawns its child with
+    /// `kill_on_drop`. That last one is why this exists. On the other two
+    /// providers a call in flight is a request that will answer in seconds, so
+    /// waiting it out was a boundary nobody could see; on that one it is an
+    /// entire `claude` run, holding the operator's plan for as long as the model
+    /// wants to think and up to the request timeout after that. A stop that
+    /// waited was a button that did nothing for minutes, which is the one thing
+    /// this button cannot be.
+    ///
+    /// The signal is the agent's own `resume`, which [`Self::stop_run`] already
+    /// wakes on every inbox. It is a nudge and not a message, so the run is
+    /// asked again on each wake: a stop anywhere in the workspace wakes this
+    /// one too, and a call whose run was not the one called off has to go back
+    /// to waiting rather than treat the wake as its answer.
+    async fn until_stopped<T>(
+        &self,
+        run_id: RunId,
+        agent_id: AgentId,
+        work: impl std::future::Future<Output = T>,
+    ) -> Option<T> {
+        let signal = { self.inner.inboxes.lock().get(&agent_id).map(|inbox| inbox.resume.clone()) };
+        // No inbox means no actor, which means nothing this could be racing.
+        let Some(signal) = signal else { return Some(work.await) };
+
+        tokio::pin!(work);
+        loop {
+            // Registered before the run is asked and not after, which is the
+            // whole reason `enable` is called by hand. A `Notified` only joins
+            // the wait list when it is first polled, so a stop landing between
+            // the question and the first poll of the select would wake nobody
+            // and this would sit out the call it exists to abandon.
+            let woken = signal.notified();
+            tokio::pin!(woken);
+            woken.as_mut().enable();
+
+            if self.stopped(run_id) {
+                return None;
+            }
+
+            tokio::select! {
+                done = &mut work => return Some(done),
+                () = woken => {}
+            }
+        }
     }
 
     /// Takes in whatever arrived while this turn was working, as context.

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -113,7 +113,22 @@ pub enum Script {
     /// arrive as different `LlmError`s and all answer `is_transient`, which is
     /// the only thing the retry loop asks them.
     Unavailable,
+    /// Take the request and never answer it.
+    ///
+    /// A call in flight, which is where a turn spends most of a long minute and
+    /// is the one place a stop cannot be noticed by looking at a boundary. It
+    /// stands in for the shape that made this matter: on the Claude provider a
+    /// model call is a whole `claude` run, and one that thinks for five minutes
+    /// holds the operator's plan for all five of them.
+    ///
+    /// Held for [`HANG`], which is far longer than any stop test waits, so a
+    /// call that is not abandoned reads as a run that never settled rather than
+    /// as a slow one.
+    Hang,
 }
+
+/// How long [`Script::Hang`] holds a request open.
+pub const HANG: Duration = Duration::from_secs(30);
 
 pub fn frame(value: serde_json::Value) -> String {
     format!("data: {value}\n\n")
@@ -341,8 +356,9 @@ pub fn render(script: &Script) -> String {
                 serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
             ));
         }
-        // Never rendered: the server answers it with a status, not a body.
-        Script::Unavailable => {}
+        // Never rendered: the server answers one with a status and the other
+        // with nothing at all.
+        Script::Unavailable | Script::Hang => {}
         Script::Directory => {
             body.push_str(&frame(serde_json::json!({"choices":[{"delta":{"tool_calls":[
                 {"index":0,"id":"call_dir","type":"function",
@@ -498,6 +514,9 @@ where
                         "the model provider is having a moment",
                     )
                         .into_response();
+                }
+                if matches!(script, Script::Hang) {
+                    tokio::time::sleep(HANG).await;
                 }
                 ([("content-type", "text/event-stream")], render(&script)).into_response()
             }

--- a/src-tauri/tests/trajectory.rs
+++ b/src-tauri/tests/trajectory.rs
@@ -477,6 +477,64 @@ async fn stopping_a_run_ends_it_and_bills_only_the_calls_it_made() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stopping_a_run_abandons_the_model_call_it_was_waiting_on() {
+    // The window every other stop test steps over. A stop is noticed at four
+    // boundaries and a call in flight is between all of them, which is where a
+    // turn spends most of a long minute: the run was marked, the wake reached
+    // nobody that was listening, and the operator watched a button they had
+    // pressed do nothing until the provider answered. On the Claude provider
+    // that wait is a whole `claude` run holding their plan, up to the request
+    // timeout, so this was the difference between a stop and a suggestion.
+    //
+    // Two calls, because the accounting is the other half of the fix. The first
+    // answers and is counted. The second is abandoned, reports no usage and
+    // raises no error, so it belongs to neither of the two buckets the run's
+    // bill is read as — `steps == calls + failures` — and its step has to be
+    // given back or `expect_normal` reads the stop as a miscounted budget.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Hang
+        } else {
+            Script::Progress("looking into it".into())
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "How is the prep going?").unwrap();
+
+    h.wait_until("the second call has been sent and not answered", |_| {
+        stub.calls.load(Ordering::SeqCst) >= 2
+    })
+    .await;
+
+    assert!(h.runtime.stop_run(run), "the turn is still outstanding");
+    assert!(
+        h.settled_within(run, 5).await,
+        "a stop waited out the call in flight, which {HANG:?} of provider is too long to call \
+         stopping:\n{}",
+        h.trajectory(run).ledger
+    );
+
+    let t = h.expect_normal(run, "a stop that landed while a call was in flight");
+    assert_eq!(t.calls(), 1, "the abandoned call answered nothing, so nothing was counted");
+    assert_eq!(
+        t.steps().map(|steps| steps as usize),
+        Some(t.calls()),
+        "the step claimed for the abandoned call was not given back:\n{}",
+        t.ledger
+    );
+    assert!(
+        t.records.iter().any(|r| matches!(
+            r,
+            Record::Noticed { kind: NoticeKind::GuardStop, text, .. } if text.contains("stopped")
+        )),
+        "and the channel says why it ended where it did:\n{}",
+        t.ledger
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn stopping_a_run_a_paused_agent_is_holding_still_ends_it() {
     // The same shape as deleting an agent mid-hold, and the reason a stop wakes
     // every inbox. A paused agent parks inside an await that only a resume


### PR DESCRIPTION
A stop marked the run and was noticed at four boundaries, all of which sit between model calls, so a call already in flight was waited out: invisible while every provider was an endpoint answering in seconds, and very visible once one became a program, because on `Provider::Claude` a model call is a whole `claude` run holding the operator's plan until the model stops thinking. `Runtime::until_stopped` now races the call, and the retry backoff with it, against the agent's own `resume` that `stop_run` already wakes on every inbox; dropping the future is the whole cancellation and no backend needed a line, since a `reqwest` response closes its connection and `llm/claude.rs` already spawns its child with `kill_on_drop`. The bill is read as `steps == calls + failures` and an abandoned call is in neither bucket, so `RunState::release_step` gives back the step claimed for it, which cannot be spent against the ceiling because the turn breaks out of its round loop on the same stop. Covered by `stopping_a_run_abandons_the_model_call_it_was_waiting_on` against a new `Script::Hang` that takes a request and never answers, verified failing without the race, plus two guard unit tests; `stopping_a_run_mid_call_does_not_let_the_answer_reach_the_peer` got stronger for free. `./scripts/ci.sh` is green.