### PR TITLE
fix: a turn the model refuses is drawn again, not filed as a spent plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,6 +310,20 @@ the model takes a screenshot to see what `browse` did.
   there both go to `Token::Reasoning`, are shown, and are dropped, exactly as
   everywhere else. It is the one way this provider looks different on screen,
   and it is a decision rather than a gap.
+- **A refusal from that program is not a failure it had, and it is the one thing
+  there worth another draw.** The model's safety check can stop an answer on a
+  call that succeeded, and the frame then reads `subtype: "success"` with
+  `is_error` true, `api_error_status` null, no `structured_output`, and a
+  `result` that opens `API Error:` and closes with the category that fired.
+  On the report this was written from that category was `reasoning_extraction`,
+  which runs on what the model wrote rather than on what the operator asked for. Told apart by the
+  error flag alone it lands in the arm that means a dead sign-in or a spent
+  plan: never retried, and answered with a paragraph of the program's own advice
+  about rephrasing in a new session and changing `/model`, neither of which
+  exists here and the second of which this app passes on purpose. `stop_reason`
+  is the field that separates them, `LlmError::ModelRefused` is transient and so
+  gets the turn's three attempts, and the sentence after the program's words is
+  this app's.
 - **The `claude` result frame is snake case and is deliberately not renamed.**
   It mixes conventions — `modelUsage` sits beside `total_cost_usd` — so a
   blanket `rename_all` is right about the fields it was written against and

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -288,6 +288,26 @@ time, because the answer is a JSON document and half a decoded escape drawn into
 a channel is worse than a message that arrives at once. `llm/claude.rs` is the
 whole of it.
 
+One failure of that arrangement is worth writing down, because it looks like
+another one and is handled the opposite way. The model's own safety check can
+stop an answer on a call that succeeded: the request is answered, the tokens are
+spent, and the program reports it with `stop_reason: "refusal"` and the model's
+account of it in `result`, which opens `API Error:` and names the category that
+fired. There is no status code, because nothing returned an error. Read by the
+error flag alone that frame is indistinguishable from a spent plan, and the two
+want opposite handling: a plan is over until the operator tops it up, while a
+refusal ran on what the model was writing, so the next draw is a different
+question. So
+`stop_reason` is what tells them apart, and `LlmError::ModelRefused` is the one
+program failure a turn's three attempts are spent on.
+
+What the operator is told is this app's sentence rather than the program's,
+which is the other half. The program's advice is written for somebody sitting in
+it: rephrase in a new session, or change the model with `/model`. Neither exists
+here, and the second is the one thing Guaca deliberately does not pass. Its
+words are still carried, because the category and the request id in them are
+what an operator would quote to the vendor.
+
 Claude models still reach Guaca the other two ways as well, through an API key or
 through OpenRouter, which remains the default endpoint and the default model.
 

--- a/src-tauri/src/llm/claude.rs
+++ b/src-tauri/src/llm/claude.rs
@@ -77,6 +77,17 @@
 //! and then has granted a real reach to a program that asked under a borrowed
 //! name.
 //!
+//! ## A refusal is not a failure of the program
+//!
+//! The model's own safety check can stop an answer on a call that succeeded,
+//! and when it does the program has nothing to report but the model's account
+//! of it. That arrives in the same place a spent plan does and has to be told
+//! apart from one, because the two want opposite handling: a plan is over until
+//! the operator does something, and a refusal ran on what the model was
+//! writing, so the next draw is a different question. [`REFUSED`] is the field
+//! that separates them and [`LlmError::ModelRefused`] is what the turn's three
+//! attempts then apply to.
+//!
 //! ## What it does not report
 //!
 //! Money that moved. `total_cost_usd` on a plan is the equivalent API price
@@ -117,6 +128,21 @@ pub const MODEL_LABEL: &str = "claude";
 const SAY: &str = "say";
 /// The field the tool calls go in.
 const CALLS: &str = "calls";
+
+/// What the program puts on the turn's stop reason when the model stopped on
+/// its own safety check rather than on an answer.
+///
+/// The one failure of this program with no status behind it, and the reason
+/// [`failure`] has to look here rather than at `is_error` alone. The request was
+/// answered, the tokens were spent, and the check ran on what was being written,
+/// so measured against 2.1.247 the frame is `subtype: "success"` with `is_error`
+/// true, `api_error_status` null, no `structured_output`, and a `result` that
+/// opens `API Error:` and closes with the category that fired. Read without
+/// this, it lands in the arm that means a dead sign-in or a spent plan: not
+/// retried, and answered with a paragraph of the program's own advice about
+/// rephrasing in a new session or changing `/model`, neither of which exists
+/// here.
+const REFUSED: &str = "refusal";
 
 /// Builds the schema the program is held to.
 ///
@@ -450,7 +476,7 @@ where
                 .map_err(|err| LlmError::Decode(format!("{PROGRAM} result frame: {err}")))?;
 
             if frame.is_error || frame.structured_output.is_none() {
-                return Err(refusal(&frame));
+                return Err(failure(&frame));
             }
 
             let answer = frame.structured_output.unwrap_or_default();
@@ -479,19 +505,28 @@ where
     }
 }
 
-/// Turns a failed result frame into the refusal an agent reads mid-turn.
+/// Turns a failed result frame into the error an agent reads mid-turn.
 ///
 /// The program's own words are carried through rather than replaced. With no
 /// endpoint and no status code, they are the only description of what went
 /// wrong that exists, and the commonest cause here is a sign-in or a spent plan
 /// that only the operator can fix.
-fn refusal(frame: &ResultFrame) -> LlmError {
+///
+/// The exception is the model refusing, which is not the program failing at
+/// all: [`REFUSED`] is what tells the two apart, and it is asked first because
+/// it is the more specific fact. A refusal comes back on an answered call, so
+/// there is no status for the arm below to find.
+fn failure(frame: &ResultFrame) -> LlmError {
     let said = frame
         .result
         .as_deref()
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .unwrap_or("it reported no reason");
+
+    if frame.stop_reason.as_deref() == Some(REFUSED) {
+        return LlmError::ModelRefused { program: PROGRAM, message: said.to_string() };
+    }
 
     if let Some(status) = frame.api_error_status.as_ref().and_then(|s| s.as_u64()) {
         return LlmError::Upstream { status: status as u16, message: said.to_string() };
@@ -848,7 +883,7 @@ mod tests {
     }
 
     #[test]
-    fn a_refusal_carries_the_programs_own_words() {
+    fn a_failure_carries_the_programs_own_words() {
         // With no endpoint and no status code they are the only account of the
         // failure there is, and the usual cause is a sign-in only the operator
         // can fix.
@@ -859,6 +894,47 @@ mod tests {
         let err = fold(line, &mut out, &mut sink()).unwrap_err();
         assert!(matches!(err, LlmError::ProgramFailed { .. }));
         assert!(err.to_string().contains("Credit balance is too low"), "{err}");
+        // A plan is over until somebody tops it up. Three attempts at it is
+        // four seconds in front of the sentence they needed to read at once.
+        assert!(!err.is_transient(), "{err}");
+    }
+
+    #[test]
+    fn a_model_refusal_is_not_a_spent_plan_and_is_worth_another_draw() {
+        // The frame this app actually got, at 2.1.247. The call was answered,
+        // so `api_error_status` is null and there is no status to classify by;
+        // `is_error` alone files it under the arm above, which means a sign-in
+        // the operator has to go and fix and which is never tried again.
+        let mut out = Completion::default();
+        let line = r#"{"type":"result","subtype":"success","is_error":true,
+            "api_error_status":null,"stop_reason":"refusal",
+            "result":"API Error: Opus 5's safeguards flagged this message. Details: `[reasoning_extraction]` Request ID: req_011"}"#;
+
+        let err = fold(line, &mut out, &mut sink()).unwrap_err();
+        assert!(matches!(err, LlmError::ModelRefused { .. }), "{err}");
+        // The whole point of telling it apart: the check ran on what the model
+        // was writing, so the next draw is a different question.
+        assert!(err.is_transient(), "{err}");
+        // The program's words, which is where the category and the request id
+        // an operator would quote are.
+        assert!(err.to_string().contains("reasoning_extraction"), "{err}");
+        // And this app's after them, because theirs end in advice about a
+        // session and a `/model` that nothing here has.
+        assert!(err.to_string().contains("provider"), "{err}");
+    }
+
+    #[test]
+    fn a_refusal_that_also_carries_a_status_is_still_a_refusal() {
+        // Today's frame carries one or the other, so the order these are asked
+        // in is only decided here. A refusal says what stopped the answer; a
+        // status says what the transport did, and a 401 read off one would send
+        // an operator to a sign-in that is working.
+        let mut out = Completion::default();
+        let line = r#"{"type":"result","subtype":"success","is_error":true,
+            "api_error_status":401,"stop_reason":"refusal","result":"API Error: flagged"}"#;
+
+        let err = fold(line, &mut out, &mut sink()).unwrap_err();
+        assert!(matches!(err, LlmError::ModelRefused { .. }), "{err}");
     }
 
     #[test]

--- a/src-tauri/src/llm/openrouter.rs
+++ b/src-tauri/src/llm/openrouter.rs
@@ -296,6 +296,25 @@ pub enum LlmError {
     /// sign-in or a spent plan that only the operator can put right.
     #[error("{program} could not answer: {message}")]
     ProgramFailed { program: &'static str, message: String },
+    /// The model stopped on its own safety check instead of answering.
+    ///
+    /// Separate from [`Self::ProgramFailed`] because it is neither the program
+    /// failing nor the account: the call was answered, the tokens were spent,
+    /// and what was stopped was the draw. That is what makes it the one failure
+    /// of a program provider where a second attempt asks a different question
+    /// rather than the same one again.
+    ///
+    /// The program's own words are carried for the reason they are carried
+    /// above, and this app's sentence is the last one because theirs ends in
+    /// advice about their own chrome: a new session and `/model` are two things
+    /// an operator here does not have.
+    #[error(
+        "{program} was refused by the model: {message}\n\nThat is the model's own safety check \
+         rather than your sign-in or your plan, and it runs on the answer rather than on what \
+         you asked for, so it can fire on an ordinary request. Reword the message, or give this \
+         group another provider in its settings."
+    )]
+    ModelRefused { program: &'static str, message: String },
     #[error("rate limited by the inference endpoint: {message}")]
     RateLimited { message: String, retry_after_secs: Option<u64> },
     #[error("model {model:?} was rejected: {message}")]
@@ -323,6 +342,11 @@ impl LlmError {
             LlmError::RateLimited { .. } | LlmError::Timeout { .. } | LlmError::Truncated => true,
             LlmError::Upstream { status, .. } => *status >= 500,
             LlmError::ProgramMissing { .. } | LlmError::ProgramFailed { .. } => false,
+            // The one failure of a program provider worth asking again.
+            // Nothing about the request was rejected: the model wrote an answer
+            // and its own check stopped that answer, so the next draw is a
+            // different one rather than the same one repeated.
+            LlmError::ModelRefused { .. } => true,
             LlmError::Transport { .. } => true,
             _ => false,
         }
@@ -336,6 +360,7 @@ impl LlmError {
             LlmError::SubscriptionRejected { .. } => "sign in to ChatGPT again".into(),
             LlmError::ProgramMissing { program } => format!("{program} could not be found"),
             LlmError::ProgramFailed { program, .. } => format!("{program} could not answer"),
+            LlmError::ModelRefused { program, .. } => format!("{program} was refused by the model"),
             LlmError::RateLimited { .. } => "rate limited".into(),
             LlmError::ModelRejected { model, .. } => format!("model {model} unavailable"),
             LlmError::Upstream { status, .. } => format!("upstream HTTP {status}"),


### PR DESCRIPTION
A safeguard flag on a Claude turn arrives on a call that succeeded: HTTP 200, tokens spent, `stop_reason: "refusal"`, `api_error_status` null, and the model's own account of it in `result`. With no status to classify by, `is_error` alone put it in the arm that means a dead sign-in or a spent plan, which `is_transient` refuses unconditionally, so the turn died on one attempt.

`stop_reason` now separates the two: `LlmError::ModelRefused` is transient and gets the turn's three attempts, and it is asked before the status arm because a status read off a refusal would send an operator to a sign-in that is working. What the operator is told after those three attempts is this app's sentence rather than the program's, whose advice ends in a new session and a `/model` that nothing here has.

Verified with `./scripts/ci.sh`; there is no live test because a safeguard flag cannot be triggered on demand, so the frame shape is asserted offline against what 2.1.247 emits.
