### PR TITLE
fix: a table column is never narrower than a word in it

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -2154,6 +2154,15 @@ button {
   border: 1px solid var(--edge);
   padding: var(--space-2) var(--space-4);
   text-align: left;
+  /* `break-word` rather than the body's `anywhere`, and the difference is the
+     whole reason this line exists. Both break a word that will not fit, but
+     `anywhere` also makes a cell's min-content width one character, and auto
+     table layout sizes a squeezed column to exactly that: a `Result` column
+     next to a wide one came out a letter wide, spelling `Re/sul/t` down three
+     lines. `break-word` leaves min-content at the longest word, so a column is
+     never narrower than a word in it, and a token genuinely longer than the
+     table gets the sideways scroller `.md__scroll` is there to give it. */
+  overflow-wrap: break-word;
 }
 
 .md th {

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -269,6 +269,41 @@ describe("a message's clock", () => {
   });
 });
 
+describe("a table in a message", () => {
+  /**
+   * A cell breaks at a word, and the body it sits in breaks anywhere.
+   *
+   * They look like the same decision and are opposite ones. Prose in a chat
+   * bubble has to break a URL mid-token or it pushes the reading column
+   * sideways, which is what `anywhere` buys. In a table it also drops every
+   * cell's min-content width to a single character, and auto layout hands a
+   * squeezed column exactly its min-content: a `Result` column beside a wide
+   * one came out one letter wide, spelling `Re/sul/t` and `Qu/eu/ed` down
+   * three lines each. The two values are indistinguishable on a paragraph,
+   * which is why this is asserted rather than left to the eye.
+   */
+  function cell(tag: "th" | "td"): HTMLElement {
+    const md = document.createElement("div");
+    md.className = "md";
+    const table = document.createElement("table");
+    const row = document.createElement("tr");
+    const at = document.createElement(tag);
+    row.append(at);
+    table.append(row);
+    md.append(table);
+    document.body.append(md);
+    return at;
+  }
+
+  it.each(["th", "td"] as const)("sizes a %s column to a word, not a letter", (tag) => {
+    expect(getComputedStyle(cell(tag)).overflowWrap).toBe("break-word");
+  });
+
+  it("still breaks anywhere in the prose around it", () => {
+    expect(getComputedStyle(nest("md")).overflowWrap).toBe("anywhere");
+  });
+});
+
 describe("the composer's mention layer", () => {
   /**
    * The pill is painted on a copy of the draft, under the operator's own text.


### PR DESCRIPTION
`.md` sets `overflow-wrap: anywhere` so a URL in a chat bubble cannot push the reading column sideways, and every table cell inherited it. `anywhere` and `break-word` break a word identically, but `anywhere` also counts those breaks toward min-content width, dropping a cell's minimum to one character, and auto table layout sizes a squeezed column to exactly that: a `Result` column beside a wide one came out a letter wide, spelling `Re/sul/t` and `Qu/eu/ed` down three lines each. The cells now declare `break-word`, so min-content goes back to the longest word and a token genuinely longer than the table gets the sideways scroller `.md__scroll` is already there to give it. A new block in `styles.test.ts` asserts both halves, since the two values are indistinguishable on a paragraph and no eye would catch a regression. Checked on screen through the real `Markdown` component at full and narrow widths, not just in the suite.