### PR TITLE
feat: a coding job can be reached, corrected and stopped while it is running

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ src/                  React + TypeScript. A view over the runtime, nothing more.
 src-tauri/src/
   domain/             AgentCard, Envelope, Routine, Connector, Signin, Approval,
                       Search, ids. No I/O.
-    repository.rs     A directory an agent may write code in, and which of two
-                      programs writes it.
+    repository.rs     A directory an agent may write code in, which of two
+                      programs writes it, and whether it asks before pushing.
     worknote.rs       A line about work in flight, and why it is not memory.
     approval.rs       The two things an agent stops to ask a person, and why
                       only one of them may draw the model's own words.
@@ -71,6 +71,8 @@ src-tauri/src/
     mod.rs            One process, one ceiling, one prompt. Read this one first.
     pi.rs             `pi`'s argument vector and its stream.
     claude_code.rs    Claude Code's, which are not the same and cannot be.
+    bridge.rs         The other end of a job that is still running: what an
+                      operator can say to one, and what it may not do alone.
   db/                 SQLite. Plain SQL, numbered migrations.
   e2b.rs              Computers: the machines agents look at and point at.
   proxy.rs            Loopback viewer for those machines.
@@ -119,6 +121,9 @@ repo: the frontend renders state and forwards intent.
 | Which program writes the code, a spent plan, a harness that will not start | *There are two harnesses because a subscription is spent by one program* in `docs/CODING.md`, then `domain::repository::Harness` and `coding/mod.rs` |
 | What branch a coding job starts on, and what it is told about the tree | *A job is told where it is standing before it is told what to do* in `docs/CODING.md`, then `repo::footing` and the brief assembled in `Runtime::start_job` |
 | An argument either harness is started with, or how its stream is read | *One process lifecycle, two of what genuinely differs* in `docs/CODING.md`, then `coding/pi.rs` and `coding/claude_code.rs`, and run the live half of `tests/coding.rs` |
+| Reaching a job that is already running, stopping one, or anything a hook does | *A job can be reached while it runs* in `docs/CODING.md`, then `coding/bridge.rs`, and run the live half of `tests/coding.rs`, which is the only thing that can check any of it |
+| Whether a job stops before it pushes, and what counts as outward-facing | *The gate is a decision the operator takes per repository* in `docs/CODING.md`, then `bridge::outward` and `Runtime::park_with` |
+| What a job inherits from the operator's own Claude Code, and what that costs | *A job inherits the operator's own Claude Code setup* in `docs/CODING.md`, which has the measurement and the one hazard in it |
 | A program that is installed and reported missing: `claude`, `pi`, `git`, `gh` | *A double-clicked app does not have the operator's `PATH`* below, then `src-tauri/src/programs.rs` |
 | Anything an agent stops to ask a person: the desk, the queue, the two kinds of request, `ask_operator` | `docs/ATTENTION.md`, then `domain/approval.rs` and `Runtime::park` |
 | The crews' column, its badges, how a crew names itself, which crew the rail is inside | *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/presence.ts`, `src/components/GroupRail.tsx` and `src/components/OrbTag.tsx` |
@@ -455,6 +460,60 @@ the model takes a screenshot to see what `browse` did.
   the store was wrong and both are tested, which is how it shipped and stayed.
   A type with no path on it is the only version of "the path is not editable"
   that nothing downstream can forget.
+- **Every part of the bridge fails open, and that is the whole error
+  handling.** A bridge that could not bind, a `curl` that is not installed, a
+  Claude Code too old for the contract and a server that already dropped the job
+  all end the same way: an empty answer, exit zero, and a job that runs exactly
+  as it did before any of this existed. The direction cannot be reversed.
+  Everything the bridge adds is an improvement on a job that already worked, so
+  a bridge that refused to start a job would trade a working harness for a
+  feature built on top of it. The one place that fails *closed* is the gate's
+  verdict: a dropped sender answers deny, because a permission that granted
+  whenever the plumbing broke is worse than none.
+- **The `Stop` hook blocks and delivers in the same call, and that is what
+  makes it terminate.** A `Stop` hook's `reason` reaches the model as feedback
+  on the refusal to stop, so the pending mail goes out in the answer that
+  refuses. Blocking without delivering would find the same mail pending on the
+  next `Stop`, refuse again, and go round until the forty-five minute ceiling
+  killed a job that had finished its work. The same reason `take_mail` reads and
+  clears together: mail delivered twice is an instruction the model was given
+  twice.
+- **A `PreToolUse` hook's `deny` overrides `--permission-mode
+  bypassPermissions`, and every job here runs in that mode.** Measured against
+  2.1.247. Without it the gate would be a suggestion, and there would be no way
+  to have both a job that never stops for the ordinary tool call and a job that
+  stops before it pushes. No offline test can see this, or the two beside it
+  (`Stop`'s `reason`, `PostToolUse`'s `additionalContext`): all three are
+  promises about how the program *behaves* rather than flags it accepts, which
+  is what the `#[ignore]`d half of `tests/coding.rs` is for.
+- **A job's session id is chosen rather than read back.** `--session-id` takes a
+  UUID, so one value is the job's address on the bridge, the key of its mailbox,
+  and what an operator hands to `claude --resume`. That last one is the reason:
+  `claude -c` resumes whatever ran last in the directory, which after two jobs is
+  the wrong one. Chosen also means a job killed at the ceiling, and one that died
+  before its first event, both still have one to hand over.
+- **A coding job is not a turn, so it must not move the agent's activity.**
+  `Runtime::park_with` is `park` with exactly that one difference. A parked turn
+  is an agent genuinely stopped mid-inference and the dot beside its name has to
+  say so; a job outlived the turn that started it by many minutes and its agent
+  may be idle or answering somebody else. Everything else about a request, the
+  row, the waker, the ten-minute window and the expiry, is shared rather than
+  copied, because a second copy is a second place for a request to be left
+  waiting on nobody.
+- **The gate is off unless the operator turned it on, and not for the reason it
+  looks like.** Not compatibility. `APPENDED_PROMPT` tells every job that nobody
+  will answer a question, and switching the gate on everywhere would make that
+  sentence false in every repository at once: a job that believes it while a
+  hook silently holds it is a job that reports a push it never made.
+- **A coding job inherits the operator's whole Claude Code setup on purpose,
+  and one thing in it can hold a job open.** No `--strict-mcp-config` and no
+  `--setting-sources`, which is the exact opposite of `llm/claude.rs` and right
+  for the opposite reason: a job works in the operator's own repository, where
+  their rules file and their servers are what make it good. Measured at 16 MCP
+  servers, 229 tools, 100 slash commands and 8 agents on one machine. The hazard
+  is theirs too: a `Stop` hook of their own answering `{"decision":"block"}`
+  holds a job against its own completion until the ceiling, in a loop nothing
+  here can see. `docs/CODING.md`.
 - **A harness is two functions, and the process around them is one.** What `pi`
   and Claude Code share is the shape of a job: one process, in one directory,
   whose stdout is JSON objects one per line, that ends. So the spawn, the read

--- a/docs/CODING.md
+++ b/docs/CODING.md
@@ -183,6 +183,161 @@ Where the work lands is not decided here. That is already the brief's to say,
 and a standing rule that overrode it would be a second answer to a question that
 has one. What the footing settles is only where the work starts.
 
+## A job can be reached while it runs, on one of the two
+
+`code` returns the moment the process is up. That is the whole shape of the
+feature and it is right: awaited inside the tool call, the agent reads as
+`Thinking` for the length of a change to a codebase.
+
+The cost used to be paid at the other end. For up to forty-five minutes a job
+was write-only: Guaca read its stdout and could say nothing back. An operator
+watching one go the wrong way at minute three had one move, which was to wait
+thirty-seven more minutes and start another. There was also no way to end one.
+Stopping the conversation that started it does nothing, because that run settled
+minutes earlier and the job is not on it; the ceiling was the only thing that
+ever stopped a job going wrong.
+
+`coding/bridge.rs` is the second half. Claude Code has an interface besides its
+stdout: hooks run at fixed points in its own loop, are handed the event on
+stdin, and what they print back is acted on. Guaca writes a settings file and a
+three-line `sh` script per job, passes them with `--settings`, and answers the
+hook over a loopback socket. Three things follow from that.
+
+- **A mailbox.** `message_coding_job` stages a correction; the `PostToolUse`
+  hook delivers it as `additionalContext` at the job's next tool boundary.
+- **A gate**, when the repository asks for one. Below.
+- **Two ways to report**, on a small MCP server passed with `--mcp-config`:
+  `note_progress` and `report_pull_request`.
+
+`pi` has none of it and gets none of it. That is a difference between the
+harnesses rather than a gap, and it is why every part of the bridge fails open:
+a bridge that did not start, a `curl` that is not installed and a server that
+already dropped the job all end with an empty answer and an exit status of zero,
+which is the job that worked before any of this existed.
+
+### The three things it rests on are behavior, not flags
+
+None of them can be checked offline, which is why `tests/coding.rs` keeps an
+`#[ignore]`d half that asks the real program. Measured against 2.1.247:
+
+- A `PreToolUse` hook answering `permissionDecision: "deny"` **overrides
+  `--permission-mode bypassPermissions`**, which is the mode every job here runs
+  in. Without that the gate would be a suggestion.
+- A `Stop` hook's `reason` reaches the model, as a synthetic user message
+  reading `Stop hook feedback: …`. That is what lets the `Stop` hook block *and*
+  deliver in one call, which is what makes it terminate: a block that did not
+  deliver would refuse to stop forever and be killed at the ceiling.
+- `additionalContext` from `PostToolUse` is put in front of the model before its
+  next round.
+
+### The mailbox is delivered once, from either end
+
+`take_mail` reads and clears together. Delivered twice is an instruction the
+model was given twice, and a job handed the same correction on four tool calls
+does the thing four times. The `Stop` hook is the other end and exists for one
+case: a correction typed at minute forty-four, which without it lands after the
+job has decided it is done.
+
+### Stopping leaves what it committed
+
+The process is killed where it stands. Nothing is reverted, because the commits
+a job is told to make as it goes are the operator's checkpoints and throwing
+them away is not that button's decision. The agent that started the job is told,
+on the same path a finished one takes and for the same reason: an agent never
+told waits forever, and answers "I started that and have not heard back", which
+is true and useless. What it is told is that the work is *partly* done and
+nobody has checked which part, because an agent told only that the job stopped
+reports the work as not done and leaves the operator to discover half of it on a
+branch.
+
+### The session id is chosen, not read back
+
+`--session-id` takes a UUID, so Guaca picks one before the job starts. One value
+is then the job's address on the bridge, the key of its mailbox, and what an
+operator hands to `claude --resume` to open the same work in their own terminal.
+That last one is the reason: `claude -c` resumes whatever ran last in the
+directory, which after two jobs is the wrong one. Chosen rather than parsed also
+means a job killed at the ceiling, and a job that died before its first event,
+both still have one.
+
+### A program too old for it still runs the job
+
+`coding::presence` reads `--version` and decides whether to wire a bridge at
+all. Below the floor the job runs exactly as every job ran before the bridge
+existed. The other direction was never on the table: refusing to run would take
+away a harness that works, to protect a feature that is an addition to it. An
+unreadable version string is treated as too old for the same reason, since the
+alternative is wiring a job to a contract nothing has ever checked.
+
+## The gate is a decision the operator takes per repository
+
+`repositories.gate`, added by migration 42, default `'open'`, which is what
+every job did before this existed.
+
+Off by default is not caution about the migration. `APPENDED_PROMPT` tells every
+job that it is running unattended and that nobody will answer a question.
+Switching this on for everybody would make that sentence false in every
+repository at once, and a job that believes it while a hook silently holds it is
+a job that reports a push it never made. An operator turning it on is an
+operator saying they will be there.
+
+What it gates is the handful of things that leave the work tree under the
+operator's own name and cannot be taken back by git: a push, a pull request, a
+merge, a release. `bridge::outward` reads the shell line, and it errs toward
+asking, because a wrong yes costs one card on the desk and a wrong no is the
+behavior the operator switched it on to stop.
+
+It parks as `ProtectedAction::ActOnBehalf` rather than as a new variant, because
+that is what that one already means. It also means the standing grant means what
+it says: an operator who has told this agent it may act on their behalf is not
+asked again per push.
+
+`Runtime::park_with` is `park` with one difference, and it is one thing: whether
+the agent's own activity is this request's to move. A parked turn is an agent
+genuinely stopped mid-inference and the dot beside its name has to say so. A
+coding job is not a turn: it outlived the one that started it by many minutes,
+and the agent that owns it may be idle or answering somebody else. Marking it
+`AwaitingApproval` would put a false state on a working agent. Everything else,
+the row, the waker, the window and the expiry, is shared, because a second copy
+of those is a second place for a request to be left waiting on nobody.
+
+The job's requests are filed against a run of its own, minted in `start_job`.
+That is what makes `release_parked` the way a job ending closes whatever it was
+waiting on, rather than a second sweep written for this.
+
+**It is not a boundary and must never be described as one.** A shell line is not
+something anything can parse without a shell, and a job that wanted to get
+around this could. The process runs as the operator, with their credentials and
+their network, which was true before the gate existed. What it buys is that the
+ordinary push, made by a job doing what it was asked, is one somebody sees
+first.
+
+## A job inherits the operator's own Claude Code setup, and that is deliberate
+
+`coding/claude_code.rs` passes no `--strict-mcp-config` and no
+`--setting-sources`, which is the exact opposite of `llm/claude.rs`, and the two
+are right for opposite reasons. A turn there is answered by a program that
+should have this app's tools and nothing else. A job here is a coding agent
+working in the operator's own repository, where their `CLAUDE.md`, their project
+settings and their MCP servers are the thing that makes it good at the work.
+`--settings` and `--mcp-config` are both additive, so the bridge adds to that
+setup rather than replacing it.
+
+The cost is real and worth writing down. Measured on one machine on 2026-08-27
+against 2.1.247, a job started this way loaded 16 MCP servers, 229 tools, 100
+slash commands and 8 agent definitions, none of which Guaca chose. That is the
+operator's own configuration doing what they set it up to do, in their own
+repository, and it is not a defect. It does mean a job can reach whatever they
+have connected.
+
+**The one hazard is a blocking `Stop` hook.** The operator's own hooks run in a
+job here, and a `Stop` hook of theirs that answers `{"decision": "block"}` will
+hold a Guaca job against its own completion in a loop nothing in `coding/mod.rs`
+can see, until the forty-five minute ceiling. Guaca cannot fix that from
+outside, and it is not hypothetical: it is the mechanism Warp's own
+`oz-harness-support` plugin uses, and any harness-integration plugin an operator
+has installed may do the same. The ceiling is the backstop.
+
 ## A failed turn is not a job with nothing to do
 
 Both programs report a failed turn *inside* their stream and can still exit zero

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -437,6 +437,8 @@ pub fn run() {
             commands::update_repository,
             commands::delete_repository,
             commands::coding_harnesses,
+            commands::message_coding_job,
+            commands::stop_coding_job,
             commands::set_agent_repository,
             commands::plugin_catalog,
             commands::group_plugins,

--- a/src-tauri/src/coding/bridge.rs
+++ b/src-tauri/src/coding/bridge.rs
@@ -1,0 +1,1486 @@
+//! Guaca's end of a running coding job.
+//!
+//! A job is a process that runs for up to [`super::CEILING`] in a directory the
+//! operator linked, and until this module existed it was write-only. Guaca read
+//! its stdout and could say nothing back. An operator watching a job go the
+//! wrong way at minute three had one move, which was to wait thirty-seven more
+//! minutes for it to finish and then start another one.
+//!
+//! Claude Code has a second interface besides its stdout, and this is it. Hooks
+//! run at fixed points in the job's own loop, are handed the event on stdin, and
+//! what they print back is *acted on*: a `PostToolUse` hook can put words in
+//! front of the model, a `Stop` hook can refuse to let the run finish, and a
+//! `PreToolUse` hook can deny a tool call that the run's permission mode would
+//! otherwise have allowed. That last one is not a guess. Measured against
+//! 2.1.247, a `permissionDecision` of `deny` overrides `--permission-mode
+//! bypassPermissions`, which is the mode every job here runs in.
+//!
+//! So the job gets three things it did not have:
+//!
+//! - **A mailbox.** The operator can redirect a job that is already running,
+//!   and the correction arrives at the next tool boundary rather than at the
+//!   end. [`Bridge::post`] stages it; the `PostToolUse` and `Stop` hooks deliver
+//!   it.
+//! - **A gate.** A push, a merge or a release is the operator's own name going
+//!   somewhere it cannot be taken back from, and those can now stop and ask.
+//!   [`Gate`] is what decides whether they do.
+//! - **Two ways to report.** An MCP server with `note_progress` and
+//!   `report_pull_request` on it, so what a job produced arrives as a value
+//!   rather than as a sentence in its closing paragraph that the agent which
+//!   asked has to parse.
+//!
+//! ## One server, two shapes of caller
+//!
+//! Everything above is one loopback HTTP server, bound on a port the OS picks,
+//! exactly as [`crate::artifact`] and [`crate::proxy`] are. Two routes:
+//! `POST /{token}/hook` carries a hook's stdin and answers with its stdout, and
+//! `POST /{token}/mcp` is JSON-RPC.
+//!
+//! The hook scripts are three lines of `sh` around `curl` for that reason. They
+//! parse nothing, decide nothing and hold no state, so there is no second
+//! implementation of any rule here in a language nothing type-checks. What they
+//! do have is one behavior worth stating: **they fail open**. A bridge that did
+//! not start, a `curl` that is not installed, a server that has already dropped
+//! the job all end the same way, with an empty answer and an exit status of
+//! zero, which is a job that runs exactly as it did before this file existed.
+//!
+//! ## The token is the session id, and it is the whole of the authorization
+//!
+//! Loopback with an unguessable path, which is the posture [`crate::proxy`]
+//! already takes. Anything else on this machine that can reach `127.0.0.1` can
+//! reach this server, and what it would need to do anything with it is a v4
+//! UUID that is never written down outside the job's own scratch directory and
+//! that stops working the moment the job ends.
+//!
+//! It is the session id because Guaca now *chooses* that rather than reading it
+//! back: `--session-id` takes a UUID, so one value is the job's name on the
+//! bridge, the key of its mailbox, and what an operator hands to `claude
+//! --resume` to open the same work in their own terminal.
+//!
+//! ## What this does not do
+//!
+//! It is not a sandbox and [`outward`] is not a security boundary. The gate
+//! reads a shell command and decides whether it looks like it reaches outside
+//! the repository, which is a judgment about the ordinary case: a model that
+//! wanted to get around it could, and the process was already running as the
+//! operator with their credentials and their network before any of this. What
+//! the gate buys is that the ordinary push, made by a job doing what it was
+//! asked, is one an operator gets to see first. `docs/CODING.md` says the same
+//! thing at more length, and neither should ever be softened into a claim about
+//! confinement.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::domain::repository::Gate;
+
+/// How long a hook may wait for Guaca to answer.
+///
+/// Only the gate ever waits, and what it waits on is `Runtime::park`, whose own
+/// window is ten minutes. Comfortably longer than that, so the timeout that
+/// fires is the one with a decision behind it: a `curl` that gave up first
+/// would fail open, which is a permission gate that grants when the operator is
+/// slow, and that is worse than not having one.
+const HOOK_TIMEOUT_SECS: u64 = 900;
+
+/// The most staged mail one job will hold.
+///
+/// An operator typing corrections faster than the job reaches a tool boundary
+/// is an operator changing their mind, and the newest of those is the one they
+/// mean. Past this the oldest is dropped, because a job handed twenty
+/// instructions at once follows none of them.
+const MAX_STAGED: usize = 8;
+
+/// The cap on one staged message.
+///
+/// It is injected in front of a model mid-run, so it is a correction rather
+/// than a brief. A whole new brief is a whole new job.
+const MAX_MESSAGE_LEN: usize = 2_000;
+
+/// The largest request body this server will read.
+///
+/// A `PostToolUse` payload carries the tool's own result, which for a `Read` of
+/// a large file is the file. Read and thrown away rather than refused: the
+/// answer does not depend on the body past its event name.
+const BODY_LIMIT: usize = 4 * 1024 * 1024;
+
+const HEAD_LIMIT: usize = 16 * 1024;
+
+/// What a running job says to the runtime that started it.
+///
+/// A channel rather than a callback, because the job's own task is already
+/// sitting there awaiting the process and can drain this beside it. Nothing
+/// here carries the agent or the repository: the task on the other end has
+/// both, and putting them on the wire would be two copies of one fact.
+#[derive(Debug)]
+pub enum Signal {
+    /// The job said something about its own progress, on purpose, through the
+    /// tool rather than in its narration.
+    Note(String),
+    /// It opened a pull request and said so.
+    PullRequest { url: String, branch: String },
+    /// It is about to do something outward-facing and the gate stopped it.
+    ///
+    /// The `reply` is what unblocks the hook, and it must always be sent:
+    /// dropping it answers `false`, which is a deny, which is the safe way for
+    /// a bug here to fail but not a way to leave it.
+    Permission { command: String, reply: oneshot::Sender<bool> },
+}
+
+/// What a job's end of the bridge adds to the harness command line.
+///
+/// A plain value rather than a method on [`Session`], so the argument vector
+/// stays a pure function of it and the offline suite can build one without
+/// binding a port. `coding/claude_code.rs` is the only reader.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Wiring {
+    /// The job's own name, chosen rather than read back. Also the bridge token
+    /// and what `claude --resume` takes.
+    pub session_id: String,
+    /// The settings file holding this job's hooks. Passed with `--settings`,
+    /// which is additive: the operator's own settings still load.
+    pub settings: PathBuf,
+    /// The MCP server config, inline. Passed without `--strict-mcp-config`, so
+    /// the operator's own servers still load too.
+    pub mcp_config: String,
+}
+
+/// One job, while it is running.
+struct Job {
+    signals: mpsc::Sender<Signal>,
+    gate: Gate,
+    /// Staged operator messages that have not reached the model yet.
+    mail: Mutex<Vec<String>>,
+}
+
+#[derive(Default)]
+struct Registry {
+    jobs: HashMap<String, Arc<Job>>,
+}
+
+/// The bridge itself: one server, and a registry of the jobs reachable through
+/// it.
+#[derive(Clone, Default)]
+pub struct Bridge {
+    inner: Arc<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    registry: Mutex<Registry>,
+    /// Bound on the first job that wants it and never again. A workspace whose
+    /// repositories all run `pi` never opens a socket at all.
+    port: tokio::sync::OnceCell<u16>,
+}
+
+impl Bridge {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Opens a job's end of the bridge.
+    ///
+    /// `None` when anything about it failed, and the caller runs the job
+    /// without it. That is the whole of the error handling and it is
+    /// deliberate: everything here is an improvement on a job that worked
+    /// without any of it, so a bridge that cannot start must degrade to the
+    /// job that worked, not to no job at all.
+    pub async fn open(&self, signals: mpsc::Sender<Signal>, gate: Gate) -> Option<Session> {
+        let port = *self.inner.port.get_or_try_init(|| listen(self.clone())).await.ok()?;
+
+        let token = uuid::Uuid::new_v4().to_string();
+        let dir = scratch(&token)?;
+        let settings = dir.join("settings.json");
+        let script = dir.join("hook.sh");
+
+        write_script(&script, port, &token)?;
+        write_settings(&settings, &script, gate)?;
+
+        self.inner
+            .registry
+            .lock()
+            .jobs
+            .insert(token.clone(), Arc::new(Job { signals, gate, mail: Mutex::new(Vec::new()) }));
+
+        Some(Session {
+            bridge: self.clone(),
+            dir,
+            wiring: Wiring { mcp_config: mcp_config(port, &token), session_id: token, settings },
+        })
+    }
+
+    /// Stages a message for a running job.
+    ///
+    /// `false` when nothing on the bridge answers to that token, which is a job
+    /// that ended between the operator pressing the button and this call. Said
+    /// rather than swallowed: the alternative is a panel that accepts a
+    /// correction into a process that is not there to read it.
+    pub fn post(&self, session_id: &str, message: &str) -> bool {
+        let message = message.trim();
+        if message.is_empty() {
+            return false;
+        }
+        let mut cut: String = message.chars().take(MAX_MESSAGE_LEN).collect();
+        if cut.len() < message.len() {
+            cut.push('…');
+        }
+
+        let registry = self.inner.registry.lock();
+        let Some(job) = registry.jobs.get(session_id) else {
+            return false;
+        };
+        let mut mail = job.mail.lock();
+        mail.push(cut);
+        // The newest is the one the operator means. Dropping from the front
+        // keeps the order the rest of this file renders in.
+        while mail.len() > MAX_STAGED {
+            mail.remove(0);
+        }
+        true
+    }
+
+    /// Whether a job is holding mail nobody has read yet.
+    ///
+    /// Only the tests ask. The hooks read and clear in one step, because the
+    /// answer to "is there mail" is worthless a line later.
+    #[cfg(test)]
+    fn pending(&self, session_id: &str) -> usize {
+        let registry = self.inner.registry.lock();
+        registry.jobs.get(session_id).map(|job| job.mail.lock().len()).unwrap_or(0)
+    }
+
+    fn job(&self, token: &str) -> Option<Arc<Job>> {
+        self.inner.registry.lock().jobs.get(token).cloned()
+    }
+
+    fn close(&self, token: &str) {
+        self.inner.registry.lock().jobs.remove(token);
+    }
+}
+
+/// A job's end of the bridge, for as long as it is running.
+///
+/// Dropping it deregisters the job and takes its scratch directory with it, so
+/// the lifetime of the mailbox is the lifetime of this value and there is no
+/// second place to remember to clean up. A job that panicked, was killed at the
+/// ceiling or was stopped by the operator all unwind through the same drop.
+pub struct Session {
+    bridge: Bridge,
+    dir: PathBuf,
+    wiring: Wiring,
+}
+
+impl Session {
+    pub fn wiring(&self) -> &Wiring {
+        &self.wiring
+    }
+
+    /// The job's own id, which is also what `claude --resume` takes.
+    pub fn session_id(&self) -> &str {
+        &self.wiring.session_id
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        self.bridge.close(&self.wiring.session_id);
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+// ---- what the job is started with ----------------------------------------
+
+/// A directory only this user can read, holding one job's hooks.
+///
+/// The hook script has the bridge token in it, which is the whole of the
+/// authorization, so the mode is not decoration. `None` on any failure, which
+/// [`Bridge::open`] turns into a job that runs without a bridge.
+fn scratch(token: &str) -> Option<PathBuf> {
+    let dir = std::env::temp_dir().join(format!("guaca-job-{token}"));
+    std::fs::create_dir_all(&dir).ok()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).ok()?;
+    }
+    Some(dir)
+}
+
+/// The one hook script, which every hook runs.
+///
+/// It knows nothing about which event it is handling. The payload names its own
+/// event, so the branch is on this side, in Rust, where the rules already are:
+/// a script that decided anything would be a second implementation of them in a
+/// language nothing type-checks.
+///
+/// `--fail-with-body` is deliberately absent. This must not distinguish a
+/// server that refused from a server that is not there, because both mean the
+/// same thing to a job: carry on. Everything is discarded to make sure of it,
+/// and the `exit 0` is unconditional for the same reason.
+fn write_script(at: &Path, port: u16, token: &str) -> Option<()> {
+    let script = format!(
+        "#!/bin/sh\n\
+         # Guaca's end of this coding job. Reads the hook payload on stdin, hands\n\
+         # it to the app, prints back whatever the app answered with.\n\
+         #\n\
+         # Fails open on purpose: no curl, no bridge, or no answer all leave the\n\
+         # job running exactly as it would without any of this.\n\
+         curl --silent --show-error --max-time {HOOK_TIMEOUT_SECS} \\\n\
+         \x20 --header 'content-type: application/json' \\\n\
+         \x20 --data-binary @- \\\n\
+         \x20 'http://127.0.0.1:{port}/{token}/hook' 2>/dev/null\n\
+         exit 0\n"
+    );
+    let mut file = std::fs::File::create(at).ok()?;
+    file.write_all(script.as_bytes()).ok()?;
+    drop(file);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(at, std::fs::Permissions::from_mode(0o700)).ok()?;
+    }
+    Some(())
+}
+
+/// The settings file this job is started with, holding its hooks and nothing
+/// else.
+///
+/// Three events, and each is here for something a job could not do without it.
+///
+/// - **`PostToolUse`** is the mailbox's ordinary delivery. It is the only point
+///   in a job's loop that comes round often enough to be worth waiting for and
+///   is safe to interrupt: the model has just finished one thing and has not
+///   started the next.
+/// - **`Stop`** is the mailbox's other end. Without it a correction typed at
+///   minute forty-four lands after the job has decided it is done, which is a
+///   message the operator watched being delivered to nobody.
+/// - **`PreToolUse`** is the gate, and it is registered only when there is one.
+///   A matcher of `Bash` rather than `*`: everything that reaches outside the
+///   repository goes through a shell, and a hook on every `Read` would be a
+///   round trip per tool call for a question whose answer is always yes.
+fn write_settings(at: &Path, script: &Path, gate: Gate) -> Option<()> {
+    let script = script.to_str()?;
+    let run = serde_json::json!([{ "type": "command", "command": script }]);
+
+    let mut hooks = serde_json::json!({
+        "PostToolUse": [{ "matcher": "*", "hooks": run }],
+        "Stop": [{ "hooks": run }],
+    });
+    if gate == Gate::AskBeforePushing {
+        hooks["PreToolUse"] = serde_json::json!([{ "matcher": "Bash", "hooks": run }]);
+    }
+
+    let body = serde_json::json!({ "hooks": hooks }).to_string();
+    std::fs::write(at, body).ok()
+}
+
+/// The job's own MCP server, named so its tools read as Guaca's.
+///
+/// Claude Code prefixes a server's tools with its name, so these arrive as
+/// `mcp__guaca__note_progress`. Passed *without* `--strict-mcp-config`, which
+/// is what keeps the operator's own servers loaded: this adds one, it does not
+/// replace theirs.
+fn mcp_config(port: u16, token: &str) -> String {
+    serde_json::json!({
+        "mcpServers": {
+            "guaca": { "type": "http", "url": format!("http://127.0.0.1:{port}/{token}/mcp") }
+        }
+    })
+    .to_string()
+}
+
+// ---- the server ----------------------------------------------------------
+
+async fn listen(bridge: Bridge) -> std::io::Result<u16> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let port = listener.local_addr()?.port();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((client, _)) = listener.accept().await else {
+                continue;
+            };
+            let bridge = bridge.clone();
+            tokio::spawn(async move {
+                if let Err(err) = serve(client, bridge).await {
+                    tracing::debug!(%err, "coding bridge connection ended");
+                }
+            });
+        }
+    });
+
+    tracing::info!(port, "coding bridge listening");
+    Ok(port)
+}
+
+/// What a request asked for, once the path has been believed as little as
+/// possible.
+#[derive(Debug, PartialEq)]
+struct Asked {
+    token: String,
+    route: Route,
+}
+
+#[derive(Debug, PartialEq)]
+enum Route {
+    Hook,
+    Mcp,
+}
+
+/// The token and route a request line names, if it names a pair this serves.
+///
+/// The token is checked for shape here rather than trusted, because it goes on
+/// to be a map key: `/{uuid}/{hook|mcp}` and nothing else. A UUID is 36
+/// characters of hex and dashes, and anything that is not one cannot be a job
+/// whatever the map says.
+fn asked(head: &[u8]) -> Option<Asked> {
+    let text = String::from_utf8_lossy(head);
+    let mut start = text.split("\r\n").next()?.split(' ');
+    if start.next()? != "POST" {
+        return None;
+    }
+    let path = start.next()?.split('?').next()?;
+    let mut parts = path.strip_prefix('/')?.split('/');
+    let token = parts.next()?;
+    let route = match parts.next()? {
+        "hook" => Route::Hook,
+        "mcp" => Route::Mcp,
+        _ => return None,
+    };
+    if parts.next().is_some() {
+        return None;
+    }
+    let shaped =
+        token.len() == 36 && token.bytes().all(|byte| byte.is_ascii_hexdigit() || byte == b'-');
+    shaped.then(|| Asked { token: token.to_string(), route })
+}
+
+async fn serve(mut client: TcpStream, bridge: Bridge) -> std::io::Result<()> {
+    let (head, body) = read_request(&mut client).await?;
+
+    let Some(Asked { token, route }) = asked(&head) else {
+        return answer(&mut client, "404 Not Found", "").await;
+    };
+    // A job that has ended is not an error worth a status of its own. The hook
+    // fails open on an empty body, and an MCP call arriving after the process
+    // it belongs to is gone has nobody to tell.
+    let Some(job) = bridge.job(&token) else {
+        return answer(&mut client, "404 Not Found", "").await;
+    };
+
+    let payload = serde_json::from_slice::<serde_json::Value>(&body).unwrap_or_default();
+    match route {
+        Route::Hook => {
+            let said = hook(&job, &payload).await;
+            answer(&mut client, "200 OK", &said).await
+        }
+        Route::Mcp => match rpc(&job, &payload).await {
+            // A notification has no id and takes no answer, which is what the
+            // 202 says. Answering one with a body is a protocol error the
+            // client is entitled to complain about.
+            None => answer(&mut client, "202 Accepted", "").await,
+            Some(said) => answer(&mut client, "200 OK", &said.to_string()).await,
+        },
+    }
+}
+
+/// Reads a request, head and body.
+///
+/// The body is bounded and the excess is read and dropped rather than refused,
+/// because a `PostToolUse` payload carries whatever the tool returned and this
+/// answer does not depend on it. Refusing would turn a job that read a large
+/// file into a job whose next hook call failed.
+async fn read_request(client: &mut TcpStream) -> std::io::Result<(Vec<u8>, Vec<u8>)> {
+    let mut head = Vec::new();
+    let mut byte = [0u8; 1];
+    while !head.ends_with(b"\r\n\r\n") {
+        if head.len() > HEAD_LIMIT {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "request head too long",
+            ));
+        }
+        if client.read(&mut byte).await? == 0 {
+            return Ok((head, Vec::new()));
+        }
+        head.push(byte[0]);
+    }
+
+    let text = String::from_utf8_lossy(&head).to_ascii_lowercase();
+    let length: usize = text
+        .split("\r\n")
+        .find_map(|line| line.strip_prefix("content-length:"))
+        .and_then(|value| value.trim().parse().ok())
+        .unwrap_or(0);
+
+    let mut body = vec![0u8; length.min(BODY_LIMIT)];
+    client.read_exact(&mut body).await?;
+    if length > BODY_LIMIT {
+        let mut rest = client.take((length - BODY_LIMIT) as u64);
+        let mut sink = Vec::new();
+        let _ = rest.read_to_end(&mut sink).await;
+    }
+    Ok((head, body))
+}
+
+async fn answer(client: &mut TcpStream, status: &str, body: &str) -> std::io::Result<()> {
+    let head = format!(
+        "HTTP/1.1 {status}\r\n\
+         content-type: application/json\r\n\
+         cache-control: no-store\r\n\
+         content-length: {}\r\n\
+         connection: close\r\n\r\n",
+        body.len()
+    );
+    client.write_all(head.as_bytes()).await?;
+    client.write_all(body.as_bytes()).await
+}
+
+// ---- hooks ---------------------------------------------------------------
+
+/// What Guaca answers one hook call with.
+///
+/// The empty string everywhere there is nothing to say, which is the common
+/// case and the one measured to be safe: a hook that prints nothing is recorded
+/// by the program as a success with no output and changes nothing about the
+/// run.
+async fn hook(job: &Job, payload: &serde_json::Value) -> String {
+    match payload["hook_event_name"].as_str().unwrap_or_default() {
+        // The ordinary delivery. `additionalContext` is put in front of the
+        // model before its next round, which is exactly where a correction is
+        // worth arriving.
+        "PostToolUse" => match take_mail(job) {
+            None => String::new(),
+            Some(mail) => serde_json::json!({
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "additionalContext": mail,
+                }
+            })
+            .to_string(),
+        },
+
+        // The other end of the mailbox, and the reason it cannot loop. `reason`
+        // reaches the model as feedback on the refusal to stop, so this both
+        // blocks *and* delivers: the mail is taken in the same call that
+        // refuses, so a second `Stop` finds nothing pending and lets the run
+        // end. A version that blocked without delivering would refuse forever
+        // and be killed at the ceiling.
+        "Stop" => match take_mail(job) {
+            None => String::new(),
+            Some(mail) => serde_json::json!({ "decision": "block", "reason": mail }).to_string(),
+        },
+
+        "PreToolUse" => gate(job, payload).await,
+
+        _ => String::new(),
+    }
+}
+
+/// Everything staged for this job, rendered once and taken in the same breath.
+///
+/// Read and clear together, because a read that left the mail behind would
+/// deliver it again on the next tool call, and an instruction a model is given
+/// four times is one it was told four times.
+fn take_mail(job: &Job) -> Option<String> {
+    let staged: Vec<String> = std::mem::take(&mut *job.mail.lock());
+    if staged.is_empty() {
+        return None;
+    }
+    let mut said = String::from(
+        "The operator sent this while you were working. It is more recent than your \
+         brief, so where the two disagree this wins:\n",
+    );
+    for message in &staged {
+        said.push_str("\n- ");
+        said.push_str(message);
+    }
+    Some(said)
+}
+
+/// The gate: whether this tool call goes to the operator first.
+///
+/// Everything that is not an outward-facing shell command answers with nothing
+/// at all, which leaves the run's own permission mode to decide, which is the
+/// mode that allows it. Only a `deny` is ever written here. There is no `allow`
+/// branch and there must not be one: a hook that answered `allow` would be
+/// granting things the operator's own settings might have had an opinion about,
+/// and this file has no business overriding those in that direction.
+async fn gate(job: &Job, payload: &serde_json::Value) -> String {
+    if job.gate != Gate::AskBeforePushing {
+        return String::new();
+    }
+    let command = payload["tool_input"]["command"].as_str().unwrap_or_default();
+    let Some(what) = outward(command) else {
+        return String::new();
+    };
+
+    let (reply, verdict) = oneshot::channel();
+    if job.signals.send(Signal::Permission { command: what, reply }).await.is_err() {
+        // Nothing is listening, which means the job's own task has gone. Say
+        // nothing and let the run decide: this is the one place a refusal would
+        // be about Guaca's plumbing rather than about the operator's answer.
+        return String::new();
+    }
+
+    // A dropped sender answers `false`. That is a deny, which is the direction
+    // a bug here should fail in, and it is why the runtime's side must always
+    // send rather than return early.
+    if verdict.await.unwrap_or(false) {
+        return String::new();
+    }
+
+    serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason":
+                "The operator did not allow this. Do not try it again or work around it: \
+                 finish everything else you can, leave the work committed on the branch, \
+                 and say in your final message that this step is waiting on them.",
+        }
+    })
+    .to_string()
+}
+
+/// What an outward-facing command in this line is, if there is one.
+///
+/// Outward-facing means it leaves the work tree under the operator's own name
+/// and cannot be taken back by git: a push, a pull request, a merge, a release.
+/// Everything else, including every edit and every test run, is what the
+/// directory and git already cover.
+///
+/// This is a judgment about the ordinary case and not a boundary. A shell line
+/// is not something anything can parse without a shell, and a job that wanted
+/// to get around this could: the process runs as the operator with their
+/// credentials either way, which was true before this existed and is stated at
+/// the top of this file and in `docs/CODING.md`. What it buys is that the
+/// ordinary push, made by a job doing what it was asked, is one the operator
+/// sees first.
+///
+/// It errs toward asking. A wrong yes costs one prompt on the desk; a wrong no
+/// is the behavior the operator switched this on to stop.
+pub fn outward(line: &str) -> Option<String> {
+    for segment in segments(line) {
+        let words = words(&segment);
+        let mut rest = words.iter().map(String::as_str);
+        // A wrapper is how the same command arrives wearing a hat. A leading
+        // environment assignment, `sudo`, and a shell handed the whole line as
+        // one `-c` argument are the three that turn up in practice, and none of
+        // them changes what actually runs. Flags are skipped with them, which
+        // is what takes the `-c` off in the third case.
+        let program = loop {
+            let word = rest.next()?;
+            let bare = word.rsplit('/').next().unwrap_or(word);
+            if WRAPPERS.contains(&bare) || bare.starts_with('-') || word.contains('=') {
+                continue;
+            }
+            break bare;
+        };
+        let args: Vec<&str> = rest.collect();
+
+        let verb = match program {
+            "git" => git_subcommand(&args),
+            "gh" | "glab" => hosted_subcommand(&args),
+            _ => None,
+        };
+        if let Some(verb) = verb {
+            return Some(format!("{program} {verb}"));
+        }
+    }
+    None
+}
+
+/// Programs that run another program, and are therefore not the answer.
+///
+/// A shell is on the list because `sh -c "git push"` reaches the network
+/// exactly as `git push` does, and the words are the same words once the quotes
+/// come off.
+const WRAPPERS: [&str; 10] =
+    ["sudo", "command", "env", "nohup", "time", "xargs", "sh", "bash", "zsh", "dash"];
+
+/// Splits a shell line into the commands it runs.
+///
+/// Crude on purpose. It splits on the separators that start a new command and
+/// keeps quoting out of it, because the thing being looked for is a program
+/// name and a subcommand, and no amount of shell grammar here would make this a
+/// boundary. See [`outward`].
+fn segments(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut chars = line.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            ';' | '\n' | '&' | '|' => {
+                // `&&` and `||` collapse into the one separator they are.
+                if chars.peek() == Some(&ch) {
+                    chars.next();
+                }
+                out.push(std::mem::take(&mut current));
+            }
+            '(' | ')' | '{' | '}' => out.push(std::mem::take(&mut current)),
+            _ => current.push(ch),
+        }
+    }
+    out.push(current);
+    out
+}
+
+/// One segment's words, with the quotes taken off.
+///
+/// `sh -c "git push"` is the case this exists for: the inner line arrives as one
+/// quoted word, so stripping the quotes and splitting again is what finds the
+/// program inside it.
+fn words(segment: &str) -> Vec<String> {
+    segment
+        .split_whitespace()
+        .map(|word| word.trim_matches(['"', '\'', '`']).to_string())
+        .filter(|word| !word.is_empty())
+        .collect()
+}
+
+/// Git's subcommand, if it is one that leaves the machine.
+///
+/// The walk over global options is what makes `git -C /repo push` and `git push`
+/// the same answer. Reading "any argument equal to `push`" instead would call
+/// `git log --grep push` an outward-facing command, which is the kind of wrong
+/// no that teaches an operator to switch the gate off.
+fn git_subcommand(args: &[&str]) -> Option<String> {
+    let mut rest = args.iter();
+    while let Some(arg) = rest.next() {
+        match *arg {
+            // Global options that take a value, so the value is not the
+            // subcommand.
+            "-C" | "-c" | "--git-dir" | "--work-tree" | "--namespace" | "--exec-path" => {
+                rest.next();
+            }
+            other if other.starts_with('-') => {}
+            "push" => return Some("push".to_string()),
+            _ => return None,
+        }
+    }
+    None
+}
+
+/// A forge CLI's topic and verb, if the pair reaches outside the repository.
+///
+/// Named rather than pattern-matched. `gh pr view` and `gh pr create` differ by
+/// one word and by everything else, and a rule about the topic alone would park
+/// a job for reading its own pull request.
+fn hosted_subcommand(args: &[&str]) -> Option<String> {
+    let plain: Vec<&str> = args.iter().copied().filter(|arg| !arg.starts_with('-')).collect();
+    let topic = plain.first()?;
+    let verb = plain.get(1).copied().unwrap_or_default();
+
+    let reaches = match *topic {
+        "pr" | "mr" => matches!(
+            verb,
+            "create" | "merge" | "close" | "reopen" | "comment" | "edit" | "ready" | "review"
+        ),
+        "release" => matches!(verb, "create" | "edit" | "delete" | "upload"),
+        "issue" => matches!(verb, "create" | "close" | "reopen" | "comment" | "edit" | "delete"),
+        "repo" => matches!(verb, "create" | "delete" | "edit" | "fork" | "sync"),
+        "workflow" | "run" => matches!(verb, "run" | "dispatch" | "cancel" | "rerun"),
+        // `gh api` is every one of the above with the topic taken off, so it is
+        // read by its method instead. A GET is a read and is left alone.
+        "api" => args.iter().any(|arg| {
+            matches!(*arg, "POST" | "PATCH" | "PUT" | "DELETE")
+                || matches!(*arg, "-f" | "--field" | "-F" | "--raw-field")
+        }),
+        _ => false,
+    };
+
+    reaches.then(|| match *topic {
+        "api" => "api".to_string(),
+        _ => format!("{topic} {verb}").trim().to_string(),
+    })
+}
+
+// ---- the job's own MCP server --------------------------------------------
+
+/// What a job may tell Guaca, deliberately, rather than in its narration.
+///
+/// Two, and there is not a third. In particular there is no way to ask the
+/// operator a question: [`super::APPENDED_PROMPT`] tells a job that nobody will
+/// answer one, and a tool that contradicted it would invite a run to spend ten
+/// of its forty-five minutes waiting on somebody who is not there. Where a
+/// human genuinely has to be asked, it is Guaca that decides, in [`gate`], about
+/// something it can name.
+fn tools() -> serde_json::Value {
+    serde_json::json!([
+        {
+            "name": "note_progress",
+            "description":
+                "Tell the operator watching this job what you are doing. Use it when you \
+                 have finished something that stands on its own, or when you are about to \
+                 start something long, so somebody reading over your shoulder knows where \
+                 you are. One sentence. It reaches a person, not a model, and it is not a \
+                 substitute for your final message.",
+            "inputSchema": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["note"],
+                "properties": {
+                    "note": { "type": "string", "description": "One sentence, in plain words." }
+                },
+            },
+        },
+        {
+            "name": "report_pull_request",
+            "description":
+                "Report a pull request you opened. Call this straight after opening one. \
+                 Guaca records the link against this job, so the agent that asked for the \
+                 work and the operator both get it as a link rather than having to find it \
+                 in your closing paragraph.",
+            "inputSchema": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["url", "branch"],
+                "properties": {
+                    "url": { "type": "string", "description": "The full URL of the pull request." },
+                    "branch": { "type": "string", "description": "The branch it was opened from." },
+                },
+            },
+        },
+    ])
+}
+
+/// Answers one JSON-RPC request, or `None` for a notification.
+///
+/// Both protocol eras are answered, because which one is used is the client's
+/// choice and not this server's. Measured against 2.1.247 the program probes
+/// `server/discover` and then falls back to `initialize` anyway, so the
+/// handshake is the path that actually runs today; `server/discover` is here so
+/// that stops being true without this becoming a server nothing can talk to.
+/// `crate::mcp` is the other end of the same two eras, from the client side.
+async fn rpc(job: &Job, request: &serde_json::Value) -> Option<serde_json::Value> {
+    let id = request.get("id").cloned()?;
+    let method = request["method"].as_str().unwrap_or_default();
+
+    let result = match method {
+        "initialize" => {
+            let asked =
+                request["params"]["protocolVersion"].as_str().unwrap_or(crate::mcp::LEGACY_VERSION);
+            serde_json::json!({
+                "protocolVersion": asked,
+                "capabilities": { "tools": {} },
+                "serverInfo": { "name": "guaca", "version": env!("CARGO_PKG_VERSION") },
+            })
+        }
+        "server/discover" => serde_json::json!({
+            "protocolVersion": crate::mcp::PROTOCOL_VERSION,
+            "capabilities": { "tools": {} },
+            "serverInfo": { "name": "guaca", "version": env!("CARGO_PKG_VERSION") },
+        }),
+        "tools/list" => serde_json::json!({ "tools": tools() }),
+        "tools/call" => {
+            let name = request["params"]["name"].as_str().unwrap_or_default();
+            let args = &request["params"]["arguments"];
+            match call(job, name, args).await {
+                Ok(said) => serde_json::json!({ "content": [{ "type": "text", "text": said }] }),
+                // A tool failure is reported inside the result rather than as a
+                // JSON-RPC error, which is what the protocol says and what lets
+                // the model read it and act on it instead of seeing a transport
+                // fault.
+                Err(why) => serde_json::json!({
+                    "content": [{ "type": "text", "text": why }],
+                    "isError": true,
+                }),
+            }
+        }
+        _ => {
+            return Some(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": { "code": -32601, "message": format!("no method {method}") },
+            }))
+        }
+    };
+
+    Some(serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": result }))
+}
+
+/// Runs one of the two tools.
+///
+/// Every refusal says what to do about it, because a coding harness reads this
+/// mid-run and a refusal that only says no gets reworded and retried.
+async fn call(job: &Job, name: &str, args: &serde_json::Value) -> Result<String, String> {
+    let signal = match name {
+        "note_progress" => {
+            let note = args["note"].as_str().unwrap_or_default().trim();
+            if note.is_empty() {
+                return Err("A progress note needs a sentence in `note`. Say what you \
+                            just finished or what you are starting."
+                    .to_string());
+            }
+            Signal::Note(super::one_line(note))
+        }
+        "report_pull_request" => {
+            let url = args["url"].as_str().unwrap_or_default().trim();
+            let branch = args["branch"].as_str().unwrap_or_default().trim();
+            if !url.starts_with("https://") {
+                return Err("A pull request is reported by its full URL, starting with \
+                            `https://`. Pass the link the forge printed when you opened it."
+                    .to_string());
+            }
+            if branch.is_empty() {
+                return Err("`branch` is the branch the pull request was opened from. \
+                            `git branch --show-current` is it."
+                    .to_string());
+            }
+            Signal::PullRequest { url: super::one_line(url), branch: super::one_line(branch) }
+        }
+        _ => {
+            return Err(format!(
+                "Guaca offers `note_progress` and `report_pull_request` and nothing else. \
+                 `{name}` is not one of them."
+            ))
+        }
+    };
+
+    match job.signals.send(signal).await {
+        Ok(()) => Ok("Noted.".to_string()),
+        // The job's own task is gone, which from in here means the run is being
+        // torn down. Said plainly rather than as a success, so a harness that
+        // is still going does not report a link nobody received.
+        Err(_) => Err("Guaca is no longer listening to this job, so that was not \
+                       recorded. Put it in your final message instead."
+            .to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn a_job(gate: Gate) -> (Arc<Job>, mpsc::Receiver<Signal>) {
+        let (signals, heard) = mpsc::channel(8);
+        (Arc::new(Job { signals, gate, mail: Mutex::new(Vec::new()) }), heard)
+    }
+
+    // ---- what a job is started with --------------------------------------
+
+    #[test]
+    fn the_gate_is_the_only_hook_that_is_conditional() {
+        // The mailbox is why this exists at all, so its two hooks are on every
+        // job. The gate costs a round trip per shell command and is off unless
+        // the operator asked for it.
+        let dir = std::env::temp_dir().join(format!("guaca-settings-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let at = dir.join("settings.json");
+
+        write_settings(&at, Path::new("/tmp/hook.sh"), Gate::Open).unwrap();
+        let open: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&at).unwrap()).unwrap();
+        assert!(open["hooks"]["PostToolUse"].is_array());
+        assert!(open["hooks"]["Stop"].is_array());
+        assert!(open["hooks"]["PreToolUse"].is_null(), "no gate, no cost");
+
+        write_settings(&at, Path::new("/tmp/hook.sh"), Gate::AskBeforePushing).unwrap();
+        let asked: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&at).unwrap()).unwrap();
+        // `Bash` rather than `*`: everything outward-facing goes through a
+        // shell, and a hook on every `Read` is a round trip whose answer is
+        // always yes.
+        assert_eq!(asked["hooks"]["PreToolUse"][0]["matcher"], "Bash");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_hook_script_fails_open_and_carries_its_own_address() {
+        let dir = std::env::temp_dir().join(format!("guaca-script-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let at = dir.join("hook.sh");
+        write_script(&at, 4242, "abc").unwrap();
+        let script = std::fs::read_to_string(&at).unwrap();
+
+        assert!(script.contains("http://127.0.0.1:4242/abc/hook"));
+        // The whole of the failure handling. No curl, no bridge and no answer
+        // all have to leave the job running as it did before this existed.
+        assert!(script.contains("exit 0"), "{script}");
+        assert!(script.contains("2>/dev/null"), "{script}");
+        // Longer than the ten minutes a parked approval may take, or the gate
+        // grants whenever the operator is slow.
+        const { assert!(HOOK_TIMEOUT_SECS > 10 * 60) };
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_operators_own_servers_and_settings_are_added_to_and_not_replaced() {
+        // The one thing that makes a coding job different from a turn: it wants
+        // the operator's tools. `--strict-mcp-config` is what would take them
+        // away and it is deliberately not in the vector.
+        let config: serde_json::Value = serde_json::from_str(&mcp_config(1, "t")).unwrap();
+        assert_eq!(config["mcpServers"]["guaca"]["url"], "http://127.0.0.1:1/t/mcp");
+        assert_eq!(config["mcpServers"]["guaca"]["type"], "http");
+    }
+
+    // ---- addressing ------------------------------------------------------
+
+    #[test]
+    fn serves_only_a_uuid_shaped_token_on_one_of_two_routes() {
+        let id = "f96abc0a-5404-4e51-b465-b96677118cf9";
+        let line = |raw: &str| asked(format!("{raw} HTTP/1.1\r\n\r\n").as_bytes());
+
+        assert_eq!(
+            line(&format!("POST /{id}/hook")),
+            Some(Asked { token: id.to_string(), route: Route::Hook })
+        );
+        assert_eq!(line(&format!("POST /{id}/mcp")).map(|a| a.route), Some(Route::Mcp));
+        // A token goes on to be a map key, so its shape is checked here rather
+        // than trusted.
+        assert_eq!(line("POST /../../etc/passwd/hook"), None);
+        assert_eq!(line(&format!("POST /{id}/other")), None);
+        assert_eq!(line(&format!("POST /{id}/hook/again")), None);
+        assert_eq!(line(&format!("GET /{id}/hook")), None, "nothing here is a read");
+    }
+
+    // ---- the mailbox -----------------------------------------------------
+
+    #[tokio::test]
+    async fn a_message_reaches_the_model_at_the_next_tool_boundary() {
+        let (job, _heard) = a_job(Gate::Open);
+        job.mail.lock().push("stop and use the other endpoint".into());
+
+        let said = hook(&job, &serde_json::json!({ "hook_event_name": "PostToolUse" })).await;
+        let out: serde_json::Value = serde_json::from_str(&said).unwrap();
+        let context = out["hookSpecificOutput"]["additionalContext"].as_str().unwrap();
+        assert!(context.contains("stop and use the other endpoint"));
+        // A correction is more recent than the brief, and a model handed two
+        // instructions with nothing ordering them picks one.
+        assert!(context.contains("this wins"), "{context}");
+    }
+
+    #[tokio::test]
+    async fn mail_is_delivered_once_and_never_again() {
+        // Read and cleared together. Delivered twice is an instruction the
+        // model was given twice, which is how a job ends up doing something
+        // once for each time it was mentioned.
+        let (job, _heard) = a_job(Gate::Open);
+        job.mail.lock().push("use the staging bucket".into());
+
+        let first = hook(&job, &serde_json::json!({ "hook_event_name": "PostToolUse" })).await;
+        assert!(first.contains("staging bucket"));
+        let second = hook(&job, &serde_json::json!({ "hook_event_name": "PostToolUse" })).await;
+        assert_eq!(second, "", "nothing pending is nothing said");
+    }
+
+    #[tokio::test]
+    async fn a_job_about_to_finish_is_held_open_and_told_in_the_same_breath() {
+        // The case the `Stop` hook exists for: a correction typed at minute
+        // forty-four. Without this it lands after the job decided it was done.
+        let (job, _heard) = a_job(Gate::Open);
+        job.mail.lock().push("do not merge it yet".into());
+
+        let said = hook(&job, &serde_json::json!({ "hook_event_name": "Stop" })).await;
+        let out: serde_json::Value = serde_json::from_str(&said).unwrap();
+        assert_eq!(out["decision"], "block");
+        // Blocking and delivering in one call is what makes this terminate. A
+        // block that did not deliver would refuse to stop forever and be killed
+        // at the ceiling.
+        assert!(out["reason"].as_str().unwrap().contains("do not merge it yet"));
+
+        let again = hook(&job, &serde_json::json!({ "hook_event_name": "Stop" })).await;
+        assert_eq!(again, "", "a second stop finds nothing pending and lets the run end");
+    }
+
+    #[tokio::test]
+    async fn an_ordinary_tool_call_costs_nothing_to_say_nothing_about() {
+        let (job, _heard) = a_job(Gate::Open);
+        assert_eq!(hook(&job, &serde_json::json!({ "hook_event_name": "PostToolUse" })).await, "");
+        assert_eq!(hook(&job, &serde_json::json!({ "hook_event_name": "SessionStart" })).await, "");
+        assert_eq!(hook(&job, &serde_json::json!({})).await, "");
+    }
+
+    #[test]
+    fn the_newest_corrections_are_the_ones_kept() {
+        let bridge = Bridge::new();
+        let (signals, _heard) = mpsc::channel(8);
+        bridge.inner.registry.lock().jobs.insert(
+            "t".into(),
+            Arc::new(Job { signals, gate: Gate::Open, mail: Mutex::new(Vec::new()) }),
+        );
+
+        for n in 0..MAX_STAGED + 3 {
+            assert!(bridge.post("t", &format!("correction {n}")));
+        }
+        assert_eq!(bridge.pending("t"), MAX_STAGED);
+
+        // Blank is not a correction, and a job nobody is running cannot be sent
+        // one: both are the panel's to report rather than to swallow.
+        assert!(!bridge.post("t", "   "));
+        assert!(!bridge.post("nobody", "hello"));
+    }
+
+    #[test]
+    fn a_pasted_document_is_cut_rather_than_delivered_whole() {
+        let bridge = Bridge::new();
+        let (signals, _heard) = mpsc::channel(8);
+        bridge.inner.registry.lock().jobs.insert(
+            "t".into(),
+            Arc::new(Job { signals, gate: Gate::Open, mail: Mutex::new(Vec::new()) }),
+        );
+        assert!(bridge.post("t", &"x".repeat(MAX_MESSAGE_LEN * 2)));
+
+        let job = bridge.job("t").unwrap();
+        let held = job.mail.lock()[0].clone();
+        assert!(held.chars().count() <= MAX_MESSAGE_LEN + 1, "{}", held.chars().count());
+        assert!(held.ends_with('…'));
+    }
+
+    // ---- the gate --------------------------------------------------------
+
+    #[test]
+    fn a_push_is_outward_facing_however_it_is_spelled() {
+        for line in [
+            "git push",
+            "git push --force-with-lease origin HEAD",
+            "git -C /srv/app push",
+            "git -c user.name=bot push origin main",
+            "cd /repo && git push",
+            "npm test && git push origin feature",
+            "sh -c 'git push'",
+            "sudo git push",
+        ] {
+            assert!(outward(line).is_some(), "{line}");
+        }
+    }
+
+    #[test]
+    fn reading_is_never_outward_facing() {
+        // The wrong `no` here is a prompt on the desk. The wrong `yes` is a
+        // job parked for reading its own history, which is what teaches an
+        // operator to switch the gate off.
+        for line in [
+            "git status",
+            "git log --grep push",
+            "git commit -m 'push the button'",
+            "git fetch origin",
+            "git branch --show-current",
+            "gh pr view 12",
+            "gh pr list",
+            "gh api /repos/o/r",
+            "cargo test",
+            "echo git push",
+            "",
+        ] {
+            assert_eq!(outward(line), None, "{line}");
+        }
+    }
+
+    #[test]
+    fn opening_and_merging_reach_outside_and_looking_does_not() {
+        assert_eq!(outward("gh pr create --fill").as_deref(), Some("gh pr create"));
+        assert_eq!(outward("gh pr merge 12 --squash").as_deref(), Some("gh pr merge"));
+        assert_eq!(outward("gh release create v1.2.0").as_deref(), Some("gh release create"));
+        assert_eq!(outward("glab mr create").as_deref(), Some("glab mr create"));
+        // `gh api` is every one of those with the topic taken off, so it is
+        // read by its method instead.
+        assert!(outward("gh api -X POST /repos/o/r/issues").is_some());
+        assert!(outward("gh api --method DELETE /repos/o/r").is_some());
+        assert_eq!(outward("gh api /user"), None, "a read is a read");
+    }
+
+    #[tokio::test]
+    async fn nothing_stops_on_a_repository_the_operator_did_not_gate() {
+        let (job, mut heard) = a_job(Gate::Open);
+        let asked = serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": { "command": "git push" },
+        });
+        assert_eq!(hook(&job, &asked).await, "", "the default is what every job did before");
+        assert!(heard.try_recv().is_err(), "and it does not reach the desk either");
+    }
+
+    #[tokio::test]
+    async fn a_gated_push_waits_for_the_operator_and_a_no_is_a_deny() {
+        let (job, mut heard) = a_job(Gate::AskBeforePushing);
+        let asked = serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": { "command": "git push origin main" },
+        });
+
+        let answering = tokio::spawn(async move {
+            let Some(Signal::Permission { command, reply }) = heard.recv().await else {
+                panic!("the gate has to reach the desk");
+            };
+            assert_eq!(command, "git push");
+            reply.send(false).unwrap();
+        });
+
+        let said = hook(&job, &asked).await;
+        answering.await.unwrap();
+
+        let out: serde_json::Value = serde_json::from_str(&said).unwrap();
+        assert_eq!(out["hookSpecificOutput"]["permissionDecision"], "deny");
+        // A refusal an agent reads mid-run needs a way forward, not just a
+        // reason, or it gets reworded and retried.
+        let why = out["hookSpecificOutput"]["permissionDecisionReason"].as_str().unwrap();
+        assert!(why.contains("waiting on them"), "{why}");
+        assert!(why.contains("committed"), "{why}");
+    }
+
+    #[tokio::test]
+    async fn a_yes_says_nothing_and_lets_the_run_decide() {
+        // There is no `allow` branch and there must not be one: answering
+        // `allow` would override whatever the operator's own settings had to
+        // say, which this file has no business doing in that direction.
+        let (job, mut heard) = a_job(Gate::AskBeforePushing);
+        let answering = tokio::spawn(async move {
+            let Some(Signal::Permission { reply, .. }) = heard.recv().await else { panic!() };
+            reply.send(true).unwrap();
+        });
+        let said = hook(
+            &job,
+            &serde_json::json!({
+                "hook_event_name": "PreToolUse",
+                "tool_input": { "command": "git push" },
+            }),
+        )
+        .await;
+        answering.await.unwrap();
+        assert_eq!(said, "");
+    }
+
+    #[tokio::test]
+    async fn a_gate_nobody_is_listening_to_says_nothing_rather_than_refusing() {
+        // The job's own task has gone, which means the run is being torn down.
+        // A refusal here would be about Guaca's plumbing rather than about the
+        // operator's answer.
+        let (job, heard) = a_job(Gate::AskBeforePushing);
+        drop(heard);
+        let said = hook(
+            &job,
+            &serde_json::json!({
+                "hook_event_name": "PreToolUse",
+                "tool_input": { "command": "git push" },
+            }),
+        )
+        .await;
+        assert_eq!(said, "");
+    }
+
+    #[tokio::test]
+    async fn an_operator_who_never_answers_is_a_deny() {
+        // A dropped sender is the shape a bug takes, and it has to fail toward
+        // refusing rather than toward granting.
+        let (job, mut heard) = a_job(Gate::AskBeforePushing);
+        let answering = tokio::spawn(async move {
+            let Some(Signal::Permission { reply, .. }) = heard.recv().await else { panic!() };
+            drop(reply);
+        });
+        let said = hook(
+            &job,
+            &serde_json::json!({
+                "hook_event_name": "PreToolUse",
+                "tool_input": { "command": "git push" },
+            }),
+        )
+        .await;
+        answering.await.unwrap();
+        assert!(said.contains("deny"), "{said}");
+    }
+
+    // ---- the job's own tools ---------------------------------------------
+
+    #[tokio::test]
+    async fn a_reported_pull_request_arrives_as_a_value() {
+        let (job, mut heard) = a_job(Gate::Open);
+        let answered = rpc(
+            &job,
+            &serde_json::json!({
+                "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+                "params": {
+                    "name": "report_pull_request",
+                    "arguments": { "url": "https://github.com/o/r/pull/12", "branch": "fix/flaky" },
+                },
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(answered["result"]["isError"].is_null());
+
+        match heard.try_recv().unwrap() {
+            Signal::PullRequest { url, branch } => {
+                assert_eq!(url, "https://github.com/o/r/pull/12");
+                assert_eq!(branch, "fix/flaky");
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_refusal_says_what_to_do_about_it() {
+        // Read by a coding harness mid-run. One that only says no gets reworded
+        // and retried, which costs the job a round trip per attempt.
+        let (job, _heard) = a_job(Gate::Open);
+        let refused = |args: serde_json::Value, name: &str| {
+            let job = job.clone();
+            let name = name.to_string();
+            async move {
+                let answered = rpc(
+                    &job,
+                    &serde_json::json!({
+                        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                        "params": { "name": name, "arguments": args },
+                    }),
+                )
+                .await
+                .unwrap();
+                assert_eq!(answered["result"]["isError"], true);
+                answered["result"]["content"][0]["text"].as_str().unwrap().to_string()
+            }
+        };
+
+        let no_url = refused(serde_json::json!({ "branch": "x" }), "report_pull_request").await;
+        assert!(no_url.contains("https://"), "{no_url}");
+        let no_branch =
+            refused(serde_json::json!({ "url": "https://x/pull/1" }), "report_pull_request").await;
+        assert!(no_branch.contains("git branch --show-current"), "{no_branch}");
+        let empty = refused(serde_json::json!({ "note": "  " }), "note_progress").await;
+        assert!(empty.contains("just finished"), "{empty}");
+        let unknown = refused(serde_json::json!({}), "ask_operator").await;
+        assert!(unknown.contains("note_progress"), "{unknown}");
+    }
+
+    #[tokio::test]
+    async fn there_is_no_way_for_a_job_to_ask_a_question() {
+        // The appended prompt tells a job that nobody will answer one, and a
+        // tool that contradicted it would invite a run to spend ten of its
+        // forty-five minutes waiting on somebody who is not there.
+        let names: Vec<String> = tools()
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool["name"].as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(names, vec!["note_progress", "report_pull_request"]);
+    }
+
+    #[tokio::test]
+    async fn both_protocol_eras_are_answered_and_a_notification_is_not() {
+        let (job, _heard) = a_job(Gate::Open);
+
+        let modern = rpc(
+            &job,
+            &serde_json::json!({ "jsonrpc": "2.0", "id": 1, "method": "server/discover" }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(modern["result"]["protocolVersion"], crate::mcp::PROTOCOL_VERSION);
+
+        // The handshake era answers with what was asked for, which is how a
+        // client learns its own request was understood.
+        let legacy = rpc(
+            &job,
+            &serde_json::json!({
+                "jsonrpc": "2.0", "id": 0, "method": "initialize",
+                "params": { "protocolVersion": "2025-11-25" },
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(legacy["result"]["protocolVersion"], "2025-11-25");
+
+        // No id is a notification, and answering one with a body is a protocol
+        // error the client is entitled to complain about.
+        assert!(rpc(
+            &job,
+            &serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" })
+        )
+        .await
+        .is_none());
+
+        let unknown = rpc(
+            &job,
+            &serde_json::json!({ "jsonrpc": "2.0", "id": 9, "method": "resources/list" }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(unknown["error"]["code"], -32601);
+    }
+
+    // ---- the whole thing, over a socket ----------------------------------
+
+    #[tokio::test]
+    async fn a_job_ending_takes_its_mailbox_and_its_scratch_with_it() {
+        let bridge = Bridge::new();
+        let (signals, _heard) = mpsc::channel(8);
+        let session = bridge.open(signals, Gate::Open).await.expect("the bridge has to start");
+        let token = session.session_id().to_string();
+
+        assert!(bridge.post(&token, "a correction"));
+        let dir = session.wiring().settings.parent().unwrap().to_path_buf();
+        assert!(dir.exists());
+        // What the operator hands to `claude --resume`, which is only the same
+        // work if Guaca chose it rather than reading it back.
+        assert_eq!(session.wiring().session_id, token);
+
+        drop(session);
+        assert!(!bridge.post(&token, "too late"), "the mailbox goes with the job");
+        assert!(!dir.exists(), "and so does the token that reached it");
+    }
+
+    #[tokio::test]
+    async fn the_server_answers_a_hook_and_refuses_a_token_it_is_not_holding() {
+        let bridge = Bridge::new();
+        let (signals, _heard) = mpsc::channel(8);
+        let session = bridge.open(signals, Gate::Open).await.unwrap();
+        let port = *bridge.inner.port.get().unwrap();
+        let token = session.session_id().to_string();
+        bridge.post(&token, "switch to the other library");
+
+        let post = |path: String, body: &'static str| async move {
+            let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+            let request = format!(
+                "POST /{path} HTTP/1.1\r\nhost: x\r\ncontent-length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            client.write_all(request.as_bytes()).await.unwrap();
+            let mut said = String::new();
+            client.read_to_string(&mut said).await.unwrap();
+            said
+        };
+
+        let delivered = post(format!("{token}/hook"), r#"{"hook_event_name":"PostToolUse"}"#).await;
+        assert!(delivered.contains("200 OK"), "{delivered}");
+        assert!(delivered.contains("switch to the other library"), "{delivered}");
+
+        // An unknown token is a job that ended, which is not an error worth a
+        // body: the hook fails open on an empty answer.
+        let gone = post(
+            "f96abc0a-5404-4e51-b465-b96677118cf9/hook".to_string(),
+            r#"{"hook_event_name":"Stop"}"#,
+        )
+        .await;
+        assert!(gone.contains("404"), "{gone}");
+    }
+
+    #[tokio::test]
+    async fn one_port_serves_every_job_and_each_reaches_only_its_own() {
+        let bridge = Bridge::new();
+        let (one, _a) = mpsc::channel(8);
+        let (two, _b) = mpsc::channel(8);
+        let first = bridge.open(one, Gate::Open).await.unwrap();
+        let second = bridge.open(two, Gate::AskBeforePushing).await.unwrap();
+
+        assert_ne!(first.session_id(), second.session_id());
+        bridge.post(first.session_id(), "for the first one only");
+        assert_eq!(bridge.pending(first.session_id()), 1);
+        assert_eq!(bridge.pending(second.session_id()), 0);
+
+        // Two jobs, two scratch directories, one socket.
+        assert_ne!(first.wiring().settings, second.wiring().settings);
+    }
+}

--- a/src-tauri/src/coding/claude_code.rs
+++ b/src-tauri/src/coding/claude_code.rs
@@ -6,7 +6,7 @@
 //! subscription is spent by this program and by nothing else holding its
 //! credential.
 
-use super::{one_line, Outcome, Progress};
+use super::{one_line, Outcome, Progress, Wiring};
 
 pub(super) const BINARY: &str = "claude";
 
@@ -26,10 +26,38 @@ pub(super) const INSTALL: &str = "npm install -g @anthropic-ai/claude-code";
 ///
 /// No `--model`. Which model runs is Claude Code's own setting, and a second
 /// place to say it is a second place for it to be wrong. No `--continue`
-/// either: each job is its own session, and a session on disk is what lets the
-/// operator pick the work up with `claude -c` in that directory.
-pub(super) fn argv(task: &str) -> Vec<String> {
-    [
+/// either: each job is its own session.
+///
+/// # What the bridge adds, and what it deliberately does not
+///
+/// With a [`Wiring`], three more flags, and the two that are absent from it
+/// matter as much as the three that are there.
+///
+/// - **`--session-id`** names the session rather than reading it back. One
+///   value is then the job's address on the bridge, the key of its mailbox, and
+///   what an operator hands to `claude --resume` to open this job in their own
+///   terminal. That last one is the whole reason it is chosen: `claude -c`
+///   resumes whatever ran last in the directory, which after two jobs is the
+///   wrong one.
+/// - **`--settings`** carries this job's hooks, which are what make it
+///   reachable while it runs. Additive: it loads *alongside* the operator's own
+///   settings files rather than replacing them.
+/// - **`--mcp-config`** adds Guaca's own two-tool server, and is passed
+///   **without `--strict-mcp-config`** for the same reason.
+///
+/// That is the opposite choice from [`crate::llm::claude`], which switches
+/// every one of those off, and the two are right for opposite reasons. A turn
+/// there is answered by a program that should have this app's tools and nothing
+/// else. A job here is a coding agent working in the operator's own repository,
+/// where their rules file, their project settings and their MCP servers are the
+/// thing that makes it useful. `docs/CODING.md` has the measurement of what
+/// that inheritance costs and the one hazard in it.
+///
+/// No `--setting-sources` either, for the same reason: naming sources here
+/// would be this app deciding which of the operator's own files count in their
+/// own repository.
+pub(super) fn argv(task: &str, wiring: Option<&Wiring>) -> Vec<String> {
+    let mut args: Vec<String> = [
         "-p",
         task,
         "--output-format",
@@ -42,7 +70,17 @@ pub(super) fn argv(task: &str) -> Vec<String> {
     ]
     .iter()
     .map(|arg| arg.to_string())
-    .collect()
+    .collect();
+
+    if let Some(wiring) = wiring {
+        args.push("--session-id".to_string());
+        args.push(wiring.session_id.clone());
+        args.push("--settings".to_string());
+        args.push(wiring.settings.to_string_lossy().into_owned());
+        args.push("--mcp-config".to_string());
+        args.push(wiring.mcp_config.clone());
+    }
+    args
 }
 
 /// Folds one event from Claude Code's stream into the outcome.
@@ -310,21 +348,53 @@ mod tests {
 
     #[test]
     fn the_brief_is_an_argument_and_the_stream_is_asked_for() {
-        let args = argv("fix the flaky test");
+        let args = argv("fix the flaky test", None);
         assert!(args.contains(&"fix the flaky test".to_string()));
         assert!(args.contains(&"stream-json".to_string()));
         // The CLI refuses stream-json without it, and the refusal is a job that
         // never starts.
         assert!(args.contains(&"--verbose".to_string()));
         // Nobody is there to answer a prompt: stdin is /dev/null and the asking
-        // mode is a process that hangs until the ceiling kills it.
+        // mode is a process that hangs until the ceiling kills it. The gate is
+        // a hook, which overrides this per command rather than replacing it.
         assert!(args.contains(&"bypassPermissions".to_string()));
         assert!(args.contains(&super::super::APPENDED_PROMPT.to_string()));
         // Which model runs is Claude Code's own setting.
         assert!(!args.contains(&"--model".to_string()));
-        // A session on disk is what lets the operator pick the work up with
-        // `claude -c` in that directory.
         assert!(!args.contains(&"--continue".to_string()));
+    }
+
+    #[test]
+    fn a_job_without_a_bridge_is_the_job_this_app_always_ran() {
+        // `pi`, an older Claude Code, or a bridge that could not start. Every
+        // one of them has to be the vector that worked before any of this.
+        let bare = argv("do the thing", None);
+        for flag in ["--session-id", "--settings", "--mcp-config"] {
+            assert!(!bare.contains(&flag.to_string()), "{flag}");
+        }
+    }
+
+    #[test]
+    fn a_bridged_job_is_named_and_hooked_and_keeps_the_operators_own_setup() {
+        let wiring = Wiring {
+            session_id: "f96abc0a-5404-4e51-b465-b96677118cf9".into(),
+            settings: std::path::PathBuf::from("/tmp/guaca-job-x/settings.json"),
+            mcp_config: r#"{"mcpServers":{"guaca":{}}}"#.into(),
+        };
+        let args = argv("do the thing", Some(&wiring));
+
+        let after =
+            |flag: &str| args.iter().position(|arg| arg == flag).map(|at| args[at + 1].clone());
+        assert_eq!(after("--session-id").as_deref(), Some(wiring.session_id.as_str()));
+        assert_eq!(after("--settings").as_deref(), Some("/tmp/guaca-job-x/settings.json"));
+        assert_eq!(after("--mcp-config").as_deref(), Some(wiring.mcp_config.as_str()));
+
+        // The two absences are the point. A coding job wants the operator's own
+        // rules file, project settings and MCP servers: this adds to them and
+        // must never replace them, which is the opposite of what `llm/claude.rs`
+        // does and right for the opposite reason.
+        assert!(!args.contains(&"--strict-mcp-config".to_string()));
+        assert!(!args.contains(&"--setting-sources".to_string()));
     }
 
     #[test]

--- a/src-tauri/src/coding/mod.rs
+++ b/src-tauri/src/coding/mod.rs
@@ -41,23 +41,52 @@
 //! in this app's usage table, because this app did not spend it. What the job
 //! reports back is what the harness says it cost.
 //!
+//! ## A job is reachable while it runs, on one of the two
+//!
+//! `code` returns as soon as the process is up, which is what keeps the agent
+//! that asked from reading as `Thinking` for the length of a change to a
+//! codebase. The cost of that used to be paid at the other end: for up to
+//! [`CEILING`] the job was write-only, and an operator watching one go the
+//! wrong way at minute three had nothing to do but wait for it to finish.
+//!
+//! [`bridge`] is what makes it two-way. Claude Code has a second interface
+//! besides its stdout, so a job on that harness gets a mailbox the operator can
+//! drop a correction into, an optional gate in front of the handful of commands
+//! that reach outside the repository, and two tools for reporting what it
+//! produced. `pi` has no equivalent and gets none of it, which is a difference
+//! between the harnesses rather than a gap: everything the bridge adds is an
+//! improvement on a job that already worked without it, so every part of it
+//! fails open.
+//!
 //! ## What is not here
 //!
 //! Any confinement. The process runs as the operator, in their repository, with
 //! their credentials and their network, and it may commit, push and open pull
 //! requests. That was asked for explicitly. Neither harness is asked to prompt
-//! for permission, because there is nobody there to answer: `pi` has no
-//! permission system of its own and says so in its own documentation, and
-//! Claude Code is started in the mode that does not ask. So the boundary is the
-//! directory the operator chose and the fact that git can undo what happens
-//! inside it. Nothing in this file should ever be described as a sandbox.
+//! for permission on the ordinary path, because there is nobody there to
+//! answer: `pi` has no permission system of its own and says so in its own
+//! documentation, and Claude Code is started in the mode that does not ask. So
+//! the boundary is the directory the operator chose and the fact that git can
+//! undo what happens inside it. Nothing in this file should ever be described
+//! as a sandbox.
+//!
+//! [`crate::domain::repository::Gate::AskBeforePushing`] does not change that
+//! sentence and must not be read as changing it. It reads a shell line and decides
+//! whether it looks like a push, which is a judgment about the ordinary case: a
+//! job that wanted to get around it could, and it was already running as the
+//! operator with their network before any of this. What it buys is that the
+//! ordinary push, made by a job doing what it was asked, is one somebody gets
+//! to see first.
 
+pub mod bridge;
 pub mod claude_code;
 pub mod pi;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::domain::repository::Harness;
+
+pub use bridge::{Bridge, Signal, Wiring};
 
 /// How long a job may run before it is killed.
 ///
@@ -142,6 +171,29 @@ pub struct Outcome {
     /// nothing needed doing, and `pi auth check` called the provider ready
     /// throughout.
     pub failed: Option<String>,
+    /// The harness session this job ran as, when Guaca chose one.
+    ///
+    /// Empty on `pi` and on any job that ran without a bridge. Where it is set
+    /// it is what the operator hands to `claude --resume` to open the same work
+    /// in their own terminal, which is not the same thing as `claude -c`:
+    /// `-c` resumes whatever ran last in that directory, and after two jobs
+    /// that is the wrong one.
+    pub session_id: String,
+    /// A pull request the job opened and said so about.
+    ///
+    /// Filled in by the runtime from [`Signal::PullRequest`] rather than by the
+    /// fold, because it does not come from the harness's stdout at all: it is
+    /// the job deliberately calling a tool. Recorded here so everything one job
+    /// produced arrives at `job_finished` as one value.
+    pub pull_request: Option<PullRequest>,
+}
+
+/// A pull request a job opened, as it reported it.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PullRequest {
+    pub url: String,
+    pub branch: String,
 }
 
 /// One line of progress, for whoever is watching the job run.
@@ -189,22 +241,90 @@ pub fn install(harness: Harness) -> &'static str {
     }
 }
 
-/// Whether a harness is installed at all.
+/// The oldest Claude Code this app will wire a [`bridge`] into.
+///
+/// Not a floor on running a job. A job on an older program runs exactly as it
+/// did before the bridge existed, which is the only honest thing to do with a
+/// version nothing here has ever been measured against: refusing it would take
+/// away a harness that works to protect a feature that is an addition to it.
+///
+/// The number is the line the contract was measured on. Every part of the
+/// bridge is a promise about how the program behaves rather than about a flag
+/// it accepts, and those cannot be checked offline: that a `PreToolUse` hook's
+/// `deny` overrides `--permission-mode bypassPermissions`, that a `Stop` hook's
+/// `reason` reaches the model, that `additionalContext` from `PostToolUse` is
+/// put in front of it. All three were verified against 2.1.247, and the live
+/// half of `tests/coding.rs` is what catches them moving.
+const BRIDGE_FLOOR: (u32, u32) = (2, 1);
+
+/// What this machine has of one harness.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Presence {
+    /// Not on this app's `PATH`.
+    Missing,
+    /// There, and what it says its version is.
+    ///
+    /// The string is the program's own answer rather than a parse of it, so a
+    /// panel shows what `--version` prints and an operator comparing it with
+    /// their terminal sees the same thing.
+    Installed { version: String, bridged: bool },
+}
+
+impl Presence {
+    pub fn installed(&self) -> bool {
+        matches!(self, Presence::Installed { .. })
+    }
+}
+
+/// What this machine has of a harness, and whether a job on it gets a bridge.
 ///
 /// Asked by the panel that offers the choice, so an operator picking one they
 /// do not have is told at the moment they pick rather than forty minutes later
-/// inside a job that never started. It is deliberately not a pre-flight in
-/// [`run`]: spawning is already the check there, it cannot go stale between the
-/// question and the answer, and a second process per job buys nothing.
-pub async fn installed(harness: Harness) -> bool {
-    tokio::process::Command::new(binary(harness))
+/// inside a job that never started. Asked again by [`crate::runtime`] when a
+/// job starts, which is one process spawn against a job that runs for minutes
+/// and is the only way to know whether the bridge is worth wiring: an operator
+/// upgrades between the panel and the job.
+///
+/// It is still not a pre-flight on whether the job can run. Spawning is the
+/// check for that, it cannot go stale between the question and the answer, and
+/// a refusal built on this one would refuse jobs that work.
+pub async fn presence(harness: Harness) -> Presence {
+    let asked = tokio::process::Command::new(binary(harness))
         .arg("--version")
-        .stdout(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
-        .status()
-        .await
-        .map(|code| code.success())
-        .unwrap_or(false)
+        .output()
+        .await;
+
+    let Ok(asked) = asked else { return Presence::Missing };
+    if !asked.status.success() {
+        return Presence::Missing;
+    }
+
+    let version = String::from_utf8_lossy(&asked.stdout).trim().to_string();
+    let bridged = harness == Harness::Claude && at_least(&version, BRIDGE_FLOOR);
+    Presence::Installed { version, bridged }
+}
+
+/// Whether a `--version` line names a release at or past a floor.
+///
+/// The programs spell it differently and both spellings are moving targets:
+/// `2.1.247 (Claude Code)` today, a bare number yesterday. So the first
+/// dotted number in the line is what is read, and a line with none in it is
+/// treated as too old rather than as new enough. That direction matters: an
+/// unreadable version turns the bridge off and leaves a working job, where the
+/// other way round would wire a job to a contract nothing has checked.
+fn at_least(version: &str, floor: (u32, u32)) -> bool {
+    let digits = |word: &str| {
+        word.split('.').all(|part| !part.is_empty() && part.bytes().all(|b| b.is_ascii_digit()))
+    };
+    let Some(found) = version.split_whitespace().find(|word| word.contains('.') && digits(word))
+    else {
+        return false;
+    };
+    let mut parts = found.split('.').map(|part| part.parse::<u32>().unwrap_or(0));
+    let (major, minor) = (parts.next().unwrap_or(0), parts.next().unwrap_or(0));
+    (major, minor) >= floor
 }
 
 /// Runs one task to completion in one repository.
@@ -213,15 +333,22 @@ pub async fn installed(harness: Harness) -> bool {
 /// lets the operator open the same work in their own terminal (`pi -c`,
 /// `claude -c`), which is the difference between a harness the app runs and a
 /// black box.
+///
+/// `wiring` is the job's end of the [`bridge`], and `None` is a job that runs
+/// without one: `pi`, a Claude Code older than [`BRIDGE_FLOOR`], or a bridge
+/// that could not start. All three run the job.
 pub async fn run(
     harness: Harness,
     repository: &str,
     task: &str,
+    wiring: Option<&Wiring>,
     mut watching: impl FnMut(Progress),
 ) -> Result<Outcome, CodingError> {
     let (args, fold): (Vec<String>, Fold) = match harness {
+        // `pi` has no hooks and no second interface, so the wiring is not
+        // offered to it rather than being offered and ignored.
         Harness::Pi => (pi::argv(task), pi::absorb),
-        Harness::Claude => (claude_code::argv(task), claude_code::absorb),
+        Harness::Claude => (claude_code::argv(task, wiring), claude_code::absorb),
     };
 
     let mut child = tokio::process::Command::new(binary(harness))
@@ -245,7 +372,14 @@ pub async fn run(
     let stdout = child.stdout.take().ok_or_else(|| CodingError::Start("no output".into()))?;
     let stderr = child.stderr.take();
     let mut lines = BufReader::new(stdout).lines();
-    let mut outcome = Outcome::default();
+    // The session is set from what was asked for rather than read back off the
+    // stream, which is the point of choosing it: a job killed at the ceiling
+    // still has a session the operator can open, and a job that died before its
+    // first event still says which one it was.
+    let mut outcome = Outcome {
+        session_id: wiring.map(|w| w.session_id.clone()).unwrap_or_default(),
+        ..Outcome::default()
+    };
 
     let reading = async {
         // Split on `\n` and nothing else: pi's own protocol note, and the

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -28,7 +28,7 @@ use crate::domain::now_ms;
 use crate::domain::plugin::{
     self, HeaderPair, Headers, Plugin, PluginAccess, PluginKind, PluginOffer, ServerReport,
 };
-use crate::domain::repository::{Harness, Repository, RepositoryDraft, RepositoryEdit};
+use crate::domain::repository::{Gate, Harness, Repository, RepositoryDraft, RepositoryEdit};
 use crate::domain::routine::{self, Routine, RoutineRun, Trigger};
 use crate::domain::search::SearchHits;
 use crate::domain::signin::Signin;
@@ -129,6 +129,13 @@ impl From<crate::runtime::RuntimeError> for CommandError {
             RuntimeError::NoRepository(_) | RuntimeError::RepositoryBusy { .. } => {
                 CommandError::new("badRequest", err.to_string())
             }
+            // A job that ended between the panel drawing a button and the
+            // operator pressing it, and two facts about a job that is running.
+            // None of them is a failure: each says what the operator can do
+            // instead, which for the first is nothing at all.
+            RuntimeError::NoJobRunning
+            | RuntimeError::JobStillStarting
+            | RuntimeError::JobUnreachable(_) => CommandError::new("badRequest", err.to_string()),
             // All three are this side answering a request with the wrong shape
             // of answer, which is a defect here rather than something the
             // operator did. Reported as an ordinary failure so it lands in the
@@ -609,10 +616,16 @@ pub fn update_repository(
     name: String,
     note: String,
     harness: Harness,
+    gate: Gate,
 ) -> Reply<Repository> {
-    let clean = RepositoryEdit { name, note, harness }.clean()?;
-    let repository =
-        state.runtime.store().update_repository(id, &clean.name, &clean.note, clean.harness)?;
+    let clean = RepositoryEdit { name, note, harness, gate }.clean()?;
+    let repository = state.runtime.store().update_repository(
+        id,
+        &clean.name,
+        &clean.note,
+        clean.harness,
+        clean.gate,
+    )?;
     state.runtime.emit(UiEvent::AgentsChanged);
     Ok(repository)
 }
@@ -624,6 +637,19 @@ pub struct HarnessOnMachine {
     pub harness: Harness,
     /// Whether the program is on this app's `PATH`.
     pub installed: bool,
+    /// What it says its version is, or empty when it is not there.
+    ///
+    /// The program's own answer rather than a parse of it, so an operator
+    /// comparing this panel with their terminal sees the same string.
+    pub version: String,
+    /// Whether a job on it can be reached while it runs.
+    ///
+    /// False for `pi`, which has no second interface, and for a Claude Code
+    /// older than the one the bridge's contract was measured against. Neither
+    /// stops a job: both run exactly as every job ran before the bridge
+    /// existed, which is why this is a fact the panel states rather than a
+    /// refusal. `coding::presence` is the argument.
+    pub bridged: bool,
     /// How to get it if it is not. Sent from here rather than spelled in the
     /// webview, because it is the same string a refused job quotes at an agent,
     /// and two copies of an install command drift the day a vendor renames a
@@ -645,13 +671,51 @@ pub struct HarnessOnMachine {
 #[tauri::command]
 pub async fn coding_harnesses() -> Reply<Vec<HarnessOnMachine>> {
     let asked = Harness::ALL.map(|harness| async move {
+        let (installed, version, bridged) = match crate::coding::presence(harness).await {
+            crate::coding::Presence::Missing => (false, String::new(), false),
+            crate::coding::Presence::Installed { version, bridged } => (true, version, bridged),
+        };
         HarnessOnMachine {
             harness,
-            installed: crate::coding::installed(harness).await,
+            installed,
+            version,
+            bridged,
             install: crate::coding::install(harness),
         }
     });
     Ok(futures_util::future::join_all(asked).await.into_iter().collect())
+}
+
+/// Sends a correction into a coding job that is already running.
+///
+/// The one thing an operator watching a job go the wrong way could not do. It
+/// is staged rather than delivered: the job reads it at its next tool boundary,
+/// or when it tries to finish, whichever comes first. `coding/bridge.rs` is
+/// both halves.
+///
+/// Refused rather than swallowed when nothing takes it. A job that has just
+/// ended, and a repository whose harness has no bridge, are two different
+/// sentences and both are things the operator can act on: the second is why
+/// the panel says which harness a repository runs.
+#[tauri::command]
+pub fn message_coding_job(
+    state: State<'_, AppState>,
+    repository_id: RepositoryId,
+    message: String,
+) -> Reply<()> {
+    state.runtime.message_job(repository_id, &message).map_err(Into::into)
+}
+
+/// Stops a coding job that is running, leaving whatever it has committed.
+///
+/// The process is killed. Nothing is reverted and nothing is cleaned up,
+/// because the commits a job was told to make as it went are the operator's
+/// checkpoints and throwing them away is not this button's decision to take.
+/// The agent that started the job is told, on the same path it is told about
+/// one that finished: an agent never told is an agent waiting forever.
+#[tauri::command]
+pub fn stop_coding_job(state: State<'_, AppState>, repository_id: RepositoryId) -> Reply<()> {
+    state.runtime.stop_job(repository_id).map_err(Into::into)
 }
 
 /// Unlinks a repository. Nothing on the operator's disk is touched.

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -1180,6 +1180,29 @@ ALTER TABLE repositories ADD COLUMN harness TEXT NOT NULL DEFAULT 'pi';
 ALTER TABLE agents ADD COLUMN discarded_at INTEGER;
 "#,
     ),
+    (
+        42,
+        r#"
+-- Whether a coding job in this directory stops before it reaches outside it.
+--
+-- A push, a pull request, a merge or a release is the operator's own name going
+-- somewhere git cannot take it back from. Until a job could be reached while it
+-- was running there was no way to ask about one, so every job did all of them
+-- unattended and the only boundary was the directory and the undo. There is a
+-- way now, and this is where an operator says they want it used here.
+--
+-- `'open'` is what every job before today did, so the default is a statement of
+-- fact rather than a preference. It is also the only safe default for a second
+-- reason: `coding::APPENDED_PROMPT` tells a job that nobody will answer a
+-- question, and a value that made that false everywhere at once would hold jobs
+-- on a desk in workspaces nobody is watching.
+--
+-- Unrecognized values read back as `open` rather than failing the row, which is
+-- `Harness::parse`'s reasoning plus one of its own: reading an unknown value as
+-- the asking variant would park jobs over a string a downgrade wrote.
+ALTER TABLE repositories ADD COLUMN gate TEXT NOT NULL DEFAULT 'open';
+"#,
+    ),
 ];
 
 /// The group every agent starts in, and the one the UI keeps out of the way

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -26,7 +26,7 @@ use crate::domain::now_ms;
 use crate::domain::plugin::{
     Headers, Plugin, PluginAccess, PluginKind, PluginTool, PluginToolCard, PluginToolset,
 };
-use crate::domain::repository::{CleanRepository, Harness, Repository};
+use crate::domain::repository::{CleanRepository, Gate, Harness, Repository};
 use crate::domain::routine::{NextSlot, Routine, RoutineRun, RunKind, Trigger};
 use crate::domain::search::{
     contains_fold, excerpt, like_pattern, links_in, FileHit, LinkHit, MessageHit, SearchHits,
@@ -1481,8 +1481,9 @@ impl Store {
         let id = RepositoryId::new();
 
         conn.execute(
-            "INSERT INTO repositories (id,group_id,name,path,note,harness,created_at,updated_at)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?7)",
+            "INSERT INTO repositories \
+             (id,group_id,name,path,note,harness,gate,created_at,updated_at)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?8)",
             params![
                 id.to_string(),
                 clean.group_id.to_string(),
@@ -1490,6 +1491,7 @@ impl Store {
                 clean.path,
                 clean.note,
                 clean.harness.as_str(),
+                clean.gate.as_str(),
                 now,
             ],
         )
@@ -1576,11 +1578,13 @@ impl Store {
         name: &str,
         note: &str,
         harness: Harness,
+        gate: Gate,
     ) -> Result<Repository, StoreError> {
         let conn = self.conn()?;
         let changed = conn.execute(
-            "UPDATE repositories SET name=?2, note=?3, harness=?4, updated_at=?5 WHERE id=?1",
-            params![id.to_string(), name, note, harness.as_str(), now_ms()],
+            "UPDATE repositories SET name=?2, note=?3, harness=?4, gate=?5, updated_at=?6 \
+             WHERE id=?1",
+            params![id.to_string(), name, note, harness.as_str(), gate.as_str(), now_ms()],
         )?;
         if changed == 0 {
             return Err(StoreError::RepositoryNotFound(id));
@@ -3643,7 +3647,7 @@ pub enum PluginReach {
 }
 
 const REPOSITORY_COLUMNS: &str =
-    "SELECT id,group_id,name,path,note,harness,created_at,updated_at FROM repositories";
+    "SELECT id,group_id,name,path,note,harness,gate,created_at,updated_at FROM repositories";
 
 /// A unique-index failure here is one directory linked twice, and the operator
 /// wants to be told which rather than told the database said no.
@@ -3672,8 +3676,9 @@ fn row_to_repository(row: &Row<'_>) -> RowResult<Repository> {
             path: row.get(3)?,
             note: row.get(4)?,
             harness: Harness::parse(&row.get::<_, String>(5)?),
-            created_at: row.get(6)?,
-            updated_at: row.get(7)?,
+            gate: Gate::parse(&row.get::<_, String>(6)?),
+            created_at: row.get(7)?,
+            updated_at: row.get(8)?,
         })
     })())
 }
@@ -4025,6 +4030,7 @@ mod tests {
 
     fn repo_at(group: GroupId, path: &str) -> CleanRepository {
         CleanRepository {
+            gate: Gate::Open,
             group_id: group,
             name: path.rsplit('/').next().unwrap_or(path).into(),
             path: path.into(),
@@ -7908,8 +7914,10 @@ mod tests {
         let ada = f.store.create_agent(&draft_in("Ada", group.id)).unwrap();
         f.store.set_agent_repository(ada.id, Some(repo.id)).unwrap();
 
-        let renamed =
-            f.store.update_repository(repo.id, "guac", "run ./scripts/ci.sh", Harness::Pi).unwrap();
+        let renamed = f
+            .store
+            .update_repository(repo.id, "guac", "run ./scripts/ci.sh", Harness::Pi, Gate::Open)
+            .unwrap();
         assert_eq!(renamed.name, "guac");
         assert_eq!(renamed.note, "run ./scripts/ci.sh");
         assert_eq!(
@@ -7933,7 +7941,8 @@ mod tests {
         assert_eq!(made.harness, Harness::Claude);
         assert_eq!(f.store.get_repository(made.id).unwrap().unwrap().harness, Harness::Claude);
 
-        let moved = f.store.update_repository(made.id, "guaca", "", Harness::Pi).unwrap();
+        let moved =
+            f.store.update_repository(made.id, "guaca", "", Harness::Pi, Gate::Open).unwrap();
         assert_eq!(moved.harness, Harness::Pi);
         // Read back through the path a turn takes, which is a different query
         // and its own column list.

--- a/src-tauri/src/domain/repository.rs
+++ b/src-tauri/src/domain/repository.rs
@@ -152,6 +152,72 @@ impl Harness {
     }
 }
 
+/// Whether a job in this directory stops before it reaches outside it.
+///
+/// A push, a merge or a release is the operator's own name going somewhere git
+/// cannot take it back from, and this is whether one of those parks on the desk
+/// first. Everything else a job does, every edit and every test run, is what the
+/// directory and git already cover and is never gated.
+///
+/// ## Why it is per repository, and why it is off
+///
+/// Per repository for the reason [`Harness`] is: it is a fact about how work
+/// happens *here*. A crew's own tooling repository and the codebase that ships
+/// to customers want opposite answers, and one global setting cannot say that.
+///
+/// Off by default, and that is not caution about a migration. `coding`'s
+/// appended prompt tells every job that it is running unattended and that
+/// nobody will answer a question. Switching this on for everybody would make
+/// that sentence false in every repository at once, and a job that believes it
+/// while a hook silently holds it is a job that reports a push it never made.
+/// An operator turning it on is an operator saying they will be there.
+///
+/// ## It is not a boundary
+///
+/// The gate reads a shell line and decides whether it looks like a push, which
+/// is a judgment about the ordinary case. A job that wanted to get around it
+/// could, and it was already running as the operator with their credentials and
+/// their network before any of this existed. `coding/bridge.rs` says the same
+/// thing where the reading happens, and `docs/CODING.md` says it at length.
+/// Neither should ever be softened into a claim about confinement.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Gate {
+    /// Nothing stops. The directory and git are the boundary, as they were
+    /// before a job could be stopped at all.
+    #[default]
+    Open,
+    /// A push, a pull request, a merge or a release asks the operator first.
+    AskBeforePushing,
+}
+
+impl Gate {
+    /// What the column holds, and what crosses IPC. One spelling for both, for
+    /// the reason [`Harness::as_str`] has one.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Gate::Open => "open",
+            Gate::AskBeforePushing => "askBeforePushing",
+        }
+    }
+
+    /// What a stored row means. Anything unrecognized is [`Gate::Open`], which
+    /// is the default the column was added with and what every job before it
+    /// did. Same reasoning as [`Harness::parse`], with one addition: reading an
+    /// unknown value as the *asking* variant would park jobs on a desk over a
+    /// value a downgrade wrote.
+    pub fn parse(raw: &str) -> Gate {
+        match raw {
+            "askBeforePushing" => Gate::AskBeforePushing,
+            _ => Gate::Open,
+        }
+    }
+
+    pub fn asks(self) -> bool {
+        self == Gate::AskBeforePushing
+    }
+}
+
 /// A directory a crew may work in.
 ///
 /// Who is in it is not on this type. An agent carries the repository it works
@@ -186,6 +252,8 @@ pub struct Repository {
     /// programs is two coding agents in one work tree, which is the thing
     /// `Runtime::start_job` takes a lock to prevent.
     pub harness: Harness,
+    /// Whether a job here stops before it reaches outside the directory.
+    pub gate: Gate,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -220,6 +288,11 @@ pub struct RepositoryDraft {
     /// means and what every repository linked before it existed ran.
     #[serde(default)]
     pub harness: Harness,
+    /// Absent is `open`, for the same reason and one more: the appended prompt
+    /// tells a job nobody will answer a question, so asking has to be something
+    /// the operator said rather than something a caller forgot to mention.
+    #[serde(default)]
+    pub gate: Gate,
 }
 
 /// A draft that has passed everything checkable without touching the disk.
@@ -230,6 +303,7 @@ pub struct CleanRepository {
     pub path: String,
     pub note: String,
     pub harness: Harness,
+    pub gate: Gate,
 }
 
 /// What an operator may change about a repository that is already linked.
@@ -254,6 +328,7 @@ pub struct RepositoryEdit {
     pub name: String,
     pub note: String,
     pub harness: Harness,
+    pub gate: Gate,
 }
 
 impl RepositoryEdit {
@@ -277,7 +352,7 @@ impl RepositoryEdit {
             return Err(RepositoryError::NoteTooLong);
         }
 
-        Ok(RepositoryEdit { name, note, harness: self.harness })
+        Ok(RepositoryEdit { name, note, harness: self.harness, gate: self.gate })
     }
 }
 
@@ -331,6 +406,7 @@ impl RepositoryDraft {
             },
             note: self.note.clone(),
             harness: self.harness,
+            gate: self.gate,
         }
         .clean()?;
 
@@ -340,6 +416,7 @@ impl RepositoryDraft {
             path: path.to_string(),
             note: edit.note,
             harness: edit.harness,
+            gate: edit.gate,
         })
     }
 }
@@ -350,6 +427,7 @@ mod tests {
 
     fn draft(path: &str) -> RepositoryDraft {
         RepositoryDraft {
+            gate: Gate::Open,
             group_id: GroupId::new(),
             name: String::new(),
             path: path.to_string(),
@@ -400,6 +478,7 @@ mod tests {
             name: "  guac  ".into(),
             note: "  never touch migrations  ".into(),
             harness: Harness::Claude,
+            gate: Gate::AskBeforePushing,
         }
         .clean()
         .expect("an edit carries no path and must not be refused for one");
@@ -407,14 +486,20 @@ mod tests {
         assert_eq!(clean.name, "guac");
         assert_eq!(clean.note, "never touch migrations");
         assert_eq!(clean.harness, Harness::Claude);
+        assert_eq!(clean.gate, Gate::AskBeforePushing);
     }
 
     #[test]
     fn an_edit_refuses_what_a_link_refuses_and_a_name_it_cannot_backfill() {
         let refused = |name: &str, note: &str| {
-            RepositoryEdit { name: name.into(), note: note.into(), harness: Harness::Pi }
-                .clean()
-                .unwrap_err()
+            RepositoryEdit {
+                name: name.into(),
+                note: note.into(),
+                harness: Harness::Pi,
+                gate: Gate::Open,
+            }
+            .clean()
+            .unwrap_err()
         };
 
         assert_eq!(refused(&"x".repeat(MAX_NAME_LEN + 1), ""), RepositoryError::NameTooLong);
@@ -444,6 +529,7 @@ mod tests {
         let repo = Repository {
             id: RepositoryId::new(),
             group_id: GroupId::new(),
+            gate: Gate::Open,
             name: "guaca".into(),
             path: "/dev/guaca".into(),
             note: "run ./scripts/ci.sh before you finish".into(),

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -443,6 +443,44 @@ const SIGNIN_SCAN_EVERY: Duration = Duration::from_secs(120);
 /// forever, because a turn that never ends is a run that never settles.
 const APPROVAL_WINDOW: Duration = Duration::from_secs(10 * 60);
 
+/// A coding job, while it is running.
+///
+/// Everything about a job that outlives the turn that started it and that
+/// something outside the job needs to reach: who owns it, how to stop it, where
+/// to post it a correction, and the run its permission requests are filed
+/// against.
+struct Running {
+    /// Who started it, and who gets the message when it ends.
+    agent: AgentId,
+    /// Where the operator's corrections go, once it is known.
+    mailbox: Mailbox,
+    /// Dropping this kills the process.
+    ///
+    /// A channel rather than an abort handle on the task, because it can be
+    /// made before the task exists: an operator pressing stop in the moment
+    /// between the spawn and the handle coming back would otherwise find a job
+    /// with no way to end it. What it does is drop the future holding the
+    /// child, which `kill_on_drop` turns into a killed process, which is the
+    /// one mechanism `coding/mod.rs` already documents for stopping one.
+    stop: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+/// Whether a running job can be reached, and why not when it cannot.
+///
+/// Three states rather than an `Option`, because the two ways of not being
+/// reachable have opposite answers for the operator: one is worth waiting a
+/// second for, and the other is a fact about the repository that no amount of
+/// waiting changes.
+enum Mailbox {
+    /// The process is up and the bridge has not answered yet. Momentary.
+    Starting,
+    /// This job has no bridge and will not get one: `pi`, which has no second
+    /// interface, or a Claude Code older than the contract was measured on.
+    Unreachable(&'static str),
+    /// Post here.
+    At(String),
+}
+
 /// How often the schedule is swept for routines that have come due.
 ///
 /// A poll rather than a timer per routine: the next due time is what is
@@ -483,6 +521,21 @@ pub enum RuntimeError {
          begin. Say that it is already in progress"
     )]
     RepositoryBusy { repository: String, who: String },
+    /// Asked to reach a job in a repository where none is running.
+    ///
+    /// Reachable in the ordinary course of things rather than only from a
+    /// confused caller: a job ends between the panel drawing a button and the
+    /// operator pressing it, which for a job that has been running for forty
+    /// minutes is exactly when they are most likely to press one.
+    #[error("no coding job is running in that repository. It has already finished")]
+    NoJobRunning,
+    #[error(
+        "that job has only just started and is not reachable yet. Try again in a moment, or \
+         stop it if it is already going the wrong way"
+    )]
+    JobStillStarting,
+    #[error("that job cannot be reached while it works: {0}")]
+    JobUnreachable(String),
     #[error(transparent)]
     Store(#[from] StoreError),
     #[error("no agent with id {0}")]
@@ -571,7 +624,13 @@ struct Inner {
     /// In memory rather than on the row: a job does not survive a restart, and
     /// a stored flag would come back true forever after a crash and lock a
     /// repository nobody was working in.
-    coding: Mutex<HashMap<RepositoryId, AgentId>>,
+    coding: Mutex<HashMap<RepositoryId, Running>>,
+    /// The loopback end of every running coding job.
+    ///
+    /// One for the app rather than one per job: it is a socket, and a workspace
+    /// whose repositories all run `pi` never binds it at all. `coding/bridge.rs`
+    /// is the whole of it.
+    bridge: crate::coding::Bridge,
     /// Loopback port of the computer viewer. Zero until it is listening.
     viewer_port: AtomicU16,
     /// Where each plugin's MCP server is, when it is not where it usually is.
@@ -652,6 +711,7 @@ impl Runtime {
                 files,
                 last_signin_scan: Mutex::new(HashMap::new()),
                 coding: Mutex::new(HashMap::new()),
+                bridge: crate::coding::Bridge::new(),
                 viewer_port: AtomicU16::new(0),
                 plugin_endpoints: std::sync::OnceLock::new(),
                 account: std::sync::OnceLock::new(),
@@ -1688,13 +1748,26 @@ impl Runtime {
         // model: a job takes minutes, the agent that started it goes idle
         // because its turn ended, and a coordinator reading the lane as free
         // sends the next brief straight into the same repository.
+        //
+        // The stop channel and the job's own run are made before the lock so
+        // the map entry is complete the moment it exists: an operator pressing
+        // stop in the window between inserting and spawning would otherwise
+        // find a job with no way to end it.
+        let (stop, stopped) = tokio::sync::oneshot::channel();
+        // The run this job's own permission requests are filed against. Minted
+        // rather than borrowed from the turn that called `code`: that run
+        // settled minutes ago, and filing against it would report work on a
+        // conversation already reported finished. A run of its own is also what
+        // makes `release_parked` the way a job ending closes whatever it was
+        // waiting on, rather than a second sweep written for this.
+        let job_run = RunId::new();
         {
             let mut coding = self.inner.coding.lock();
             if let Some(busy) = coding.get(&repository.id) {
                 let who = self
                     .inner
                     .store
-                    .get_agent(*busy)
+                    .get_agent(busy.agent)
                     .ok()
                     .flatten()
                     .map(|card| card.name)
@@ -1704,7 +1777,20 @@ impl Runtime {
                     who,
                 });
             }
-            coding.insert(repository.id, card.id);
+            coding.insert(
+                repository.id,
+                Running {
+                    agent: card.id,
+                    mailbox: match repository.harness {
+                        Harness::Claude => Mailbox::Starting,
+                        Harness::Pi => Mailbox::Unreachable(
+                            "pi has no way to be reached while it is working. A repository set \
+                             to Claude Code can be sent one",
+                        ),
+                    },
+                    stop: Some(stop),
+                },
+            );
         }
 
         let runtime = self.clone();
@@ -1715,6 +1801,7 @@ impl Runtime {
         let note = repository.note.clone();
         let repository_id = repository.id;
         let harness = repository.harness;
+        let gate = repository.gate;
 
         self.emit(UiEvent::CodingJobStarted {
             agent_id: card.id,
@@ -1751,26 +1838,143 @@ impl Runtime {
                 ));
             }
 
+            // The job's own end of the bridge, which is what makes it
+            // reachable while it runs. Opened here rather than before the spawn
+            // because it asks the program its version, which is a process, and
+            // `start_job` has already returned to a turn that must not wait.
+            //
+            // `None` is a job that runs exactly as every job ran before any of
+            // this: `pi`, a Claude Code older than the contract was measured
+            // on, or a bridge that could not start. Every one of them is a
+            // working job, so none of them is an error.
+            let (signals, mut heard) = tokio::sync::mpsc::channel(32);
+            let session = match harness {
+                Harness::Pi => None,
+                Harness::Claude => match crate::coding::presence(harness).await {
+                    crate::coding::Presence::Installed { bridged: true, .. } => {
+                        runtime.inner.bridge.open(signals, gate).await
+                    }
+                    _ => None,
+                },
+            };
+            if let Some(job) = runtime.inner.coding.lock().get_mut(&repository_id) {
+                match &session {
+                    Some(session) => job.mailbox = Mailbox::At(session.session_id().to_string()),
+                    // Only a job that was expecting one. `pi` already carries a
+                    // more specific reason, written before the process started,
+                    // and replacing it here would tell the operator to upgrade
+                    // a program they are not running.
+                    None if matches!(job.mailbox, Mailbox::Starting) => {
+                        job.mailbox = Mailbox::Unreachable(
+                            "this job is running without a bridge, so nothing can reach it until \
+                             it finishes. Claude Code has to be installed, and new enough, for one",
+                        )
+                    }
+                    None => {}
+                }
+            }
+
+            // Copied off the session rather than borrowed from it, so the
+            // session can be dropped the moment the job ends instead of at the
+            // end of this task: the mailbox and the scratch directory go with
+            // it, and neither should outlive the process by the length of a
+            // message delivery.
+            let wiring = session.as_ref().map(|session| session.wiring().clone());
+
             let watcher = runtime.clone();
-            let outcome = crate::coding::run(harness, &path, &brief, move |progress| {
-                let (tool, detail) = match progress {
-                    crate::coding::Progress::Using { tool, detail } => (tool, detail),
-                    crate::coding::Progress::Said(said) => (String::new(), said),
-                };
-                watcher.emit(UiEvent::CodingProgress {
-                    agent_id: agent,
-                    repository_id,
-                    tool,
-                    detail,
+            let running =
+                crate::coding::run(harness, &path, &brief, wiring.as_ref(), move |progress| {
+                    let (tool, detail) = match progress {
+                        crate::coding::Progress::Using { tool, detail } => (tool, detail),
+                        crate::coding::Progress::Said(said) => (String::new(), said),
+                    };
+                    watcher.emit(UiEvent::CodingProgress {
+                        agent_id: agent,
+                        repository_id,
+                        tool,
+                        detail,
+                    });
                 });
-            })
-            .await;
+
+            // What the job says about itself through its own tools, drained
+            // beside the process rather than after it: a progress note is worth
+            // nothing once the job has finished, and a permission request has
+            // a harness holding a hook open waiting for the answer.
+            let mut reported: Option<crate::coding::PullRequest> = None;
+            tokio::pin!(running);
+            tokio::pin!(stopped);
+
+            let outcome = loop {
+                tokio::select! {
+                    done = &mut running => break Some(done),
+
+                    // The operator pressed stop. Dropping the run future drops
+                    // the child, and `kill_on_drop` kills the process.
+                    _ = &mut stopped => break None,
+
+                    Some(signal) = heard.recv() => match signal {
+                        crate::coding::Signal::Note(note) => runtime.emit(UiEvent::CodingProgress {
+                            agent_id: agent,
+                            repository_id,
+                            tool: String::new(),
+                            detail: note,
+                        }),
+                        crate::coding::Signal::PullRequest { url, branch } => {
+                            runtime.emit(UiEvent::CodingProgress {
+                                agent_id: agent,
+                                repository_id,
+                                tool: "pull request".to_string(),
+                                detail: url.clone(),
+                            });
+                            reported = Some(crate::coding::PullRequest { url, branch });
+                        }
+                        // Spawned rather than awaited here, so the loop keeps
+                        // draining and a stop still lands while the operator is
+                        // deciding. The reply is sent on every path out of the
+                        // task, because a dropped sender is a deny and a job
+                        // denied by Guaca's own plumbing is the one refusal
+                        // that would be a lie.
+                        crate::coding::Signal::Permission { command, reply } => {
+                            let asking = runtime.clone();
+                            let repository = name.clone();
+                            tokio::spawn(async move {
+                                let allowed =
+                                    asking.ask_about_push(agent, job_run, &repository, &command).await;
+                                let _ = reply.send(allowed);
+                            });
+                        }
+                    },
+                }
+            };
+
+            // Whatever the job was waiting on is over, however it ended. The
+            // window would close it in ten minutes anyway; this is what keeps a
+            // card for a job that is already gone off the operator's desk.
+            runtime.release_parked(job_run);
+
             // Released before the result is delivered, so the turn that reads
             // "it finished" can start the next job in the same repository. The
             // other order is a lane that has to wait a turn to carry on.
             runtime.inner.coding.lock().remove(&repository_id);
             runtime.emit(UiEvent::CodingJobFinished { agent_id: agent, repository_id });
-            runtime.job_finished(agent, &name, harness, outcome);
+
+            // Dropped before the message goes out rather than at the end of the
+            // task, so the mailbox and the scratch directory are gone by the
+            // time the agent is told the job is over.
+            drop(session);
+
+            match outcome {
+                None => runtime.job_stopped(agent, &name),
+                Some(outcome) => {
+                    let outcome = outcome.map(|mut done| {
+                        // Filled in here because it never came from the
+                        // harness's stdout: it is the job calling a tool.
+                        done.pull_request = reported;
+                        done
+                    });
+                    runtime.job_finished(agent, &name, harness, outcome);
+                }
+            }
         });
 
         Ok(repository.name)
@@ -1836,6 +2040,18 @@ impl Runtime {
                      did, say it was done by the coding agent, and do not claim to have checked \
                      anything you have not.",
                 );
+                // A link the job reported through its own tool rather than a
+                // link parsed out of the paragraph above. The difference is
+                // that this one is either right or absent: guessing a URL out
+                // of prose is how an agent reports a pull request that does not
+                // exist.
+                if let Some(pull_request) = &done.pull_request {
+                    text.push_str(&format!(
+                        "\n\nIt opened a pull request from `{}`: {}. That link is the job's own \
+                         report of it, so it is safe to pass on as it stands.",
+                        pull_request.branch, pull_request.url,
+                    ));
+                }
                 text
             }
             Err(err) => {
@@ -2261,6 +2477,168 @@ impl Runtime {
         }
     }
 
+    /// Asks the operator whether a running coding job may reach outside its
+    /// repository.
+    ///
+    /// The gate in `coding/bridge.rs` decides *that* the question is worth
+    /// asking and names what is being asked about. This decides what happens
+    /// next, and it is a [`ProtectedAction::ActOnBehalf`] rather than a new
+    /// variant because it is exactly what that one already means: something
+    /// outside the workspace, in the operator's name, that cannot be taken
+    /// back. A push to their remote is that.
+    ///
+    /// Reusing it also means the standing grant means what it says. An operator
+    /// who has already told this agent it may act on their behalf is not asked
+    /// again per push, which is the difference between a gate and a nuisance.
+    ///
+    /// The wording is Guaca's, built from what the runtime validated, and the
+    /// command appears as a quoted detail field. That is the rule every
+    /// permission in this app follows and it matters more here than anywhere:
+    /// the string came out of a coding model that has been reading the web all
+    /// afternoon.
+    ///
+    /// Anything other than a yes is a no. Unanswered, expired, a job whose
+    /// agent has been deleted, a store that could not be read: none of them is
+    /// the operator saying go ahead, and the only safe reading of all of them
+    /// is the one that leaves the push unmade.
+    async fn ask_about_push(
+        &self,
+        agent: AgentId,
+        run_id: RunId,
+        repository: &str,
+        command: &str,
+    ) -> bool {
+        let Ok(Some(card)) = self.inner.store.get_agent(agent) else {
+            return false;
+        };
+
+        let summary = format!(
+            "The coding agent working in {repository} for {} wants to run `{command}`, which \
+             reaches outside the repository under your name.",
+            card.name
+        );
+        let detail = vec![DetailField { label: "Command".to_string(), value: command.to_string() }];
+
+        let settled = self
+            .park_with(
+                &card,
+                run_id,
+                Request::Permission { action: ProtectedAction::ActOnBehalf },
+                summary,
+                detail,
+                false,
+            )
+            .await;
+
+        // A standing grant is read after the row rather than before it, which
+        // is the opposite order to `ask_permission` and deliberate: there the
+        // shortcut saves a turn from stopping, and here the job is already
+        // stopped by the time anything can be checked. Checked at all because
+        // an operator who said "always" meant it.
+        if matches!(
+            self.inner.store.has_standing_grant(card.id, ProtectedAction::ActOnBehalf),
+            Ok(true)
+        ) {
+            return true;
+        }
+
+        matches!(
+            settled,
+            Ok(Some(Approval { state: ApprovalState::Allow | ApprovalState::AlwaysAllow, .. }))
+        )
+    }
+
+    /// Tells the agent that started a job that the operator ended it.
+    ///
+    /// A message rather than silence, on the same path a finished job takes and
+    /// for the same reason: an agent never told is an agent waiting forever for
+    /// something that is not coming, and an operator asking it later gets "I
+    /// started that and have not heard back", which is true and useless.
+    ///
+    /// What it says about the tree is the important half. A stopped job was
+    /// killed wherever it happened to be, so the commits it made are real and
+    /// whatever it was in the middle of is not. An agent told only that the job
+    /// stopped reports the work as not done, and the operator is left to find
+    /// out for themselves that half of it is on a branch.
+    fn job_stopped(&self, agent: AgentId, repository: &str) {
+        let text = format!(
+            "The operator stopped the coding agent working in {repository} before it \
+             finished. Whatever it had already committed is still there and whatever it was in \
+             the middle of is not, so the work is partly done and nobody has checked which \
+             part. Do not report it as finished and do not start it again: the operator \
+             stopped it on purpose and will say what they want next. Say plainly that it was \
+             stopped."
+        );
+
+        let envelope = Envelope {
+            id: MessageId::new(),
+            run_id: RunId::new(),
+            channel_id: agent,
+            from: Participant::System,
+            to: Participant::Agent { id: agent },
+            parts: vec![Part::Text { text }],
+            trust: Trust::System,
+            hop: 0,
+            expects_reply: true,
+            intent: Intent::Work,
+            cause: None,
+            created_at: now_ms(),
+        };
+
+        if let Err(err) = self.deliver(envelope) {
+            tracing::error!(%err, agent = %agent.short(), "a stopped coding job reached nobody");
+        }
+    }
+
+    /// Sends a correction into a coding job that is already running.
+    ///
+    /// Staged rather than delivered: the job reads it at its next tool
+    /// boundary, or when it tries to finish, whichever comes first.
+    /// `coding/bridge.rs` owns both halves of that.
+    pub fn message_job(&self, repository: RepositoryId, message: &str) -> Result<(), RuntimeError> {
+        let token = {
+            let coding = self.inner.coding.lock();
+            let job = coding.get(&repository).ok_or(RuntimeError::NoJobRunning)?;
+            match &job.mailbox {
+                Mailbox::At(token) => token.clone(),
+                Mailbox::Starting => return Err(RuntimeError::JobStillStarting),
+                Mailbox::Unreachable(why) => {
+                    return Err(RuntimeError::JobUnreachable(why.to_string()))
+                }
+            }
+        };
+
+        // The bridge is the authority on whether the job is still there, and it
+        // can have ended between the read above and here. Reported rather than
+        // swallowed: a box that accepts a correction into a process that is not
+        // there to read it is worse than one that says so.
+        match self.inner.bridge.post(&token, message) {
+            true => Ok(()),
+            false => Err(RuntimeError::NoJobRunning),
+        }
+    }
+
+    /// Stops a coding job, leaving whatever it has committed.
+    ///
+    /// Taking the sender rather than dropping the whole entry: the job's own
+    /// task is what removes it, after the process has actually gone, and
+    /// removing it here would free the repository lock while a harness was
+    /// still writing in it.
+    pub fn stop_job(&self, repository: RepositoryId) -> Result<(), RuntimeError> {
+        let stop = {
+            let mut coding = self.inner.coding.lock();
+            let job = coding.get_mut(&repository).ok_or(RuntimeError::NoJobRunning)?;
+            job.stop.take()
+        };
+
+        // Already taken means somebody pressed it twice, and the second press
+        // is not an error: the job it was asked about is ending either way.
+        if let Some(stop) = stop {
+            let _ = stop.send(());
+        }
+        Ok(())
+    }
+
     /// Asks the operator a question, and holds the turn until they answer it.
     ///
     /// Nothing here grants anything, which is what makes it a different call
@@ -2301,6 +2679,34 @@ impl Runtime {
         request: Request,
         summary: String,
         detail: Vec<DetailField>,
+    ) -> Result<Option<Approval>, String> {
+        self.park_with(card, run_id, request, summary, detail, true).await
+    }
+
+    /// The same, for a request whose asker is not a turn.
+    ///
+    /// `holds_turn` is the whole difference and it is one thing: whether the
+    /// agent's own activity is this request's to move. A parked turn is an
+    /// agent that is genuinely stopped mid-inference and the dot beside its
+    /// name has to say so. A coding job is not a turn at all: it outlived the
+    /// one that started it by many minutes, and the agent that owns it may be
+    /// idle, may be answering somebody else, and is in either case not waiting
+    /// on this. Marking it `AwaitingApproval` would put a false state on a
+    /// working agent, and putting it back to `Thinking` afterward would be
+    /// worse.
+    ///
+    /// Everything else is shared on purpose. A second copy of the row, the
+    /// waker, the window and the expiry is a second place for a request to be
+    /// left waiting on nobody, which is the failure this whole mechanism exists
+    /// to make impossible.
+    async fn park_with(
+        &self,
+        card: &AgentCard,
+        run_id: RunId,
+        request: Request,
+        summary: String,
+        detail: Vec<DetailField>,
+        holds_turn: bool,
     ) -> Result<Option<Approval>, String> {
         let approval = match self.inner.store.create_approval(
             card.id,
@@ -2358,14 +2764,18 @@ impl Runtime {
         // Parked before the request is announced, so anything that reacts to
         // the announcement sees an agent that is already waiting rather than
         // one that still looks like it is thinking.
-        self.set_activity(card.id, Activity::AwaitingApproval);
+        if holds_turn {
+            self.set_activity(card.id, Activity::AwaitingApproval);
+        }
         self.inner
             .events
             .emit(UiEvent::ApprovalRequested { approval_id: approval.id, agent_id: card.id });
 
         let woken = tokio::time::timeout(APPROVAL_WINDOW, wait).await.is_ok();
         self.inner.waiting.lock().remove(&approval.id);
-        self.set_activity(card.id, Activity::Thinking);
+        if holds_turn {
+            self.set_activity(card.id, Activity::Thinking);
+        }
 
         if !woken {
             // Expiring can lose to an answer landing in this instant, and when

--- a/src-tauri/tests/coding.rs
+++ b/src-tauri/tests/coding.rs
@@ -26,7 +26,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use guac_lib::coding::{self, Progress};
-use guac_lib::domain::repository::{CleanRepository, Harness as Which};
+use guac_lib::domain::repository::{CleanRepository, Gate, Harness as Which};
 use guac_lib::runtime::guard::GuardLimits;
 
 use harness::*;
@@ -44,6 +44,13 @@ const SAY: &str = ".say";
 /// environment is process-wide and these tests run concurrently: a test asking
 /// for a non-zero exit would be asking it of whatever else was running.
 const EXIT: &str = ".exit";
+
+/// How long the stand-in waits before it answers.
+///
+/// Everything else here is about a job that has finished. A job that can be
+/// *reached* has to still be running when the test reaches it, and the only
+/// honest way to arrange that against a real process is to make it slow.
+const LINGER: &str = ".linger";
 
 /// A directory holding both stand-ins, put on `PATH` exactly once.
 ///
@@ -73,6 +80,7 @@ fn write_stand_in(dir: &Path, name: &str, canned: &str) {
          if [ \"$1\" = '--version' ]; then echo 'stand-in'; exit 0; fi\n\
          : > {ARGV}\n\
          for arg in \"$@\"; do printf '%s\\n<<>>\\n' \"$arg\" >> {ARGV}; done\n\
+         if [ -f {LINGER} ]; then sleep \"$(cat {LINGER})\"; fi\n\
          if [ -f {SAY} ]; then cat {SAY}; fi\n\
          if [ -f {EXIT} ]; then exit \"$(cat {EXIT})\"; fi\n\
          if [ -f {SAY} ]; then exit 0; fi\n\
@@ -156,9 +164,10 @@ async fn a_repository_set_to_claude_starts_claude_and_not_the_other_one() {
     stand_ins();
     let repo = a_repository("claude");
 
-    let outcome = coding::run(Which::Claude, repo.to_str().unwrap(), "fix the flaky test", |_| {})
-        .await
-        .unwrap();
+    let outcome =
+        coding::run(Which::Claude, repo.to_str().unwrap(), "fix the flaky test", None, |_| {})
+            .await
+            .unwrap();
 
     let argv = argv_at(&repo);
     // The brief reaches the program as an argument, not as something it has to
@@ -186,10 +195,11 @@ async fn a_repository_set_to_pi_starts_pi() {
     let repo = a_repository("pi");
 
     let mut seen = Vec::new();
-    let outcome =
-        coding::run(Which::Pi, repo.to_str().unwrap(), "fix the flaky test", |p| seen.push(p))
-            .await
-            .unwrap();
+    let outcome = coding::run(Which::Pi, repo.to_str().unwrap(), "fix the flaky test", None, |p| {
+        seen.push(p)
+    })
+    .await
+    .unwrap();
 
     let argv = argv_at(&repo);
     assert!(argv.contains(&"--mode".to_string()), "{argv:?}");
@@ -215,7 +225,7 @@ async fn both_harnesses_are_given_the_same_standing_instruction() {
     stand_ins();
     for (which, name) in [(Which::Pi, "prompt-pi"), (Which::Claude, "prompt-claude")] {
         let repo = a_repository(name);
-        coding::run(which, repo.to_str().unwrap(), "do the thing", |_| {}).await.unwrap();
+        coding::run(which, repo.to_str().unwrap(), "do the thing", None, |_| {}).await.unwrap();
         let argv = argv_at(&repo);
         assert!(argv.contains(&"--append-system-prompt".to_string()), "{which:?}: {argv:?}");
         assert!(
@@ -255,7 +265,7 @@ async fn a_harness_that_reports_a_failed_turn_is_not_a_job_with_nothing_to_do() 
         std::fs::write(repo.join(SAY), format!("{stream}\n")).unwrap();
         std::fs::write(repo.join(EXIT), exit).unwrap();
 
-        let outcome = coding::run(which, repo.to_str().unwrap(), "do the thing", |_| {})
+        let outcome = coding::run(which, repo.to_str().unwrap(), "do the thing", None, |_| {})
             .await
             .expect("a stream that reports its own failure is not a dead process");
         let why = outcome.failed.unwrap_or_else(|| panic!("{which:?} reported a silent no-op"));
@@ -272,7 +282,7 @@ async fn a_harness_that_dies_without_answering_says_so_rather_than_reporting_suc
     std::fs::write(repo.join(SAY), "not json at all\n").unwrap();
     std::fs::write(repo.join(EXIT), "3").unwrap();
 
-    let err = coding::run(Which::Pi, repo.to_str().unwrap(), "do the thing", |_| {})
+    let err = coding::run(Which::Pi, repo.to_str().unwrap(), "do the thing", None, |_| {})
         .await
         .expect_err("nothing was said and the process failed");
     assert!(err.to_string().contains("exit 3"), "{err}");
@@ -289,8 +299,33 @@ async fn a_harness_that_dies_without_answering_says_so_rather_than_reporting_suc
 #[tokio::test]
 async fn a_harness_on_this_machine_is_found_by_name() {
     stand_ins();
-    assert!(coding::installed(Which::Pi).await);
-    assert!(coding::installed(Which::Claude).await);
+    assert!(coding::presence(Which::Pi).await.installed());
+    assert!(coding::presence(Which::Claude).await.installed());
+}
+
+/// A harness too old for the bridge is still a harness.
+///
+/// The stand-ins print `stand-in` for `--version`, which carries no number at
+/// all, so this is also the unreadable case: both have to leave the program
+/// usable and turn only the bridge off. The other direction would wire a job to
+/// a contract nothing has ever checked, on the strength of a version string
+/// nobody could parse.
+#[tokio::test]
+async fn a_version_nothing_can_read_runs_the_job_without_a_bridge() {
+    stand_ins();
+    match coding::presence(Which::Claude).await {
+        coding::Presence::Installed { bridged, version } => {
+            assert!(!bridged, "an unreadable version cannot claim the contract holds");
+            assert_eq!(version, "stand-in", "the program's own answer, not a parse of it");
+        }
+        other => panic!("{other:?}"),
+    }
+    // `pi` has no second interface at all, so it is never bridged whatever it
+    // says its version is.
+    assert!(matches!(
+        coding::presence(Which::Pi).await,
+        coding::Presence::Installed { bridged: false, .. }
+    ));
 }
 
 // ---- the whole path ------------------------------------------------------
@@ -329,6 +364,7 @@ async fn an_agent_is_told_what_the_harness_it_was_given_said() {
             path: repo.to_string_lossy().to_string(),
             note: String::new(),
             harness: Which::Claude,
+            gate: Gate::Open,
         })
         .unwrap();
     h.runtime.store().set_agent_repository(engineer.id, Some(linked.id)).unwrap();
@@ -383,6 +419,7 @@ async fn a_job_is_told_which_branch_it_is_standing_on() {
             path: repo.to_string_lossy().to_string(),
             note: "run ./scripts/ci.sh before you finish".into(),
             harness: Which::Pi,
+            gate: Gate::Open,
         })
         .unwrap();
     h.runtime.store().set_agent_repository(engineer.id, Some(linked.id)).unwrap();
@@ -432,6 +469,7 @@ async fn the_real_claude_still_answers_the_way_this_build_reads() {
         Which::Claude,
         repo.to_str().unwrap(),
         "Read a.txt and say what one word it contains. Change nothing and commit nothing.",
+        None,
         |_| {},
     )
     .await
@@ -441,6 +479,300 @@ async fn the_real_claude_still_answers_the_way_this_build_reads() {
     assert!(outcome.said.to_lowercase().contains("banana"), "{}", outcome.said);
     assert!(outcome.tool_calls > 0, "it has to have read the file rather than guessed");
     assert!(!outcome.model.is_empty(), "the stream still names the model");
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+/// A job can be ended, and what it committed is not taken back with it.
+///
+/// The gap this closes is that there was no way to end one at all. A job runs
+/// for up to forty-five minutes, `code` returns the moment the process is up,
+/// and stopping the conversation that started it does not touch the job:
+/// that run settled minutes earlier. The ceiling was the only thing that ever
+/// ended one that was going wrong.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_job_going_the_wrong_way_can_be_stopped_and_the_agent_is_told() {
+    stand_ins();
+    let repo = a_repository("stopped");
+    // Long enough that the test reaches it while it is still running, and
+    // short enough that a broken stop fails the test rather than hanging it.
+    std::fs::write(repo.join(LINGER), "30").unwrap();
+
+    let stub = serve(|body| {
+        if anyone_said(body, "stopped the coding agent") {
+            Script::Say("I have stopped it.".into())
+        } else {
+            Script::Code("fix the flaky test".into())
+        }
+    })
+    .await;
+    let h = harness(&stub, &["Engineer"], GuardLimits::default());
+    let engineer = h.agent_named("Engineer").unwrap();
+    let linked = h
+        .runtime
+        .store()
+        .create_repository(&CleanRepository {
+            group_id: engineer.group_id,
+            name: "guaca".into(),
+            path: repo.to_string_lossy().to_string(),
+            note: String::new(),
+            harness: Which::Claude,
+            gate: Gate::Open,
+        })
+        .unwrap();
+    h.runtime.store().set_agent_repository(engineer.id, Some(linked.id)).unwrap();
+
+    let run = h.runtime.send_from_human(h.id("Engineer"), "fix the flaky test").unwrap();
+    h.settle(run).await;
+    h.wait_until("the harness is up", |_| repo.join(ARGV).exists()).await;
+
+    h.runtime.stop_job(linked.id).expect("a running job has to be stoppable");
+
+    // Told, rather than left waiting for a message that is not coming. An agent
+    // that is never told answers "I started that and have not heard back",
+    // which is true and useless.
+    h.wait_until("the agent is told it was stopped", |h| {
+        h.channel_texts("Engineer").iter().any(|line| line.contains("stopped the coding agent"))
+    })
+    .await;
+
+    // And the lane is free, so the next brief does not come back busy about a
+    // job that is over.
+    h.runtime.message_job(linked.id, "anything").expect_err("a stopped job is not a running one");
+
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+/// Pressing stop twice is not an error, and neither is pressing it late.
+///
+/// Both are the ordinary case rather than a confused caller: a job that has
+/// been running for forty minutes is one an operator presses a button on at
+/// exactly the moment it ends.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stopping_a_job_that_is_already_over_says_so_rather_than_failing() {
+    let h = harness(
+        &serve(|_| Script::Say("hello".into())).await,
+        &["Engineer"],
+        GuardLimits::default(),
+    );
+    let engineer = h.agent_named("Engineer").unwrap();
+    let repo = a_repository("stop-twice");
+    let linked = h
+        .runtime
+        .store()
+        .create_repository(&CleanRepository {
+            group_id: engineer.group_id,
+            name: "guaca".into(),
+            path: repo.to_string_lossy().to_string(),
+            note: String::new(),
+            harness: Which::Pi,
+            gate: Gate::Open,
+        })
+        .unwrap();
+
+    let why = h.runtime.stop_job(linked.id).unwrap_err().to_string();
+    assert!(why.contains("already finished"), "{why}");
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+/// A `pi` job says why it cannot be reached, rather than accepting a message
+/// nothing will read.
+///
+/// The two ways of being unreachable have opposite answers for the operator,
+/// which is why they are different sentences: one is worth waiting a moment
+/// for and the other is a fact about the repository.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_harness_with_no_second_interface_says_so_instead_of_swallowing_it() {
+    stand_ins();
+    let repo = a_repository("unreachable");
+    std::fs::write(repo.join(LINGER), "30").unwrap();
+
+    let stub = serve(|body| {
+        if anyone_said(body, "has finished") {
+            Script::Say("done".into())
+        } else {
+            Script::Code("fix the flaky test".into())
+        }
+    })
+    .await;
+    let h = harness(&stub, &["Engineer"], GuardLimits::default());
+    let engineer = h.agent_named("Engineer").unwrap();
+    let linked = h
+        .runtime
+        .store()
+        .create_repository(&CleanRepository {
+            group_id: engineer.group_id,
+            name: "guaca".into(),
+            path: repo.to_string_lossy().to_string(),
+            note: String::new(),
+            harness: Which::Pi,
+            gate: Gate::Open,
+        })
+        .unwrap();
+    h.runtime.store().set_agent_repository(engineer.id, Some(linked.id)).unwrap();
+
+    let run = h.runtime.send_from_human(h.id("Engineer"), "fix the flaky test").unwrap();
+    h.settle(run).await;
+    h.wait_until("the harness is up", |_| repo.join(ARGV).exists()).await;
+
+    let why = h.runtime.message_job(linked.id, "use the other endpoint").unwrap_err().to_string();
+    assert!(why.contains("pi"), "{why}");
+    // The way out is named, because an operator cannot guess it from a message
+    // about a harness.
+    assert!(why.contains("Claude Code"), "{why}");
+
+    h.runtime.stop_job(linked.id).unwrap();
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+/// The three promises the bridge is built on, asked of the real program.
+///
+/// Not one of them is a flag, which is why this cannot be an offline test. Each
+/// is a promise about how `claude` *behaves* when it is handed a hook, and the
+/// offline suite can only check that Guaca said the right thing into a socket:
+///
+/// - a `PreToolUse` hook answering `deny` overrides `--permission-mode
+///   bypassPermissions`, which is the mode every job here runs in, so the gate
+///   is a gate rather than a suggestion;
+/// - `additionalContext` from a `PostToolUse` hook, or a `Stop` hook's own
+///   `reason`, is put in front of the model, so a correction typed into a
+///   running job actually reaches it;
+/// - an MCP server named on `--mcp-config` is reachable and its tools are
+///   callable, so a job can report what it produced.
+///
+/// One model call covers all three: the brief asks for a push, which the gate
+/// stops, and the staged message asks for a note, which only the bridge could
+/// have delivered and only the MCP server could receive.
+#[tokio::test]
+#[ignore = "live: spends the operator's own Claude plan"]
+async fn the_real_claude_still_honors_what_the_bridge_asks_of_it() {
+    let repo = a_repository("live-bridge");
+    std::fs::write(repo.join("a.txt"), "banana").unwrap();
+
+    let bridge = coding::Bridge::new();
+    let (signals, mut heard) = tokio::sync::mpsc::channel(32);
+    let session = bridge
+        .open(signals, Gate::AskBeforePushing)
+        .await
+        .expect("the bridge has to start before anything else here means anything");
+    let named = session.session_id().to_string();
+
+    // Staged before the job starts, so the first boundary it reaches has it.
+    assert!(bridge.post(
+        session.session_id(),
+        "Before you do anything else, call the guaca note_progress tool with the note \
+         `the mailbox works`.",
+    ));
+
+    let watching = tokio::spawn(async move {
+        let (mut asked, mut noted) = (None, None);
+        while let Some(signal) = heard.recv().await {
+            match signal {
+                // Answered `false`, which is the half that proves the override:
+                // the run's own permission mode would have allowed this.
+                coding::Signal::Permission { command, reply } => {
+                    asked = Some(command);
+                    let _ = reply.send(false);
+                }
+                coding::Signal::Note(note) => noted = Some(note),
+                coding::Signal::PullRequest { .. } => {}
+            }
+        }
+        (asked, noted)
+    });
+
+    let outcome = coding::run(
+        Which::Claude,
+        repo.to_str().unwrap(),
+        "Use the Bash tool to run: git push. Then use the Bash tool to run: echo hello. \
+         Then say in one sentence what happened.",
+        Some(session.wiring()),
+        |_| {},
+    )
+    .await
+    .expect("the harness has to start and answer");
+
+    drop(session);
+    let (asked, noted) = watching.await.unwrap();
+
+    assert_eq!(outcome.failed, None, "the sign-in is spent or the vector is stale");
+    // Chosen rather than read back off the stream, which is what makes it the
+    // thing an operator can hand to `claude --resume` whatever the run did.
+    assert_eq!(outcome.session_id, named);
+
+    let asked = asked.expect(
+        "a PreToolUse deny has to reach the desk. If this is None the program stopped \
+         calling the hook, or stopped letting it refuse under bypassPermissions",
+    );
+    assert!(asked.contains("push"), "{asked}");
+
+    let noted = noted.expect(
+        "the staged message never reached the model, or the MCP server was not \
+         reachable. Either way a job can no longer be corrected while it runs",
+    );
+    assert!(noted.to_lowercase().contains("mailbox"), "{noted}");
+
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+/// A bridged job carries three more flags and keeps everything the operator has.
+///
+/// The offline half of the above, and it is the seam nothing else can see: drop
+/// the wiring in `Runtime::start_job` and every other suite in this repo still
+/// passes while no job in any workspace can be reached again.
+#[tokio::test]
+async fn a_bridged_job_is_started_with_its_own_session_hooks_and_server() {
+    let repo = a_repository("bridged-argv");
+    stand_ins();
+
+    let bridge = coding::Bridge::new();
+    let (signals, _heard) = tokio::sync::mpsc::channel(8);
+    let session = bridge.open(signals, Gate::AskBeforePushing).await.unwrap();
+
+    coding::run(
+        Which::Claude,
+        repo.to_str().unwrap(),
+        "do the thing",
+        Some(session.wiring()),
+        |_| {},
+    )
+    .await
+    .unwrap();
+
+    let argv = argv_at(&repo);
+    let after = |flag: &str| {
+        argv.iter().position(|arg| arg == flag).and_then(|at| argv.get(at + 1)).cloned()
+    };
+
+    // Chosen rather than read back, which is what makes `claude --resume` open
+    // *this* job rather than whatever ran last in the directory.
+    assert_eq!(after("--session-id").as_deref(), Some(session.session_id()));
+
+    // The hooks are a real file on disk with this job's own address in them,
+    // and the script has to be executable or the program cannot run it.
+    let settings = after("--settings").expect("a bridged job carries its hooks");
+    let written: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&settings).unwrap()).unwrap();
+    for event in ["PostToolUse", "Stop", "PreToolUse"] {
+        assert!(written["hooks"][event].is_array(), "{event}");
+    }
+    let script = written["hooks"]["Stop"][0]["hooks"][0]["command"].as_str().unwrap();
+    let mode =
+        std::os::unix::fs::PermissionsExt::mode(&std::fs::metadata(script).unwrap().permissions());
+    assert_eq!(mode & 0o111, 0o100, "the hook has to be runnable, and by nobody else");
+    assert!(std::fs::read_to_string(script).unwrap().contains(session.session_id()));
+
+    // Added to the operator's own setup rather than replacing it. A coding job
+    // in their repository wants their rules file and their servers, which is
+    // the opposite of what a turn wants and right for the opposite reason.
+    assert!(after("--mcp-config").unwrap().contains("guaca"));
+    assert!(!argv.contains(&"--strict-mcp-config".to_string()));
+    assert!(!argv.contains(&"--setting-sources".to_string()));
+
+    // And the scratch goes when the job does, so a token that reached a running
+    // job cannot be read off the disk afterward.
+    let dir = std::path::PathBuf::from(&settings).parent().unwrap().to_path_buf();
+    drop(session);
+    assert!(!dir.exists());
     let _ = std::fs::remove_dir_all(&repo);
 }
 
@@ -455,6 +787,7 @@ async fn the_real_pi_still_answers_the_way_this_build_reads() {
         Which::Pi,
         repo.to_str().unwrap(),
         "Read a.txt and say what one word it contains. Change nothing and commit nothing.",
+        None,
         |_| {},
     )
     .await

--- a/src/components/AgentRepositories.test.tsx
+++ b/src/components/AgentRepositories.test.tsx
@@ -48,6 +48,7 @@ function repository(over: Partial<Repository> = {}): Repository {
     path: "/Users/you/dev/api",
     note: "",
     harness: "pi",
+    gate: "open",
     createdAt: 0,
     updatedAt: 0,
     ...over,

--- a/src/components/CodingPanel.test.tsx
+++ b/src/components/CodingPanel.test.tsx
@@ -1,8 +1,16 @@
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { api } from "../lib/ipc";
 import { useStore } from "../lib/store";
 import { CodingPanel } from "./CodingPanel";
+
+vi.mock("../lib/ipc", () => ({
+  api: { messageCodingJob: vi.fn(), stopCodingJob: vi.fn() },
+}));
+
+const messageCodingJob = vi.mocked(api.messageCodingJob);
+const stopCodingJob = vi.mocked(api.stopCodingJob);
 
 const AGENT = "a1";
 const REPO = "r1";
@@ -19,6 +27,7 @@ function seed(over: Partial<ReturnType<typeof useStore.getState>> = {}) {
         path: "/Users/you/dev/vision-ios",
         note: "",
         harness: "pi",
+        gate: "open",
         createdAt: 0,
         updatedAt: 0,
       },
@@ -28,7 +37,12 @@ function seed(over: Partial<ReturnType<typeof useStore.getState>> = {}) {
 }
 
 describe("CodingPanel", () => {
-  beforeEach(() => seed());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    messageCodingJob.mockResolvedValue(undefined);
+    stopCodingJob.mockResolvedValue(undefined);
+    seed();
+  });
 
   it("draws nothing when no job is running", () => {
     // Furniture that is always there is furniture. This is on screen only
@@ -90,6 +104,70 @@ describe("CodingPanel", () => {
     });
     render(<CodingPanel agent={AGENT} />);
     expect(screen.getAllByText("swift test")).toHaveLength(2);
+  });
+
+  it("sends a correction into the job that is running", async () => {
+    // The gap this closes: a job runs for up to forty-five minutes and used to
+    // be write-only. An operator watching one go wrong at minute three could
+    // only wait for it to finish.
+    seed({ building: { [REPO]: AGENT } });
+    render(<CodingPanel agent={AGENT} />);
+
+    const box = screen.getByLabelText("Send a correction to the running coding job");
+    fireEvent.change(box, { target: { value: "  use the staging bucket  " } });
+    fireEvent.click(screen.getByText("Send"));
+
+    await waitFor(() =>
+      expect(messageCodingJob).toHaveBeenCalledWith(REPO, "use the staging bucket"),
+    );
+    // Said, because what was typed never becomes a message anywhere: without a
+    // word here the only evidence it arrived is the job changing course later.
+    expect(await screen.findByText(/Sent\./)).toBeTruthy();
+    expect((box as HTMLInputElement).value).toBe("");
+  });
+
+  it("says why a correction was refused rather than looking like it landed", async () => {
+    seed({ building: { [REPO]: AGENT } });
+    messageCodingJob.mockRejectedValue(new Error("pi has no way to be reached"));
+    render(<CodingPanel agent={AGENT} />);
+
+    fireEvent.change(screen.getByLabelText("Send a correction to the running coding job"), {
+      target: { value: "stop after the tests" },
+    });
+    fireEvent.click(screen.getByText("Send"));
+
+    expect(await screen.findByText(/no way to be reached/)).toBeTruthy();
+    // The text stays in the box: it was not delivered, so it is still the
+    // operator's to send somewhere.
+    expect(
+      (screen.getByLabelText("Send a correction to the running coding job") as HTMLInputElement)
+        .value,
+    ).toBe("stop after the tests");
+  });
+
+  it("arms the stop before it fires it, and says what survives", async () => {
+    // This ends work that cannot be resumed. The confirmation is drawn where
+    // the click happened rather than somewhere the operator has to go and find.
+    seed({ building: { [REPO]: AGENT } });
+    render(<CodingPanel agent={AGENT} />);
+
+    fireEvent.click(screen.getByText("Stop"));
+    expect(stopCodingJob).not.toHaveBeenCalled();
+    expect(screen.getByText(/Whatever it has committed stays/)).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Stop it"));
+    await waitFor(() => expect(stopCodingJob).toHaveBeenCalledWith(REPO));
+  });
+
+  it("lets an armed stop be called off", async () => {
+    seed({ building: { [REPO]: AGENT } });
+    render(<CodingPanel agent={AGENT} />);
+
+    fireEvent.click(screen.getByText("Stop"));
+    fireEvent.click(screen.getByText("Keep going"));
+
+    expect(screen.queryByText("Stop it")).toBeNull();
+    expect(stopCodingJob).not.toHaveBeenCalled();
   });
 
   it("belongs to the agent that started the job and nobody else", () => {

--- a/src/components/CodingPanel.tsx
+++ b/src/components/CodingPanel.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
+import { api } from "../lib/ipc";
 import { useStore } from "../lib/store";
-import type { AgentId } from "../lib/types";
+import { type AgentId, errorMessage } from "../lib/types";
 
 interface Props {
   agent: AgentId;
@@ -42,6 +43,14 @@ export function CodingPanel({ agent }: Props) {
   const building = useStore((s) => s.building);
   const repositories = useStore((s) => s.repositories);
   const floor = useRef<HTMLDivElement>(null);
+  const [correction, setCorrection] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+  // Armed before it fires, like the two destructive items in `AgentMenu`. This
+  // ends forty minutes of work that cannot be resumed, and the confirmation is
+  // drawn where the click happened rather than somewhere the operator has to
+  // go and find it.
+  const [confirming, setConfirming] = useState(false);
 
   // Follows its own end unconditionally, unlike the transcript. The panel is
   // short, it is only ever on screen while something is happening in it, and
@@ -54,42 +63,138 @@ export function CodingPanel({ agent }: Props) {
   const working = Object.entries(building).find(([, who]) => who === agent);
   if (!working) return null;
 
-  const repository = repositories.find((r) => r.id === working[0]);
+  const repositoryId = working[0];
+  const repository = repositories.find((r) => r.id === repositoryId);
   const held = lines ?? [];
+
+  const send = async () => {
+    const message = correction.trim();
+    if (!message) return;
+    setBusy(true);
+    try {
+      await api.messageCodingJob(repositoryId, message);
+      setCorrection("");
+      // Said rather than left to the transcript. What the operator typed goes
+      // to the harness and never becomes a message anywhere, so without this
+      // the only evidence it arrived is the job changing course minutes later.
+      setNote("Sent. It reaches the job at its next step.");
+    } catch (err) {
+      setNote(errorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const stop = async () => {
+    setBusy(true);
+    try {
+      await api.stopCodingJob(repositoryId);
+    } catch (err) {
+      setNote(errorMessage(err));
+    } finally {
+      setBusy(false);
+      setConfirming(false);
+    }
+  };
 
   return (
     <section className="coding" aria-label="Coding job in progress">
       <div className="coding__head">
         <span className="coding__pulse" aria-hidden="true" />
         <span className="coding__title">Writing code in {repository?.name ?? "a repository"}</span>
+        {confirming ? (
+          <>
+            <button
+              type="button"
+              className="btn btn--small btn--danger"
+              disabled={busy}
+              onClick={() => void stop()}
+            >
+              Stop it
+            </button>
+            <button
+              type="button"
+              className="btn btn--small btn--ghost"
+              onClick={() => setConfirming(false)}
+            >
+              Keep going
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            className="btn btn--small btn--ghost"
+            disabled={busy}
+            onClick={() => setConfirming(true)}
+          >
+            Stop
+          </button>
+        )}
       </div>
 
-      {held.length === 0 ? (
-        // The gap between starting the harness and its first tool call is
-        // several seconds of model call. Silence there reads as a panel that is
-        // broken rather than a job that has not got going.
-        <p className="coding__waiting">Starting the coding agent…</p>
-      ) : (
-        <ol className="coding__lines">
-          {held.map((line, at) => (
-            // Indexed on purpose: these are positions in a tail, not entities.
-            // Two identical `bash: npm test` lines are two runs of the tests
-            // and both belong on screen.
-            // biome-ignore lint/suspicious/noArrayIndexKey: a tail has no ids
-            <li className="coding__line" key={at}>
-              {line.tool ? (
-                <>
-                  <span className="coding__tool">{line.tool}</span>
-                  <span className="coding__detail">{line.detail}</span>
-                </>
-              ) : (
-                <span className="coding__said">{line.detail}</span>
-              )}
-            </li>
-          ))}
-        </ol>
+      <div className="coding__tail">
+        {held.length === 0 ? (
+          // The gap between starting the harness and its first tool call is
+          // several seconds of model call. Silence there reads as a panel that is
+          // broken rather than a job that has not got going.
+          <p className="coding__waiting">Starting the coding agent…</p>
+        ) : (
+          <ol className="coding__lines">
+            {held.map((line, at) => (
+              // Indexed on purpose: these are positions in a tail, not entities.
+              // Two identical `bash: npm test` lines are two runs of the tests
+              // and both belong on screen.
+              // biome-ignore lint/suspicious/noArrayIndexKey: a tail has no ids
+              <li className="coding__line" key={at}>
+                {line.tool ? (
+                  <>
+                    <span className="coding__tool">{line.tool}</span>
+                    <span className="coding__detail">{line.detail}</span>
+                  </>
+                ) : (
+                  <span className="coding__said">{line.detail}</span>
+                )}
+              </li>
+            ))}
+          </ol>
+        )}
+        <div ref={floor} />
+      </div>
+
+      {confirming && (
+        // What survives is the half an operator cannot see from here, and it is
+        // the half that decides whether they press it.
+        <p className="coding__waiting">
+          Stopping kills the program where it stands. Whatever it has committed stays; whatever it
+          was in the middle of does not. It cannot be resumed from here.
+        </p>
       )}
-      <div ref={floor} />
+
+      <div className="coding__say">
+        <input
+          className="input input--slim"
+          placeholder="change course: use the other endpoint, stop after the tests…"
+          value={correction}
+          disabled={busy}
+          aria-label="Send a correction to the running coding job"
+          onChange={(event) => {
+            setCorrection(event.target.value);
+            setNote(null);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && correction.trim()) void send();
+          }}
+        />
+        <button
+          type="button"
+          className="btn btn--small"
+          disabled={busy || !correction.trim()}
+          onClick={() => void send()}
+        >
+          Send
+        </button>
+      </div>
+      {note && <p className="coding__waiting">{note}</p>}
     </section>
   );
 }

--- a/src/components/RailRepositories.test.tsx
+++ b/src/components/RailRepositories.test.tsx
@@ -39,6 +39,7 @@ function repository(over: Partial<Repository> = {}): Repository {
     path: "/Users/you/dev/guaca",
     note: "",
     harness: "pi",
+    gate: "open",
     createdAt: 0,
     updatedAt: 0,
     ...over,

--- a/src/components/RepositoryList.test.tsx
+++ b/src/components/RepositoryList.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
   AgentCard,
+  Gate,
   Harness,
   HarnessOnMachine,
   Repository,
@@ -21,8 +22,8 @@ vi.mock("../lib/ipc", () => ({
   api: {
     groupRepositories: (groupId: string) => groupRepositories(groupId),
     createRepository: (draft: RepositoryDraft) => createRepository(draft),
-    updateRepository: (id: string, name: string, note: string, harness: Harness) =>
-      updateRepository(id, name, note, harness),
+    updateRepository: (id: string, name: string, note: string, harness: Harness, gate: Gate) =>
+      updateRepository(id, name, note, harness, gate),
     deleteRepository: (id: string) => deleteRepository(id),
     setAgentRepository: vi.fn(),
     codingHarnesses: () => codingHarnesses(),
@@ -66,6 +67,7 @@ function repository(over: Partial<Repository> = {}): Repository {
     path: "/Users/you/dev/guaca",
     note: "",
     harness: "pi",
+    gate: "open",
     createdAt: 0,
     updatedAt: 0,
     ...over,
@@ -81,8 +83,20 @@ describe("RepositoryList", () => {
     codingHarnesses.mockReset();
     groupRepositories.mockResolvedValue([]);
     codingHarnesses.mockResolvedValue([
-      { harness: "pi", installed: true, install: "npm install -g pi" },
-      { harness: "claude", installed: true, install: "npm install -g @anthropic-ai/claude-code" },
+      {
+        harness: "pi",
+        installed: true,
+        version: "0.9.0",
+        bridged: false,
+        install: "npm install -g pi",
+      },
+      {
+        harness: "claude",
+        installed: true,
+        version: "2.1.247 (Claude Code)",
+        bridged: true,
+        install: "npm install -g @anthropic-ai/claude-code",
+      },
     ]);
   });
 
@@ -144,6 +158,7 @@ describe("RepositoryList", () => {
         path: "/Users/you/dev/guaca",
         note: "",
         harness: "pi",
+        gate: "open",
       }),
     );
   });
@@ -189,7 +204,13 @@ describe("RepositoryList", () => {
     fireEvent.click(screen.getByText("Save"));
 
     await waitFor(() =>
-      expect(updateRepository).toHaveBeenCalledWith("r1", "guaca", "run ./scripts/ci.sh", "pi"),
+      expect(updateRepository).toHaveBeenCalledWith(
+        "r1",
+        "guaca",
+        "run ./scripts/ci.sh",
+        "pi",
+        "open",
+      ),
     );
   });
 
@@ -213,6 +234,7 @@ describe("RepositoryList", () => {
         "guaca",
         "never touch migrations",
         "claude",
+        "open",
       ),
     );
   });
@@ -229,7 +251,9 @@ describe("RepositoryList", () => {
     fireEvent.change(screen.getByDisplayValue("guaca"), { target: { value: "guac" } });
     fireEvent.click(screen.getByRole("button", { name: "Coding harness: Claude Code" }));
 
-    await waitFor(() => expect(updateRepository).toHaveBeenCalledWith("r1", "guaca", "", "claude"));
+    await waitFor(() =>
+      expect(updateRepository).toHaveBeenCalledWith("r1", "guaca", "", "claude", "open"),
+    );
   });
 
   it("says which program a repository runs without opening it", async () => {
@@ -260,8 +284,56 @@ describe("RepositoryList", () => {
         path: "/Users/you/dev/guaca",
         note: "",
         harness: "claude",
+        gate: "open",
       }),
     );
+  });
+
+  it("saves the gate on the stored name and note, not on a half-typed rename", async () => {
+    // The same rule the harness above follows. A click on a tick is not the
+    // gesture that saves a rename somebody is in the middle of typing.
+    groupRepositories.mockResolvedValue([repository()]);
+    updateRepository.mockResolvedValue(repository({ gate: "askBeforePushing" }));
+    render(<RepositoryList groupId={GROUP} crew={CREW} />);
+
+    fireEvent.click(await screen.findByText("Edit"));
+    fireEvent.change(screen.getByPlaceholderText("what you call it"), {
+      target: { value: "half-typed" },
+    });
+    fireEvent.click(screen.getByRole("checkbox"));
+
+    await waitFor(() =>
+      expect(updateRepository).toHaveBeenCalledWith("r1", "guaca", "", "pi", "askBeforePushing"),
+    );
+  });
+
+  it("does not offer the gate on a harness that cannot be reached while it works", async () => {
+    // A control that silently does nothing is worse than one that is not
+    // offered, and the hint has to say which harness cannot take it.
+    codingHarnesses.mockResolvedValue([
+      {
+        harness: "pi",
+        installed: true,
+        version: "0.9.0",
+        bridged: false,
+        install: "npm install -g pi",
+      },
+      {
+        harness: "claude",
+        installed: true,
+        version: "2.1.247 (Claude Code)",
+        bridged: true,
+        install: "npm install -g @anthropic-ai/claude-code",
+      },
+    ]);
+    groupRepositories.mockResolvedValue([repository()]);
+    render(<RepositoryList groupId={GROUP} crew={CREW} />);
+
+    fireEvent.click(await screen.findByText("Edit"));
+    await waitFor(() =>
+      expect((screen.getByRole("checkbox") as HTMLInputElement).disabled).toBe(true),
+    );
+    expect(screen.getByText(/pi cannot be reached while it works/)).toBeTruthy();
   });
 
   it("offers a harness that is not installed, disabled, with the command that installs it", async () => {
@@ -270,8 +342,20 @@ describe("RepositoryList", () => {
     // either: the only symptom of storing it would be a coding job that never
     // starts, reported to an agent forty minutes later.
     codingHarnesses.mockResolvedValue([
-      { harness: "pi", installed: true, install: "npm install -g pi" },
-      { harness: "claude", installed: false, install: "npm install -g @anthropic-ai/claude-code" },
+      {
+        harness: "pi",
+        installed: true,
+        version: "0.9.0",
+        bridged: false,
+        install: "npm install -g pi",
+      },
+      {
+        harness: "claude",
+        installed: false,
+        version: "",
+        bridged: false,
+        install: "npm install -g @anthropic-ai/claude-code",
+      },
     ]);
     groupRepositories.mockResolvedValue([repository()]);
     render(<RepositoryList groupId={GROUP} crew={CREW} />);

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -4,6 +4,7 @@ import { api } from "../lib/ipc";
 import {
   type AgentCard,
   errorMessage,
+  type Gate,
   type GroupId,
   HARNESSES,
   type Harness,
@@ -83,6 +84,65 @@ function HarnessChoice({
         ))}
       </p>
     </>
+  );
+}
+
+/**
+ * Whether a job here asks before it reaches outside the directory.
+ *
+ * A checkbox rather than a pair of buttons, because it is one decision with a
+ * default rather than a choice between two things: the harness above is the
+ * second shape and they should not look alike.
+ *
+ * Disabled on a harness that cannot be reached while it works, and the hint
+ * says which, because a control that silently does nothing is worse than one
+ * that is not offered. `pi` has no second interface at all.
+ */
+function GateChoice({
+  chosen,
+  harness,
+  machine,
+  disabled,
+  onChoose,
+}: {
+  chosen: Gate;
+  harness: Harness;
+  machine: HarnessOnMachine[] | null;
+  disabled: boolean;
+  onChoose: (gate: Gate) => void;
+}) {
+  // Null is the check still running, and it must not disable the control on a
+  // machine that would have supported it.
+  const row = machine?.find((known) => known.harness === harness);
+  const reachable = machine === null || (row?.bridged ?? true);
+
+  return (
+    <label className="field field--row">
+      <input
+        type="checkbox"
+        checked={chosen === "askBeforePushing"}
+        disabled={disabled || !reachable}
+        onChange={(event) => onChoose(event.target.checked ? "askBeforePushing" : "open")}
+      />
+      <span>
+        <span className="field__label">Ask me before pushing</span>
+        <span className="field__hint">
+          A push, a pull request, a merge or a release waits on your desk first. Everything else a
+          job does is what the directory and git already cover. It is not a sandbox: the program
+          runs as you, with your credentials, and a job that wanted to get around this could. What
+          it buys is that the ordinary push is one you see first. Leave it off for a repository
+          nobody is watching: a job is told nobody will answer a question, and one waiting on you is
+          one that runs out its own clock.
+          {!reachable && (
+            <>
+              {" "}
+              {labelOf(harness)} cannot be reached while it works, so nothing here can stop it.
+              {row?.version ? ` This machine has ${row.version}.` : ""}
+            </>
+          )}
+        </span>
+      </span>
+    </label>
   );
 }
 
@@ -166,12 +226,19 @@ export function RepositoryList({ groupId, crew }: Props) {
     name: "",
     note: "",
     harness: "pi",
+    gate: "open",
   });
   const [editing, setEditing] = useState<RepositoryId | null>(null);
-  const [edit, setEdit] = useState<{ name: string; note: string; harness: Harness }>({
+  const [edit, setEdit] = useState<{
+    name: string;
+    note: string;
+    harness: Harness;
+    gate: Gate;
+  }>({
     name: "",
     note: "",
     harness: "pi",
+    gate: "open",
   });
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
@@ -230,7 +297,7 @@ export function RepositoryList({ groupId, crew }: Props) {
 
   const reset = () => {
     setAdding(false);
-    setDraft({ path: "", name: "", note: "", harness: "pi" });
+    setDraft({ path: "", name: "", note: "", harness: "pi", gate: "open" });
   };
 
   const add = () =>
@@ -257,6 +324,7 @@ export function RepositoryList({ groupId, crew }: Props) {
                   name: repository.name,
                   note: repository.note,
                   harness: repository.harness,
+                  gate: repository.gate,
                 });
               }}
             >
@@ -293,7 +361,13 @@ export function RepositoryList({ groupId, crew }: Props) {
                   disabled={busy !== null || !edit.name.trim()}
                   onClick={() =>
                     void run(`${repository.id}-edit`, () =>
-                      api.updateRepository(repository.id, edit.name, edit.note, edit.harness),
+                      api.updateRepository(
+                        repository.id,
+                        edit.name,
+                        edit.note,
+                        edit.harness,
+                        edit.gate,
+                      ),
                     ).then((ok) => ok && setEditing(null))
                   }
                 >
@@ -310,7 +384,33 @@ export function RepositoryList({ groupId, crew }: Props) {
                   // click is not the gesture that saves it.
                   setEdit({ ...edit, harness });
                   void run(`${repository.id}-harness`, () =>
-                    api.updateRepository(repository.id, repository.name, repository.note, harness),
+                    api.updateRepository(
+                      repository.id,
+                      repository.name,
+                      repository.note,
+                      harness,
+                      repository.gate,
+                    ),
+                  );
+                }}
+              />
+              <GateChoice
+                chosen={edit.gate}
+                harness={edit.harness}
+                machine={machine}
+                disabled={busy !== null}
+                onChoose={(gate) => {
+                  // The stored name and note, for the reason the harness above
+                  // uses them: a half-typed rename is not what this click saves.
+                  setEdit({ ...edit, gate });
+                  void run(`${repository.id}-gate`, () =>
+                    api.updateRepository(
+                      repository.id,
+                      repository.name,
+                      repository.note,
+                      edit.harness,
+                      gate,
+                    ),
                   );
                 }}
               />
@@ -384,6 +484,13 @@ export function RepositoryList({ groupId, crew }: Props) {
             machine={machine}
             disabled={busy !== null}
             onChoose={(harness) => setDraft({ ...draft, harness })}
+          />
+          <GateChoice
+            chosen={draft.gate}
+            harness={draft.harness}
+            machine={machine}
+            disabled={busy !== null}
+            onChoose={(gate) => setDraft({ ...draft, gate })}
           />
           <p className="field__hint">
             The full path to the directory, which has to be the root of a git repository. Git is the

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -138,8 +138,20 @@ const signOutAccount = vi.fn<() => Promise<AccountStatus>>(async () => noAccount
  *  suite that had to opt in to a present program would be asserting the
  *  refusal rather than the row. */
 const codingHarnesses = vi.fn<() => Promise<HarnessOnMachine[]>>(async () => [
-  { harness: "claude", installed: true, install: "npm install -g @anthropic-ai/claude-code" },
-  { harness: "pi", installed: true, install: "npm install -g @mariozechner/pi" },
+  {
+    harness: "claude",
+    installed: true,
+    version: "2.1.247 (Claude Code)",
+    bridged: true,
+    install: "npm install -g @anthropic-ai/claude-code",
+  },
+  {
+    harness: "pi",
+    installed: true,
+    version: "0.9.0",
+    bridged: false,
+    install: "npm install -g @mariozechner/pi",
+  },
 ]);
 
 vi.mock("../lib/ipc", () => ({

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -35,6 +35,7 @@ import type {
   Decision,
   DeviceCode,
   Envelope,
+  Gate,
   Group,
   GroupDraft,
   GroupId,
@@ -171,8 +172,8 @@ export const api = {
    * does the writing. The path is not among them: a different directory is a
    * different repository, because reach was granted for that one.
    */
-  updateRepository: (id: RepositoryId, name: string, note: string, harness: Harness) =>
-    invoke<Repository>("update_repository", { id, name, note, harness }),
+  updateRepository: (id: RepositoryId, name: string, note: string, harness: Harness, gate: Gate) =>
+    invoke<Repository>("update_repository", { id, name, note, harness, gate }),
 
   /** Unlinks it. Nothing on disk is touched. */
   deleteRepository: (id: RepositoryId) => invoke<void>("delete_repository", { id }),
@@ -184,6 +185,26 @@ export const api = {
    * than the person choosing.
    */
   codingHarnesses: () => invoke<HarnessOnMachine[]>("coding_harnesses"),
+
+  /**
+   * Sends a correction into a coding job that is already running.
+   *
+   * Staged rather than delivered: the job reads it at its next tool boundary,
+   * or when it tries to finish, whichever comes first. Refused when nothing
+   * takes it, and the two reasons are different sentences the operator can act
+   * on: the job has already ended, or its harness cannot be reached at all.
+   */
+  messageCodingJob: (repositoryId: RepositoryId, message: string) =>
+    invoke<void>("message_coding_job", { repositoryId, message }),
+
+  /**
+   * Stops one, leaving whatever it has committed.
+   *
+   * Nothing is reverted. The commits a job was told to make as it went are the
+   * operator's checkpoints, and throwing them away is not this button's
+   * decision to take. The agent that started it is told it was stopped.
+   */
+  stopCodingJob: (repositoryId: RepositoryId) => invoke<void>("stop_coding_job", { repositoryId }),
 
   /**
    * Gives one agent a repository, or takes it back. One agent per call, so a

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -307,6 +307,8 @@ export interface Repository {
   note: string;
   /** Which coding harness a job in this directory starts. */
   harness: Harness;
+  /** Whether a job here asks before it reaches outside the directory. */
+  gate: Gate;
   createdAt: number;
   updatedAt: number;
 }
@@ -318,6 +320,20 @@ export const HARNESSES: { readonly id: Harness; readonly label: string }[] = [
 ];
 
 /**
+ * Whether a coding job in a directory stops before it reaches outside it.
+ *
+ * A push, a pull request, a merge or a release is the operator's own name going
+ * somewhere git cannot take it back from. Everything else a job does is what
+ * the directory and the undo already cover, and is never gated.
+ *
+ * `open` is the default and is what every job did before a job could be reached
+ * at all. It stays the default because the prompt every job is given says
+ * nobody will answer a question: an operator turning this on is an operator
+ * saying they will be there.
+ */
+export type Gate = "open" | "askBeforePushing";
+
+/**
  * One harness, as the machine reports it.
  *
  * The install command comes from Rust rather than being spelled here, because
@@ -327,6 +343,17 @@ export const HARNESSES: { readonly id: Harness; readonly label: string }[] = [
 export interface HarnessOnMachine {
   harness: Harness;
   installed: boolean;
+  /** What it says its version is, or empty when it is not there. */
+  version: string;
+  /**
+   * Whether a job on it can be reached while it runs.
+   *
+   * False for `pi`, which has no second interface, and for a Claude Code older
+   * than the one the behavior was measured against. Neither stops a job: both
+   * run exactly as every job ran before any of this, so this is a fact the
+   * panel states rather than a reason to refuse.
+   */
+  bridged: boolean;
   install: string;
 }
 
@@ -370,6 +397,7 @@ export interface RepositoryDraft {
   path: string;
   note: string;
   harness: Harness;
+  gate: Gate;
 }
 
 export type PluginId = string;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1150,20 +1150,46 @@ button {
    composer off the screen. */
 .coding {
   flex: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
   margin: 0 var(--space-6) var(--space-3);
   padding: var(--space-4) var(--space-5);
   border-radius: var(--radius);
   border: 1px solid color-mix(in oklab, var(--flesh) 28%, transparent);
   background: color-mix(in oklab, var(--flesh) 7%, transparent);
+}
+
+/* The cap and the scroll are on the tail, not on the panel. The panel also
+   holds the box the operator types a correction into, and a long job whose
+   tail owned the scrolling pushed that box out of reach exactly when it was
+   worth reaching for. */
+.coding__tail {
   max-height: 11rem;
   overflow-y: auto;
+}
+
+.coding__say {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.coding__say .input {
+  flex: 1;
+  min-width: 0;
 }
 
 .coding__head {
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  margin-bottom: var(--space-3);
+}
+
+/* Pushes the stop away from the title, so the one destructive control here is
+   not next to the words naming the repository it would stop. */
+.coding__head .btn:first-of-type {
+  margin-left: auto;
 }
 
 .coding__pulse {


### PR DESCRIPTION
Built from a read of [warpdotdev/claude-code-warp](https://github.com/warpdotdev/claude-code-warp). The transferable finding is that Claude Code has a second interface besides its stdout, and Guaca was using none of it.

## What was wrong

`code` returns the moment the process is up. That is right, and the cost was paid at the other end: for up to forty-five minutes a job was write-only. An operator watching one go the wrong way at minute three had one move, which was to wait thirty-seven more minutes and start another. Nothing could end a job either. Stopping the conversation does nothing, because that run settled minutes earlier and the job is not on it.

## What this adds

`coding/bridge.rs` writes a settings file and a three-line `sh` script per job, passes them with `--settings`, and answers the hook over a loopback socket.

- **A mailbox.** The operator can correct a running job from its panel. `PostToolUse` delivers it as `additionalContext` at the next tool boundary; `Stop` delivers it as the `reason` it refuses to finish with, which is what covers a correction typed at minute forty-four.
- **A gate**, per repository, off by default. A push, a pull request, a merge or a release parks on the desk as `ProtectedAction::ActOnBehalf`.
- **Two ways to report**, on a small MCP server: `note_progress` and `report_pull_request`.
- **A stop.** The process is killed where it stands; nothing is reverted, and the agent that started it is told the work is partly done.
- **A chosen session id.** `--session-id` takes a UUID, so `claude --resume` opens *that* job rather than whatever ran last in the directory.
- **A version floor.** `coding::presence` reports the harness version; too old runs the job without a bridge rather than refusing it.

## What it is not

Not a sandbox, and `bridge::outward` is not a security boundary. It reads a shell line and decides whether it looks like a push, which is a judgment about the ordinary case. The process runs as the operator with their credentials either way, which was true before the gate existed. What it buys is that the ordinary push is one somebody sees first. The docs say this in three places and none of them should be softened.

## Two decisions worth arguing with

**The gate is off by default.** Not compatibility. `APPENDED_PROMPT` tells every job that nobody will answer a question, and switching the gate on everywhere would make that false in every repository at once.

**A coding job still inherits the operator's whole Claude Code setup.** No `--strict-mcp-config`, no `--setting-sources`, which is the exact opposite of `llm/claude.rs` and right for the opposite reason: a job works in the operator's own repository, where their rules file and their servers are what make it good. Measured on one machine at 16 MCP servers, 229 tools, 100 slash commands and 8 agents. The hazard is documented rather than fixed: a `Stop` hook of the operator's own answering `{"decision":"block"}` holds a job against its own completion until the ceiling, and Guaca cannot see that from outside.

## Everything fails open

A bridge that could not bind, a missing `curl`, a program too old and a job that already ended all end the same way: empty answer, exit zero, and the job that worked before any of this. The one thing that fails closed is the gate's verdict, where a dropped sender is a deny.

## Testing

The three promises underneath are behavior rather than flags, so no offline test can see them: a `PreToolUse` deny overriding `--permission-mode bypassPermissions`, a `Stop` hook's `reason` reaching the model, and `PostToolUse` `additionalContext` being put in front of it. All three were measured against 2.1.247 and are asserted by a new `#[ignore]`d test that makes one real model call. It passes.

```
cargo test --manifest-path src-tauri/Cargo.toml --test coding -- --ignored \
  the_real_claude_still_honors_what_the_bridge_asks_of_it
```

Offline: the argument vector against a stand-in on `PATH`, the hook answers, the gate's reading of a shell line, both MCP protocol eras, stop and message end to end against a lingering stand-in, and the panel. `./scripts/ci.sh` passes.