### PR TITLE
feat: an agent in a repository can run a command there without a coding job

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ src-tauri/src/
   oauth.rs            Signing a crew in to a plugin's server. PKCE, no client id.
   plugins.rs          Where those two meet the store, and a turn spends a grant.
   repo.rs             Whether a directory is one an agent may be given. Runs git.
+  shell.rs            One line in that directory, run and answered in the turn
+                      that asked. The small door; `coding/` is the big one.
   coding/             Starting something that writes code, and reading it back.
     mod.rs            One process, one ceiling, one prompt. Read this one first.
     pi.rs             `pi`'s argument vector and its stream.
@@ -118,11 +120,13 @@ repo: the frontend renders state and forwards intent.
 | Stopping a conversation: what a stop marks, wakes, and must never release | *A stop marks the run and releases nothing*, then `Runtime::stop_run` |
 | Permission prompts, parked turns, acting in the operator's name | *A protected action parks the turn that asked for it* |
 | An agent writing code at all: the repository, the grant, the `code` tool, the job | `docs/CODING.md`, then `domain/repository.rs` and `Runtime::start_job` |
+| An agent running one command in its repository, and which of the two doors a piece of work goes through | *A repository has two doors, and the small one is `shell`* in `docs/CODING.md`, then `src-tauri/src/shell.rs` and `Runtime::run_in_repository` |
 | Which program writes the code, a spent plan, a harness that will not start | *There are two harnesses because a subscription is spent by one program* in `docs/CODING.md`, then `domain::repository::Harness` and `coding/mod.rs` |
 | What branch a coding job starts on, and what it is told about the tree | *A job is told where it is standing before it is told what to do* in `docs/CODING.md`, then `repo::footing` and the brief assembled in `Runtime::start_job` |
 | An argument either harness is started with, or how its stream is read | *One process lifecycle, two of what genuinely differs* in `docs/CODING.md`, then `coding/pi.rs` and `coding/claude_code.rs`, and run the live half of `tests/coding.rs` |
 | Reaching a job that is already running, stopping one, or anything a hook does | *A job can be reached while it runs* in `docs/CODING.md`, then `coding/bridge.rs`, and run the live half of `tests/coding.rs`, which is the only thing that can check any of it |
 | Whether a job stops before it pushes, and what counts as outward-facing | *The gate is a decision the operator takes per repository* in `docs/CODING.md`, then `bridge::outward` and `Runtime::park_with` |
+| Whether a `shell` line stops before it pushes, and which asker the card names | *The gate is asked from the same function* in `docs/CODING.md`, then `Runtime::ask_about_push` and `Asker`, which have to answer for both doors |
 | What a job inherits from the operator's own Claude Code, and what that costs | *A job inherits the operator's own Claude Code setup* in `docs/CODING.md`, which has the measurement and the one hazard in it |
 | A program that is installed and reported missing: `claude`, `pi`, `git`, `gh` | *A double-clicked app does not have the operator's `PATH`* below, then `src-tauri/src/programs.rs` |
 | Anything an agent stops to ask a person: the desk, the queue, the two kinds of request, `ask_operator` | `docs/ATTENTION.md`, then `domain/approval.rs` and `Runtime::park` |
@@ -492,6 +496,26 @@ the model takes a screenshot to see what `browse` did.
   `claude -c` resumes whatever ran last in the directory, which after two jobs is
   the wrong one. Chosen also means a job killed at the ceiling, and one that died
   before its first event, both still have one to hand over.
+- **A repository has two doors and one gate, and the gate is one function.**
+  `code` hands a brief to a harness for minutes; `shell` runs one line and
+  answers in the turn. The second exists because the first was the only way in,
+  which made `gh pr merge` cost a coding job and made an agent whose harness
+  would not start — a spent plan, a program missing, a work tree already busy —
+  report that it had no shell at all, on a machine where `gh` was installed and
+  signed in. It adds no reach: a job in that directory already ran arbitrary
+  commands as the operator under `bypassPermissions`. What it must not add is a
+  second answer to *what counts as outward-facing*, so both doors ask
+  `coding::bridge::outward` and both park through `Runtime::ask_about_push`. Two
+  readings of one gate is a gate an agent walks around by picking the other
+  tool, which is worse than none: the operator switched it on and would be told
+  it was holding. `docs/CODING.md`.
+- **`shell` takes no lock, and `code` takes one.** They look like the same
+  decision about one work tree and are opposite ones. Two harnesses in a
+  directory interleave their edits over minutes and nothing downstream could say
+  which of them wrote what; one line is the operator typing in their own
+  terminal while a job runs, which nothing prevents and which is ordinary.
+  Refusing it would take away the read an agent most wants while a job is going,
+  which is what the job is doing.
 - **A coding job is not a turn, so it must not move the agent's activity.**
   `Runtime::park_with` is `park` with exactly that one difference. A parked turn
   is an agent genuinely stopped mid-inference and the dot beside its name has to

--- a/docs/CODING.md
+++ b/docs/CODING.md
@@ -31,6 +31,112 @@ inside the tool call, the agent would read as `Thinking` for the length of a
 change to a codebase, its inbox would back up behind it, and every routine that
 came due would be skipped.
 
+## A repository has two doors, and the small one is `shell`
+
+The section above is the argument for the harness. It is not an argument for the
+harness being the *only* way in, and for a while it was, which turned out to be
+the more expensive half.
+
+An agent given a repository could do exactly one thing with it: hand a brief to
+a coding harness and wait minutes for a message. That is right for a change to a
+codebase and wrong for everything else an agent needs from a directory. `git
+status`. `git log -1`. Reading a file. `gh pr view`. `gh pr merge 98`. Each of
+those is a question with an answer, and each of them cost a whole coding job:
+its own process, its own context window, its own spend on somebody's plan, and
+an answer that arrives after the turn that wanted it has ended.
+
+The failure that made it worth fixing was not the cost. It was what an agent
+does when the one door will not open. A harness refuses to start for ordinary
+reasons — a spent plan, a program not installed, another job already in the work
+tree — and an agent holding a repository, asked to merge a pull request, then
+reports to the operator that it has no shell and no way to reach GitHub. Both
+sentences are true of a design with one door in it, and neither is true of the
+machine it is running on, where `gh` is installed and signed in.
+
+So `shell` runs one line in the repository and hands back what it printed, in
+the turn that asked. It is offered on exactly the same condition as `code` —
+`Surfaces::repository`, which is the operator having put this agent in a
+directory — and it is the same directory. `src-tauri/src/shell.rs` is the whole
+of the running; `Runtime::run_in_repository` is the gate and the lookup in front
+of it.
+
+### It adds directness, not reach
+
+The line runs as the operator, in their directory, with their credentials and
+their network. That is the same sentence *What is not here* writes below, and it
+was already true: a coding job in that directory runs arbitrary commands under
+`--permission-mode bypassPermissions`, with the operator's own MCP servers and
+hooks loaded. Nothing an agent can do through `shell` was out of reach through
+`code`. What is new is that it costs a second instead of ten minutes.
+
+That is also why there is no new operator setting. The decision was taken when
+they linked the directory and put an agent in it; a second switch would be a
+second place to say the same thing, and the first agent to find the switch off
+would report the repository as broken rather than as fenced.
+
+### The gate is asked from the same function, and that is the point
+
+`Gate::AskBeforePushing` stops a job before a push, a merge, a pull request or a
+release. It stops `shell` at the same commands, decided by the same
+`bridge::outward` call, answered on the same desk through the same
+`Runtime::ask_about_push`. Two doors into one directory that disagreed about
+what counts as outward-facing would be a gate an agent walks around by picking
+the other tool, which is worse than no gate at all: the operator switched it on
+and would be told it was holding.
+
+`Asker` is everything that differs. A job is not a turn and its agent may be
+idle or answering somebody else, so its request does not move the dot beside the
+agent's name; a `shell` call is a turn genuinely stopped mid-inference and has
+to say so. The card says which it is, because an operator deciding needs to know
+whether they are looking at a job that has been running for ten minutes or at
+the agent they are talking to.
+
+A denial refuses the *call*, not the outward-facing part of it, exactly as the
+hook's `deny` does. `touch a.txt && git push` runs neither half. A refusal that
+ran the first command and stopped at the second would leave the tree in a state
+nobody asked for and nobody was told about.
+
+### Two bounds, and neither is confinement
+
+A job gets forty-five minutes because it is its own unit of work. A `shell` call
+happens inside a turn, so it gets `shell::PATIENCE`, and its output is clipped
+to `KEPT` bytes with both ends kept and the middle counted. Those keep one call
+from taking a turn or a context window with it. They are not a boundary and must
+not be described as one: what confines this is the directory the operator chose
+and the fact that git can undo what happens inside it.
+
+Both bounds say what to do next when they bite, because a tool result an agent
+cannot act on is one it reruns unchanged. A killed line names `code` as the tool
+for work that takes minutes. A clipped stream names `head`, `tail` and `grep` in
+the gap where the middle was.
+
+### No lock, deliberately
+
+`Runtime::start_job` takes one per work tree, because two harnesses in a
+directory interleave their edits over minutes and nothing downstream could say
+which of them wrote what. One line is not that. It is the same thing as the
+operator typing in their own terminal while a job runs, which nothing here
+prevents and which is ordinary.
+
+Refusing it would also take away the read an agent most wants while a job is
+running, which is what the job is doing — and would put back a version of the
+failure the busy refusal already caused once: an agent told to wait for a
+message its own turn was holding up.
+
+### A shell and a computer are two machines
+
+An agent with both a computer and a repository is holding two tools that run
+shell commands on two unrelated filesystems, which is the `browse`/`use_screen`
+hazard one level up. So each description names the other, and only when the
+other is actually in the list: `run_command` says the repository is not on that
+machine, `shell` says the sandbox is not where the codebase is. A model reads
+one description and takes the nearest shell.
+
+A connector's value reaches a sandbox's environment and nothing else, so a
+`shell` line naming `$STRIPE_KEY` names a variable that is not set. That is why
+`credentials_named_in` is not applied here: prefixing the summary with `used
+Stripe` would put a spend in the operator's audit trail that never happened.
+
 ## There are two harnesses because a subscription is spent by one program
 
 This is the part that is not a preference and not a configuration surface.
@@ -382,6 +488,17 @@ stand-in records the argument vector it was handed, so the suite can assert that
 a repository set to Claude Code starts `claude` with Claude Code's vector, which
 is the seam nothing else can see. Drop the column read in `Runtime::start_job`
 and every other suite in this repo still passes.
+
+The four `shell` tests in the same file need no stand-in, because the program
+they run is `bash` and the repository is a real one `git init` made in the temp
+directory. They are the only place the two doors are checked against each other:
+that a line runs in the linked directory and answers inside the turn, that the
+gate stops the same commands through both and that a denial runs no part of the
+line, that an ordinary line is not stopped, and that a work tree with a job in
+it still answers one. `shell.rs` has the rest beside it, against a real shell
+for the reason the stand-ins exist: what a child prints, whether it is still
+running and what happens when it fills a pipe are only observable from outside
+it.
 
 The `#[ignore]`d half asks the real programs whether they still accept those
 vectors and still answer in the shape this build reads. That is the failure no

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -129,6 +129,12 @@ impl From<crate::runtime::RuntimeError> for CommandError {
             RuntimeError::NoRepository(_) | RuntimeError::RepositoryBusy { .. } => {
                 CommandError::new("badRequest", err.to_string())
             }
+            // A `shell` failure is answered to the model inside its turn and
+            // never to the webview: no command here runs one. The arm exists
+            // because the enum is one enum, and it says what it would say if a
+            // command ever did: a directory that has moved is something the
+            // operator fixes from the repository's panel.
+            RuntimeError::Shell(_) => CommandError::new("badRequest", err.to_string()),
             // A job that ended between the panel drawing a button and the
             // operator pressing it, and two facts about a job that is running.
             // None of them is a failure: each says what the operator can do

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ pub mod programs;
 pub mod proxy;
 pub mod repo;
 pub mod runtime;
+pub mod shell;
 pub mod subscription;
 pub mod trajectory;
 pub mod tray;

--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -34,6 +34,7 @@ pub const ASK_OPERATOR: &str = "ask_operator";
 pub const ATTACH_FILE: &str = "attach_file";
 pub const WRITE_DOCUMENT: &str = "write_document";
 pub const CODE: &str = "code";
+pub const SHELL: &str = "shell";
 
 /// Which of the two places an agent has been given, which decides which tools
 /// it is offered.
@@ -199,8 +200,8 @@ pub fn specs(surfaces: Surfaces, modalities: Modalities) -> Vec<ToolSpec> {
             USE_SCREEN => surfaces.computer && modalities.image,
             RUN_COMMAND | OPEN_ON_DESKTOP => surfaces.computer,
             BROWSE => surfaces.browser,
-            CODE => surfaces.repository,
-            REQUEST_PERMISSION => surfaces.computer || surfaces.browser,
+            CODE | SHELL => surfaces.repository,
+            REQUEST_PERMISSION => surfaces.computer || surfaces.browser || surfaces.repository,
             _ => true,
         })
         .collect()
@@ -319,12 +320,27 @@ fn all_specs(surfaces: Surfaces) -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: RUN_COMMAND.to_string(),
-            description: "Run a shell command on your own computer: a Linux machine with a \
-                          terminal, a filesystem and internet access, kept between turns. Use it \
-                          to look things up (`curl`), read and write files, install packages, \
-                          and run code. This is how you reach anything you do not already know. \
-                          The first call may take a few seconds while the machine starts."
-                .to_string(),
+            // The disclaimer is conditional because the tool it disclaims is:
+            // an agent with no repository has one shell and telling it about a
+            // second is a sentence about a tool that is not in its list. Both
+            // sides say it, for the reason a computer and a browser both do —
+            // a model reads one description and takes the nearest shell.
+            description: {
+                let mut said = String::from(
+                    "Run a shell command on your own computer: a Linux machine with a terminal, \
+                     a filesystem and internet access, kept between turns. Use it to look things \
+                     up (`curl`), read and write files, install packages, and run code. This is \
+                     how you reach anything you do not already know. The first call may take a \
+                     few seconds while the machine starts.",
+                );
+                if surfaces.repository {
+                    said.push_str(
+                        "\nThis machine is not where your repository is. Nothing of that \
+                         codebase is on this filesystem: for anything in it, use `shell`.",
+                    );
+                }
+                said
+            },
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -794,6 +810,67 @@ fn all_specs(surfaces: Surfaces) -> Vec<ToolSpec> {
             }),
         },
         ToolSpec {
+            name: SHELL.to_string(),
+            // The small door into the same repository `code` is the big door
+            // into, offered on the same condition. Two ways in, because the
+            // work genuinely comes in two sizes and a design with only the
+            // large one made an agent spend a coding job on `gh pr merge` —
+            // and, when the harness would not start, report to the operator
+            // that it had no shell at all.
+            //
+            // Three things have to be unmistakable and each is a way this gets
+            // used wrongly. It waits, which is what makes it the wrong tool for
+            // a build. It is bounded, so a model that would otherwise reach for
+            // it to run a test suite is told where the line is before it spends
+            // two minutes finding out. And on an agent that also has a computer
+            // there are now two shells in the tool list pointed at two
+            // different machines, which is the `browse`/`use_screen` hazard
+            // again: each has to name the other or a model takes the nearest
+            // one and reports that the repository is empty.
+            description: {
+                let mut said = String::from(
+                    "Run one shell command in your repository, on the operator's own machine, \
+                     and get its output back. This is how you look at the codebase and how you \
+                     do the small things to it: `git status`, `git log`, `git diff`, reading a \
+                     file, `gh pr view`, `gh pr merge`, `gh run list`, a quick script.\n\
+                     It waits for the command and hands you what it printed, so use it whenever \
+                     you need the answer in this turn. It is for commands that answer in \
+                     seconds: anything still going after two minutes is killed. For work that \
+                     takes longer than that, or that means reading the code and editing it, use \
+                     `code` instead.\n\
+                     You are running as the operator, with their credentials, in their \
+                     repository. Ordinary commands are yours to run. A command that pushes, \
+                     merges, opens a pull request or cuts a release leaves the repository under \
+                     their name and cannot be undone by git, so say what you did afterward, and \
+                     ask them first if you are not sure they want it.",
+                );
+                if surfaces.computer {
+                    said.push_str(
+                        "\nThis is not `run_command`. That one runs on your own Linux machine \
+                         somewhere else, which is a different filesystem with none of this \
+                         repository on it. Anything about this codebase is this tool.",
+                    );
+                }
+                said
+            },
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "One bash command line, e.g. `git log --oneline -10`. It \
+                                        runs at the top of the repository, so paths are relative \
+                                        to that and there is no need to `cd` there first. Long \
+                                        output is cut in the middle, so narrow it yourself when \
+                                        you can."
+                    }
+                },
+                "required": ["command"],
+                "additionalProperties": false
+            }),
+        },
+        ToolSpec {
             name: WRITE_DOCUMENT.to_string(),
             // The twelfth, and it exists because the eleventh had a hole under
             // it. `attach_file` hands over a file; until this, the only way an
@@ -926,6 +1003,18 @@ pub enum ToolInvocation {
     /// routine firing already uses.
     Code {
         task: String,
+    },
+    /// Run one line in this agent's repository and wait for it.
+    ///
+    /// The other half of [`ToolInvocation::Code`] and its opposite in the one
+    /// way that matters to a turn: this blocks and answers, that one starts
+    /// something and returns. Kept as its own variant rather than a shape of
+    /// [`ToolInvocation::RunCommand`] because the two run on different
+    /// machines, and a single variant would leave the runtime deciding which
+    /// from the agent's surfaces at dispatch time, which is a machine chosen by
+    /// inference rather than by the model.
+    Shell {
+        command: String,
     },
     /// Write a document out of the turn's own words and hand it over.
     ///
@@ -1083,6 +1172,8 @@ pub enum ToolParseError {
     MissingNote,
     #[error("run_command needs a non-empty `command` string")]
     MissingCommand,
+    #[error("shell needs a non-empty `command` string")]
+    MissingShellCommand,
     #[error("open_on_desktop needs a non-empty `command` string")]
     MissingDesktopCommand,
     #[error("use_screen needs a known `action`")]
@@ -1152,6 +1243,11 @@ impl ToolParseError {
             ToolParseError::MissingCommand => {
                 "Error: `command` must be a non-empty string, for example \
                  {\"command\": \"curl -s wttr.in/Charleston?format=3\"}."
+                    .to_string()
+            }
+            ToolParseError::MissingShellCommand => {
+                "Error: `command` must be a non-empty string: one bash command line to run in \
+                 your repository, for example {\"command\": \"git status --short\"}."
                     .to_string()
             }
             ToolParseError::MissingRecipients => {
@@ -1769,6 +1865,24 @@ pub fn parse(call: &ToolCall, connected: &[PluginKind]) -> Result<ToolInvocation
                 return Err(ToolParseError::MissingFiles);
             }
             Ok(ToolInvocation::AttachFile { files })
+        }
+        // `bash` and `terminal` are what a model calls this when it has been
+        // told it has a shell, and `run_shell_command` is what it reaches for
+        // having seen `run_command` in the same list. None of them is ambiguous
+        // with anything else here, and the alternative to matching them is a
+        // turn spent on the spelling of a tool the agent does have.
+        SHELL | "bash" | "sh" | "terminal" | "run_shell" | "run_shell_command"
+        | "shell_command" => {
+            let value = call.parsed_arguments().map_err(|e| ToolParseError::BadJson {
+                name: SHELL.to_string(),
+                detail: e.to_string(),
+            })?;
+            match first_string(&value, &["command", "cmd", "line", "script", "shell"]) {
+                Some(command) if !command.trim().is_empty() => {
+                    Ok(ToolInvocation::Shell { command })
+                }
+                _ => Err(ToolParseError::MissingShellCommand),
+            }
         }
         CODE | "write_code" | "run_coding_agent" | "delegate_code" => {
             let value = call.parsed_arguments().map_err(|e| ToolParseError::BadJson {
@@ -2442,14 +2556,32 @@ mod tests {
             "nothing it could do needs authorizing: {neither:?}"
         );
 
-        // A repository is the third thing an agent is given, and `code` is the
-        // only tool that reaches one. An agent in no repository must not be
-        // offered it: it costs a model call and a turn to discover, and the
-        // agent reports the capability as broken rather than as absent.
+        // A repository is the third thing an agent is given, and two tools
+        // reach one: `code` for work that takes minutes and `shell` for the
+        // answer it needs in this turn. An agent in no repository must be
+        // offered neither: either one costs a model call and a turn to
+        // discover, and the agent reports the capability as broken rather than
+        // as absent.
         let coder = names(Surfaces { computer: false, browser: false, repository: true });
-        assert!(coder.contains(&CODE.to_string()), "a repository needs no machine: {coder:?}");
-        assert!(!neither.contains(&CODE.to_string()), "nowhere to write code: {neither:?}");
-        assert!(!computer_only.contains(&CODE.to_string()), "a sandbox is not a repository");
+        for reaches in [CODE, SHELL] {
+            assert!(
+                coder.contains(&reaches.to_string()),
+                "a repository needs no machine: {coder:?}"
+            );
+            assert!(!neither.contains(&reaches.to_string()), "no repository: {neither:?}");
+            assert!(
+                !computer_only.contains(&reaches.to_string()),
+                "a sandbox is not a repository: {reaches}"
+            );
+        }
+        // And a repository is a way out of the workspace, so asking to act in
+        // the operator's name means something there. It is the same push either
+        // tool makes, and an agent holding one told nothing it can call reaches
+        // outside the workspace has been told something false.
+        assert!(
+            coder.contains(&REQUEST_PERMISSION.to_string()),
+            "a push is in the operator's name: {coder:?}"
+        );
 
         assert_eq!(names(Surfaces::both()).len(), all_specs(Surfaces::both()).len());
     }
@@ -2475,6 +2607,94 @@ mod tests {
             "the operator can still watch the screen: {blind:?}"
         );
         assert!(blind.contains(&BROWSE.to_string()), "the browser answers in text: {blind:?}");
+    }
+
+    /// The `browse`/`use_screen` hazard, one level over: an agent with both a
+    /// computer and a repository is holding two shells pointed at two
+    /// filesystems, and a model reads one description and takes the nearest
+    /// one. Each has to name the other, and only when the other is there.
+    #[test]
+    fn two_shells_on_one_agent_each_say_which_machine_they_are_not() {
+        let described = |surfaces: Surfaces, name: &str| -> String {
+            specs(surfaces, Modalities::seeing())
+                .into_iter()
+                .find(|spec| spec.name == name)
+                .unwrap_or_else(|| panic!("{name} was not offered"))
+                .description
+        };
+
+        let both = Surfaces { computer: true, browser: false, repository: true };
+        assert!(described(both, SHELL).contains("not `run_command`"), "shell says nothing of it");
+        assert!(described(both, RUN_COMMAND).contains("`shell`"), "run_command says nothing of it");
+
+        // And neither disclaims a tool the agent does not have, which would be
+        // a sentence about something absent from its list.
+        let repository_only = Surfaces { computer: false, browser: false, repository: true };
+        assert!(!described(repository_only, SHELL).contains("run_command"), "there is no other");
+        let computer_only = Surfaces { computer: true, browser: false, repository: false };
+        assert!(!described(computer_only, RUN_COMMAND).contains("`shell`"), "there is no other");
+    }
+
+    /// The two things a model gets wrong about it, and both are the opposite of
+    /// what `code` gets wrong: this one waits, and it has a ceiling low enough
+    /// that a build does not belong in it.
+    #[test]
+    fn the_shell_tool_says_it_waits_and_where_the_line_is() {
+        let spec = specs(Surfaces::both(), Modalities::seeing())
+            .into_iter()
+            .find(|spec| spec.name == SHELL)
+            .expect("offered with a repository");
+
+        assert!(spec.description.contains("waits"), "{}", spec.description);
+        assert!(spec.description.contains("two minutes"), "{}", spec.description);
+        assert!(spec.description.contains("`code`"), "the other door: {}", spec.description);
+        // And that what it does is in the operator's name, which is the whole
+        // of why the gate exists.
+        assert!(spec.description.contains("operator"), "{}", spec.description);
+    }
+
+    /// A model that has been told it has a shell calls it `bash`. Refusing that
+    /// is a turn spent on the spelling of a tool the agent does have.
+    #[test]
+    fn a_shell_call_parses_from_the_names_a_model_reaches_for() {
+        for name in ["shell", "bash", "sh", "terminal", "run_shell", "run_shell_command"] {
+            let call = ToolCall {
+                id: "1".into(),
+                name: name.into(),
+                arguments: r#"{"command": "git status --short"}"#.into(),
+            };
+            assert_eq!(
+                parse(&call).unwrap(),
+                ToolInvocation::Shell { command: "git status --short".to_string() },
+                "{name} did not parse"
+            );
+        }
+
+        // The field, and the two near misses beside it.
+        for field in ["command", "cmd", "line"] {
+            let call = ToolCall {
+                id: "1".into(),
+                name: SHELL.into(),
+                arguments: format!(r#"{{"{field}": "git log -1"}}"#),
+            };
+            assert_eq!(
+                parse(&call).unwrap(),
+                ToolInvocation::Shell { command: "git log -1".to_string() },
+                "{field} did not parse"
+            );
+        }
+    }
+
+    #[test]
+    fn a_shell_call_with_nothing_in_it_says_what_a_correct_one_looks_like() {
+        let call = ToolCall {
+            id: "1".into(),
+            name: SHELL.into(),
+            arguments: r#"{"command": "   "}"#.into(),
+        };
+        let err = parse(&call).unwrap_err();
+        assert_eq!(err, ToolParseError::MissingShellCommand);
+        assert!(err.guidance().contains("git status"), "{}", err.guidance());
     }
 
     #[test]
@@ -2736,8 +2956,8 @@ mod tests {
         let specs = specs(Surfaces::both(), Modalities::seeing());
         assert_eq!(
             specs.len(),
-            15,
-            "directory, run_command, open_on_desktop, use_screen, browse, code, schedule, \
+            16,
+            "directory, run_command, open_on_desktop, use_screen, browse, code, shell, schedule, \
              create_agent, request_permission, ask_operator, send_message, write_document, \
              attach_file, update_memory, note_progress"
         );

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -339,7 +339,7 @@ use crate::domain::envelope::{
 use crate::domain::ids::{AgentId, ApprovalId, GroupId, MessageId, RepositoryId, RunId};
 use crate::domain::now_ms;
 use crate::domain::plugin::PluginKind;
-use crate::domain::repository::Harness;
+use crate::domain::repository::{Gate, Harness};
 use crate::domain::routine::{Routine, RunKind};
 use crate::domain::signin::{self, BrowserState, Signin, Surface};
 use crate::domain::worknote;
@@ -348,6 +348,7 @@ use crate::llm::modality::{self, Modalities};
 use crate::llm::openrouter::{ChatMessage, ChatRequest, LlmClient, LlmError, Token, ToolCall};
 use crate::llm::tools::{self, Delivery, ToolInvocation};
 use crate::plugins;
+use crate::shell::{self, Ran};
 use crate::workspace::Workspace;
 use events::{Activity, EventSink, UiEvent};
 use guard::{GuardLimits, GuardRegistry, Refusal, SendRequest, Verdict};
@@ -497,6 +498,33 @@ const SCHEDULE_TICK: Duration = Duration::from_secs(20);
 /// rather than by what it costs.
 const COMPOST_TICK: Duration = Duration::from_secs(60 * 60);
 
+/// What one `shell` call came to.
+///
+/// A refusal is not an error and must not be one. The operator answering no is
+/// the gate doing its job, and the agent has to be told so in words it can act
+/// on rather than handed something that reads like a broken repository.
+enum Line {
+    Ran(Ran),
+    /// The operator was asked about an outward-facing command and did not
+    /// allow it. Nothing ran.
+    Refused,
+}
+
+/// Who wants to reach outside the repository, which is the only thing that
+/// differs between the two askers.
+///
+/// Both are the same protected action and the same card on the same desk. What
+/// changes is the sentence: an operator deciding needs to know whether they are
+/// looking at a coding job that has been running for ten minutes or at the
+/// agent they are talking to, because those are answered differently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Asker {
+    /// A coding job's harness, stopped by the `PreToolUse` hook.
+    Job,
+    /// The agent itself, in `shell`, with its turn held open.
+    Agent,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum RuntimeError {
     /// Asked to code with nowhere to do it.
@@ -538,6 +566,8 @@ pub enum RuntimeError {
     JobUnreachable(String),
     #[error(transparent)]
     Store(#[from] StoreError),
+    #[error(transparent)]
+    Shell(#[from] crate::shell::ShellError),
     #[error("no agent with id {0}")]
     UnknownAgent(AgentId),
     #[error("{0} has been deleted")]
@@ -1719,6 +1749,64 @@ impl Runtime {
         }
     }
 
+    /// One shell line in this agent's repository, run and answered here.
+    ///
+    /// The opposite of [`Runtime::start_job`] in the one way that matters to a
+    /// turn: this waits. That is the point of it. An agent asking what branch
+    /// the tree is on, or merging a pull request it has already been told to
+    /// merge, needs the answer in the sentence it is writing, and handing that
+    /// to a coding harness costs minutes and a model's whole budget to find out
+    /// something `git status` knows. It is also the door that stays open when
+    /// the other one will not: a spent plan, a harness not installed and a work
+    /// tree another job is already in all stop `code` and none of them stop
+    /// this.
+    ///
+    /// ## No lock, deliberately
+    ///
+    /// `start_job` takes one per work tree because two harnesses in a directory
+    /// interleave their edits over minutes and nothing downstream could say
+    /// which of them wrote what. One line is not that. It is the same thing as
+    /// the operator typing in their own terminal while a job runs, which
+    /// nothing here prevents and which is ordinary. Refusing it would also take
+    /// away the read an agent most wants while a job is running, which is what
+    /// the job is doing.
+    ///
+    /// ## The gate is asked from the same function the hook asks
+    ///
+    /// A repository set to [`Gate::AskBeforePushing`] stops a job before a
+    /// push, a merge or a release. It has to stop this too, from
+    /// [`crate::coding::bridge::outward`] rather than from a second reading of
+    /// the same idea: two doors into one directory that disagreed about what
+    /// counts as outward-facing would be a gate an agent walks around by
+    /// picking the other tool. It is a judgment about the ordinary case and not
+    /// a boundary, exactly as it is there, and for exactly the same reason: the
+    /// line runs as the operator either way.
+    async fn run_in_repository(
+        &self,
+        card: &AgentCard,
+        run_id: RunId,
+        command: &str,
+    ) -> Result<Line, RuntimeError> {
+        let repository = self
+            .inner
+            .store
+            .agent_repository(card.id)?
+            .ok_or_else(|| RuntimeError::NoRepository(card.name.clone()))?;
+
+        if repository.gate == Gate::AskBeforePushing {
+            if let Some(what) = crate::coding::bridge::outward(command) {
+                if !self
+                    .ask_about_push(card.id, run_id, &repository.name, &what, Asker::Agent)
+                    .await
+                {
+                    return Ok(Line::Refused);
+                }
+            }
+        }
+
+        Ok(Line::Ran(shell::run(&repository.path, command, shell::PATIENCE).await?))
+    }
+
     /// Starts a coding job and returns the repository it is working in.
     ///
     /// Returns as soon as the process is spawned. The result comes back later
@@ -1939,7 +2027,15 @@ impl Runtime {
                             let repository = name.clone();
                             tokio::spawn(async move {
                                 let allowed =
-                                    asking.ask_about_push(agent, job_run, &repository, &command).await;
+                                    asking
+                                        .ask_about_push(
+                                            agent,
+                                            job_run,
+                                            &repository,
+                                            &command,
+                                            Asker::Job,
+                                        )
+                                        .await;
                                 let _ = reply.send(allowed);
                             });
                         }
@@ -2477,15 +2573,23 @@ impl Runtime {
         }
     }
 
-    /// Asks the operator whether a running coding job may reach outside its
-    /// repository.
+    /// Asks the operator whether something in a repository may reach outside
+    /// it.
     ///
-    /// The gate in `coding/bridge.rs` decides *that* the question is worth
-    /// asking and names what is being asked about. This decides what happens
-    /// next, and it is a [`ProtectedAction::ActOnBehalf`] rather than a new
-    /// variant because it is exactly what that one already means: something
-    /// outside the workspace, in the operator's name, that cannot be taken
-    /// back. A push to their remote is that.
+    /// Two callers, one question. A coding job's `PreToolUse` hook is one and
+    /// [`Runtime::run_in_repository`] is the other, and both arrive here having
+    /// asked `coding::bridge::outward` the same thing about the same shape of
+    /// shell line. One row, one desk, one wording: the gate an operator
+    /// switched on is a fact about the repository, so it cannot mean one thing
+    /// through `code` and another through `shell`. [`Asker`] is the whole of
+    /// what differs.
+    ///
+    /// The gate decides *that* the question is worth asking and names what is
+    /// being asked about. This decides what happens next, and it is a
+    /// [`ProtectedAction::ActOnBehalf`] rather than a new variant because it is
+    /// exactly what that one already means: something outside the workspace, in
+    /// the operator's name, that cannot be taken back. A push to their remote
+    /// is that.
     ///
     /// Reusing it also means the standing grant means what it says. An operator
     /// who has already told this agent it may act on their behalf is not asked
@@ -2494,8 +2598,8 @@ impl Runtime {
     /// The wording is Guaca's, built from what the runtime validated, and the
     /// command appears as a quoted detail field. That is the rule every
     /// permission in this app follows and it matters more here than anywhere:
-    /// the string came out of a coding model that has been reading the web all
-    /// afternoon.
+    /// the string came out of a model that has been reading the web all
+    /// afternoon, whichever of the two it was.
     ///
     /// Anything other than a yes is a no. Unanswered, expired, a job whose
     /// agent has been deleted, a store that could not be read: none of them is
@@ -2507,16 +2611,24 @@ impl Runtime {
         run_id: RunId,
         repository: &str,
         command: &str,
+        asker: Asker,
     ) -> bool {
         let Ok(Some(card)) = self.inner.store.get_agent(agent) else {
             return false;
         };
 
-        let summary = format!(
-            "The coding agent working in {repository} for {} wants to run `{command}`, which \
-             reaches outside the repository under your name.",
-            card.name
-        );
+        let summary = match asker {
+            Asker::Job => format!(
+                "The coding agent working in {repository} for {} wants to run `{command}`, which \
+                 reaches outside the repository under your name.",
+                card.name
+            ),
+            Asker::Agent => format!(
+                "{} wants to run `{command}` in {repository}, which reaches outside the \
+                 repository under your name.",
+                card.name
+            ),
+        };
         let detail = vec![DetailField { label: "Command".to_string(), value: command.to_string() }];
 
         let settled = self
@@ -2526,7 +2638,11 @@ impl Runtime {
                 Request::Permission { action: ProtectedAction::ActOnBehalf },
                 summary,
                 detail,
-                false,
+                // A job is not a turn and its agent may be idle or answering
+                // somebody else, so the dot beside its name is not the job's to
+                // move. `shell` is the opposite: the turn that called it is
+                // genuinely stopped here, waiting, and has to say so.
+                asker == Asker::Agent,
             )
             .await;
 
@@ -4238,6 +4354,46 @@ impl Runtime {
                 (rendered, Part::tool_call(tools::CODE, arguments, outcome))
             }
 
+            ToolInvocation::Shell { command } => {
+                // No `credentials_named_in` here, and that is not an omission.
+                // A connector's value reaches a sandbox's environment and
+                // nothing else, so a line naming `$STRIPE_KEY` in a repository
+                // names a variable that is not set. Prefixing the summary with
+                // `used Stripe` would put a spend in the operator's audit trail
+                // that never happened, which is worse than the silence.
+                let (rendered, outcome) = match self.run_in_repository(card, run_id, &command).await
+                {
+                    Ok(Line::Ran(ran)) => {
+                        let summary = match ran.exit_code {
+                            None => format!("killed after {}s", shell::PATIENCE.as_secs()),
+                            Some(code) => format!(
+                                "exit {code}, {} bytes out",
+                                ran.stdout.len() + ran.stderr.len()
+                            ),
+                        };
+                        (ran.rendered(), ToolOutcome::Ok { summary })
+                    }
+                    // A no from the desk, said as the thing to do next. The
+                    // wording is the hook's, because it is the same answer
+                    // to the same question and an agent that met it through
+                    // `code` should not learn a different lesson here.
+                    Ok(Line::Refused) => (
+                        "Refused: that command reaches outside the repository under the \
+                             operator's name, and they did not allow it. Nothing ran. Do not try \
+                             it again or work around it: finish everything else you can, and say \
+                             in your reply that this step is waiting on them."
+                            .to_string(),
+                        ToolOutcome::Refused {
+                            reason: "the operator did not allow it".to_string(),
+                        },
+                    ),
+                    Err(err) => {
+                        (format!("Error: {err}"), ToolOutcome::Failed { error: err.to_string() })
+                    }
+                };
+                (rendered, Part::tool_call(tools::SHELL, arguments, outcome))
+            }
+
             ToolInvocation::WriteDocument { name, content } => {
                 let (rendered, outcome) = match self.inner.files.put(&name, content.as_bytes()) {
                     Ok(file) => {
@@ -4614,15 +4770,20 @@ impl Runtime {
         arguments: serde_json::Value,
     ) -> (String, Part) {
         let surfaces = self.surfaces_for(card);
-        if !surfaces.computer && !surfaces.browser {
+        // A repository counts, and was missing here until an agent had a shell
+        // in one: `code` and `shell` both push under the operator's own name,
+        // which is the definition this refusal is written against. An agent
+        // that has one and is told nothing it can call reaches outside the
+        // workspace is told something false about the tool it is holding.
+        if !surfaces.computer && !surfaces.browser && !surfaces.repository {
             let reason = "nothing this agent can do reaches outside the workspace".to_string();
             return (
-                "Refused, and the operator was not asked: you have no computer and no browser, so \
-                 nothing you can call reaches outside this workspace and there is no action here \
-                 for them to authorize. What you are missing is access, not permission, and no \
-                 answer of theirs would give you any. Say in your reply what you could not reach \
-                 and that they can give you a computer or a browser from your panel, then carry \
-                 on with the part you can do from here."
+                "Refused, and the operator was not asked: you have no computer, no browser and no \
+                 repository, so nothing you can call reaches outside this workspace and there is \
+                 no action here for them to authorize. What you are missing is access, not \
+                 permission, and no answer of theirs would give you any. Say in your reply what \
+                 you could not reach and that they can give you a computer or a browser from your \
+                 panel, then carry on with the part you can do from here."
                     .to_string(),
                 Part::tool_call(
                     tools::REQUEST_PERMISSION,

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -712,21 +712,31 @@ pub fn system_prompt(
         out.push_str(&format!(
             "\n## Your repository\n\
              You work in one codebase: {}. It is a real git repository on the operator's own \
-             machine, with their uncommitted work and their branches in it.\n\
-             - `code` is how you reach it. Hand it a brief and a coding agent does the work \
-              there: reading, editing, running the tests, committing, pushing, opening a pull \
-              request.\n\
-             - It does not block. You get a message back when the work finishes, which may be \
-              many minutes. Start it, say you have started it, and end your turn.\n\
+             machine, with their uncommitted work and their branches in it. You reach it two \
+             ways, and picking the wrong one is the mistake worth avoiding here.\n\
+             - `shell` runs one command there and hands you what it printed, in this turn. It is \
+              for everything you want an answer to: `git status`, `git log`, `git diff`, reading \
+              a file, `gh pr view`, `gh pr merge`, `gh run list`. Reach for it first. If a \
+              question about this repository can be settled by a command, settle it rather than \
+              guessing or asking somebody.\n\
+             - `code` hands a brief to a coding agent that works there for minutes. It is for \
+              changing the codebase and for anything that means reading it properly to answer.\n\
+             - `code` does not block. You get a message back when the work finishes, which may be \
+              many minutes. Start it, say you have started it, and end your turn. `shell` is the \
+              opposite: it waits, so use it when you need the answer now.\n\
              - The coding agent cannot see this conversation and cannot ask you anything, so the \
               brief has to carry everything: what to change, how to tell it worked, and what to \
               do with the result.\n\
-             - You have not read the code yourself. When the work comes back, report what the \
-              coding agent says it did rather than claiming to have checked it.\n\
+             - When work comes back from `code`, report what it says it did. If it matters \
+              whether it landed, check with `shell` and say what you found.\n\
              - The coding agent is told the state of the work tree as it starts: the branch, \
               whether anything is uncommitted, and whether that branch has already been merged. \
               So do not put branch instructions in the brief and do not guess at one. Say what \
-              the work is and where it should end up.\n",
+              the work is and where it should end up.\n\
+             - Commands run as the operator, with their credentials. Pushing, merging, opening a \
+              pull request and cutting a release leave the repository under their name and git \
+              cannot undo them, so say afterward what you did, and ask first when you are not \
+              sure they want it.\n",
             repository.own_line().trim_start_matches("- "),
         ));
     }

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -1,0 +1,403 @@
+//! One shell line, in a directory on this machine, with two bounds on it.
+//!
+//! This is the second way into a repository and the small one. [`crate::coding`]
+//! is the other: a whole harness, in its own process, on its own budget, for
+//! minutes at a time. That is the right unit for a change to a codebase and the
+//! wrong unit for every question an agent has about the tree it is standing in.
+//! Before this existed there was only the big one, and the shape of the failure
+//! was consistent: an agent asked to merge a pull request either spent a coding
+//! job on `gh pr merge`, or, when the harness would not start — a spent plan, a
+//! program not installed, another job already in the work tree — reported to the
+//! operator that it had no shell and no way to reach GitHub. Both are true
+//! sentences about a design with one door in it.
+//!
+//! ## It is not a sandbox, and must never be described as one
+//!
+//! The line runs as the operator, in their directory, with their credentials
+//! and their network. That is the same sentence `docs/CODING.md` writes under
+//! *What is not here*, and it is not a widening: a coding job in that directory
+//! already ran arbitrary commands as the operator, under
+//! `--permission-mode bypassPermissions`, with the operator's own MCP servers
+//! loaded. What this adds is directness, not reach. What confines it is what
+//! confined that: the directory the operator chose, and the fact that git can
+//! undo what happens inside it.
+//!
+//! The one control that does apply is [`crate::domain::repository::Gate`], and
+//! it applies here for the same reason it applies to a job. A push, a merge or
+//! a release leaves the work tree under the operator's own name and git cannot
+//! take it back. `Runtime::run_in_repository` asks `coding::bridge::outward`
+//! about the line before running it, from the same function the `PreToolUse`
+//! hook asks, so the two doors give the same answer to the same command. A gate
+//! that read only one of them would be a gate an agent could walk around by
+//! choosing the other tool.
+//!
+//! ## The two bounds
+//!
+//! A job has forty-five minutes because it is its own unit of work. This
+//! happens *inside a turn*, so it has [`PATIENCE`], which is what an operator
+//! will watch a reply take. And its output is what a model is about to be
+//! charged for reading, so both ends are kept and the middle is counted and
+//! dropped. Neither bound is confinement and neither is a security control;
+//! they are what keeps one call from taking a turn or a context window with it.
+
+use std::collections::VecDeque;
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+/// How long one line gets before it is killed.
+///
+/// Bounded by what an operator will watch a single message take, because this
+/// runs inside a turn. Anything slower than this is a piece of work rather than
+/// a question, and `code` is the tool with the long ceiling on it. The refusal
+/// says exactly that, because a timeout an agent cannot act on gets retried.
+pub const PATIENCE: Duration = Duration::from_secs(120);
+
+/// How much of one stream is kept, in bytes, split between its two ends.
+///
+/// Both ends rather than one, because which end carries the answer depends on
+/// the command and nothing here knows which was run: `git log` puts it at the
+/// top and a failing test run puts it at the bottom. Keeping the head alone
+/// sends a model back to re-run a slow command through `tail`; keeping the tail
+/// alone silently drops the newest commits off a log. What fell out of the
+/// middle is counted and said, so the model narrows the command rather than
+/// concluding that was all the output there was.
+const KEPT: usize = 12_000;
+
+/// The shell a line is handed to.
+///
+/// `bash` rather than `sh`, because a model writes bash: `[[ ]]`, `pipefail`
+/// and `$(...)` inside a conditional are what turn up, and under a POSIX `sh`
+/// each is a syntax error about a token the model does not believe it wrote.
+///
+/// Not a login shell. [`crate::programs::adopt_operator_path`] already put the
+/// operator's `PATH` on this process at startup, so `-l` would re-read their rc
+/// files on every call to arrive at the same answer, slowly, and would run a
+/// version manager's startup hook in front of every `git status`.
+const SHELL: &str = "bash";
+
+/// What one line did.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ran {
+    pub stdout: String,
+    pub stderr: String,
+    /// Absent when the line was killed at [`PATIENCE`], which is the one way it
+    /// ends without reporting one. Absent is not zero: a killed command has not
+    /// succeeded, and a `0` here would say it had.
+    pub exit_code: Option<i32>,
+    /// Bytes that fell out of the middle of either stream.
+    pub dropped: usize,
+}
+
+impl Ran {
+    /// What the model is shown.
+    ///
+    /// Both streams, labeled, with the exit code only when it is not zero: a
+    /// command that worked should read as its output and nothing else. The two
+    /// unusual endings each say what to do next, because a tool result an agent
+    /// cannot act on is one it reruns unchanged.
+    pub fn rendered(&self) -> String {
+        let mut out = String::new();
+        if !self.stdout.trim().is_empty() {
+            out.push_str(self.stdout.trim_end());
+        }
+        if !self.stderr.trim().is_empty() {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str("stderr: ");
+            out.push_str(self.stderr.trim_end());
+        }
+        match self.exit_code {
+            None => {
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+                out.push_str(&format!(
+                    "(killed after {} seconds, so it did not finish and whatever it was doing may \
+                     be half done. This tool is for commands that answer quickly. If the work \
+                     genuinely takes minutes, hand it to `code` instead.)",
+                    PATIENCE.as_secs()
+                ));
+            }
+            Some(code) if code != 0 => {
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+                out.push_str(&format!("(exit code {code})"));
+            }
+            Some(_) => {}
+        }
+        if out.is_empty() {
+            out.push_str("(no output)");
+        }
+        out
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+pub enum ShellError {
+    #[error(
+        "`{0}` is not a directory on this machine any more. The repository was linked when it \
+         was there, so it has been moved, renamed or deleted since. Tell the operator, and say \
+         they can point the repository at where it is now from its panel"
+    )]
+    Gone(String),
+    #[error(
+        "the shell could not be started ({0}). Nothing ran. This is the app's own plumbing \
+         rather than anything about your command, so tell the operator what you were trying to \
+         do rather than rewriting it"
+    )]
+    Unstartable(String),
+}
+
+/// Runs one line in one directory and answers with what it did.
+///
+/// `stdin` is closed rather than inherited, and it is load-bearing twice over.
+/// There is no terminal to read from, so a command that waits for input would
+/// hold the turn until [`PATIENCE`] and then be killed with nothing to show for
+/// it. `GIT_TERMINAL_PROMPT=0` is the same hazard from git's own end: a push to
+/// a remote this machine is not signed in to prompts for a username, and a
+/// prompt nobody can answer is two minutes of a turn spent on a question.
+///
+/// A killed line kills its own process and no further. A command that
+/// backgrounded something outlives this, exactly as a coding job's does, and
+/// for the same reason: a process group would also take out whatever the
+/// operator's own tooling started in there.
+pub async fn run(directory: &str, line: &str, patience: Duration) -> Result<Ran, ShellError> {
+    // Checked here rather than left to the spawn, because the spawn's own error
+    // for a missing directory is an errno the operator cannot act on and this
+    // is the one failure that happens to people: a repository linked last month
+    // and a directory renamed last week.
+    if !Path::new(directory).is_dir() {
+        return Err(ShellError::Gone(directory.to_string()));
+    }
+
+    let mut child = tokio::process::Command::new(SHELL)
+        .arg("-c")
+        .arg(line)
+        .current_dir(directory)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        // So a dropped future is a killed process rather than a shell left
+        // running in somebody's repository with nothing holding a handle to it.
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|err| ShellError::Unstartable(err.to_string()))?;
+
+    // Taken before the wait, because both pipes have to be drained while the
+    // child runs. A child that fills one and blocks on it, while this waits for
+    // the child, is a deadlock that only shows up on commands that print more
+    // than a pipe buffer holds.
+    let mut out = child.stdout.take();
+    let mut err = child.stderr.take();
+
+    let reading = async {
+        let (stdout, stderr) = tokio::join!(drain(&mut out), drain(&mut err));
+        let status = child.wait().await;
+        (stdout, stderr, status)
+    };
+
+    match tokio::time::timeout(patience, reading).await {
+        Ok(((stdout, out_dropped), (stderr, err_dropped), status)) => Ok(Ran {
+            stdout,
+            stderr,
+            // A status that could not be read is reported as killed rather than
+            // as a success: the one thing this must never do is say a command
+            // worked when nothing here knows whether it did.
+            exit_code: status.ok().and_then(|status| status.code()),
+            dropped: out_dropped + err_dropped,
+        }),
+        Err(_) => {
+            // `kill_on_drop` would do this when the future is dropped, but the
+            // kill is awaited here so the process is gone before the turn
+            // carries on rather than at some point after it.
+            let _ = child.kill().await;
+            Ok(Ran { stdout: String::new(), stderr: String::new(), exit_code: None, dropped: 0 })
+        }
+    }
+}
+
+/// Reads one stream to its end, keeping both of its ends.
+///
+/// Reads past the cap rather than stopping at it, because a reader that stops
+/// leaves the pipe to fill and the child to block on a write nobody will take:
+/// the command would never finish and the only thing that ended the call would
+/// be [`PATIENCE`]. So everything is read and the middle is thrown away as it
+/// goes, which is what makes the memory this holds bounded by [`KEPT`] rather
+/// than by what the command decided to print.
+async fn drain<R: AsyncRead + Unpin>(reader: &mut Option<R>) -> (String, usize) {
+    let Some(reader) = reader.as_mut() else { return (String::new(), 0) };
+
+    let ends = KEPT / 2;
+    let mut head: Vec<u8> = Vec::new();
+    let mut tail: VecDeque<u8> = VecDeque::new();
+    let mut dropped = 0usize;
+    let mut chunk = [0u8; 8192];
+
+    loop {
+        let read = match reader.read(&mut chunk).await {
+            Ok(0) | Err(_) => break,
+            Ok(read) => read,
+        };
+        for &byte in &chunk[..read] {
+            if head.len() < ends {
+                head.push(byte);
+                continue;
+            }
+            tail.push_back(byte);
+            if tail.len() > ends {
+                tail.pop_front();
+                dropped += 1;
+            }
+        }
+    }
+
+    if dropped == 0 {
+        head.extend(tail);
+        // Lossy because a stream is bytes and a command is entitled to print
+        // any of them. A model reading one replacement character in a binary
+        // file is a better outcome than a tool that fails on it.
+        return (String::from_utf8_lossy(&head).into_owned(), 0);
+    }
+
+    // The gap says what is missing and how to go and get it. Without the
+    // second half a model reads the two ends as one continuous output, which
+    // is how a summary comes back describing a file that is not there.
+    let gap = format!(
+        "\n\n… {dropped} bytes from the middle were dropped. Narrow the command — `head`, \
+         `tail`, `grep`, a smaller range — if you need what was in there. …\n\n"
+    );
+    let mut whole = String::from_utf8_lossy(&head).into_owned();
+    whole.push_str(&gap);
+    whole.push_str(&String::from_utf8_lossy(tail.make_contiguous()));
+    (whole, dropped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ran(stdout: &str, stderr: &str, exit_code: Option<i32>) -> Ran {
+        Ran { stdout: stdout.to_string(), stderr: stderr.to_string(), exit_code, dropped: 0 }
+    }
+
+    #[test]
+    fn a_command_that_worked_reads_as_its_output_and_nothing_else() {
+        assert_eq!(ran("on branch main\n", "", Some(0)).rendered(), "on branch main");
+    }
+
+    #[test]
+    fn a_failure_carries_its_code_and_its_stderr() {
+        let rendered = ran("", "fatal: not a git repository\n", Some(128)).rendered();
+        assert!(rendered.contains("stderr: fatal: not a git repository"), "{rendered}");
+        assert!(rendered.contains("(exit code 128)"), "{rendered}");
+    }
+
+    /// The one ending an agent has to be told what to do about, because the
+    /// obvious move — run it again — is the one that spends another two
+    /// minutes arriving in the same place.
+    #[test]
+    fn a_killed_command_says_it_did_not_finish_and_names_the_other_tool() {
+        let rendered = ran("half of a build\n", "", None).rendered();
+        assert!(rendered.contains("did not finish"), "{rendered}");
+        assert!(rendered.contains("`code`"), "{rendered}");
+        assert!(!rendered.contains("exit code"), "a kill is not an exit: {rendered}");
+    }
+
+    #[test]
+    fn a_command_that_said_nothing_says_so() {
+        assert_eq!(ran("", "", Some(0)).rendered(), "(no output)");
+    }
+}
+
+/// Against a real shell, because the thing being tested is a process.
+///
+/// Same argument `tests/coding.rs` makes for its stand-ins and `programs.rs`
+/// makes for its: what a child is handed, what it prints and whether it is
+/// still running are only observable from outside it.
+#[cfg(all(test, unix))]
+mod running {
+    use super::*;
+
+    /// Generous, because these are real processes on a machine also running the
+    /// rest of the suite. What is being asserted is the answer, not the
+    /// deadline; the deadline has a test of its own.
+    const ENOUGH: Duration = Duration::from_secs(60);
+
+    #[tokio::test]
+    async fn a_line_runs_in_the_directory_it_was_given() {
+        let dir = std::env::temp_dir();
+        let ran = run(dir.to_str().unwrap(), "pwd", ENOUGH).await.unwrap();
+        assert_eq!(ran.exit_code, Some(0));
+        // Compared by canonical path: macOS puts the temp directory under
+        // `/var`, which is a symlink to `/private/var`, and `pwd` answers with
+        // the resolved one.
+        let said = std::fs::canonicalize(ran.stdout.trim()).unwrap();
+        assert_eq!(said, std::fs::canonicalize(&dir).unwrap());
+    }
+
+    #[tokio::test]
+    async fn a_failing_line_answers_rather_than_erroring() {
+        let ran = run(".", "exit 3", ENOUGH).await.unwrap();
+        assert_eq!(ran.exit_code, Some(3));
+    }
+
+    #[tokio::test]
+    async fn both_streams_come_back() {
+        let ran = run(".", "echo out; echo err >&2", ENOUGH).await.unwrap();
+        assert_eq!(ran.stdout.trim(), "out");
+        assert_eq!(ran.stderr.trim(), "err");
+    }
+
+    /// The bound that keeps one call from taking a context window with it, and
+    /// the reason both ends are kept rather than one.
+    #[tokio::test]
+    async fn a_command_that_prints_too_much_keeps_both_ends_and_counts_the_middle() {
+        // Numbered lines well past the cap, so the first and the last are far
+        // enough apart that keeping both is the only way to have both.
+        let ran = run(".", "seq 1 200000", ENOUGH).await.unwrap();
+        assert!(ran.dropped > 0, "nothing was dropped, so the cap did not apply");
+        assert!(ran.stdout.starts_with("1\n2\n3\n"), "the head is not the head");
+        assert!(ran.stdout.trim_end().ends_with("200000"), "the tail is not the tail");
+        assert!(ran.stdout.contains("bytes from the middle were dropped"), "the gap is silent");
+        assert!(ran.stdout.len() < KEPT + 500, "kept {} bytes", ran.stdout.len());
+        assert_eq!(ran.exit_code, Some(0), "the command still finished");
+    }
+
+    /// The deadlock this would have without the two pipes being drained while
+    /// the child runs: more output than a pipe buffer holds, from a command
+    /// that then has to exit.
+    #[tokio::test]
+    async fn a_command_that_fills_the_pipe_still_finishes() {
+        let ran = run(".", "seq 1 100000 >&2; echo done", ENOUGH).await.unwrap();
+        assert_eq!(ran.exit_code, Some(0));
+        assert_eq!(ran.stdout.trim(), "done");
+    }
+
+    #[tokio::test]
+    async fn a_line_that_will_not_end_is_killed_and_says_so() {
+        let ran = run(".", "sleep 30", Duration::from_millis(300)).await.unwrap();
+        assert_eq!(ran.exit_code, None);
+        assert!(ran.rendered().contains("did not finish"), "{}", ran.rendered());
+    }
+
+    /// Not a nicety: with stdin inherited there is no terminal to read from,
+    /// and a command that asks for input holds the turn until the ceiling.
+    #[tokio::test]
+    async fn a_command_that_waits_for_input_gets_nothing_and_ends() {
+        let ran = run(".", "read line; echo \"got [$line]\"", ENOUGH).await.unwrap();
+        assert_eq!(ran.stdout.trim(), "got []");
+    }
+
+    #[tokio::test]
+    async fn a_directory_that_is_no_longer_there_says_who_can_fix_it() {
+        let err = run("/no/such/directory/here", "pwd", ENOUGH).await.unwrap_err();
+        assert_eq!(err, ShellError::Gone("/no/such/directory/here".to_string()));
+        assert!(err.to_string().contains("operator"), "{err}");
+    }
+}

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -3266,7 +3266,7 @@ async fn a_computer_belongs_to_an_agent_the_operator_gave_one_to_and_not_to_the_
         if has_tool_result(body) {
             Script::Say("I could not run that: I have no computer.".into())
         } else if speaker(body) == "Talker" {
-            Script::Shell("uname -a".into())
+            Script::RunCommand("uname -a".into())
         } else {
             Script::Say("Nothing needed doing.".into())
         }

--- a/src-tauri/tests/coding.rs
+++ b/src-tauri/tests/coding.rs
@@ -26,6 +26,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use guac_lib::coding::{self, Progress};
+use guac_lib::domain::approval::Decision;
 use guac_lib::domain::repository::{CleanRepository, Gate, Harness as Which};
 use guac_lib::runtime::guard::GuardLimits;
 
@@ -448,6 +449,182 @@ async fn a_job_is_told_which_branch_it_is_standing_on() {
     let note = brief.find("Standing instruction").expect("the note still rides along");
     assert!(state < work && work < note, "the three parts are out of order: {brief}");
 
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+// ---- the other door ------------------------------------------------------
+
+/// Links a repository to an agent and answers with where it is on disk.
+fn put_in_a_repository(h: &Harness, agent: &str, repo: &Path, gate: Gate) {
+    let card = h.agent_named(agent).unwrap();
+    let linked = h
+        .runtime
+        .store()
+        .create_repository(&CleanRepository {
+            group_id: card.group_id,
+            name: "guaca".into(),
+            path: repo.to_string_lossy().to_string(),
+            note: String::new(),
+            harness: Which::Claude,
+            gate,
+        })
+        .unwrap();
+    h.runtime.store().set_agent_repository(card.id, Some(linked.id)).unwrap();
+}
+
+/// The small door, end to end: a real shell, in the operator's own repository,
+/// answering inside the turn that asked.
+///
+/// This is the seam nothing else can see. `shell` is offered on the same
+/// condition as `code` and reads the same column, and the failure it exists to
+/// stop is not a crash: it is an agent that has to spend a coding job, minutes
+/// and somebody's plan on `git status`, and that reports having no shell at all
+/// when the harness will not start.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_agent_in_a_repository_runs_a_line_there_and_is_answered_in_the_same_turn() {
+    let repo = a_repository("shell-here");
+    let here = repo.to_string_lossy().to_string();
+
+    // Branched on the tool result rather than on a counter, because a turn can
+    // take more than one call. The needle is the repository's own path, which
+    // is the whole assertion: a shell that ran somewhere else answers with
+    // somewhere else.
+    let stub = serve(move |body| {
+        if anyone_said(body, &here) {
+            Script::Say("I am standing in the repository.".into())
+        } else {
+            Script::InRepository("git rev-parse --show-toplevel".into())
+        }
+    })
+    .await;
+    let h = harness(&stub, &["Engineer"], GuardLimits::default());
+    put_in_a_repository(&h, "Engineer", &repo, Gate::Open);
+
+    let run = h.runtime.send_from_human(h.id("Engineer"), "which directory are you in?").unwrap();
+    h.settle(run).await;
+
+    let told = tool_results(&stub).join("\n");
+    assert!(
+        told.contains(&repo.to_string_lossy().to_string()),
+        "the line did not run in the repository:\n{told}"
+    );
+    assert!(
+        h.channel_texts("Engineer").iter().any(|t| t.contains("standing in the repository")),
+        "and the turn finished on it:\n{}",
+        h.transcript()
+    );
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+/// The gate is a fact about the repository, so it cannot mean one thing through
+/// `code` and another through `shell`.
+///
+/// Both doors ask `coding::bridge::outward` about the same shell line, from the
+/// same function. A gate that read only the harness's calls would be a gate an
+/// agent walks around by picking the other tool, which is worse than no gate:
+/// the operator switched it on and would be told it was holding.
+///
+/// The line is deliberately two commands. A `deny` refuses the *call*, exactly
+/// as the `PreToolUse` hook does, so the harmless half must not have happened
+/// either — a refusal that ran the first half and stopped at the push is a
+/// tree in a state nobody asked for.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_line_that_reaches_outside_a_gated_repository_asks_first_and_a_no_runs_nothing() {
+    let repo = a_repository("shell-gated");
+
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Say("The operator did not allow the push.".into())
+        } else {
+            Script::InRepository("touch pushed.txt && git push origin main".into())
+        }
+    })
+    .await;
+    let h = harness(&stub, &["Engineer"], GuardLimits::default());
+    put_in_a_repository(&h, "Engineer", &repo, Gate::AskBeforePushing);
+
+    let run = h.runtime.send_from_human(h.id("Engineer"), "ship it").unwrap();
+
+    let request = h.awaited_request().await;
+    h.runtime.decide_approval(request, Decision::Deny).unwrap();
+    h.settle(run).await;
+
+    let told = tool_results(&stub).join("\n");
+    assert!(told.contains("Refused"), "the model was not told it was refused:\n{told}");
+    assert!(told.contains("waiting on them"), "a refusal needs a way forward:\n{told}");
+    assert!(
+        !repo.join("pushed.txt").exists(),
+        "the call was refused, so no part of the line may have run"
+    );
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+/// And the gate stops nothing else.
+///
+/// Everything that is not outward-facing is what the directory and git already
+/// cover, in both doors. A gate that parked `git status` would be one the
+/// operator switches off within the hour, which is the behavior they turned it
+/// on to get.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_ordinary_line_in_a_gated_repository_runs_without_asking_anybody() {
+    let repo = a_repository("shell-ungated");
+
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Say("Nothing is staged.".into())
+        } else {
+            Script::InRepository("git status --porcelain; echo read-the-tree".into())
+        }
+    })
+    .await;
+    let h = harness(&stub, &["Engineer"], GuardLimits::default());
+    put_in_a_repository(&h, "Engineer", &repo, Gate::AskBeforePushing);
+
+    let run = h.runtime.send_from_human(h.id("Engineer"), "anything uncommitted?").unwrap();
+    h.settle(run).await;
+
+    let told = tool_results(&stub).join("\n");
+    assert!(told.contains("read-the-tree"), "the line did not run:\n{told}");
+    assert!(
+        h.runtime.store().pending_approvals(10).unwrap().is_empty(),
+        "nobody should have been asked about reading the tree"
+    );
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+/// The door that stays open when the other one will not.
+///
+/// A work tree with a job already in it refuses `code`, on purpose: two
+/// harnesses in one directory interleave their edits. One line is not that, and
+/// refusing it here would take away the read an agent most wants while a job
+/// runs, which is what the job is doing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_line_still_runs_in_a_work_tree_a_coding_job_is_already_in() {
+    stand_ins();
+    let repo = a_repository("shell-alongside");
+    // Slow enough that the job is genuinely still running when the line does.
+    std::fs::write(repo.join(LINGER), "3").unwrap();
+
+    let stub = serve(|body| {
+        if anyone_said(body, "alongside-the-job") {
+            Script::Say("The job is still going.".into())
+        } else if has_tool_result(body) {
+            Script::InRepository("echo alongside-the-job".into())
+        } else {
+            Script::Code("something long".into())
+        }
+    })
+    .await;
+    let h = harness(&stub, &["Engineer"], GuardLimits::default());
+    put_in_a_repository(&h, "Engineer", &repo, Gate::Open);
+
+    let run =
+        h.runtime.send_from_human(h.id("Engineer"), "start it and tell me where we are").unwrap();
+    h.settle(run).await;
+
+    let told = tool_results(&stub).join("\n");
+    assert!(told.contains("A coding agent is working"), "the job did not start:\n{told}");
+    assert!(told.contains("alongside-the-job"), "the line was refused or never ran:\n{told}");
     let _ = std::fs::remove_dir_all(&repo);
 }
 

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -95,7 +95,14 @@ pub enum Script {
     AskQuestion { question: String, options: Vec<String> },
     /// Emit a `run_command` tool call: a model reaching for a computer, whether
     /// or not it was offered one.
-    Shell(String),
+    ///
+    /// Named for the tool rather than for what it is, because there are two
+    /// shells now and they run on two machines: this one is the sandbox, and
+    /// [`Script::InRepository`] is the operator's own repository.
+    RunCommand(String),
+    /// Emit a `shell` tool call: one line in the agent's repository, on the
+    /// operator's machine, answered in the turn that asked.
+    InRepository(String),
     /// Emit a `use_screen` tool call that looks at the screen. The same reach
     /// at the one place whose entire answer is a picture, which is what a model
     /// running on an endpoint that takes text only must not be served.
@@ -281,11 +288,21 @@ pub fn render(script: &Script) -> String {
                 serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
             ));
         }
-        Script::Shell(command) => {
+        Script::RunCommand(command) => {
+            let args = serde_json::json!({ "command": command }).to_string();
+            body.push_str(&frame(serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                {"index":0,"id":"call_run_command","type":"function",
+                 "function":{"name":"run_command","arguments": args}}
+            ]}}]})));
+            body.push_str(&frame(
+                serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
+            ));
+        }
+        Script::InRepository(command) => {
             let args = serde_json::json!({ "command": command }).to_string();
             body.push_str(&frame(serde_json::json!({"choices":[{"delta":{"tool_calls":[
                 {"index":0,"id":"call_shell","type":"function",
-                 "function":{"name":"run_command","arguments": args}}
+                 "function":{"name":"shell","arguments": args}}
             ]}}]})));
             body.push_str(&frame(
                 serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),

--- a/src/lib/trail.test.ts
+++ b/src/lib/trail.test.ts
@@ -57,6 +57,26 @@ describe("what one call was", () => {
     expect(step?.said).toBe("exit 0, 8 bytes out");
   });
 
+  it("tells the two shells apart, because they run on two machines", () => {
+    // An agent with a computer and a repository draws both in one turn, and the
+    // chip is the only place an operator finds out which filesystem a command
+    // touched.
+    const [inRepo] = steps(
+      call("shell", { command: "git status --short" }, ok("exit 0, 12 bytes out")),
+    );
+    expect(inRepo?.title).toBe("Ran a command in its repository");
+    expect(inRepo?.target).toBe("git status --short");
+
+    const [onSandbox] = steps(call("run_command", { command: "uname -a" }, ok("exit 0")));
+    expect(onSandbox?.title).toBe("Ran a command");
+  });
+
+  it("names the brief a coding agent was started with", () => {
+    const [step] = steps(call("code", { task: "fix the flaky test" }, ok("started work in guaca")));
+    expect(step?.title).toBe("Started a coding agent");
+    expect(step?.target).toBe("fix the flaky test");
+  });
+
   it("reads a screen action as the place it happened", () => {
     const [step] = steps(call("use_screen", { action: "click", x: 412, y: 96 }));
     expect(step?.title).toBe("Clicked on its screen");

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -197,6 +197,15 @@ function describe(tool: string, args: Args): Described {
     case "run_command":
       return { title: "Ran a command", target: text(args, "command") };
 
+    // Named apart from `run_command` rather than sharing its label, because
+    // the two run on different machines and the chip is where an operator
+    // finds out which. An agent that has both draws both in one turn.
+    case "shell":
+      return { title: "Ran a command in its repository", target: text(args, "command") };
+
+    case "code":
+      return { title: "Started a coding agent", target: text(args, "task") };
+
     case "open_on_desktop": {
       const command = text(args, "command");
       return {
@@ -331,6 +340,10 @@ export function callInFlight(name: string, raw: unknown): string {
   switch (name) {
     case "run_command":
       return "Running a command";
+    case "shell":
+      return "Running a command in its repository";
+    case "code":
+      return "Starting a coding agent";
     case "browse": {
       const url = text(args, "url");
       return url && text(args, "action") === "open"
@@ -377,6 +390,8 @@ function manyLabel(group: TrailGroup): string {
   switch (group.steps[0]!.tool) {
     case "run_command":
       return `Ran ${count} commands`;
+    case "shell":
+      return `Ran ${count} commands in its repository`;
     case "browse": {
       const places = new Set(group.steps.map((step) => step.where).filter(Boolean));
       const only = places.size === 1 ? [...places][0] : null;


### PR DESCRIPTION
A repository had one door: `code`, which hands a brief to a harness that runs for minutes in its own process on its own budget, so `git status` or `gh pr merge 98` cost a whole coding job whose answer arrived after the turn that wanted it had ended, and when a harness would not start (a spent plan, a program not installed, another job already in the work tree) an agent holding a repository reported to the operator that it had no shell at all. `shell` runs one line in the linked directory and answers in the turn that asked, offered on the same condition as `code` and with no second setting; it adds directness rather than reach, since a job in that directory already ran arbitrary commands as the operator under `bypassPermissions`. Both doors ask `bridge::outward` and park through `Runtime::ask_about_push`, so the gate cannot mean one thing through `code` and another through `shell`, and a denial refuses the whole call rather than only its outward-facing half: `touch a.txt && git push` runs neither part. It deliberately takes no lock (one line is the operator typing in their own terminal while a job runs), is killed at two minutes, and clips a stream to 12KB keeping both ends with the dropped middle counted; `request_permission` is now offered to repository-only agents too, which was already wrong to withhold given that a job pushes in the operator's name. Tested against a real `bash` and a real `git init`, because the thing being tested is a process: a line runs in the linked directory and answers in the turn, the gate stops the same commands through both doors and a no runs no part of the line, an ordinary line asks nobody, and a work tree with a job in it still answers one.
