### PR TITLE
feat: an agent that cannot go on says so where the operator will see it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ src-tauri/src/
     worknote.rs       A line about work in flight, and why it is not memory.
     approval.rs       The two things an agent stops to ask a person, and why
                       only one of them may draw the model's own words.
+    escalation.rs     The third thing, which stops nothing: work an agent
+                      cannot move and only the operator can.
     group.rs          A crew's wall, and the settings its agents run on.
     plugin.rs         The servers a crew can sign in to, what it got, and
                       which of its agents may spend it.
@@ -130,6 +132,7 @@ repo: the frontend renders state and forwards intent.
 | What a job inherits from the operator's own Claude Code, and what that costs | *A job inherits the operator's own Claude Code setup* in `docs/CODING.md`, which has the measurement and the one hazard in it |
 | A program that is installed and reported missing: `claude`, `pi`, `git`, `gh` | *A double-clicked app does not have the operator's `PATH`* below, then `src-tauri/src/programs.rs` |
 | Anything an agent stops to ask a person: the desk, the queue, the two kinds of request, `ask_operator` | `docs/ATTENTION.md`, then `domain/approval.rs` and `Runtime::park` |
+| An agent that cannot go on at all, what reaches the operator without parking a turn, `escalate` | *Three things an agent can do about a person* and *What an escalation is* in `docs/ATTENTION.md`, then `domain/escalation.rs` and `Store::raise_escalation` |
 | The crews' column, its badges, how a crew names itself, which crew the rail is inside | *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/presence.ts`, `src/components/GroupRail.tsx` and `src/components/OrbTag.tsx` |
 | What an agent may do with a page it has just read | *A page that was read this turn cannot quietly press a button* |
 | Screenshots, coordinates, what a screen action answers with | *A computer is looked at, never asked* in `docs/MACHINES.md` |
@@ -433,6 +436,32 @@ the model takes a screenshot to see what `browse` did.
   against 16,000 and told operators their memory was about to be cut by a runtime
   storing it whole. A warning is read as a fact about what will happen, so the
   number is only worth drawing while it is the runtime's number.
+- **An escalation is not an approval with the parking taken out, and folding
+  it into one would break the half that matters.** Both mean the operator, and
+  everything else about them is opposite. A request stops a turn mid-flight to
+  get something back, holds a run booking while it waits, and lapses after ten
+  minutes because holding one costs money. An escalation is a turn that has run
+  out of road saying so on its way out: nothing parks, so nothing expires, so a
+  row can sit for the two days it has actually been true. Given ten minutes it
+  would lapse before the operator got back from lunch, having spent a booking
+  proving that a broken tool chain was still broken. `docs/ATTENTION.md`.
+- **`raised_at` never moves and `times` only goes up.** An agent that hits the
+  same wall on six turns raises six times and holds one row. Refreshing the
+  stamp is the obvious implementation and it destroys the only thing the row is
+  worth: *stuck since Tuesday, six turns into it* is a fact nothing else in the
+  app can see, and *stuck just now* is what the message in the channel already
+  said five times. Same argument a working note's stamp is built on, one store
+  over, and the same reason nothing lets an agent withdraw its own escalation:
+  it would take the record of a lost fortnight with it at the moment it decided
+  things were fine.
+- **`Store::raise_escalation` takes an immediate transaction and a deferred one
+  would look identical until it did not.** The read and the insert are one
+  decision, and an agent writes from every thread it holds. Deferred, two turns
+  both read "nothing open", both try to insert, and the second is refused with
+  `SQLITE_BUSY_SNAPSHOT`, which no busy timeout can wait out because the
+  snapshot it read from is already stale. The failure lands inside a turn that
+  had already given up on getting anywhere, which is the worst place in the app
+  for one. The test is the eight-thread one beside it.
 - **A deleted agent is `Terminated` with a stamp, not a fourth lifecycle.** The
   compost holds it for thirty days and everything it owns privately waits with
   it, but to the rest of the app it is deleted: unreachable, undiscoverable, out

--- a/docs/ATTENTION.md
+++ b/docs/ATTENTION.md
@@ -34,21 +34,26 @@ one of them.
 
 One rule: **it holds stopped work, and only the operator can start it again.**
 
-A parked turn qualifies by definition. That is the whole list today, and the
-rule is what keeps it that way. A run that failed does not qualify, because
-nothing is waiting on anybody and a failure is understood in the channel it
-happened in. Neither does a run that finished, a routine that fired, a paused
-agent, or a workspace with no API key: that last one is a precondition rather
-than a request, it already has a banner at the top of the reading column where
-somebody setting up is looking, and moving it into a panel that can be collapsed
-would make first-run setup quieter for no gain.
+Two things qualify, and the rule is what keeps the list at two. A parked turn
+qualifies by definition. An escalation qualifies by the same sentence with the
+parking taken out: an agent that cannot go on until the operator does something,
+which said so and carried on with what it could. A run that failed does not
+qualify, because nothing is waiting on anybody and a failure is understood in
+the channel it happened in. Neither does a run that finished, a routine that
+fired, a paused agent, or a workspace with no API key: that last one is a
+precondition rather than a request, it already has a banner at the top of the
+reading column where somebody setting up is looking, and moving it into a panel
+that can be collapsed would make first-run setup quieter for no gain.
 
 Three more refusals, each of which is a thing this could easily become.
 
 **It is usually absent.** No queue, no surface: not a small empty one, not a
 collapsed bar. A panel that is always there is furniture within a week and
 furniture is not read. Being gone almost all the time is what buys the corner of
-the screen.
+the screen. An escalation is the one thing on it that can stay up for days, and
+it is allowed to for the reason it exists: a crew that has been stuck since
+Tuesday *should* be furniture in the corner of the operator's screen until they
+deal with it.
 
 **It has no composer and no scrollback.** Every control on it is bounded, and
 what has been answered is gone from it. The transcript is the record. A second
@@ -79,7 +84,7 @@ copy is the truth: it is taken rather than argued with, and both readings of it
 are corrected together. Nothing is believed until the read comes back, so a card
 whose answer was refused is still there and still answerable.
 
-## Two things an agent can stop to ask, and the line between them
+## Three things an agent can do about a person, and two lines between them
 
 Before this there was one, and it was "may I". An agent that needed a judgment
 call had no way to ask for one: it wrote the question into a channel nobody was
@@ -87,7 +92,8 @@ watching and either guessed or stalled. In a workspace with a dozen crews that
 is the common case, and it is invisible, because nothing parks and nothing is
 counted. You find out when the work comes back wrong.
 
-So there are two kinds of request, and the line between them is what a yes does.
+So there are two kinds of *request*, and the line between them is what a yes
+does.
 
 **A permission authorizes.** The agent could not do the thing; the operator's
 answer is what lets it. Every word on one of these is Guaca's, because an agent
@@ -112,11 +118,69 @@ timeout, one read back: `Runtime::park`, with `ask_permission` and
 `ask_question` as the two ways in. A second copy of that machinery would be a
 second place for a turn to be left parked forever.
 
+And a third thing that is not a request at all, because nothing waits on it.
+
+**An escalation reports.** The agent cannot go on and the operator is the only
+one who can change that: a harness that will not start, a sign-in that has
+expired, a machine only they can touch. Nothing about that is answerable inside
+a turn, and none of it stops being true because ten minutes passed. So the turn
+does not park. It says so on the way out, carries on with whatever it can still
+do, and what it said becomes a row. `escalate`.
+
+That is the second line, and it is about waiting rather than about severity.
+Both requests stop a turn mid-flight to get something back. An escalation is a
+turn that has run out of road saying so, and before it existed the agent's only
+move was to write a good clear paragraph into a channel addressed to somebody
+who was not reading it. That is not a hypothetical: five turns of one crew went
+that way, each one reporting the same broken tool chain, each one invisible,
+because nothing had parked and all three surfaces above are fed from the
+approvals table.
+
+## What an escalation is, and what it deliberately is not
+
+**Nothing parks, so nothing expires.** The ten minutes below exists because a
+parked turn holds a run booking and costs money to hold. An escalation holds
+nothing, so there is no window on it and no cost to it sitting for two days.
+
+**Nothing is answered.** There is no verdict and no value. Clearing is the
+operator saying they have dealt with it, and it tells the agent nothing: what
+actually unblocks an agent is a message in its channel, which is why the desk
+card leads with **Open channel** and not with **Clear**. An operator who only
+ever presses the cheaper button is running a desk they tidy instead of a desk
+they work, and the size of the two buttons is what says so.
+
+**One per agent, and it counts.** An agent that hits the same wall on six turns
+raises six times and the desk holds one row. `raised_at` never moves and `times`
+only goes up, so the row says *stuck since Tuesday, six turns into it*. That
+pair is the whole point. "Stuck" is a state and a message in a channel can carry
+it; a duration and a count are what say whether a crew has quietly stopped, and
+nothing else in the app can see them.
+
+**The agent is shown its own open escalation.** In the prompt, beside what it is
+waiting on, with the age and the count on it. An agent that cannot see what it
+already said raises it again as news every turn, which is the behavior in a
+channel that this replaced rather than an improvement on it.
+
+**The operator clears it, and the agent never can.** There is no tool to
+withdraw one, for the reason there is none to revise a working note: an agent
+that could take its own escalation off the desk would take with it the only
+record that a crew lost two days, at exactly the moment it decides it is fine
+now. A restore from the compost is the one other way one goes: a discarded agent
+has its escalation cleared, because thirty days later it would come back as news
+about a wall nobody has walked into since.
+
 **A question is counted in the menu bar and cannot be answered there.** Its
 answer is a word the operator picks or writes and a menu item is a thing you
 click; the shapes do not meet. So it appears as a row that opens the channel.
 Left out entirely it would still be in the title's count, and the operator would
 open the window looking for a request the menu had not mentioned.
+
+An escalation is in the menu bar too, in a section of its own with the age on
+the row, and it cannot be cleared from there either. Clearing is one click and
+would fit a menu item perfectly, which is exactly the problem: the click that
+takes it off the desk is not the click that deals with it, and the two must not
+be the same size. So the row opens the channel, which is what a question's row
+does and for a neighboring reason.
 
 ## What bounds the asking
 
@@ -128,7 +192,10 @@ third limit on something two limits already hold.
 
 What is not bounded is a crew of eight each asking once. That is eight cards,
 and it is correct: eight agents genuinely need answers, and the count on their
-crew's circle is what says so at a glance.
+crew's circle is what says so at a glance. The same bound holds an escalation
+without a limit of its own: an agent has one, so a workspace has as many as it
+has agents, and a crew where all eight have stopped is a workspace with eight
+things wrong with it.
 
 ## The ten minutes
 
@@ -157,7 +224,19 @@ that seam — a variant added in Rust and never written down in TypeScript at al
 
 `Desk.test.tsx` and `QuestionRequest.test.tsx` hold the refusals: no verdict on
 a question, no standing yes for anything done in the operator's name, no empty
-answer, no card dropped before the runtime has confirmed it.
+answer, no card dropped before the runtime has confirmed it. It also holds the
+one about ordering, which is not cosmetic: requests are drawn above escalations
+because one of them has ten minutes to be answered in and the other has as long
+as it takes, and sorting the perishable half under the durable half is how a
+permission lapses while the operator reads about a two-day-old wall.
+
+The store suite holds what a row is worth. A second raise is one row with a
+count and an unmoved stamp; a concurrent pair of raises from one agent is still
+one row, which is the case the unique index would otherwise refuse inside a turn
+that had already given up on getting anywhere. The cascade suite drives the
+whole of it: a scripted model escalates, the turn finishes rather than parking,
+the next turn is shown its own escalation in the prompt and does not raise it
+again.
 
 The cascade suite drives a real turn through a question end to end: it parks,
 the operator answers, the answer reaches the turn. What no offline suite can

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -460,6 +460,8 @@ pub fn run() {
             commands::disband_group,
             commands::approval_states,
             commands::pending_approvals,
+            commands::open_escalations,
+            commands::clear_escalation,
             commands::decide_approval,
             commands::answer_question,
             commands::agent_grants,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -20,9 +20,11 @@ use crate::domain::approval::{Approval, ApprovalState, Decision, ProtectedAction
 use crate::domain::attachment::Attachment;
 use crate::domain::connector::{Connector, ConnectorDraft};
 use crate::domain::envelope::Envelope;
+use crate::domain::escalation::Escalation;
 use crate::domain::group::{Group, GroupDraft, GroupInference};
 use crate::domain::ids::{
-    AgentId, ApprovalId, ConnectorId, GroupId, MessageId, PluginId, RepositoryId, RoutineId, RunId,
+    AgentId, ApprovalId, ConnectorId, EscalationId, GroupId, MessageId, PluginId, RepositoryId,
+    RoutineId, RunId,
 };
 use crate::domain::now_ms;
 use crate::domain::plugin::{
@@ -1259,6 +1261,27 @@ pub fn answer_question(
     answer: String,
 ) -> Reply<Approval> {
     Ok(state.runtime.answer_question(id, &answer)?)
+}
+
+/// Everything an agent has said it cannot get past without the operator.
+///
+/// The other half of the desk's queue, read the same way and for the same
+/// reason: what is on it is whatever the store says is open, so nothing can
+/// appear there that is not a row somewhere.
+///
+/// Unbounded in practice by the same argument `MAX_PENDING` rests on, one step
+/// stronger: an agent holds at most one open escalation, so this is bounded by
+/// the size of the crew.
+#[tauri::command]
+pub fn open_escalations(state: State<'_, AppState>) -> Reply<Vec<Escalation>> {
+    Ok(state.runtime.store().open_escalations(MAX_PENDING)?)
+}
+
+/// Takes one off the desk. Not an answer: nothing is waiting on it.
+#[tauri::command]
+pub fn clear_escalation(state: State<'_, AppState>, id: EscalationId) -> Reply<()> {
+    state.runtime.clear_escalation(id)?;
+    Ok(())
 }
 
 // ---- groups --------------------------------------------------------------

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -1203,6 +1203,61 @@ ALTER TABLE agents ADD COLUMN discarded_at INTEGER;
 ALTER TABLE repositories ADD COLUMN gate TEXT NOT NULL DEFAULT 'open';
 "#,
     ),
+    (
+        43,
+        r#"
+-- An escalation: work that has stopped and that only the operator can move.
+--
+-- There were two ways for an agent to reach a person and both of them park the
+-- turn inside a tool call, waiting ten minutes for an answer. Both are right
+-- for a decision the turn needs now. Neither is right for the case they kept
+-- being reached for anyway, which is an agent that cannot go on at all: a
+-- coding harness that will not start, a sign-in that has expired, a machine
+-- only the operator can touch. None of that is answerable inside a turn and
+-- none of it stops being true because ten minutes passed, so the agent wrote it
+-- into its channel instead, clearly, addressed to somebody who was not reading
+-- it. Five turns of one crew went that way before anybody noticed, and what
+-- made it invisible is that the three surfaces built for exactly this -- the
+-- count on a crew's circle, the desk, the menu bar -- are all fed from
+-- `approvals`. Nothing had parked, so all three said the workspace was fine.
+--
+-- Nothing parks here either, and that is the difference rather than an
+-- omission: the turn ends, no run booking is held, and so there is no window,
+-- no expiry, and no cost to a row staying open for two days. Nothing is
+-- answered either. Clearing is the operator saying they have dealt with it;
+-- what actually unblocks the agent is a message in the channel this row opens.
+--
+-- One open row per agent. An agent that hits the same wall on six turns must
+-- not fill the desk with six rows saying one thing, and must not be told to
+-- keep quiet either: the sixth raise restates the line, counts, and leaves
+-- `raised_at` exactly where it is. `raised_at` says how long this has been
+-- true, `times` says how many turns have hit it, and the pair is what says "a
+-- crew has been stuck for two days" rather than "an agent mentioned something".
+CREATE TABLE escalations (
+    id         TEXT    PRIMARY KEY,
+    agent_id   TEXT    NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    group_id   TEXT    NOT NULL,
+    run_id     TEXT    NOT NULL,
+    summary    TEXT    NOT NULL,
+    raised_at  INTEGER NOT NULL,
+    said_at    INTEGER NOT NULL,
+    times      INTEGER NOT NULL DEFAULT 1,
+    cleared_at INTEGER
+);
+
+-- One open escalation per agent, enforced here rather than by whoever writes
+-- one. A second open row is the failure the desk exists to prevent, one level
+-- down: a queue that says six things when six is one thing said six times.
+CREATE UNIQUE INDEX escalations_open_per_agent
+    ON escalations (agent_id)
+    WHERE cleared_at IS NULL;
+
+-- What the desk, the crews' column and the menu bar all read: what is still
+-- open, oldest first. Partial, so it stays the size of the problem rather than
+-- the size of the history.
+CREATE INDEX escalations_open ON escalations (raised_at) WHERE cleared_at IS NULL;
+"#,
+    ),
 ];
 
 /// The group every agent starts in, and the one the UI keeps out of the way

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use r2d2::{Pool, PooledConnection};
 use r2d2_sqlite::SqliteConnectionManager;
-use rusqlite::{named_params, params, OptionalExtension, Row};
+use rusqlite::{named_params, params, OptionalExtension, Row, TransactionBehavior};
 
 use crate::db::migrations;
 use crate::domain::agent::{AgentCard, CleanDraft, Lifecycle};
@@ -18,9 +18,11 @@ use crate::domain::approval::{
 };
 use crate::domain::connector::{CleanConnector, Connector};
 use crate::domain::envelope::{Envelope, Intent, Part, Participant, Trust};
+use crate::domain::escalation::{Escalation, Raised};
 use crate::domain::group::{CleanGroup, Group, GroupInference, GroupLimits, InferenceOverrides};
 use crate::domain::ids::{
-    AgentId, ApprovalId, ConnectorId, GroupId, MessageId, PluginId, RepositoryId, RoutineId, RunId,
+    AgentId, ApprovalId, ConnectorId, EscalationId, GroupId, MessageId, PluginId, RepositoryId,
+    RoutineId, RunId,
 };
 use crate::domain::now_ms;
 use crate::domain::plugin::{
@@ -1321,6 +1323,178 @@ impl Store {
     pub fn delete_agent_approvals(&self, agent: AgentId) -> Result<usize, StoreError> {
         let conn = self.conn()?;
         Ok(conn.execute("DELETE FROM approvals WHERE agent_id=?1", params![agent.to_string()])?)
+    }
+
+    // ---- escalations -----------------------------------------------------
+
+    /// Puts an agent's escalation up, or restates the one it already has.
+    ///
+    /// One transaction, because the read and the write are the same decision:
+    /// an agent writes from every thread it holds, and a check outside the
+    /// transaction lets two turns each find nothing open and each insert, which
+    /// the unique index then refuses at the worst possible moment. Inside it,
+    /// the second turn finds the first one's row and counts against it.
+    ///
+    /// `raised_at` never moves and `times` only goes up. That is the whole
+    /// design: what the operator needs is not that an agent is stuck, it is
+    /// that it has been stuck since Tuesday and that six turns have been spent
+    /// walking into it. A fresh stamp on every raise would hide the one number
+    /// that says so, exactly as refreshing a working note's stamp would.
+    pub fn raise_escalation(
+        &self,
+        agent: AgentId,
+        group: GroupId,
+        run: RunId,
+        summary: &str,
+        at: i64,
+    ) -> Result<Raised, StoreError> {
+        let mut conn = self.conn()?;
+        // Immediate, not deferred, and that is the difference between this
+        // working and this failing under exactly the concurrency it is for. A
+        // deferred transaction takes its write lock on the first write, so two
+        // turns of one agent both read "nothing open", both try to insert, and
+        // the second is refused with `SQLITE_BUSY_SNAPSHOT` -- which the busy
+        // handler cannot wait out, because there is nothing to wait for: the
+        // snapshot it read from is already stale. Taking the lock at BEGIN
+        // makes the second one queue and then find the first one's row.
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+
+        let open: Option<(String, String, i64, u32)> = tx
+            .query_row(
+                "SELECT id,run_id,raised_at,times FROM escalations
+                  WHERE agent_id=?1 AND cleared_at IS NULL",
+                params![agent.to_string()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()?;
+
+        if let Some((id, run_id, raised_at, times)) = open {
+            let id = id.parse::<EscalationId>().map_err(|e| StoreError::Corrupt(e.to_string()))?;
+            // The first raise's run, kept rather than replaced: it is the one
+            // with the beginning of the story in it.
+            let run_id = run_id.parse::<RunId>().map_err(|e| StoreError::Corrupt(e.to_string()))?;
+            let times = times.saturating_add(1);
+            tx.execute(
+                "UPDATE escalations SET summary=?2, said_at=?3, times=?4 WHERE id=?1",
+                params![id.to_string(), summary, at, times],
+            )?;
+            tx.commit()?;
+            return Ok(Raised::Again(Escalation {
+                id,
+                agent_id: agent,
+                group_id: group,
+                run_id,
+                summary: summary.to_string(),
+                raised_at,
+                said_at: at,
+                times,
+                cleared_at: None,
+            }));
+        }
+
+        let escalation = Escalation {
+            id: EscalationId::new(),
+            agent_id: agent,
+            group_id: group,
+            run_id: run,
+            summary: summary.to_string(),
+            raised_at: at,
+            said_at: at,
+            times: 1,
+            cleared_at: None,
+        };
+        tx.execute(
+            "INSERT INTO escalations (id,agent_id,group_id,run_id,summary,raised_at,said_at,times)
+             VALUES (?1,?2,?3,?4,?5,?6,?6,1)",
+            params![
+                escalation.id.to_string(),
+                agent.to_string(),
+                group.to_string(),
+                run.to_string(),
+                escalation.summary,
+                at,
+            ],
+        )?;
+        tx.commit()?;
+        Ok(Raised::First(escalation))
+    }
+
+    /// What one agent currently has up, if anything.
+    ///
+    /// Read on every turn of that agent, so the prompt can say what it already
+    /// told the operator and how long ago. An agent that cannot see its own
+    /// open escalation restates it as news.
+    pub fn open_escalation_for(&self, agent: AgentId) -> Result<Option<Escalation>, StoreError> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT id,agent_id,group_id,run_id,summary,raised_at,said_at,times,cleared_at
+               FROM escalations WHERE agent_id=?1 AND cleared_at IS NULL",
+        )?;
+        match stmt.query_row(params![agent.to_string()], row_to_escalation).optional()? {
+            Some(row) => Ok(Some(row?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Everything still up, oldest first.
+    ///
+    /// Oldest first because the age is the point: the row at the top is the one
+    /// that has been true longest, which is the opposite of a feed and is what
+    /// keeps a two-day-old escalation from sinking under this morning's.
+    ///
+    /// Terminated agents are left out, which is the same question fifteen other
+    /// queries ask. An agent in the compost is unreachable and out of every
+    /// crew, so a row on the desk offering to open its channel is an offer
+    /// nothing can take up.
+    pub fn open_escalations(&self, limit: u32) -> Result<Vec<Escalation>, StoreError> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT e.id,e.agent_id,e.group_id,e.run_id,e.summary,e.raised_at,e.said_at,e.times,
+                    e.cleared_at
+               FROM escalations e JOIN agents a ON a.id = e.agent_id
+              WHERE e.cleared_at IS NULL AND a.lifecycle <> 'terminated'
+              ORDER BY e.raised_at ASC, e.id ASC LIMIT ?1",
+        )?;
+        let rows = stmt.query_map(params![limit], row_to_escalation)?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row??);
+        }
+        Ok(out)
+    }
+
+    /// Takes one off the desk, and only from open.
+    ///
+    /// `cleared_at IS NULL` in the WHERE clause for the reason `settle_approval`
+    /// has `state='pending'` in its own: the operator can press this twice, and
+    /// a second clear must not move a stamp that already says when the first
+    /// one happened.
+    ///
+    /// `false` is a row that was already cleared or was never there, which the
+    /// caller reports as nothing rather than as a failure. Both mean the desk
+    /// the operator is looking at is behind the store, and the read that
+    /// follows is what corrects it.
+    pub fn clear_escalation(&self, id: EscalationId, at: i64) -> Result<bool, StoreError> {
+        let conn = self.conn()?;
+        Ok(conn.execute(
+            "UPDATE escalations SET cleared_at=?2 WHERE id=?1 AND cleared_at IS NULL",
+            params![id.to_string(), at],
+        )? > 0)
+    }
+
+    /// Everything one agent has up, cleared because the agent is going.
+    ///
+    /// A purge would take the rows with it either way -- the foreign key
+    /// cascades -- but a discarded agent is not deleted for thirty days, and
+    /// its escalation would sit on the desk for all of them asking the operator
+    /// to deal with work that has stopped for good.
+    pub fn clear_agent_escalations(&self, agent: AgentId, at: i64) -> Result<usize, StoreError> {
+        let conn = self.conn()?;
+        Ok(conn.execute(
+            "UPDATE escalations SET cleared_at=?2 WHERE agent_id=?1 AND cleared_at IS NULL",
+            params![agent.to_string(), at],
+        )?)
     }
 
     // ---- connectors ------------------------------------------------------
@@ -3515,6 +3689,35 @@ fn row_to_routine_run(row: &Row<'_>) -> RowResult<RoutineRun> {
                 cost: row.get::<_, Option<f64>>(5)?,
                 calls: row.get::<_, i64>(6)? as u64,
             },
+        })
+    })())
+}
+
+fn row_to_escalation(row: &Row<'_>) -> RowResult<Escalation> {
+    let id_raw: String = row.get(0)?;
+    let agent_raw: String = row.get(1)?;
+    let group_raw: String = row.get(2)?;
+    let run_raw: String = row.get(3)?;
+
+    Ok((|| {
+        Ok(Escalation {
+            id: id_raw
+                .parse::<EscalationId>()
+                .map_err(|e| StoreError::Corrupt(format!("bad escalation id {id_raw:?}: {e}")))?,
+            agent_id: agent_raw
+                .parse::<AgentId>()
+                .map_err(|e| StoreError::Corrupt(format!("bad agent id {agent_raw:?}: {e}")))?,
+            group_id: group_raw
+                .parse::<GroupId>()
+                .map_err(|e| StoreError::Corrupt(format!("bad group id {group_raw:?}: {e}")))?,
+            run_id: run_raw
+                .parse::<RunId>()
+                .map_err(|e| StoreError::Corrupt(format!("bad run id {run_raw:?}: {e}")))?,
+            summary: row.get(4)?,
+            raised_at: row.get(5)?,
+            said_at: row.get(6)?,
+            times: row.get(7)?,
+            cleared_at: row.get(8)?,
         })
     })())
 }
@@ -6353,6 +6556,173 @@ mod tests {
         assert_eq!(f.store.delete_agent_approvals(manager.id).unwrap(), 1);
         assert!(!f.store.has_standing_grant(manager.id, ProtectedAction::CreateAgent).unwrap());
         assert!(f.store.get_approval(request.id).unwrap().is_none());
+    }
+
+    // ---- escalations -----------------------------------------------------
+
+    /// One escalation from `agent`, raised at `at`.
+    fn stuck(store: &Store, agent: &AgentCard, summary: &str, at: i64) -> Raised {
+        store.raise_escalation(agent.id, agent.group_id, RunId::new(), summary, at).unwrap()
+    }
+
+    #[test]
+    fn an_escalation_goes_up_once_and_is_read_back_whole() {
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let raised = stuck(&f.store, &manager, "the deploy needs a key only you have", 1_000);
+
+        assert!(matches!(raised, Raised::First(_)));
+        let open = f.store.open_escalation_for(manager.id).unwrap().unwrap();
+        assert_eq!(open.summary, "the deploy needs a key only you have");
+        assert_eq!(open.raised_at, 1_000);
+        assert_eq!(open.times, 1);
+        assert_eq!(open.cleared_at, None);
+    }
+
+    #[test]
+    fn raising_it_again_counts_the_turn_and_leaves_the_stamp_where_it_is() {
+        // The whole reason a row beats the message it replaces. What the
+        // operator needs is not that an agent is stuck, it is that it has been
+        // stuck since Tuesday and that three turns have gone into it. A fresh
+        // stamp on every raise hides the one number that says so.
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        stuck(&f.store, &manager, "the tooling is down", 1_000);
+        stuck(&f.store, &manager, "the tooling is down", 2_000);
+        let third = stuck(&f.store, &manager, "the tooling is still down", 3_000);
+
+        let Raised::Again(one) = third else { panic!("a second raise is not a second row") };
+        assert_eq!(one.raised_at, 1_000, "the age is the news and must not move");
+        assert_eq!(one.said_at, 3_000, "and when it was last said is a second question");
+        assert_eq!(one.times, 3);
+        assert_eq!(one.summary, "the tooling is still down", "the latest wording stands");
+        assert_eq!(one.run_id, f.store.open_escalation_for(manager.id).unwrap().unwrap().run_id);
+        assert_eq!(f.store.open_escalations(50).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn two_agents_stuck_are_two_rows() {
+        // One per agent, not one per workspace. A crew where three agents have
+        // each run into a different wall is three things to deal with.
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let critic = f.store.create_agent(&draft("Critic")).unwrap();
+        stuck(&f.store, &manager, "no key", 1_000);
+        stuck(&f.store, &critic, "no machine", 2_000);
+
+        let open = f.store.open_escalations(50).unwrap();
+        assert_eq!(open.len(), 2);
+        assert_eq!(open[0].agent_id, manager.id, "oldest first: the age is what is being read");
+    }
+
+    #[test]
+    fn clearing_one_takes_it_off_the_desk_and_frees_the_agent_to_raise_another() {
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let Raised::First(one) = stuck(&f.store, &manager, "no key", 1_000) else {
+            panic!("the first raise is the first row")
+        };
+
+        assert!(f.store.clear_escalation(one.id, 5_000).unwrap());
+        assert!(f.store.open_escalations(50).unwrap().is_empty());
+        assert!(f.store.open_escalation_for(manager.id).unwrap().is_none());
+
+        // The unique index is over the open rows only, so a cleared one does
+        // not block the next. An agent that gets stuck twice with a fortnight
+        // between must not be refused the second time.
+        let next = stuck(&f.store, &manager, "no machine either", 9_000);
+        assert!(matches!(next, Raised::First(_)));
+        assert_eq!(f.store.open_escalation_for(manager.id).unwrap().unwrap().raised_at, 9_000);
+    }
+
+    #[test]
+    fn clearing_one_twice_changes_nothing_the_second_time() {
+        // The operator pressed it twice, or two windows are looking at one
+        // desk. The second press must not move a stamp that already says when
+        // the first one happened.
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        let Raised::First(one) = stuck(&f.store, &manager, "no key", 1_000) else {
+            panic!("the first raise is the first row")
+        };
+
+        assert!(f.store.clear_escalation(one.id, 5_000).unwrap());
+        assert!(!f.store.clear_escalation(one.id, 8_000).unwrap(), "already off the desk");
+    }
+
+    #[test]
+    fn a_composted_agents_escalation_is_not_on_the_desk() {
+        // The same question fifteen other queries ask. An agent in the compost
+        // is unreachable and out of every crew, so a row offering to open its
+        // channel is an offer nothing can take up.
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        stuck(&f.store, &manager, "no key", 1_000);
+        f.store.discard_agent(manager.id, 2_000).unwrap();
+
+        assert!(f.store.open_escalations(50).unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_discarded_agents_escalation_is_cleared_rather_than_left_open() {
+        // Left open it would come back with a restore three weeks later, as
+        // news about a wall nobody has walked into since.
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        stuck(&f.store, &manager, "no key", 1_000);
+
+        assert_eq!(f.store.clear_agent_escalations(manager.id, 2_000).unwrap(), 1);
+        assert!(f.store.open_escalation_for(manager.id).unwrap().is_none());
+        assert_eq!(
+            f.store.clear_agent_escalations(manager.id, 3_000).unwrap(),
+            0,
+            "and there is nothing left to clear"
+        );
+    }
+
+    #[test]
+    fn an_escalation_is_not_an_approval_and_shares_no_queue_with_one() {
+        // Two reads, two tables. Folding them would put a row with no verdict
+        // and no expiry into a list every caller answers with a decision.
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+        ask(&f.store, &manager);
+        stuck(&f.store, &manager, "no key", 1_000);
+
+        assert_eq!(f.store.pending_approvals(50).unwrap().len(), 1);
+        assert_eq!(f.store.open_escalations(50).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn concurrent_raises_from_one_agent_are_one_row() {
+        // An agent writes from every thread it holds. A check outside the
+        // transaction lets two turns each find nothing open and each insert,
+        // which the unique index then refuses at the worst possible moment:
+        // inside a turn that had already given up on getting anywhere.
+        let f = fixture();
+        let manager = f.store.create_agent(&draft("Manager")).unwrap();
+
+        std::thread::scope(|scope| {
+            for i in 0..8 {
+                let store = f.store.clone();
+                let card = manager.clone();
+                scope.spawn(move || {
+                    store
+                        .raise_escalation(
+                            card.id,
+                            card.group_id,
+                            RunId::new(),
+                            &format!("stuck {i}"),
+                            1_000 + i,
+                        )
+                        .expect("a raise must never be refused by the index");
+                });
+            }
+        });
+
+        let open = f.store.open_escalations(50).unwrap();
+        assert_eq!(open.len(), 1);
+        assert_eq!(open[0].times, 8);
     }
 
     #[test]

--- a/src-tauri/src/domain/escalation.rs
+++ b/src-tauri/src/domain/escalation.rs
@@ -1,0 +1,138 @@
+//! An escalation: work that has stopped, and that only the operator can move.
+//!
+//! The third thing an agent can do about a person, and the first one that does
+//! not park a turn. [`super::approval`] holds the other two, and both of them
+//! are a turn stopped inside a tool call waiting ten minutes for an answer:
+//! `request_permission` asks to be let off something, `ask_operator` asks which
+//! way to go. Both are right for a decision the turn needs *now*.
+//!
+//! Neither is right for the case they kept being reached for anyway, which is
+//! an agent that cannot go on at all. A coding harness that will not start, a
+//! sign-in that has expired, a machine only the operator can touch: none of
+//! that is answerable inside a turn, and none of it stops being true because
+//! ten minutes passed. So the agent did the one thing left and wrote it into
+//! its channel, in a good clear paragraph, addressed to somebody who was not
+//! reading it. That paragraph is the thing this exists to replace.
+//!
+//! What makes it a different shape rather than a longer approval:
+//!
+//! - **Nothing parks.** The turn ends. No run booking is held, so there is no
+//!   window, no expiry, and no cost to it staying open for two days.
+//! - **Nothing is answered.** There is no verdict and no value: clearing is the
+//!   operator saying they have dealt with it. What actually unblocks the agent
+//!   is a message in its channel, which is what the row on the desk opens.
+//! - **It is one per agent, and it counts.** An agent that hits the same wall
+//!   on six turns raises six times and the desk holds one row, which says it
+//!   has been true for two days and that six turns have hit it. That pair is
+//!   the whole signal, and it is the one a message in a channel cannot carry.
+
+use serde::{Deserialize, Serialize};
+
+use super::cut_to;
+use super::ids::{AgentId, EscalationId, GroupId, RunId};
+
+/// How much of what the agent wrote the operator reads on the desk.
+///
+/// A headline, not the report. The escalation is raised from a turn that also
+/// writes a reply, and the reply is where the detail belongs: the desk card is
+/// two lines in the corner of a screen and the way out of it is the channel.
+/// Given room for a page an agent writes one, and a desk holding three pages is
+/// a desk that gets collapsed.
+pub const MAX_SUMMARY: usize = 400;
+
+/// One escalation, as it is stored and as it is read back.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Escalation {
+    pub id: EscalationId,
+    pub agent_id: AgentId,
+    pub group_id: GroupId,
+    /// The run of the turn that raised it, so it can be traced back to whatever
+    /// set that turn off. Not the run of the latest raise: the first one is the
+    /// one that has the beginning of the story in it.
+    pub run_id: RunId,
+    /// The agent's own words, which is why every surface draws them as text
+    /// under a heading Guaca wrote. Same rule a question's options follow.
+    pub summary: String,
+    /// When this first went up. Never moved, and the reason the row is worth
+    /// more than the message: an escalation is not news, it is a duration.
+    pub raised_at: i64,
+    /// When it was last restated. The difference between this and `raised_at`
+    /// is what says whether an agent is still walking into the wall or has gone
+    /// quiet in front of it, which are different problems.
+    pub said_at: i64,
+    /// How many turns have hit it. One when it goes up.
+    pub times: u32,
+    pub cleared_at: Option<i64>,
+}
+
+/// What became of a raise.
+///
+/// The two are worded differently to the agent and only the second one can be,
+/// because only the second one knows how long the operator has had this. An
+/// agent told "raised" for the sixth time learns that raising is how you say
+/// something is still true; told "you raised this two days ago and this is the
+/// sixth turn to hit it" it has what it needs to stop, work around it, or say
+/// something the operator has not already been told.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Raised {
+    /// Nothing was open for this agent. It is on the desk now.
+    First(Escalation),
+    /// One was already open. Restated and counted; the stamp did not move.
+    Again(Escalation),
+}
+
+impl Raised {
+    pub fn escalation(&self) -> &Escalation {
+        match self {
+            Raised::First(one) | Raised::Again(one) => one,
+        }
+    }
+}
+
+/// What is actually stored, which is the input trimmed and cut.
+///
+/// Handed back rather than applied silently, for the reason every other cut in
+/// this app is: an agent that believes it said something it did not will not
+/// say it again.
+pub fn store_as(summary: &str) -> (String, bool) {
+    cut_to(summary, MAX_SUMMARY)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_summary_within_the_cap_is_stored_whole() {
+        let (body, cut) = store_as("  the deploy needs a key only you have  ");
+        assert_eq!(body, "the deploy needs a key only you have");
+        assert!(!cut);
+    }
+
+    #[test]
+    fn an_oversized_summary_is_cut_and_says_so() {
+        let (body, cut) = store_as(&"word ".repeat(200));
+        assert!(cut);
+        assert!(body.chars().count() <= MAX_SUMMARY);
+    }
+
+    #[test]
+    fn both_outcomes_carry_the_row() {
+        // Every caller words its answer from the row rather than from what it
+        // passed in, so a raise that was cut reports what was kept.
+        let one = Escalation {
+            id: EscalationId::new(),
+            agent_id: AgentId::new(),
+            group_id: GroupId::new(),
+            run_id: RunId::new(),
+            summary: "stuck".into(),
+            raised_at: 1,
+            said_at: 1,
+            times: 1,
+            cleared_at: None,
+        };
+        assert_eq!(Raised::First(one.clone()).escalation(), &one);
+        assert_eq!(Raised::Again(one.clone()).escalation(), &one);
+    }
+}

--- a/src-tauri/src/domain/ids.rs
+++ b/src-tauri/src/domain/ids.rs
@@ -65,6 +65,7 @@ macro_rules! declare_id {
 declare_id!(AgentId, "agent");
 declare_id!(ApprovalId, "approval");
 declare_id!(ConnectorId, "connector");
+declare_id!(EscalationId, "escalation");
 declare_id!(GroupId, "group");
 declare_id!(MessageId, "msg");
 declare_id!(PluginId, "plugin");

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -3,6 +3,7 @@ pub mod approval;
 pub mod attachment;
 pub mod connector;
 pub mod envelope;
+pub mod escalation;
 pub mod group;
 pub mod ids;
 pub mod plugin;
@@ -32,6 +33,27 @@ pub fn now_ms() -> i64 {
     LAST.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |prev| Some(wall.max(prev + 1)))
         .map(|prev| wall.max(prev + 1))
         .unwrap_or(wall)
+}
+
+/// Trims a string and cuts it to `max` characters, on a word where it can.
+///
+/// Characters rather than bytes, which is not a detail: a line of emoji is a
+/// quarter of the bytes it looks like and must not be cut four times as early.
+/// The flag is what makes this honest — every caller hands it back to whoever
+/// wrote the text, because an agent that believes it recorded something it did
+/// not will not write it again.
+pub fn cut_to(body: &str, max: usize) -> (String, bool) {
+    let trimmed = body.trim();
+    if trimmed.chars().count() <= max {
+        return (trimmed.to_string(), false);
+    }
+    let mut kept: String = trimmed.chars().take(max).collect();
+    if let Some(space) = kept.rfind(char::is_whitespace) {
+        if space > max / 2 {
+            kept.truncate(space);
+        }
+    }
+    (kept.trim_end().to_string(), true)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/domain/worknote.rs
+++ b/src-tauri/src/domain/worknote.rs
@@ -92,19 +92,9 @@ pub struct WorkingNote {
 /// hands back its own truncation: an agent that believes it recorded something
 /// it did not will not write it again.
 pub fn store_as(body: &str) -> (String, bool) {
-    let trimmed = body.trim();
-    if trimmed.chars().count() <= MAX_NOTE {
-        return (trimmed.to_string(), false);
-    }
     // Cut on a word so the fragment that survives is still readable. A note is
     // one line, so there is no line boundary to fall back on the way memory has.
-    let mut kept: String = trimmed.chars().take(MAX_NOTE).collect();
-    if let Some(space) = kept.rfind(char::is_whitespace) {
-        if space > MAX_NOTE / 2 {
-            kept.truncate(space);
-        }
-    }
-    (kept.trim_end().to_string(), true)
+    super::cut_to(body, MAX_NOTE)
 }
 
 /// How long ago, in the coarsest unit that is still true.

--- a/src-tauri/src/llm/tools.rs
+++ b/src-tauri/src/llm/tools.rs
@@ -31,6 +31,7 @@ pub const SCHEDULE: &str = "schedule";
 pub const CREATE_AGENT: &str = "create_agent";
 pub const REQUEST_PERMISSION: &str = "request_permission";
 pub const ASK_OPERATOR: &str = "ask_operator";
+pub const ESCALATE: &str = "escalate";
 pub const ATTACH_FILE: &str = "attach_file";
 pub const WRITE_DOCUMENT: &str = "write_document";
 pub const CODE: &str = "code";
@@ -706,6 +707,33 @@ fn all_specs(surfaces: Surfaces) -> Vec<ToolSpec> {
             }),
         },
         ToolSpec {
+            name: ESCALATE.to_string(),
+            // The description has one job that the other two operator tools do
+            // not: it has to be reached for by a turn that is *ending*. Both of
+            // those stop a turn mid-flight to get something back, so a model
+            // that has run out of road reads them as the wrong shape and does
+            // the only other thing it has, which is to write a good clear
+            // paragraph into a channel nobody is reading. So the line drawn
+            // here is about waiting rather than about severity, the cost is
+            // stated in what it puts on a screen rather than in what it spends,
+            // and the thing it replaces is named: models do not infer that a
+            // message they addressed to the operator did not reach them.
+            description: "Put something on the operator's desk that has stopped your work, and                           carry on without waiting for them. Use this when you cannot make                           progress and they are the only one who can change that: a program or                           tool that will not run, a sign-in that has expired, a key or a machine                           only they can touch, an approval that has already lapsed twice. This                           does not stop your turn and does not wait for an answer. It puts one                           row in front of them wherever they are in the app, and it stays there                           until they clear it. Saying it in your reply instead does not reach                           them: a message waits in a channel they may not open for days, which                           is exactly what this exists to replace. The cost is their screen, so                           this is for work that has stopped and never for a progress report,                           a summary, or something you can do a different way. If a colleague                           could unblock you, use send_message. If you can go on and say what                           you assumed, do that and say it in your reply. If you need an answer                           inside this turn, use ask_operator instead: that one waits, this one                           does not. Raise it again on a later turn if you hit the same wall                           again -- you will not make a second row, and they will be shown how                           long it has been up and how many turns have run into it."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "summary": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "What has stopped and what you need them to do, in one or                                         two sentences. Write it for somebody who has not read                                         your channel and does not know what you were working on.                                         Put the exact command, address or name they will need                                         in it; the rest of the account goes in your reply."
+                    }
+                },
+                "required": ["summary"],
+                "additionalProperties": false
+            }),
+        },
+        ToolSpec {
             name: SEND_MESSAGE.to_string(),
             description: "Send a message to the other agents a piece of work belongs to. Choose \
                           them by fit: the agents whose skills cover this task, and no others. \
@@ -1030,6 +1058,15 @@ pub enum ToolInvocation {
     RequestPermission {
         action: String,
         because: String,
+    },
+    /// Put something the operator has to deal with on their desk, and carry on.
+    ///
+    /// The one way to an operator that does not park the turn, which is what
+    /// makes it a third variant rather than a shape of the two above: those are
+    /// a turn waiting for something back, and this is a turn that has run out
+    /// of road saying so on the way out.
+    Escalate {
+        summary: String,
     },
     /// Stop and ask the operator which way to go. Grants nothing.
     AskOperator {
@@ -1804,6 +1841,26 @@ pub fn parse(call: &ToolCall, connected: &[PluginKind]) -> Result<ToolInvocation
             }
 
             Ok(ToolInvocation::AskOperator { question, options })
+        }
+        // The aliases are the words a model reaches for when it has run out of
+        // road, and every one of them costs a whole turn to learn if it is
+        // refused -- on the one call where the turn was already going nowhere.
+        ESCALATE | "escalate_to_operator" | "flag_operator" | "report_blocked" => {
+            let value = call.parsed_arguments().map_err(|e| ToolParseError::BadJson {
+                name: ESCALATE.to_string(),
+                detail: e.to_string(),
+            })?;
+            let summary = ["summary", "what", "blocked", "problem", "reason", "text", "message"]
+                .iter()
+                .find_map(|key| value.get(*key).and_then(|v| v.as_str()))
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                // An escalation with nothing in it is a row on the operator's
+                // desk that says an agent is stuck and cannot say at what,
+                // which is worse than the message in the channel it replaces.
+                .ok_or(ToolParseError::MissingText)?;
+
+            Ok(ToolInvocation::Escalate { summary })
         }
         SEND_MESSAGE => {
             let value = call.parsed_arguments().map_err(|e| ToolParseError::BadJson {
@@ -2952,14 +3009,59 @@ mod tests {
     }
 
     #[test]
+    fn escalating_is_told_apart_from_the_two_tools_that_wait() {
+        // The one job of this description. Both of the others stop a turn
+        // mid-flight to get something back, so a model that has run out of road
+        // reads them as the wrong shape and writes a paragraph into a channel
+        // instead. The line drawn here is about waiting rather than about how
+        // bad the problem is, and what it replaces has to be named: models do
+        // not infer that a message addressed to the operator never reached one.
+        let spec = spec(ESCALATE);
+        assert!(spec.description.contains("does not wait"), "{}", spec.description);
+        assert!(spec.description.contains(ASK_OPERATOR), "{}", spec.description);
+        assert!(spec.description.contains(SEND_MESSAGE), "{}", spec.description);
+        assert!(spec.description.contains("channel"), "{}", spec.description);
+    }
+
+    #[test]
+    fn an_escalation_is_parsed_from_the_words_a_stuck_model_reaches_for() {
+        // Every alias costs a whole turn to learn if it is refused, on the one
+        // call where the turn was already going nowhere.
+        for (name, field) in [
+            (ESCALATE, "summary"),
+            ("escalate_to_operator", "what"),
+            ("flag_operator", "problem"),
+            ("report_blocked", "blocked"),
+        ] {
+            let arguments = format!("{{\"{field}\": \"  the deploy needs your key  \"}}");
+            assert_eq!(
+                parse(&call(name, &arguments)).unwrap(),
+                ToolInvocation::Escalate { summary: "the deploy needs your key".to_string() },
+                "{name} with {field}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_escalation_with_nothing_in_it_is_refused() {
+        // A row on the operator's desk saying an agent is stuck and unable to
+        // say at what is worse than the message in a channel it replaces.
+        assert!(matches!(
+            parse(&call(ESCALATE, "{\"summary\": \"   \"}")),
+            Err(ToolParseError::MissingText)
+        ));
+        assert!(matches!(parse(&call(ESCALATE, "{}")), Err(ToolParseError::MissingText)));
+    }
+
+    #[test]
     fn every_tool_is_offered_with_a_strict_schema() {
         let specs = specs(Surfaces::both(), Modalities::seeing());
         assert_eq!(
             specs.len(),
-            16,
+            17,
             "directory, run_command, open_on_desktop, use_screen, browse, code, shell, schedule, \
-             create_agent, request_permission, ask_operator, send_message, write_document, \
-             attach_file, update_memory, note_progress"
+             create_agent, request_permission, ask_operator, escalate, send_message, \
+             write_document, attach_file, update_memory, note_progress"
         );
         for spec in &specs {
             assert_eq!(

--- a/src-tauri/src/menubar.rs
+++ b/src-tauri/src/menubar.rs
@@ -22,8 +22,10 @@
 use std::collections::HashMap;
 
 use crate::domain::approval::{Approval, Decision, ProtectedAction};
+use crate::domain::escalation::Escalation;
 use crate::domain::ids::{AgentId, ApprovalId};
 use crate::domain::usage::Tokens;
+use crate::domain::worknote;
 use crate::runtime::events::{Activity, UiEvent};
 
 /// The most requests listed before the rest become a count. Answering the
@@ -32,6 +34,12 @@ const MAX_WAITING: usize = 5;
 
 /// The most working agents listed, for the same reason.
 const MAX_WORKING: usize = 6;
+
+/// The most escalations listed. Bounded by the crew rather than by the app --
+/// an agent holds one -- so this is only ever reached by a workspace where a
+/// lot has gone wrong at once, which is the workspace least helped by a menu
+/// forty rows long.
+const MAX_STUCK: usize = 5;
 
 /// The most fields of a request shown under it, and how much of each.
 ///
@@ -212,6 +220,10 @@ pub struct Presence {
     pub activity: HashMap<AgentId, Activity>,
     /// Pending requests, oldest first.
     pub waiting: Vec<Approval>,
+    /// Open escalations, oldest first. Beside the requests rather than in with
+    /// them because the two are answered differently and only one of them can
+    /// be answered from here at all.
+    pub stuck: Vec<Escalation>,
     /// Spent since the window opened.
     pub session: Tokens,
     /// Spent ever, across every crew.
@@ -263,7 +275,11 @@ impl Presence {
 
     /// The glyph, the title and the tooltip.
     pub fn look(&self) -> Look {
-        let waiting = self.waiting.len();
+        // One number, because the operator is answering one question with it:
+        // is anything over there mine. A parked turn and an agent that has
+        // stopped are different work and the same answer to that question, and
+        // two numbers in the menu bar is the state nobody can read at a glance.
+        let waiting = self.waiting.len() + self.stuck.len();
         let busy = self.busy().len();
 
         let glyph = if waiting > 0 {
@@ -280,7 +296,14 @@ impl Presence {
         let title = (waiting > 0).then(|| waiting.to_string());
 
         let state = if waiting == 1 {
-            format!("{} is waiting on you", self.name_of(self.waiting[0].agent_id))
+            // Named either way, because one is the case where a name fits and
+            // it is the whole difference between "something needs you" and
+            // knowing whether to go and look now.
+            let who = match self.waiting.first() {
+                Some(approval) => self.name_of(approval.agent_id),
+                None => self.name_of(self.stuck[0].agent_id),
+            };
+            format!("{who} is waiting on you")
         } else if waiting > 1 {
             format!("{waiting} agents are waiting on you")
         } else if busy == 1 {
@@ -356,6 +379,37 @@ impl Presence {
             rows.push(Row::Separator);
         }
 
+        // Its own section rather than more rows under "Waiting on you", which
+        // they would be dishonest as: nothing here is parked, none of it
+        // expires, and every one of them has been true for longer than a menu
+        // usually reports on. The age is on the row for that reason -- an
+        // escalation is a duration rather than a piece of news, and the number
+        // in the title says how many and never how long.
+        //
+        // Each row opens its channel and none of them clears from here. Clearing
+        // is one click and would fit a menu item, which is exactly the problem:
+        // the click that takes it off the desk is not the click that deals with
+        // it, and the two must not be the same size. `docs/ATTENTION.md`.
+        if !self.stuck.is_empty() {
+            rows.push(Row::Note("Stuck on you".to_string()));
+            let now = crate::domain::now_ms();
+            for one in self.stuck.iter().take(MAX_STUCK) {
+                rows.push(Row::Agent {
+                    id: one.agent_id,
+                    label: format!(
+                        "{} · {} · {}",
+                        self.name_of(one.agent_id),
+                        one_line(&one.summary, 90),
+                        worknote::how_long_ago(one.raised_at, now)
+                    ),
+                });
+            }
+            if let Some(more) = overflow(self.stuck.len(), MAX_STUCK) {
+                rows.push(Row::Note(format!("{more} more stuck, in Guaca")));
+            }
+            rows.push(Row::Separator);
+        }
+
         let busy = self.busy();
         if !busy.is_empty() {
             rows.push(Row::Note("Working".to_string()));
@@ -368,7 +422,7 @@ impl Presence {
             rows.push(Row::Separator);
         }
 
-        if self.waiting.is_empty() && busy.is_empty() {
+        if self.waiting.is_empty() && self.stuck.is_empty() && busy.is_empty() {
             rows.push(Row::Note("Nothing running".to_string()));
             rows.push(Row::Separator);
         }
@@ -463,6 +517,8 @@ pub fn touches(event: &UiEvent) -> bool {
             | UiEvent::RunSettled { .. }
             | UiEvent::ApprovalRequested { .. }
             | UiEvent::ApprovalSettled { .. }
+            | UiEvent::EscalationRaised { .. }
+            | UiEvent::EscalationCleared { .. }
     )
 }
 
@@ -646,6 +702,97 @@ mod tests {
                 _ => None,
             })
             .collect()
+    }
+
+    /// One open escalation from `agent`, raised `days` ago.
+    fn escalation(agent: AgentId, summary: &str, days: i64) -> Escalation {
+        let now = crate::domain::now_ms();
+        Escalation {
+            id: crate::domain::ids::EscalationId::new(),
+            agent_id: agent,
+            group_id: GroupId::new(),
+            run_id: RunId::new(),
+            summary: summary.to_string(),
+            raised_at: now - days * 24 * 3_600_000,
+            said_at: now,
+            times: 1,
+            cleared_at: None,
+        }
+    }
+
+    #[test]
+    fn an_agent_that_has_stopped_turns_the_glyph_without_anything_being_parked() {
+        // The state this whole mechanism exists for. Nothing is parked, so the
+        // activity map says idle and the approvals table is empty: read from
+        // either of those alone, a workspace where a crew gave up on Friday
+        // draws exactly like one where everything is fine.
+        let (mut presence, scout) = quiet();
+        presence.stuck.push(escalation(scout, "the deploy needs a key only you have", 2));
+
+        let look = presence.look();
+        assert_eq!(look.glyph, Glyph::Attention);
+        assert_eq!(look.title.as_deref(), Some("1"));
+        assert_eq!(look.tooltip, "Guaca · Scout is waiting on you");
+    }
+
+    #[test]
+    fn the_title_is_one_number_over_both_kinds() {
+        // The operator is answering one question with it: is anything over
+        // there mine. Two numbers in the menu bar is a state nobody can read at
+        // a glance, and a title that counted only the parked turns would say
+        // "1" about a workspace holding three things.
+        let (mut presence, scout) = quiet();
+        presence.waiting.push(approval(scout, ProtectedAction::CreateAgent, "wants an agent"));
+        presence.stuck.push(escalation(scout, "the tooling is down", 2));
+
+        assert_eq!(presence.look().title.as_deref(), Some("2"));
+        assert_eq!(presence.look().tooltip, "Guaca · 2 agents are waiting on you");
+    }
+
+    #[test]
+    fn a_stuck_agent_is_its_own_section_with_the_age_on_the_row() {
+        // An escalation is a duration rather than a piece of news, and the
+        // title says how many and never how long. This row is the only place
+        // the operator can read it without opening the window.
+        let (mut presence, scout) = quiet();
+        presence.stuck.push(escalation(scout, "the deploy needs a key only you have", 2));
+
+        let rows = presence.rows();
+        assert!(notes(&rows).contains(&"Stuck on you".to_string()));
+        assert!(
+            rows.contains(&Row::Agent {
+                id: scout,
+                label: "Scout · the deploy needs a key only you have · 2d ago".to_string(),
+            }),
+            "{rows:?}"
+        );
+    }
+
+    #[test]
+    fn a_stuck_agent_is_not_also_listed_as_nothing_running() {
+        // "Nothing running" beside a crew that has stopped dead is the strip
+        // saying the one thing that is not true.
+        let (mut presence, scout) = quiet();
+        presence.stuck.push(escalation(scout, "no key", 1));
+
+        assert!(!notes(&presence.rows()).contains(&"Nothing running".to_string()));
+    }
+
+    #[test]
+    fn nothing_clears_an_escalation_from_the_menu() {
+        // Clearing is one click and would fit a menu item, which is exactly the
+        // problem: the click that takes it off the desk is not the click that
+        // deals with it, and the two must not be the same size. The row opens
+        // the channel instead.
+        let (mut presence, scout) = quiet();
+        presence.stuck.push(escalation(scout, "no key", 1));
+
+        for row in presence.rows() {
+            assert!(
+                !matches!(row, Row::Waiting { .. }),
+                "an escalation has no verdict to take from a menu"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/runtime/events.rs
+++ b/src-tauri/src/runtime/events.rs
@@ -11,7 +11,9 @@ use serde::Serialize;
 
 use crate::domain::approval::ApprovalState;
 use crate::domain::envelope::{Envelope, Part, Participant};
-use crate::domain::ids::{AgentId, ApprovalId, GroupId, MessageId, RepositoryId, RunId};
+use crate::domain::ids::{
+    AgentId, ApprovalId, EscalationId, GroupId, MessageId, RepositoryId, RunId,
+};
 
 /// What an agent is doing right now, surfaced as the dot next to its name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -197,6 +199,22 @@ pub enum UiEvent {
     ApprovalSettled {
         approval_id: ApprovalId,
         state: ApprovalState,
+    },
+
+    /// An agent has put something on the operator's desk and carried on.
+    ///
+    /// The id and the agent, for the reason `ApprovalRequested` carries those
+    /// two and nothing else: what the UI is missing is not the wording, which
+    /// it reads back whole, but that the desk it is drawing is now behind the
+    /// store.
+    EscalationRaised {
+        escalation_id: EscalationId,
+        agent_id: AgentId,
+    },
+    /// The operator has dealt with one, or it went with the agent that raised
+    /// it. Not a settlement: nothing was answered and nothing was granted.
+    EscalationCleared {
+        escalation_id: EscalationId,
     },
 
     /// A coding job started, and the repository it is working in is now busy.

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -336,7 +336,10 @@ use crate::domain::envelope::{
     channel_for, Envelope, Intent, NoticeKind, Part, Participant, RefusedRecipient, ToolOutcome,
     Trust,
 };
-use crate::domain::ids::{AgentId, ApprovalId, GroupId, MessageId, RepositoryId, RunId};
+use crate::domain::escalation;
+use crate::domain::ids::{
+    AgentId, ApprovalId, EscalationId, GroupId, MessageId, RepositoryId, RunId,
+};
 use crate::domain::now_ms;
 use crate::domain::plugin::PluginKind;
 use crate::domain::repository::{Gate, Harness};
@@ -896,6 +899,17 @@ impl Runtime {
         let id = card.id;
         self.inner.store.discard_agent(id, now_ms())?;
         self.stop_agent(id);
+
+        // The one thing it holds that is not its own. Everything else waits
+        // out the thirty days untouched because it belongs to this agent and
+        // nobody else can use it; an escalation is a row on the operator's
+        // desk, and a desk that still asks them to deal with an agent they have
+        // just thrown out is asking about work that has stopped for good. It
+        // must not come back with a restore either: thirty days later it would
+        // arrive as news about a wall nobody has walked into since.
+        if let Err(err) = self.inner.store.clear_agent_escalations(id, now_ms()) {
+            tracing::warn!(%err, "could not take a discarded agent's escalation off the desk");
+        }
 
         if let Some(sandbox) = card.sandbox_id.as_ref() {
             match crate::e2b::E2bClient::new(&self.config().e2b.api_key) {
@@ -2346,6 +2360,24 @@ impl Runtime {
     /// The row is settled first and only from pending, so a second click, or a
     /// click that arrives as the request times out, is refused here rather than
     /// overwriting an answer that is already recorded.
+    /// Takes one escalation off the desk.
+    ///
+    /// There is no waker to fire and no turn to resume, which is what makes
+    /// this a different act from settling an approval rather than a variation
+    /// on it: nothing is parked on an escalation. The operator is saying they
+    /// have dealt with it, and the way they actually unblock the agent is the
+    /// channel the row opened.
+    ///
+    /// A row that was already cleared is not an error. The operator pressed it
+    /// twice, or two windows are looking at one desk, and the event that
+    /// follows either way is what puts both of them back in step.
+    pub fn clear_escalation(&self, id: EscalationId) -> Result<(), RuntimeError> {
+        if self.inner.store.clear_escalation(id, now_ms())? {
+            self.inner.events.emit(UiEvent::EscalationCleared { escalation_id: id });
+        }
+        Ok(())
+    }
+
     pub fn decide_approval(
         &self,
         id: ApprovalId,
@@ -3096,6 +3128,15 @@ impl Runtime {
             tracing::warn!(%err, "could not read what this agent is waiting on");
             Vec::new()
         });
+        // The other half of that question, arrived at from the opposite end:
+        // one is derived from what this agent sent and cannot go stale, and
+        // this is what it said out loud to the operator and has had no answer
+        // to. A read that fails is nothing in the prompt, which costs a repeat
+        // rather than a turn.
+        let escalation = self.inner.store.open_escalation_for(card.id).unwrap_or_else(|err| {
+            tracing::warn!(%err, "could not read this agent's open escalation");
+            None
+        });
         // Settings resolve agent over group over app. An agent that names its own
         // model keeps it; otherwise the group's choice applies; otherwise the
         // app default. The endpoint resolves the same way, so one crew can run
@@ -3135,6 +3176,7 @@ impl Runtime {
             &batch,
             mode,
             &waiting_on,
+            escalation.as_ref(),
             repository.as_ref(),
             surfaces,
             modalities,
@@ -4137,6 +4179,77 @@ impl Runtime {
                         format!("Error: your note could not be saved ({err})."),
                         Part::tool_call(
                             tools::NOTE_PROGRESS,
+                            arguments,
+                            ToolOutcome::Failed { error: err.to_string() },
+                        ),
+                    ),
+                }
+            }
+
+            ToolInvocation::Escalate { summary } => {
+                let (body, cut) = escalation::store_as(&summary);
+                match self.inner.store.raise_escalation(
+                    card.id,
+                    card.group_id,
+                    run_id,
+                    &body,
+                    now_ms(),
+                ) {
+                    Ok(raised) => {
+                        let one = raised.escalation();
+                        self.emit(UiEvent::EscalationRaised {
+                            escalation_id: one.id,
+                            agent_id: card.id,
+                        });
+                        // Two answers, and only the second one can carry the
+                        // number that matters. An agent told "raised" for the
+                        // sixth time learns that raising is how you say
+                        // something is still true; told how long the operator
+                        // has had it and how many turns have gone into the same
+                        // wall, it has what it needs to stop hitting it.
+                        let summary = match &raised {
+                            escalation::Raised::First(_) => {
+                                "That is on the operator's desk now, and it stays there until they \
+                                 clear it. Do not wait for them and do not raise it again this \
+                                 turn: finish with whatever you can still do, and say in your \
+                                 reply what has stopped and what you did instead."
+                                    .to_string()
+                            }
+                            escalation::Raised::Again(one) => format!(
+                                "You already had that up, raised {}, and this is turn {} to run \
+                                 into it. The wording is updated and nothing was added to their \
+                                 desk. They have not cleared it, so treat it as unseen: do not \
+                                 spend another turn on the same wall, do what you can without it, \
+                                 or stop and say plainly that you are waiting.",
+                                worknote::how_long_ago(one.raised_at, now_ms()),
+                                one.times
+                            ),
+                        };
+                        let summary = if cut {
+                            format!(
+                                "{summary}\n\nIt was long for a desk row and the end was cut, so \
+                                 check the part they will read says what you need. The rest \
+                                 belongs in your reply."
+                            )
+                        } else {
+                            summary
+                        };
+                        (
+                            summary.clone(),
+                            Part::tool_call(
+                                tools::ESCALATE,
+                                arguments,
+                                ToolOutcome::Ok { summary },
+                            ),
+                        )
+                    }
+                    Err(err) => (
+                        format!(
+                            "Error: that could not be put in front of the operator ({err}). Say it \
+                             in your reply instead, plainly and at the top."
+                        ),
+                        Part::tool_call(
+                            tools::ESCALATE,
                             arguments,
                             ToolOutcome::Failed { error: err.to_string() },
                         ),

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -22,6 +22,7 @@ use crate::domain::plugin::PluginToolset;
 /// twelfth, and the list is on every turn of every agent. Newest first, so what
 /// is cut is the oldest, which is also the least likely to still be live.
 const MAX_WAITING: usize = 10;
+use crate::domain::escalation::Escalation;
 use crate::domain::repository::Repository;
 use crate::domain::routine::Routine;
 use crate::domain::signin::Signin;
@@ -95,6 +96,15 @@ pub fn system_prompt(
     // three assignments stale and reported work as outstanding that had never
     // been sent.
     waiting_on: &[Outstanding],
+    // What this agent has already put on the operator's desk and had no answer
+    // to, if anything. At most one: an agent holds one open escalation, and a
+    // second raise restates the first rather than adding a row.
+    //
+    // In the prompt for the reason the two lists above it are, and with one of
+    // its own: an agent that cannot see what it has already escalated raises it
+    // again as news every turn, which is the behavior this whole mechanism
+    // exists to stop being written into a channel.
+    escalation: Option<&Escalation>,
     // The codebase this agent works in, if the operator put it in one. At most
     // one, always: two agents on one repository coordinate through the crew,
     // and one agent on two is a change nobody can see the shape of.
@@ -703,6 +713,27 @@ pub fn system_prompt(
         );
     }
 
+    // After the two lists above rather than beside the tools, because this is
+    // read while deciding whether the work can move at all. An agent that
+    // cannot see its own open escalation reports it again every turn, in a
+    // channel, which is the failure the escalation replaced.
+    if let Some(one) = escalation {
+        out.push_str("\n## What you have already escalated\n");
+        out.push_str(&format!(
+            "You put this in front of {} {}, and {} turns have run into it since:\n\n> {}\n\n",
+            if operator.trim().is_empty() { "the operator" } else { operator },
+            worknote::how_long_ago(one.raised_at, crate::domain::now_ms()),
+            one.times,
+            one_line(&one.summary)
+        ));
+        out.push_str(
+            "It is still on their desk and they have not cleared it, so assume they have not \
+             dealt with it yet. Do not raise it again unless what you would say has changed, and \
+             do not spend this turn waiting on it: work around it if there is a way around it, or \
+             say plainly what is stopped and stop. If it has come unstuck, carry on and say so.\n",
+        );
+    }
+
     // Named here as well as offered as a tool, and for the reason the plugins
     // are: a tool list is read while deciding *how* to do something, and this
     // is read while deciding whether it can be done at all, which happens
@@ -973,6 +1004,7 @@ pub fn build_messages(
     inbound: &[Envelope],
     mode: ReplyMode,
     waiting_on: &[Outstanding],
+    escalation: Option<&Escalation>,
     repository: Option<&Repository>,
     surfaces: Surfaces,
     modalities: Modalities,
@@ -989,6 +1021,7 @@ pub fn build_messages(
         routines,
         mode,
         waiting_on,
+        escalation,
         repository,
         surfaces,
         modalities,
@@ -1041,6 +1074,7 @@ mod tests {
             mode,
             &[],
             None,
+            None,
             Surfaces::both(),
             Modalities::seeing(),
         )
@@ -1061,6 +1095,7 @@ mod tests {
             &[],
             ReplyMode::ToOperator,
             &[],
+            None,
             None,
             Surfaces::both(),
             Modalities::seeing(),
@@ -1085,6 +1120,7 @@ mod tests {
             routines,
             ReplyMode::ToOperator,
             &[],
+            None,
             None,
             Surfaces::both(),
             Modalities::seeing(),
@@ -1116,6 +1152,7 @@ mod tests {
             inbound,
             mode,
             &[],
+            None,
             None,
             Surfaces::both(),
             Modalities::seeing(),
@@ -1356,6 +1393,7 @@ mod tests {
             ReplyMode::ToOperator,
             &[],
             None,
+            None,
             Surfaces::both(),
             Modalities::seeing(),
         );
@@ -1415,6 +1453,7 @@ mod tests {
             ReplyMode::ToOperator,
             &[],
             None,
+            None,
             Surfaces::both(),
             Modalities::seeing(),
         );
@@ -1449,6 +1488,7 @@ mod tests {
             &[],
             ReplyMode::ToOperator,
             &[],
+            None,
             None,
             Surfaces::none(),
             Modalities::seeing(),
@@ -1486,6 +1526,7 @@ mod tests {
             ReplyMode::ToOperator,
             &[],
             None,
+            None,
             Surfaces::none(),
             Modalities::seeing(),
         );
@@ -1518,6 +1559,7 @@ mod tests {
             &[],
             ReplyMode::ToOperator,
             &[],
+            None,
             None,
             Surfaces::none(),
             Modalities::seeing(),
@@ -1559,6 +1601,7 @@ mod tests {
             ReplyMode::ToOperator,
             &[],
             None,
+            None,
             Surfaces::both(),
             Modalities::seeing(),
         );
@@ -1593,6 +1636,7 @@ mod tests {
             &[],
             ReplyMode::ToOperator,
             &[],
+            None,
             None,
             Surfaces::both(),
             Modalities::seeing(),
@@ -1632,6 +1676,7 @@ mod tests {
             ReplyMode::ToOperator,
             &[],
             None,
+            None,
             Surfaces::both(),
             Modalities::seeing(),
         );
@@ -1664,6 +1709,7 @@ mod tests {
             &[],
             ReplyMode::ToOperator,
             &[],
+            None,
             None,
             Surfaces::both(),
             Modalities::seeing(),
@@ -1984,6 +2030,7 @@ mod tests {
             ReplyMode::ToOperator,
             &[],
             None,
+            None,
             Surfaces::both(),
             Modalities::seeing(),
         );
@@ -2082,6 +2129,7 @@ mod tests {
             ReplyMode::ToOperator,
             &[],
             None,
+            None,
             Surfaces::both(),
             Modalities::seeing(),
         );
@@ -2100,6 +2148,7 @@ mod tests {
             &[],
             ReplyMode::ToOperator,
             &[],
+            None,
             None,
             Surfaces::both(),
             Modalities::seeing(),
@@ -2185,6 +2234,7 @@ mod tests {
             ReplyMode::ToOperator,
             &waiting,
             None,
+            None,
             Surfaces::both(),
             Modalities::seeing(),
         );
@@ -2199,6 +2249,60 @@ mod tests {
             derived.contains("working notes above do not need to carry it"),
             "and the derived one has to say why the other is short: {derived}"
         );
+    }
+
+    #[test]
+    fn an_agent_is_shown_what_it_has_already_escalated_and_how_long_ago() {
+        // An agent that cannot see its own open escalation raises it again as
+        // news every turn, which is the behavior this whole mechanism exists to
+        // stop being written into a channel. The age and the count are what
+        // make the section worth reading rather than a repeat of the tool.
+        let now = crate::domain::now_ms();
+        let open = Escalation {
+            id: crate::domain::ids::EscalationId::new(),
+            agent_id: card("Manager").id,
+            group_id: card("Manager").group_id,
+            run_id: crate::domain::ids::RunId::new(),
+            summary: "the workspace tooling is down and I cannot verify anything".into(),
+            raised_at: now - 2 * 24 * 3_600_000,
+            said_at: now,
+            times: 5,
+            cleared_at: None,
+        };
+        let prompt = system_prompt(
+            &card("Manager"),
+            "",
+            &[],
+            &[],
+            &[],
+            &[],
+            "",
+            &[],
+            &[],
+            ReplyMode::ToOperator,
+            &[],
+            Some(&open),
+            None,
+            Surfaces::both(),
+            Modalities::seeing(),
+        );
+        let said = section(&prompt, "## What you have already escalated");
+
+        assert!(said.contains("2d ago"), "{said}");
+        assert!(said.contains("5 turns"), "{said}");
+        assert!(said.contains("the workspace tooling is down"), "{said}");
+        assert!(
+            said.contains("Do not raise it again unless what you would say has changed"),
+            "a section that only reports costs a turn and changes nothing: {said}"
+        );
+    }
+
+    #[test]
+    fn an_agent_with_nothing_escalated_is_told_nothing_about_it() {
+        // The section is the state, so an empty one is a heading about a thing
+        // that has not happened, in a prompt every turn pays for.
+        let prompt = prompt_for(&card("Manager"), &[], "", ReplyMode::ToOperator);
+        assert!(!prompt.contains("## What you have already escalated"), "{prompt}");
     }
 
     #[test]
@@ -2370,6 +2474,7 @@ mod tests {
             ReplyMode::ToOperator,
             &[],
             None,
+            None,
             Surfaces::none(),
             Modalities::seeing(),
         );
@@ -2391,6 +2496,7 @@ mod tests {
             &[],
             ReplyMode::ToOperator,
             &[],
+            None,
             None,
             Surfaces { computer: true, browser: false, repository: false },
             Modalities::seeing(),
@@ -2416,6 +2522,7 @@ mod tests {
             &[],
             mode,
             &[],
+            None,
             None,
             Surfaces::both(),
             modalities,
@@ -2518,6 +2625,7 @@ mod tests {
             ReplyMode::ToOperator,
             &[],
             None,
+            None,
             Surfaces::none(),
             Modalities::seeing(),
         );
@@ -2545,6 +2653,7 @@ mod tests {
             &[],
             ReplyMode::ToOperator,
             &[],
+            None,
             None,
             Surfaces { computer: false, browser: true, repository: false },
             Modalities::seeing(),
@@ -2826,6 +2935,7 @@ mod tests {
             ReplyMode::ToOperator,
             &waiting,
             None,
+            None,
             Surfaces::both(),
             Modalities::seeing(),
         );
@@ -2857,6 +2967,7 @@ mod tests {
             &[],
             ReplyMode::ToOperator,
             &[],
+            None,
             None,
             Surfaces::both(),
             Modalities::seeing(),

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -377,6 +377,14 @@ fn read(runtime: &Runtime, session: Tokens) -> Presence {
         }
     };
 
+    let stuck = match store.open_escalations(APPROVAL_WINDOW) {
+        Ok(stuck) => stuck,
+        Err(err) => {
+            tracing::debug!(%err, "could not read open escalations for the menu bar");
+            Vec::new()
+        }
+    };
+
     let all_time = match store.usage_by_group() {
         Ok(groups) => menubar::sum(groups.into_values()),
         Err(err) => {
@@ -389,6 +397,7 @@ fn read(runtime: &Runtime, session: Tokens) -> Presence {
         names,
         activity: runtime.activity_snapshot(),
         waiting,
+        stuck,
         session,
         all_time,
         running: runtime.live_runs(),

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -3776,6 +3776,162 @@ async fn an_agent_reading_an_acknowledgment_may_still_say_nothing_quietly() {
     );
 }
 
+// ---- saying it has stopped, without stopping ------------------------------
+
+/// Everything the model was sent this call, as one string.
+///
+/// Deliberately every message rather than only the last: what these stubs
+/// branch on is whether a tool has already answered, and that answer arrives as
+/// a message of its own. It reads the system prompt too, which is what one of
+/// them is asking about.
+fn said(body: &serde_json::Value) -> String {
+    body["messages"]
+        .as_array()
+        .map(|m| m.iter().filter_map(|m| m["content"].as_str()).collect::<Vec<_>>().join("\n"))
+        .unwrap_or_default()
+}
+
+/// Whether `escalate` has already answered this turn.
+///
+/// Two phrases because there are deliberately two answers, and the difference
+/// between them is the feature: a first raise is told it is on the desk, and a
+/// repeat is told how long the operator has had it and how many turns have gone
+/// into the same wall. A stub keyed on one of them loops on the other.
+fn escalated(body: &serde_json::Value) -> bool {
+    let said = said(body);
+    said.contains("on the operator's desk now") || said.contains("You already had that up")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_agent_that_cannot_go_on_puts_it_on_the_desk_and_finishes_its_turn() {
+    // The case neither of the two parking tools could cover. Nothing here can
+    // be answered inside a turn: the operator has to go and do something, and
+    // ten minutes of a parked turn would end with the wall still there and a
+    // run booking spent. So the agent says so on its way out and carries on,
+    // and what it said becomes a row rather than a paragraph in a channel
+    // nobody has open.
+    let stub = serve(|body| {
+        if escalated(body) {
+            Script::Say("Flagged it. I have done what I can without the deploy key.".into())
+        } else {
+            Script::Escalate("The deploy needs a key only you have.".into())
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Analyst"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Analyst"), "Ship it.").unwrap();
+    h.settle(run).await;
+
+    // Nothing parked, and that is the point rather than a gap: the turn ran to
+    // the end and the agent was never held anywhere.
+    assert_eq!(
+        h.sink.count_of(|e| matches!(e, UiEvent::ApprovalRequested { .. })),
+        0,
+        "an escalation must not park a turn"
+    );
+    assert_eq!(h.sink.count_of(|e| matches!(e, UiEvent::EscalationRaised { .. })), 1);
+
+    let open = h.runtime.store().open_escalations(50).unwrap();
+    assert_eq!(open.len(), 1);
+    assert_eq!(open[0].summary, "The deploy needs a key only you have.");
+    assert_eq!(open[0].agent_id, h.id("Analyst"));
+    assert_eq!(open[0].times, 1);
+
+    assert!(
+        h.transcript().contains("done what I can"),
+        "the turn has to finish rather than stop on it:\n{}",
+        h.transcript()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_second_turn_that_hits_the_same_wall_counts_rather_than_queues() {
+    // Six turns into one wall is one thing to deal with, and the operator has
+    // to be able to see that it is six. A row each would be a desk that reads
+    // as six problems; a silent second raise would be a desk that reads as one
+    // bad afternoon.
+    let stub = serve(|body| {
+        if escalated(body) {
+            Script::Say("Nothing else I can do here.".into())
+        } else {
+            Script::Escalate("The workspace tooling is down.".into())
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Analyst"], GuardLimits::default());
+    for _ in 0..2 {
+        let run = h.runtime.send_from_human(h.id("Analyst"), "Any progress?").unwrap();
+        h.settle(run).await;
+    }
+
+    let open = h.runtime.store().open_escalations(50).unwrap();
+    assert_eq!(open.len(), 1, "one agent, one open row");
+    assert_eq!(open[0].times, 2, "and the count is what says how much has been lost to it");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_open_escalation_is_in_the_next_turns_prompt() {
+    // An agent that cannot see what it has already escalated raises it again as
+    // news every turn, which is the behavior in a channel that this replaced.
+    let stub = serve(|body| {
+        if said(body).contains("What you have already escalated") {
+            Script::Say("Still waiting on the key. Nothing has moved.".into())
+        } else if escalated(body) {
+            Script::Say("Flagged it.".into())
+        } else {
+            Script::Escalate("The deploy needs a key only you have.".into())
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Analyst"], GuardLimits::default());
+    let first = h.runtime.send_from_human(h.id("Analyst"), "Ship it.").unwrap();
+    h.settle(first).await;
+    let second = h.runtime.send_from_human(h.id("Analyst"), "Any progress?").unwrap();
+    h.settle(second).await;
+
+    assert!(
+        h.transcript().contains("Nothing has moved"),
+        "the second turn has to have been shown its own open escalation:\n{}",
+        h.transcript()
+    );
+    assert_eq!(
+        h.runtime.store().open_escalations(50).unwrap()[0].times,
+        1,
+        "and having been shown it, must not have raised it again as news"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn clearing_one_says_so_and_leaves_the_agent_free_to_raise_another() {
+    let stub = serve(|body| {
+        if escalated(body) {
+            Script::Say("Nothing else I can do here.".into())
+        } else {
+            Script::Escalate("The workspace tooling is down.".into())
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Analyst"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Analyst"), "Ship it.").unwrap();
+    h.settle(run).await;
+
+    let one = h.runtime.store().open_escalations(50).unwrap().remove(0);
+    h.runtime.clear_escalation(one.id).unwrap();
+
+    assert_eq!(h.sink.count_of(|e| matches!(e, UiEvent::EscalationCleared { .. })), 1);
+    assert!(h.runtime.store().open_escalations(50).unwrap().is_empty());
+
+    // Cleared is not answered. Nothing was waiting on it, so nothing resumed,
+    // and the agent is not told: what unblocks it is a message in its channel.
+    let again = h.runtime.send_from_human(h.id("Analyst"), "And now?").unwrap();
+    h.settle(again).await;
+    assert_eq!(h.runtime.store().open_escalations(50).unwrap().len(), 1);
+}
+
 // ---- asking the operator what, rather than whether ------------------------
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -93,6 +93,9 @@ pub enum Script {
     AskPermission { action: String, because: String },
     /// Emit an `ask_operator` tool call. Empty options is a written answer.
     AskQuestion { question: String, options: Vec<String> },
+    /// Emit an `escalate` tool call: the one way to an operator that does not
+    /// park the turn, played by a model on its way out of one.
+    Escalate(String),
     /// Emit a `run_command` tool call: a model reaching for a computer, whether
     /// or not it was offered one.
     ///
@@ -283,6 +286,16 @@ pub fn render(script: &Script) -> String {
             body.push_str(&frame(serde_json::json!({"choices":[{"delta":{"tool_calls":[
                 {"index":0,"id":"call_question","type":"function",
                  "function":{"name":"ask_operator","arguments": args}}
+            ]}}]})));
+            body.push_str(&frame(
+                serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
+            ));
+        }
+        Script::Escalate(summary) => {
+            let args = serde_json::json!({ "summary": summary }).to_string();
+            body.push_str(&frame(serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                {"index":0,"id":"call_escalate","type":"function",
+                 "function":{"name":"escalate","arguments": args}}
             ]}}]})));
             body.push_str(&frame(
                 serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -56,6 +56,7 @@ vi.mock("./lib/ipc", () => ({
     usageSummary: async () => [],
     approvalStates: async () => ({}),
     pendingApprovals: async () => [],
+    openEscalations: async () => [],
     agentLastActive: () => agentLastActive(),
     getSettings: () => getSettings(),
     channelMessages: async () => [],

--- a/src/components/Desk.test.tsx
+++ b/src/components/Desk.test.tsx
@@ -2,19 +2,23 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useStore } from "../lib/store";
-import type { AgentCard, Approval, ApprovalId } from "../lib/types";
+import type { AgentCard, Approval, ApprovalId, Escalation } from "../lib/types";
 import { DEFAULT_GROUP } from "../test-fixtures";
 import { Desk } from "./Desk";
 
 const decideApproval = vi.fn<(id: string, decision: string) => Promise<Approval>>();
 const answerQuestion = vi.fn<(id: string, answer: string) => Promise<Approval>>();
 const pendingApprovals = vi.fn<() => Promise<Approval[]>>();
+const clearEscalation = vi.fn<(id: string) => Promise<void>>();
+const openEscalations = vi.fn<() => Promise<Escalation[]>>();
 
 vi.mock("../lib/ipc", () => ({
   api: {
     decideApproval: (id: string, decision: string) => decideApproval(id, decision),
     answerQuestion: (id: string, answer: string) => answerQuestion(id, answer),
     pendingApprovals: () => pendingApprovals(),
+    clearEscalation: (id: string) => clearEscalation(id),
+    openEscalations: () => openEscalations(),
     approvalStates: async () => ({}),
     channelMessages: async () => [],
     conversationFlow: async () => [],
@@ -63,8 +67,24 @@ function request(over: Partial<Approval> = {}): Approval {
   };
 }
 
-function draw(pending: Approval[]) {
-  useStore.setState({ agents: [agent("Manager")], pending, approvals: {}, banner: null });
+/** An escalation, raised a fortnight ago unless a test says otherwise. */
+function stuckOn(over: Partial<Escalation> = {}): Escalation {
+  return {
+    id: "esc-1",
+    agentId: "Manager",
+    groupId: DEFAULT_GROUP,
+    runId: "run-1",
+    summary: "The deploy needs a key only you have.",
+    raisedAt: Date.now() - 2 * 24 * 60 * 60 * 1000,
+    saidAt: Date.now(),
+    times: 1,
+    clearedAt: null,
+    ...over,
+  };
+}
+
+function draw(pending: Approval[], stuck: Escalation[] = []) {
+  useStore.setState({ agents: [agent("Manager")], pending, stuck, approvals: {}, banner: null });
   return render(<Desk />);
 }
 
@@ -85,7 +105,11 @@ beforeEach(() => {
   decideApproval.mockResolvedValue(request({ state: "allow" }));
   pendingApprovals.mockReset();
   pendingApprovals.mockResolvedValue([]);
-  useStore.setState({ agents: [], pending: [], approvals: {}, banner: null });
+  clearEscalation.mockReset();
+  clearEscalation.mockResolvedValue(undefined);
+  openEscalations.mockReset();
+  openEscalations.mockResolvedValue([]);
+  useStore.setState({ agents: [], pending: [], stuck: [], approvals: {}, banner: null });
 });
 
 describe("the desk", () => {
@@ -234,5 +258,75 @@ describe("the desk", () => {
     await vi.waitFor(() =>
       expect(screen.getByRole<HTMLButtonElement>("button", { name: "Allow" }).disabled).toBe(false),
     );
+  });
+});
+
+describe("an escalation on the desk", () => {
+  it("is on it with nothing parked, because nothing has to be parked", () => {
+    draw([], [stuckOn()]);
+    expect(screen.getByText("The deploy needs a key only you have.")).toBeTruthy();
+    expect(screen.getByText("1 agent is stuck on you")).toBeTruthy();
+  });
+
+  // The two numbers the message in a channel could not carry. "Stuck" is a
+  // state; "stuck for two days, six turns into it" is a decision.
+  it("says how long it has been true and how many turns have hit it", () => {
+    draw([], [stuckOn({ times: 6 })]);
+    expect(screen.getByText("Manager · stuck 2d")).toBeTruthy();
+    expect(screen.getByText("6 turns have run into this")).toBeTruthy();
+  });
+
+  // Opening the channel is what actually unblocks the agent. Clearing only
+  // takes the row away, so it must not be the loud button.
+  it("leads with the channel and not with the clear", () => {
+    draw([], [stuckOn()]);
+    const open = screen.getByRole("button", { name: "Open channel" });
+    expect(open.className).toContain("btn--primary");
+    expect(screen.getByRole("button", { name: "Clear" }).className).toContain("btn--ghost");
+  });
+
+  it("opens the channel of the agent that raised it", () => {
+    draw([], [stuckOn()]);
+    fireEvent.click(screen.getByRole("button", { name: "Open channel" }));
+    expect(useStore.getState().selected).toBe("Manager");
+  });
+
+  it("clears the one it was asked about", () => {
+    draw([], [stuckOn({ id: "esc-9" })]);
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(clearEscalation).toHaveBeenCalledWith("esc-9");
+  });
+
+  // A clear that failed must not leave the desk missing a row the store still
+  // has: the read is what decides, exactly as it does for a refused verdict.
+  it("reads the queue back after a clear that was refused", async () => {
+    clearEscalation.mockRejectedValue(new Error("gone"));
+    openEscalations.mockResolvedValue([stuckOn()]);
+    draw([], [stuckOn()]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    await vi.waitFor(() => expect(useStore.getState().stuck).toHaveLength(1));
+    expect(useStore.getState().banner?.tone).toBe("error");
+  });
+
+  // One of these has ten minutes to be answered in and the other has as long as
+  // it takes. Sorting the perishable half under the durable half is how a
+  // permission lapses while the operator reads about a two-day-old wall.
+  it("draws requests above escalations, whatever their ages are", () => {
+    const { container } = draw([request()], [stuckOn()]);
+    const cards = [...container.querySelectorAll(".desk__card")];
+    expect(cards).toHaveLength(2);
+    expect(cards[0]?.getAttribute("data-kind")).toBeNull();
+    expect(cards[1]?.getAttribute("data-kind")).toBe("stuck");
+  });
+
+  it("counts both kinds in one line without adding them up for the operator", () => {
+    draw([request()], [stuckOn()]);
+    expect(screen.getByText("2 things are waiting on you")).toBeTruthy();
+  });
+
+  it("names the agent as deleted rather than drawing an empty card", () => {
+    draw([], [stuckOn({ agentId: "gone" })]);
+    expect(screen.getByText(/A deleted agent · stuck/)).toBeTruthy();
   });
 });

--- a/src/components/Desk.tsx
+++ b/src/components/Desk.tsx
@@ -2,7 +2,8 @@ import { type FormEvent, useEffect, useRef, useState } from "react";
 
 import { AgentAvatar } from "../avatars/AgentAvatar";
 import { useStore } from "../lib/store";
-import type { AgentCard, Approval, Decision } from "../lib/types";
+import { relativeTime } from "../lib/time";
+import type { AgentCard, Approval, Decision, Escalation } from "../lib/types";
 
 /**
  * Everything waiting on the operator, wherever they are in the app.
@@ -23,15 +24,19 @@ import type { AgentCard, Approval, Decision } from "../lib/types";
  * is a thing it refuses to do.
  *
  * **It holds stopped work and nothing else.** A parked turn qualifies by
- * definition. A run that failed does not: nothing is waiting, and the channel
- * is where a failure is understood. Neither does a run that finished, a routine
- * that fired, or a paused agent. Guaca already has a surface for "something
- * happened" and it is a notification; this is for "something has stopped, and
- * you are the reason".
+ * definition, and so does an escalation, which is the same sentence without the
+ * parking: an agent that cannot go on until the operator does something. A run
+ * that failed does not: nothing is waiting, and the channel is where a failure
+ * is understood. Neither does a run that finished, a routine that fired, or a
+ * paused agent. Guaca already has a surface for "something happened" and it is
+ * a notification; this is for "something has stopped, and you are the reason".
  *
  * **It is usually absent.** No queue, no surface, not even a small empty one.
  * A panel that is always there is furniture within a week, and furniture is not
  * read. Being gone almost all the time is what buys the corner of the screen.
+ * An escalation is the one thing here that can stay up for days, and it is
+ * allowed to for the reason it exists: a crew stuck since Tuesday should be
+ * furniture in the corner of the operator's screen until they deal with it.
  *
  * **It has no composer and no scrollback.** Every control on it is bounded, and
  * what has been answered is gone from it. The transcript is the record; a
@@ -44,11 +49,14 @@ import type { AgentCard, Approval, Decision } from "../lib/types";
  */
 export function Desk() {
   const pending = useStore((s) => s.pending);
+  const stuck = useStore((s) => s.stuck);
   const agents = useStore((s) => s.agents);
   const select = useStore((s) => s.select);
   const decide = useStore((s) => s.decideApproval);
   const answerQuestion = useStore((s) => s.answerQuestion);
+  const clear = useStore((s) => s.clearEscalation);
   const [open, setOpen] = useState(true);
+  const count = pending.length + stuck.length;
 
   // Opens itself again for a queue that has refilled. Collapsing is about the
   // requests that were on screen at the time, not a standing instruction to
@@ -56,9 +64,9 @@ export function Desk() {
   // silently hold the one thing that has stopped work.
   const wasEmpty = useRef(true);
   useEffect(() => {
-    if (wasEmpty.current && pending.length > 0) setOpen(true);
-    wasEmpty.current = pending.length === 0;
-  }, [pending.length]);
+    if (wasEmpty.current && count > 0) setOpen(true);
+    wasEmpty.current = count === 0;
+  }, [count]);
 
   // The lowest-priority owner of Escape: a dialog, a menu or a drag all have
   // something more urgent to close, and every one of them stops the event
@@ -72,10 +80,9 @@ export function Desk() {
     return () => window.removeEventListener("keydown", onKey);
   }, [open]);
 
-  if (pending.length === 0) return null;
+  if (count === 0) return null;
 
-  const count = pending.length;
-  const summary = count === 1 ? "1 turn is waiting on you" : `${count} turns are waiting on you`;
+  const summary = deskSummary(pending.length, stuck.length);
 
   return (
     <section className="desk" aria-label="Waiting on you" data-open={open ? "true" : undefined}>
@@ -101,6 +108,11 @@ export function Desk() {
 
       {open && (
         <div className="desk__queue">
+          {/* Requests first, and that ordering is not arbitrary: one of these
+              has ten minutes to be answered in and the other has as long as it
+              takes. Sorting the perishable half under the durable half is how a
+              permission lapses while the operator reads about a wall that has
+              been there since Tuesday. */}
           {pending.map((request) => (
             <DeskCard
               key={request.id}
@@ -111,9 +123,97 @@ export function Desk() {
               onOpenChannel={() => void select(request.agentId)}
             />
           ))}
+          {stuck.map((one) => (
+            <StuckCard
+              key={one.id}
+              escalation={one}
+              agent={agents.find((a) => a.id === one.agentId)}
+              onClear={() => void clear(one.id)}
+              onOpenChannel={() => void select(one.agentId)}
+            />
+          ))}
         </div>
       )}
     </section>
+  );
+}
+
+/**
+ * The line at the top, over a queue that holds two different things.
+ *
+ * One sentence rather than two counts, because the operator is answering one
+ * question with it and a head that read "2 waiting, 1 stuck" makes them add up
+ * before they can decide whether to open it. The kinds are named while there is
+ * only one kind, since that is when the word is worth something: "1 agent is
+ * stuck on you" says where to go and "3 things are waiting on you" says how
+ * many, and the queue underneath says the rest.
+ */
+export function deskSummary(waiting: number, stuck: number): string {
+  if (stuck === 0) {
+    return waiting === 1 ? "1 turn is waiting on you" : `${waiting} turns are waiting on you`;
+  }
+  if (waiting === 0) {
+    return stuck === 1 ? "1 agent is stuck on you" : `${stuck} agents are stuck on you`;
+  }
+  return `${waiting + stuck} things are waiting on you`;
+}
+
+interface StuckProps {
+  escalation: Escalation;
+  agent: AgentCard | undefined;
+  onClear: () => void;
+  onOpenChannel: () => void;
+}
+
+/**
+ * One escalation, and the two things that can be done about it.
+ *
+ * Open is the primary and Clear is not, which is the whole card. Clearing takes
+ * the row away and changes nothing about the agent: what actually unblocks it
+ * is a message in the channel, and an operator who only ever presses the
+ * cheaper button is running a desk they tidy instead of a desk they work. So
+ * the button that leads somewhere is the loud one, and the one that ends it
+ * quietly is the quiet one.
+ *
+ * The age and the count are on the card rather than in the summary because they
+ * are the news. "Stuck" is a state; "stuck since Tuesday, six turns into it" is
+ * a decision. Neither number can be recovered from the transcript without
+ * reading a week of it.
+ */
+function StuckCard({ escalation, agent, onClear, onOpenChannel }: StuckProps) {
+  const asker = agent?.name ?? "A deleted agent";
+  const age = relativeTime(escalation.raisedAt, Date.now());
+  const turns = escalation.times === 1 ? "1 turn" : `${escalation.times} turns`;
+
+  return (
+    <article className="desk__card" data-kind="stuck">
+      <header className="desk__who">
+        <AgentAvatar
+          avatar={agent?.avatar ?? "blank"}
+          color={agent?.color ?? "#8aa0a6"}
+          size="sm"
+          seed={agent?.id ?? escalation.id}
+        />
+        <div className="desk__whotext">
+          <p className="desk__asker">
+            {asker} · stuck {age}
+          </p>
+          {/* The agent's own words, drawn as text under a heading Guaca wrote,
+              exactly as a request's detail is. */}
+          <p className="desk__summary">{escalation.summary}</p>
+        </div>
+      </header>
+
+      <div className="desk__actions">
+        <button type="button" className="btn btn--primary btn--small" onClick={onOpenChannel}>
+          Open channel
+        </button>
+        <button type="button" className="btn btn--ghost btn--small" onClick={onClear}>
+          Clear
+        </button>
+        <span className="desk__aside">{turns} have run into this</span>
+      </div>
+    </article>
   );
 }
 

--- a/src/components/GroupOrb.tsx
+++ b/src/components/GroupOrb.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties } from "react";
 import { AgentAvatar } from "../avatars/AgentAvatar";
 import { cluster } from "../lib/orb";
 import { presenceLabel, presenceNote, presenceOf } from "../lib/presence";
-import type { Activity, AgentCard, AgentId, Group } from "../lib/types";
+import type { Activity, AgentCard, AgentId, Escalation, Group } from "../lib/types";
 import { OrbTag, useOrbTag } from "./OrbTag";
 
 interface Props {
@@ -11,6 +11,8 @@ interface Props {
   /** Live members, in the order the rail arranged them. */
   members: AgentCard[];
   activity: Record<AgentId, Activity>;
+  /** Every open escalation in the workspace. Filtered to this crew inside. */
+  stuck: readonly Escalation[];
   /** Whether the rail is currently looking inside this group. */
   current: boolean;
   /** Whether a dragged row would land here if it were dropped now. */
@@ -45,6 +47,7 @@ export function GroupOrb({
   group,
   members,
   activity,
+  stuck,
   current,
   over,
   onOpen,
@@ -57,7 +60,7 @@ export function GroupOrb({
   // The two states worth interrupting a glance for, and why they are not one
   // mark: `lib/presence.ts`. This column is the only thing on screen about the
   // crews the operator is not looking at, so what it can say is all they get.
-  const presence = presenceOf(members, activity);
+  const presence = presenceOf(members, activity, stuck);
 
   return (
     <button

--- a/src/components/GroupRail.tsx
+++ b/src/components/GroupRail.tsx
@@ -1,5 +1,5 @@
 import type { DropTarget } from "../lib/rail";
-import type { Activity, AgentCard, AgentId, Group, GroupId } from "../lib/types";
+import type { Activity, AgentCard, AgentId, Escalation, Group, GroupId } from "../lib/types";
 import { GroupOrb } from "./GroupOrb";
 import { OrbTag, useOrbTag } from "./OrbTag";
 
@@ -8,6 +8,8 @@ interface Props {
   /** Every live agent, across every crew. */
   agents: AgentCard[];
   activity: Record<AgentId, Activity>;
+  /** Every open escalation, so a circle can say a crew has stopped. */
+  stuck: readonly Escalation[];
   /** The crew the rail is inside, or `null` for all of them. */
   focused: GroupId | null;
   onFocus: (id: GroupId | null) => void;
@@ -43,6 +45,7 @@ export function GroupRail({
   groups,
   agents,
   activity,
+  stuck,
   focused,
   onFocus,
   isOver,
@@ -92,6 +95,7 @@ export function GroupRail({
             group={group}
             members={agents.filter((a) => a.groupId === group.id)}
             activity={activity}
+            stuck={stuck}
             current={focused === group.id}
             over={isOver({ kind: "group", id: group.id })}
             onOpen={() => onFocus(focused === group.id ? null : group.id)}

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -1319,6 +1319,7 @@ describe("notifications", () => {
 
     expect(useStore.getState().prefs.notify.kinds).toEqual({
       approval: true,
+      stuck: true,
       routine: false,
       settled: true,
       failed: true,

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -84,6 +84,10 @@ const NOTIFY_COPY: Record<NotifyKind, { label: string; hint: string }> = {
     label: "An agent needs permission",
     hint: "The only one that blocks: the turn that asked is parked until you answer, and gives up after ten minutes. Reaches you even while Guaca is open, if the request is in a channel you are not looking at.",
   },
+  stuck: {
+    label: "An agent is stuck on you",
+    hint: "It could not go on without you and said so on its way out of a turn. Nothing is parked and nothing expires, so it sits on your desk until you clear it. Same channel rule as above.",
+  },
   routine: {
     label: "A routine fired",
     hint: "Work that starts on a schedule rather than because you asked. It lands in whichever channel it was pointed at, which is usually not the one on screen.",

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useStore } from "../lib/store";
-import type { Activity, AgentCard, Group } from "../lib/types";
+import type { Activity, AgentCard, Escalation, Group } from "../lib/types";
 import { aGroup, DEFAULT_GROUP } from "../test-fixtures";
 import { Sidebar } from "./Sidebar";
 
@@ -56,11 +56,17 @@ function agent(name: string, over: Partial<AgentCard> = {}): AgentCard {
   };
 }
 
-function draw(groups: Group[], agents: AgentCard[] = [], activity: Record<string, Activity> = {}) {
+function draw(
+  groups: Group[],
+  agents: AgentCard[] = [],
+  activity: Record<string, Activity> = {},
+  stuck: Escalation[] = [],
+) {
   useStore.setState({
     agents,
     groups,
     activity,
+    stuck,
     lastActive: {},
     usage: Object.fromEntries(
       groups.map((g) => [g.id, { prompt: 900_000, completion: 900_000, calls: 400, cost: 123.45 }]),
@@ -622,5 +628,53 @@ describe("groups as places", () => {
     fireEvent.pointerUp(window, { clientX: 60, clientY: 120 });
 
     await vi.waitFor(() => expect(moveAgent).toHaveBeenCalledWith("Manager", RESEARCH, null));
+  });
+});
+
+describe("an agent that has stopped and said so", () => {
+  const stuckOn = (by: string, over: Partial<Escalation> = {}): Escalation => ({
+    id: `esc-${by}`,
+    agentId: by,
+    groupId: DEFAULT_GROUP,
+    runId: "run-1",
+    summary: "The deploy needs a key only you have.",
+    raisedAt: Date.now() - 2 * 24 * 60 * 60 * 1000,
+    saidAt: Date.now(),
+    times: 3,
+    clearedAt: null,
+    ...over,
+  });
+
+  // This column is what somebody scans when they have noticed that nothing is
+  // moving. An agent stuck since Tuesday reading as idle is the whole reason
+  // the escalation exists, one surface up.
+  it("says so on the row, with how long it has been", () => {
+    draw([group("everyone")], [agent("Manager")], {}, [stuckOn("Manager")]);
+    expect(screen.getByText("stuck 2d")).toBeTruthy();
+  });
+
+  // A state that resolves itself must not hide one that does not.
+  it("says it over anything the agent happens to be doing right now", () => {
+    draw([group("everyone")], [agent("Manager")], { Manager: { state: "thinking" } }, [
+      stuckOn("Manager"),
+    ]);
+    expect(screen.getByText("stuck 2d")).toBeTruthy();
+    expect(screen.queryByText("typing")).toBeNull();
+  });
+
+  // The one state that outranks it, and only because it is the same statement
+  // with a turn parked behind it: that one has ten minutes and this one does not.
+  it("gives way to a parked turn, which is the more urgent version of itself", () => {
+    draw([group("everyone")], [agent("Manager")], { Manager: { state: "awaitingApproval" } }, [
+      stuckOn("Manager"),
+    ]);
+    expect(screen.getByText("needs you")).toBeTruthy();
+  });
+
+  it("leaves every other row alone", () => {
+    draw([group("everyone")], [agent("Manager"), agent("Reader", { railOrder: 1 })], {}, [
+      stuckOn("Manager"),
+    ]);
+    expect(screen.getAllByText("stuck 2d")).toHaveLength(1);
   });
 });

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -75,6 +75,7 @@ export function Sidebar({
   const repoStatus = useStore((s) => s.repoStatus);
   const refreshRepoStatuses = useStore((s) => s.refreshRepoStatuses);
   const activity = useStore((s) => s.activity);
+  const stuck = useStore((s) => s.stuck);
   const lastActive = useStore((s) => s.lastActive);
   const selected = useStore((s) => s.selected);
   const select = useStore((s) => s.select);
@@ -307,6 +308,22 @@ export function Sidebar({
     id: AgentId,
     state: Activity | undefined,
   ): { text: string; kind: string | undefined } => {
+    // Above everything but a parked turn, and above it in the same voice. Both
+    // of the states a person is the fix for outrank every state that will
+    // resolve itself, because this column is what somebody scans when they have
+    // noticed that nothing is moving: an agent stuck since Tuesday that happens
+    // to be typing right now must not read as an agent that is fine.
+    //
+    // The age is the label. "Stuck" is a state and "stuck 2d" is a decision,
+    // and the second one is the whole reason this is on the row rather than in
+    // a channel somebody has to open.
+    if (state?.state !== "awaitingApproval") {
+      const open = stuck.find((one) => one.agentId === id);
+      if (open) {
+        return { text: `stuck ${relativeTime(open.raisedAt, now)}`, kind: "asking" };
+      }
+    }
+
     // Before the turn states, because a coding job outlives the turn that
     // started it: the agent goes idle the moment `code` returns and stays that
     // way while a coding agent works in its repository for twenty minutes.
@@ -437,6 +454,7 @@ export function Sidebar({
         groups={groups}
         agents={agents}
         activity={activity}
+        stuck={stuck}
         focused={railGroup}
         onFocus={(id) => void focusGroup(id)}
         isOver={isOver}

--- a/src/lib/announce.test.ts
+++ b/src/lib/announce.test.ts
@@ -236,6 +236,38 @@ describe("what each interruption says", () => {
     expect(said?.channel).toBe(SCRIBE);
   });
 
+  it("names the agent that has stopped, and sends the operator to its channel", () => {
+    const said = announcementFor(
+      { type: "escalationRaised", escalationId: "escalation-1", agentId: SCRIBE },
+      nameOf,
+    );
+    expect(said?.kind).toBe("stuck");
+    expect(said?.title).toBe("Scribe is stuck");
+    expect(said?.channel).toBe(SCRIBE);
+  });
+
+  // The event carries an id and an agent, exactly as a request does, so what
+  // the agent is stuck on is not here to be said. The body must not pretend
+  // otherwise: a notification quoting an empty summary is worse than one that
+  // says where to look.
+  it("says what an escalation does rather than what it is about", () => {
+    const said = announcementFor(
+      { type: "escalationRaised", escalationId: "escalation-1", agentId: CHEF },
+      nameOf,
+    );
+    expect(said?.body).toContain("until you clear it");
+    expect(said?.body).not.toMatch(/undefined/);
+  });
+
+  // Nothing is announced when one comes off the desk. The operator took it off
+  // themselves, or the agent that raised it was thrown out, and neither is news
+  // to interrupt somebody with.
+  it("says nothing when an escalation is cleared", () => {
+    expect(
+      announcementFor({ type: "escalationCleared", escalationId: "escalation-1" }, nameOf),
+    ).toBeNull();
+  });
+
   it("keys a permission request on the agent rather than on the request", () => {
     // Two requests from one agent within the second are one interruption; the
     // burst check can only collapse them if the approval id is not in the key.

--- a/src/lib/announce.ts
+++ b/src/lib/announce.ts
@@ -1,12 +1,12 @@
 /**
- * Turning runtime events into the four things worth interrupting someone for.
+ * Turning runtime events into the five things worth interrupting someone for.
  *
  * Kept apart from `notify`, which decides *whether* to interrupt, and from
  * `App`, which is a view. This decides *what* the interruption would say, and
  * it is a pure function of one event so it can be argued with in a test rather
  * than in a running window.
  *
- * Three of the four kinds are read out of the event stream directly. The fourth
+ * Four of the five kinds are read out of the event stream directly. The other
  * is not: `runSettled` says which run ended and nothing about where it
  * happened, and "only tell me about the channel I was looking at" needs a
  * channel. So the one piece of state here is a run's channel, learned from the
@@ -72,6 +72,20 @@ export function announcementFor(
         body: "Its turn is parked until you answer, and gives up after ten minutes.",
         channel: event.agentId,
         key: `approval:${event.agentId}`,
+      };
+
+    case "escalationRaised":
+      return {
+        kind: "stuck",
+        title: `${nameOf(event.agentId)} is stuck`,
+        // What it is stuck on is deliberately not here. The event carries an id
+        // and an agent, exactly as `approvalRequested` does, so this says the
+        // one thing it can say without reading the store from a pure function:
+        // that there is now something on the desk, and that nothing will take
+        // it off again.
+        body: "It cannot go on without you. On your desk until you clear it.",
+        channel: event.agentId,
+        key: `stuck:${event.agentId}`,
       };
 
     case "runSettled": {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -35,6 +35,8 @@ import type {
   Decision,
   DeviceCode,
   Envelope,
+  Escalation,
+  EscalationId,
   Gate,
   Group,
   GroupDraft,
@@ -327,6 +329,15 @@ export const api = {
   approvalStates: () => invoke<Record<ApprovalId, ApprovalState>>("approval_states"),
   /** Every request still waiting on the operator, oldest first. */
   pendingApprovals: () => invoke<Approval[]>("pending_approvals"),
+
+  /**
+   * Everything an agent has said it cannot get past without the operator,
+   * oldest first. The other half of the desk's queue, and read the same way:
+   * nothing can be on the desk that is not a row in the store.
+   */
+  openEscalations: () => invoke<Escalation[]>("open_escalations"),
+  /** Takes one off the desk. Not an answer: nothing is waiting on it. */
+  clearEscalation: (id: EscalationId) => invoke<void>("clear_escalation", { id }),
 
   /** Refused if it was already answered or has lapsed. */
   decideApproval: (id: ApprovalId, decision: Decision) =>

--- a/src/lib/notify.test.ts
+++ b/src/lib/notify.test.ts
@@ -36,11 +36,11 @@ import { NOTIFY_KINDS, type NotifyKind, type NotifyPrefs } from "./prefs";
  * case worth interrupting for and the one `document.hidden` misses.
  */
 
-/** The master switch on and all four kinds wanted: prefs are never the refusal. */
+/** The master switch on and every kind wanted: prefs are never the refusal. */
 function wanted(): NotifyPrefs {
   return {
     on: true,
-    kinds: { approval: true, routine: true, settled: true, failed: true },
+    kinds: { approval: true, stuck: true, routine: true, settled: true, failed: true },
   };
 }
 
@@ -121,8 +121,15 @@ describe("the quiet window after a launch", () => {
 });
 
 describe("the class of news a kind is", () => {
-  it("makes a permission request the only thing that can break through", () => {
+  it("makes a permission request one of the two that can break through", () => {
     expect(classOf("approval")).toBe("attention");
+  });
+
+  // The same class from the other end, and the case for it is stronger rather
+  // than weaker: a permission expires in ten minutes and stops mattering, and
+  // an agent that has stopped stays stopped until somebody does something.
+  it("makes an agent that has stopped the other one", () => {
+    expect(classOf("stuck")).toBe("attention");
   });
 
   it("treats a schedule firing as ambient, because it was pointed somewhere else", () => {

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -16,10 +16,12 @@
  * The second is where the judgment is. "Away" is not one condition, because a
  * permission request and a finished conversation are not the same news:
  *
- *   attention   an agent is blocked on you. Reaches you when the window is not
- *               in front of you, and also when it is but the request belongs to
- *               a channel you are not looking at. Nobody finds a parked turn by
- *               noticing a row change color three screens up the rail.
+ *   attention   an agent is blocked on you, whether or not its turn is parked.
+ *               Reaches you when the window is not in front of you, and also
+ *               when it is but the request belongs to a channel you are not
+ *               looking at. Nobody finds a parked turn by noticing a row change
+ *               color three screens up the rail, and nobody finds an agent that
+ *               gave up four turns ago by reading its channel.
  *   ambient     nothing was addressed to you and no channel is implied. A
  *               routine fires wherever it was pointed. Reaches you whenever you
  *               are away, with no channel to match against.
@@ -36,6 +38,10 @@ export type NotifyClass = "attention" | "ambient" | "completion";
 export function classOf(kind: NotifyKind): NotifyClass {
   switch (kind) {
     case "approval":
+    // An escalation is the same class from the other end: nothing is parked on
+    // it, so nothing lapses, and it has to reach the operator anyway because
+    // the agent that raised it has already carried on without them.
+    case "stuck":
       return "attention";
     case "routine":
       return "ambient";

--- a/src/lib/prefs.test.ts
+++ b/src/lib/prefs.test.ts
@@ -45,7 +45,7 @@ const DEFAULTS: Prefs = {
   surface: "light",
   notify: {
     on: true,
-    kinds: { approval: true, routine: true, settled: true, failed: true },
+    kinds: { approval: true, stuck: true, routine: true, settled: true, failed: true },
   },
 };
 
@@ -99,7 +99,7 @@ describe("a blob that cannot be trusted", () => {
       surface: "light",
       notify: {
         on: false,
-        kinds: { approval: true, routine: false, settled: true, failed: true },
+        kinds: { approval: true, stuck: true, routine: false, settled: true, failed: true },
       },
     });
   });
@@ -196,7 +196,7 @@ describe("a preference that outlives the window", () => {
       surface: "dark",
       notify: {
         on: false,
-        kinds: { approval: true, routine: false, settled: false, failed: true },
+        kinds: { approval: true, stuck: true, routine: false, settled: false, failed: true },
       },
     };
     savePrefs(chosen);

--- a/src/lib/prefs.ts
+++ b/src/lib/prefs.ts
@@ -25,14 +25,26 @@ export type SurfaceMode = "light" | "dark" | "system";
 /**
  * What an agent doing something can interrupt you for.
  *
- * Four kinds rather than one switch, because they are not the same question.
- * A permission request is blocking and stays blocking until you answer it. A
- * routine fires in a channel you were never looking at. A conversation
- * finishing is only interesting if you were waiting for it.
+ * Five kinds rather than one switch, because they are not the same question.
+ * A permission request is blocking and stays blocking until you answer it. An
+ * agent that has stopped is blocking and has no clock on it at all. A routine
+ * fires in a channel you were never looking at. A conversation finishing is
+ * only interesting if you were waiting for it.
+ *
+ * The first two are close enough to look like one switch and are not: an
+ * operator who turns off permission prompts because a crew asks too often has
+ * not said they want to stop hearing that an agent has stopped dead, and one
+ * switch would take that decision for them.
  */
-export type NotifyKind = "approval" | "routine" | "settled" | "failed";
+export type NotifyKind = "approval" | "stuck" | "routine" | "settled" | "failed";
 
-export const NOTIFY_KINDS: readonly NotifyKind[] = ["approval", "routine", "settled", "failed"];
+export const NOTIFY_KINDS: readonly NotifyKind[] = [
+  "approval",
+  "stuck",
+  "routine",
+  "settled",
+  "failed",
+];
 
 export interface NotifyPrefs {
   /** The master switch. Off means no kind fires, whatever the kinds say. */
@@ -72,7 +84,13 @@ export const DEFAULT_PREFS: Prefs = Object.freeze({
   surface: "light",
   notify: Object.freeze({
     on: true,
-    kinds: Object.freeze({ approval: true, routine: true, settled: true, failed: true }),
+    kinds: Object.freeze({
+      approval: true,
+      stuck: true,
+      routine: true,
+      settled: true,
+      failed: true,
+    }),
   }),
 }) as Prefs;
 

--- a/src/lib/presence.test.ts
+++ b/src/lib/presence.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { presenceLabel, presenceNote, presenceOf, QUIET } from "./presence";
-import type { Activity, AgentCard, AgentId } from "./types";
+import type { Activity, AgentCard, AgentId, Escalation } from "./types";
 
 function anAgent(id: string, over: Partial<AgentCard> = {}): AgentCard {
   return {
@@ -29,43 +29,59 @@ function states(map: Record<string, Activity>): Record<AgentId, Activity> {
   return map as Record<AgentId, Activity>;
 }
 
+/** One open escalation, held by `by`. Nothing else on it is read here. */
+function raisedBy(by: string): Escalation {
+  return {
+    id: `e-${by}`,
+    agentId: by as AgentId,
+    groupId: "g1",
+    runId: "r1",
+    summary: "the deploy needs a key only you have",
+    raisedAt: 0,
+    saidAt: 0,
+    times: 1,
+    clearedAt: null,
+  } as Escalation;
+}
+
 describe("presenceOf", () => {
   it("is quiet when nobody is doing anything", () => {
-    expect(presenceOf(crew, states({}))).toEqual(QUIET);
+    expect(presenceOf(crew, states({}), [])).toEqual(QUIET);
   });
 
   it("counts every parked turn, not just that there is one", () => {
     const presence = presenceOf(
       crew,
       states({ a: { state: "awaitingApproval" }, c: { state: "awaitingApproval" } }),
+      [],
     );
     expect(presence.blocked).toBe(2);
   });
 
   it("reports working without a number", () => {
-    const presence = presenceOf(crew, states({ a: { state: "thinking" } }));
+    const presence = presenceOf(crew, states({ a: { state: "thinking" } }), []);
     expect(presence).toEqual({ blocked: 0, working: true });
   });
 
   it("counts queued work as working, because the turn is coming", () => {
-    expect(presenceOf(crew, states({ b: { state: "queued", depth: 2 } })).working).toBe(true);
+    expect(presenceOf(crew, states({ b: { state: "queued", depth: 2 } }), []).working).toBe(true);
   });
 
   // A paused row is not work in progress. It scores nothing in `liftOf` for the
   // same reason, and a ring lit for one would never go out.
   it("does not call a paused agent working", () => {
-    expect(presenceOf(crew, states({ a: { state: "paused" } }))).toEqual(QUIET);
+    expect(presenceOf(crew, states({ a: { state: "paused" } }), [])).toEqual(QUIET);
   });
 
   it("does not call an idle agent working", () => {
-    expect(presenceOf(crew, states({ a: { state: "idle" } }))).toEqual(QUIET);
+    expect(presenceOf(crew, states({ a: { state: "idle" } }), [])).toEqual(QUIET);
   });
 
   // A parked agent is not also counted as working: it is the one thing the
   // count is for, and a ring around a number says the crew is busy when in fact
   // it has stopped.
   it("does not double count a parked agent as working too", () => {
-    const presence = presenceOf(crew, states({ a: { state: "awaitingApproval" } }));
+    const presence = presenceOf(crew, states({ a: { state: "awaitingApproval" } }), []);
     expect(presence).toEqual({ blocked: 1, working: false });
   });
 
@@ -73,13 +89,43 @@ describe("presenceOf", () => {
     const presence = presenceOf(
       crew,
       states({ a: { state: "awaitingApproval" }, b: { state: "thinking" } }),
+      [],
     );
     expect(presence).toEqual({ blocked: 1, working: true });
   });
 
   // The activity map is workspace-wide and the column draws one crew at a time.
   it("ignores an agent that is not in the crew", () => {
-    const presence = presenceOf([anAgent("a")], states({ z: { state: "awaitingApproval" } }));
+    const presence = presenceOf([anAgent("a")], states({ z: { state: "awaitingApproval" } }), []);
+    expect(presence).toEqual(QUIET);
+  });
+
+  // The half no activity state can carry. Nothing is parked on an escalation:
+  // the turn that raised it ended, so the agent holding one is idle or off
+  // doing something else, and a count read off `activity` alone says a crew
+  // that has been stuck since Tuesday is quiet.
+  it("counts an open escalation, which no activity state says anything about", () => {
+    const presence = presenceOf(crew, states({}), [raisedBy("a")]);
+    expect(presence).toEqual({ blocked: 1, working: false });
+  });
+
+  it("counts an escalation held by an agent that is working", () => {
+    const presence = presenceOf(crew, states({ a: { state: "thinking" } }), [raisedBy("a")]);
+    expect(presence).toEqual({ blocked: 1, working: true });
+  });
+
+  // Two things for the operator to deal with, and the desk has two cards for
+  // them. Collapsing them to one would say a crew needs one answer when it
+  // needs two, which is the count being wrong in the direction that matters.
+  it("counts a parked turn and that agent's older escalation separately", () => {
+    const presence = presenceOf(crew, states({ a: { state: "awaitingApproval" } }), [
+      raisedBy("a"),
+    ]);
+    expect(presence.blocked).toBe(2);
+  });
+
+  it("ignores an escalation raised by an agent in another crew", () => {
+    const presence = presenceOf([anAgent("a")], states({}), [raisedBy("z")]);
     expect(presence).toEqual(QUIET);
   });
 });
@@ -118,8 +164,9 @@ describe("the whole workspace", () => {
     const everyone = [anAgent("a"), anAgent("b", { groupId: "g2" as AgentCard["groupId"] })];
     const activity = states({ a: { state: "awaitingApproval" }, b: { state: "awaitingApproval" } });
     const parts =
-      presenceOf([everyone[0]!], activity).blocked + presenceOf([everyone[1]!], activity).blocked;
-    expect(presenceOf(everyone, activity).blocked).toBe(parts);
+      presenceOf([everyone[0]!], activity, []).blocked +
+      presenceOf([everyone[1]!], activity, []).blocked;
+    expect(presenceOf(everyone, activity, []).blocked).toBe(parts);
   });
 });
 

--- a/src/lib/presence.ts
+++ b/src/lib/presence.ts
@@ -7,9 +7,10 @@
  *
  * Two marks, and they are deliberately not one:
  *
- *   a count    turns in this crew parked on the operator. A number, because
- *              "three" and "one" are different amounts of work and a dot says
- *              neither. This is the one state a person is the fix for.
+ *   a count    things in this crew that a person is the fix for: turns parked
+ *              on the operator, and agents that have stopped and said so. A
+ *              number, because "three" and "one" are different amounts of work
+ *              and a dot says neither.
  *   a ring     somebody here is working. No number: how many agents are
  *              mid-turn is not a thing anybody acts on, and a second number
  *              beside the first would make the first harder to read.
@@ -27,10 +28,18 @@
  * migration, not a badge, and it is not in this change.
  */
 
-import type { Activity, AgentCard, AgentId } from "./types";
+import type { Activity, AgentCard, AgentId, Escalation } from "./types";
 
 export interface Presence {
-  /** Turns in this crew parked on the operator, waiting to be answered. */
+  /**
+   * What in this crew is waiting on the operator: turns parked on a request,
+   * plus escalations nobody has cleared.
+   *
+   * One number over two sources, because the circle is answering one question
+   * and the question is "is anything over there mine". They are worth
+   * distinguishing on the desk, which can afford two cards, and not here, where
+   * the whole statement is a digit on a circle the size of a thumbnail.
+   */
   blocked: number;
   /** Anyone here is mid-turn or holding queued work. */
   working: boolean;
@@ -41,12 +50,18 @@ export const QUIET: Presence = { blocked: 0, working: false };
 /**
  * What one crew amounts to right now.
  *
- * Counted off `activity` rather than off the pending requests, because this is
- * a question about agents and that is a table of requests. The two are one to
- * one by construction: an agent runs one turn at a time and a turn parks on one
- * request, so a crew with two parked agents has two rows in `approvals` and a
- * crew with none has none. Reading the activity map is what lets this be a fold
- * over the roster the column is already drawing, with nothing else fetched.
+ * Parked turns are counted off `activity` rather than off the pending requests,
+ * because that half is a question about agents. The two are one to one by
+ * construction: an agent runs one turn at a time and a turn parks on one
+ * request, so a crew with two parked agents has two rows in `approvals`.
+ *
+ * Escalations are not, and cannot be. Nothing parks on one -- the turn that
+ * raised it ended -- so the agent holding one is idle, or working on something
+ * else, and its activity says so correctly. The list is the only place it
+ * exists, which is why it is an argument rather than something read off the
+ * roster. An agent parked on a request while an older escalation of its own is
+ * still open counts twice, and that is right: they are two things to deal with,
+ * and the desk has two cards for them.
  *
  * Every state is named rather than defaulted, and that is what makes this safe
  * to leave alone. A variant added to the runtime and not weighed here would
@@ -54,9 +69,18 @@ export const QUIET: Presence = { blocked: 0, working: false };
  * draw as idle: the one reading that makes the column not worth a glance. Named
  * exhaustively, the same addition fails the build instead.
  */
-export function presenceOf(members: AgentCard[], activity: Record<AgentId, Activity>): Presence {
+export function presenceOf(
+  members: AgentCard[],
+  activity: Record<AgentId, Activity>,
+  stuck: readonly Escalation[],
+): Presence {
   let blocked = 0;
   let working = false;
+
+  const here = new Set(members.map((member) => member.id));
+  for (const one of stuck) {
+    if (here.has(one.agentId)) blocked += 1;
+  }
 
   for (const member of members) {
     const state = activity[member.id];

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -33,6 +33,8 @@ import type {
   CodingLine,
   Decision,
   Envelope,
+  Escalation,
+  EscalationId,
   Group,
   GroupId,
   GroupUsage,
@@ -171,6 +173,17 @@ interface State {
    */
   pending: Approval[];
 
+  /**
+   * Every escalation still open, oldest first.
+   *
+   * The other half of the desk's queue, held the same way and for the same
+   * reason. Beside `pending` rather than merged into it because the two are
+   * answered differently: one takes a verdict or a value and has ten minutes to
+   * take it in, and this one is cleared when the operator has dealt with it and
+   * waits as long as it takes.
+   */
+  stuck: Escalation[];
+
   selected: ChannelKey | null;
   /**
    * The group the rail is looking inside, or `null` for all of them.
@@ -267,6 +280,16 @@ interface State {
   refreshRepoStatuses: () => Promise<void>;
   refreshUsage: () => Promise<void>;
   refreshApprovals: () => Promise<void>;
+  /**
+   * Re-reads the open escalations.
+   *
+   * Its own call rather than a third read inside `refreshApprovals`: the two
+   * queues change on different events, and folding them together would make
+   * every answered permission re-read a list that cannot have moved.
+   */
+  refreshEscalations: () => Promise<void>;
+  /** Takes one off the desk. Nothing is waiting on it, so nothing resumes. */
+  clearEscalation: (id: EscalationId) => Promise<void>;
   select: (key: ChannelKey) => Promise<void>;
   /**
    * Looks inside one group, or back out at all of them. Closes the open channel
@@ -418,6 +441,7 @@ export const useStore = create<State>((set, get) => ({
   pulse: {},
   approvals: {},
   pending: [],
+  stuck: [],
   selected: null,
   railGroup: null,
   messages: {},
@@ -443,6 +467,7 @@ export const useStore = create<State>((set, get) => ({
       usage,
       approvals,
       pending,
+      stuck,
     ] = await Promise.all([
       api.listAgents(),
       api.listGroups(),
@@ -456,6 +481,10 @@ export const useStore = create<State>((set, get) => ({
       // has to be right on the first paint, or the operator's first read of
       // it says nobody is waiting.
       api.pendingApprovals(),
+      // And an agent that gave up on a Friday is still stuck on Monday. This
+      // one has no window at all, so first paint is the only thing that decides
+      // whether the operator ever sees it.
+      api.openEscalations(),
     ]);
     set({
       agents,
@@ -467,6 +496,7 @@ export const useStore = create<State>((set, get) => ({
       usage: byGroup(usage),
       approvals,
       pending,
+      stuck,
     });
 
     const live = agents.filter((a) => a.lifecycle !== "terminated");
@@ -683,6 +713,22 @@ export const useStore = create<State>((set, get) => ({
   async refreshApprovals() {
     const [approvals, pending] = await Promise.all([api.approvalStates(), api.pendingApprovals()]);
     set({ approvals, pending });
+  },
+
+  async refreshEscalations() {
+    set({ stuck: await api.openEscalations() });
+  },
+
+  async clearEscalation(id) {
+    try {
+      await api.clearEscalation(id);
+    } catch (error) {
+      get().setBanner({ tone: "error", text: errorMessage(error) });
+    }
+    // Read back either way, for the reason `settle` does: a clear that failed
+    // must not leave the desk missing a row the store still has, and one that
+    // worked is confirmed rather than assumed.
+    await get().refreshEscalations();
   },
 
   async decideApproval(id, decision) {
@@ -1008,6 +1054,15 @@ export const useStore = create<State>((set, get) => ({
           approvals: { ...state.approvals, [event.approvalId]: event.state },
         }));
         void get().refreshApprovals();
+        break;
+      }
+
+      // Nothing to patch first, unlike the two above: an escalation has no
+      // state a card is keyed on, and the wording is the whole row. Both events
+      // invalidate the queue and the read is where the desk's card comes from.
+      case "escalationRaised":
+      case "escalationCleared": {
+        void get().refreshEscalations();
         break;
       }
 

--- a/src/lib/trail.test.ts
+++ b/src/lib/trail.test.ts
@@ -381,6 +381,42 @@ describe("a progress note", () => {
   });
 });
 
+describe("an escalation", () => {
+  it("says what it is, and is not called asking", () => {
+    // Nothing was asked. The word has to separate it from the two calls that
+    // stop a turn to get something back, in a chip that is one line.
+    const [step] = steps(call("escalate", { summary: "The deploy needs a key only you have." }));
+    expect(step!.title).toBe("Escalated to the operator");
+    expect(step!.target).toBe("The deploy needs a key only you have.");
+    expect(callInFlight("escalate", { summary: "x" })).toBe("Escalating to the operator");
+  });
+
+  it("adds nothing beside a chip that already said it", () => {
+    // What comes back is an instruction to the model, and the two numbers in it
+    // the operator would want are on the desk, read live from the row. Frozen
+    // into a transcript, "2d ago" is wrong by the next morning.
+    const [step] = steps(
+      call(
+        "escalate",
+        { summary: "The tooling is down." },
+        ok("That is on the operator's desk now, and it stays there until they clear it."),
+      ),
+    );
+    expect(tellsMore(step!)).toBe(false);
+  });
+
+  it("shows what went wrong when one could not be raised", () => {
+    const [step] = steps(
+      call(
+        "escalate",
+        { summary: "The tooling is down." },
+        { status: "failed", error: "database is locked" },
+      ),
+    );
+    expect(tellsMore(step!)).toBe(true);
+  });
+});
+
 describe("what the turn has done, on one line", () => {
   it("counts the calls that came back, and says nothing about their kind", () => {
     // The kinds are what the chips behind the count are for. A line naming the

--- a/src/lib/trail.ts
+++ b/src/lib/trail.ts
@@ -194,6 +194,11 @@ function describe(tool: string, args: Args): Described {
     case "request_permission":
       return { title: "Asked for permission", target: text(args, "summary") };
 
+    // Not "asked" and not "said": nothing was asked, and this is the one call
+    // that reaches the operator wherever they are without stopping the turn.
+    case "escalate":
+      return { title: "Escalated to the operator", target: text(args, "summary") };
+
     case "run_command":
       return { title: "Ran a command", target: text(args, "command") };
 
@@ -371,6 +376,8 @@ export function callInFlight(name: string, raw: unknown): string {
       return "Asking to add an agent";
     case "request_permission":
       return "Asking for permission";
+    case "escalate":
+      return "Escalating to the operator";
     default:
       return `Using ${name}`;
   }
@@ -412,6 +419,8 @@ function manyLabel(group: TrailGroup): string {
       return `Noted where its work stands ${count} times`;
     case "directory":
       return `Checked who is available ${count} times`;
+    case "escalate":
+      return `Escalated to the operator ${count} times`;
     default:
       return `Used ${group.steps[0]!.tool} ${count} times`;
   }
@@ -538,6 +547,11 @@ const ECHOES = new Set([
   "update_notes",
   "note_progress",
   "attach_file",
+  // Every word of what comes back is an instruction to the model -- do not
+  // wait, do what you can, do not raise it again -- and the two numbers in it
+  // that the operator would want are on the desk and the rail, read live from
+  // the row. Frozen into a transcript, "2d ago" is wrong by the next morning.
+  "escalate",
 ]);
 
 /** Whether what came back is worth reading beside the call it came from. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,6 +157,37 @@ export interface Approval {
   decidedAt: number | null;
 }
 
+export type EscalationId = string;
+
+/**
+ * Work that has stopped, and that only the operator can move.
+ *
+ * Not an {@link Approval} and deliberately not a third {@link Request}: nothing
+ * is parked on one, so there is no verdict, no value and no ten minute fuse.
+ * The agent raised it on its way out of a turn and carried on without it.
+ *
+ * What makes a row worth more than the message it replaces is the pair at the
+ * bottom. `raisedAt` never moves and `times` only goes up, so an agent that
+ * hits the same wall on six turns is one row that says it has been true since
+ * Tuesday and that six turns have gone into it.
+ */
+export interface Escalation {
+  id: EscalationId;
+  agentId: AgentId;
+  groupId: GroupId;
+  runId: RunId;
+  /** The agent's own words, so every surface draws it as text. */
+  summary: string;
+  /** When it first went up. Never moved by a later raise. */
+  raisedAt: number;
+  /** When it was last restated, which is not the same question. */
+  saidAt: number;
+  /** How many turns have run into it. One when it goes up. */
+  times: number;
+  /** Set once the operator has taken it off the desk. */
+  clearedAt: number | null;
+}
+
 export interface Envelope {
   id: MessageId;
   runId: RunId;
@@ -920,6 +951,8 @@ export type UiEvent =
   | { type: "runSettled"; runId: RunId; stepsUsed: number }
   | { type: "approvalRequested"; approvalId: ApprovalId; agentId: AgentId }
   | { type: "approvalSettled"; approvalId: ApprovalId; state: ApprovalState }
+  | { type: "escalationRaised"; escalationId: EscalationId; agentId: AgentId }
+  | { type: "escalationCleared"; escalationId: EscalationId }
   /**
    * One agent's schedule changed: it set a routine, edited one, canceled one,
    * or one came due and moved. The list refetches; nothing here is patched,

--- a/src/styles.css
+++ b/src/styles.css
@@ -548,6 +548,24 @@ button {
   margin-left: auto;
 }
 
+/* How long it has been true and how many turns have run into it. At the far end
+   and quiet, because it is what the operator reads after deciding to look at
+   this card rather than what makes them look: the card's own first line already
+   carries the age. */
+.desk__aside {
+  margin-left: auto;
+  font-size: var(--type-meta);
+  color: var(--faint);
+}
+
+/* An escalation is the one card here that nothing is parked on, so it is the
+   one that can sit for days. Marked down the edge rather than in a color of its
+   own: the panel already says everything on it needs the operator, and a second
+   alarm color would make the two kinds compete instead of stack. */
+.desk__card[data-kind="stuck"] {
+  border-left: 2px solid var(--alarm);
+}
+
 /* ==========================================================================
    Group column
 


### PR DESCRIPTION
Both existing ways for an agent to reach a person park the turn and lapse after ten minutes, which is right for a decision the turn needs now and wrong for an agent that cannot go on at all: a harness that will not start, an expired sign-in, a key only the operator has. With nothing to reach for, agents wrote it into a channel nobody was reading, and the three surfaces built for exactly this — the crew circle, the desk, the menu bar — all read from `approvals`, so nothing had parked and all three said the workspace was fine.

`escalate` adds a third thing that waits on nothing: the turn finishes, and what it said becomes a durable row that reaches the desk, the crew count, the rail (`stuck 2d`), the menu bar and its own notification kind, and stays there until the operator clears it. One open row per agent, where `raised_at` never moves and `times` only goes up, so six turns into one wall reads as *stuck since Tuesday, six turns into it* rather than six copies of one sentence; the agent is shown its own open escalation in its prompt so it stops re-reporting it as news.

`Store::raise_escalation` takes an immediate transaction, because deferred lets two turns of one agent both read "nothing open" and the second is refused with `SQLITE_BUSY_SNAPSHOT` inside a turn that had already given up — the eight-thread test beside it found that. Covered at every level it crosses (store, desk, crews' column, menu bar, and the cascade suite end to end) and `./scripts/ci.sh` is green; `./scripts/evals.sh` has not been run, and should be, since a new tool changes how a crew behaves and CI cannot see it.