### PR TITLE
feat: the app is ink on paper with one amber, and everything reads a size up

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fontsource-variable/instrument-sans": "^5.3.0",
     "@fontsource-variable/inter": "^5.3.0",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
-    "@fontsource-variable/space-grotesk": "^5.3.0",
     "@tauri-apps/api": "^2.9.0",
     "@tauri-apps/plugin-dialog": "^2.4.0",
     "@tauri-apps/plugin-notification": "^2.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,13 +8,13 @@ importers:
 
   .:
     dependencies:
+      '@fontsource-variable/instrument-sans':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@fontsource-variable/inter':
         specifier: ^5.3.0
         version: 5.3.0
       '@fontsource-variable/jetbrains-mono':
-        specifier: ^5.3.0
-        version: 5.3.0
-      '@fontsource-variable/space-grotesk':
         specifier: ^5.3.0
         version: 5.3.0
       '@tauri-apps/api':
@@ -447,14 +447,14 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@fontsource-variable/instrument-sans@5.3.0':
+    resolution: {integrity: sha512-u4gKbDBTNFGkg997tfQn3eHOhHuquWUFTRT/rwzuKtrxX5P2ekfs2x+LgBPP4P32+cC+vUwF1Cr+IdRoPQbrGw==}
+
   '@fontsource-variable/inter@5.3.0':
     resolution: {integrity: sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==}
 
   '@fontsource-variable/jetbrains-mono@5.3.0':
     resolution: {integrity: sha512-F32xpS2NsGYoQi2ADSkKTgpJj7ozajsGgDJ8woTnqjmIB+dxDIqImjl4pXZVEExu8UFZ2ndhmX18EBS/hdz3Lw==}
-
-  '@fontsource-variable/space-grotesk@5.3.0':
-    resolution: {integrity: sha512-2IxmvfB08i9vnGB3Ym/AXvhRE+8XOjWMXIyDum03c+tPwH0FUoMNQfGpU8NXPxjbws0Vvss3AH0Zqt4oJBBAdw==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2032,11 +2032,11 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
+  '@fontsource-variable/instrument-sans@5.3.0': {}
+
   '@fontsource-variable/inter@5.3.0': {}
 
   '@fontsource-variable/jetbrains-mono@5.3.0': {}
-
-  '@fontsource-variable/space-grotesk@5.3.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:

--- a/src/components/ActivityFlow.tsx
+++ b/src/components/ActivityFlow.tsx
@@ -45,7 +45,7 @@ import { MessageModal } from "./WireRow";
  */
 const LANE_REM = 4.5;
 
-const YOU: WirePeer = { id: "human", name: "You", color: "#5b665e", avatar: "plain" };
+const YOU: WirePeer = { id: "human", name: "You", color: "#54524d", avatar: "plain" };
 
 interface Props {
   messages: Envelope[];
@@ -368,7 +368,7 @@ function buildBlocks(messages: Envelope[], byId: (id: AgentId) => AgentCard | un
           : participant.kind === "human"
             ? { peer: YOU, gone: false }
             : {
-                peer: { id: "system", name: "Guaca", color: "#8a5a2f", avatar: "plain" },
+                peer: { id: "system", name: "Guaca", color: "#2f4858", avatar: "plain" },
                 gone: false,
               };
 

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -43,8 +43,8 @@ interface Props {
   named?: boolean;
 }
 
-const HUMAN = { id: "human", name: "You", color: "#5b665e", avatar: "plain" };
-const SYSTEM = { id: "system", name: "Guaca", color: "#8a5a2f", avatar: "plain" };
+const HUMAN = { id: "human", name: "You", color: "#54524d", avatar: "plain" };
+const SYSTEM = { id: "system", name: "Guaca", color: "#2f4858", avatar: "plain" };
 
 function identity(participant: Participant, byId: Lookups["byId"]) {
   if (participant.kind === "human") return HUMAN;

--- a/src/lib/palette.test.ts
+++ b/src/lib/palette.test.ts
@@ -20,7 +20,7 @@ import { describe, expect, it } from "vitest";
 import { MAX_SCATTER_HUES, SCATTER_MARKS, SLOTS, seriesColor, seriesMark } from "./palette";
 
 /** The surface a figure card is drawn on, which is `--raised` in both. */
-const SURFACE = { paper: "#ffffff", ink: "#222622" };
+const SURFACE = { paper: "#ffffff", ink: "#171715" };
 
 /** Neighbors must clear this under simulated colorblindness. */
 const CVD_TARGET = 8;

--- a/src/lib/palette.ts
+++ b/src/lib/palette.ts
@@ -15,7 +15,7 @@
  * choice cost nothing: of the orders that pass, this is one of the best.
  *
  * Measured on this app's own chart surface (`--raised`: `#ffffff` on paper,
- * `#222622` on ink), simulating protanopia and deuteranopia at full severity,
+ * `#171715` on ink), simulating protanopia and deuteranopia at full severity,
  * as OKLab distance ×100:
  *
  * | gate                        | target | paper | ink  |

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 import "@fontsource-variable/inter";
-import "@fontsource-variable/space-grotesk";
+import "@fontsource-variable/instrument-sans";
 import "@fontsource-variable/jetbrains-mono";
 
 import React, { useMemo } from "react";

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,61 +3,82 @@
 /* ==========================================================================
    Guaca design tokens
 
-   A dark rail against a page. The rail carries the identity — warm olive-black,
-   ripe avocado flesh as the one bright accent, pit brown for anything the
-   system says — and the reading column is the page.
+   Ink on paper, and one amber that only ever means the app wants something
+   from a person. There is no second surface color and no tinted panel: what
+   carries hierarchy is size, weight and air, which is why the type ladder
+   below is wider than a chat app usually needs and why the reading anchor is
+   17px rather than 15. A transcript with room around it reads as one thing at
+   a time. A dense one reads as a wall, and this app is mostly machines
+   talking, so the wall is the failure mode it falls into by default.
 
-   Paper is what long-form text wants and it is still the default: a chat log is
-   read for minutes at a time and white wins that argument in a lit room. It
-   does not win it in a dark one, which is the whole reason the reading column
-   is a token block behind `data-surface` rather than a set of literals. The
-   rail is not part of that question. It is dark in both surfaces, and it pins
-   its own accents so nothing the reading column does can reach it.
+   The accent is the whole color system. `--flesh` is the amber, `--pit` is a
+   cold slate beside it for anything the system says about itself, and
+   everything else on screen is ink, paper or one of three grays. That is the
+   discipline the rest of it hangs off: spend amber on decoration and it stops
+   meaning "answer me", and the one thing this app must never do is ask
+   quietly.
 
-   Type is three roles, not one. Space Grotesk carries names and titles, where
-   a little character belongs. Inter carries everything you actually read for
-   minutes at a time. JetBrains Mono carries the machine texture: times, hops,
-   routes, code. All three ship with the app, so the window looks the same on
-   every machine and needs no network.
+   The token names are the old ones. `--flesh` was ripe avocado and is now the
+   signal amber; 71 rules read it, and renaming a color is a mechanical change
+   worth doing on its own rather than folded into a change of mind about what
+   the color is.
+
+   Paper is the default and does not win in a dark room, which is the whole
+   reason the reading column is a token block behind `data-surface` rather
+   than a set of literals. The rail is not part of that question. It is dark
+   in both surfaces, and it pins its own accents so nothing the reading column
+   does can reach it.
+
+   Type is three roles, not one. Instrument Sans carries names and titles,
+   where a tight fit at a large size is the point. Inter carries everything
+   you actually read for minutes at a time. JetBrains Mono carries the machine
+   texture: times, hops, routes, code. All three ship with the app, so the
+   window looks the same on every machine and needs no network.
    ========================================================================== */
 
 :root {
   /* The rail stays dark in both halves of the app: it is Guaca's face, and a
      dark rail against a white page is what makes the reading column read as
      paper rather than as another panel. */
-  --rail-ground: #131c17;
-  --rail-raised: #1c2921;
-  --rail-edge: #2a3a30;
-  --rail-text: #e7ebdc;
-  --rail-muted: #8b9c8d;
-  --rail-wire: #2b3c32;
+  --rail-ground: #0c0c0b;
+  --rail-raised: #191917;
+  --rail-edge: #2b2a27;
+  --rail-text: #faf8f3;
+  --rail-muted: #9c9992;
+  --rail-wire: #2b2a27;
   /* A shade under the rail. The crews sit behind the crew, and a column that
      is the same ground as the one it borders needs a rule drawn between them
      to be a second surface at all. */
-  --grail-ground: #0e1512;
+  --grail-ground: #050504;
 
   /* The reading surface, and the only half of the app a surface choice moves.
      Messages are long-form text read for minutes at a time, and paper is the
      right ground for that in a lit room; the dark block below is the same seven
      names and nothing else, which is what keeps "dark" from meaning "repaint
-     the app". The avocado palette stays where it belongs: the rail, the agents,
-     and the accents. */
-  --ground: #fcfcfa;
+     the app".
+
+     `--ground` and `--raised` are both white, and that is the decision rather
+     than an oversight: a card here is separated by a rule or by the lift's
+     ring, never by being a slightly different white. Two whites a percent
+     apart is exactly the kind of thing that accretes into 41 font sizes, and
+     it buys nothing a border does not. `--sunken` is the one recessed value,
+     and it is warm rather than gray so the page does not read as blue. */
+  --ground: #ffffff;
   --raised: #ffffff;
-  --sunken: #f2f1ea;
-  --edge: #e3e1d6;
-  --text: #18211b;
-  --muted: #5b665e;
-  --faint: #8a938a;
+  --sunken: #f4f3f0;
+  --edge: #e2e0da;
+  --text: #0b0b0a;
+  --muted: #54524d;
+  --faint: #8a877f;
 
-  --flesh: #4e6b16;
-  --flesh-soft: #eef2d8;
-  --pit: #8a5a2f;
-  --pit-soft: #f6ebdd;
-  --mint: #1c7a51;
-  --alarm: #b03728;
+  --flesh: #b4530a;
+  --flesh-soft: #fdeed9;
+  --pit: #2f4858;
+  --pit-soft: #e9eff3;
+  --mint: #14713f;
+  --alarm: #c1271b;
 
-  --font-display: "Space Grotesk Variable", "Inter Variable", system-ui, sans-serif;
+  --font-display: "Instrument Sans Variable", "Inter Variable", system-ui, sans-serif;
   --font-ui: "Inter Variable", system-ui, -apple-system, "Segoe UI", sans-serif;
   --font-mono: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, monospace;
 
@@ -78,33 +99,42 @@
      operator can pick, and gaps of a quarter pixel do not survive one.
 
      A step is named for the job, not for its rank, because the job is what a
-     rule knows about itself. */
+     rule knows about itself.
+
+     The ladder is wider than it was and the whole of it moved up: the bottom
+     four steps are the mono furniture and stayed where they were, because a
+     timestamp is not something anybody reads at length, and everything above
+     them grew. That is the one change that makes hierarchy legible without a
+     panel, a tint or a border doing it, and it is why the four sizes between
+     13px and 17px are four rather than the eleven this file used to have. */
   --type-mark: 0.5625rem; /* 9px.  Uppercase mono: eyebrows, states, counts. */
   --type-fine: 0.625rem; /* 10px. Timestamps, keycaps, field labels. */
   --type-meta: 0.6875rem; /* 11px. Chips, routes, hop lines. */
-  --type-small: 0.75rem; /* 12px. Hints, captions, dense secondary text. */
-  --type-aside: 0.8125rem; /* 13px. Second lines, notes, previews. */
-  --type-ui: 0.875rem; /* 14px. Every control, and names in a list. */
-  --type-body: 0.9375rem; /* 15px. Messages and markdown. The anchor. */
-  --type-lede: 1.0625rem; /* 17px. Dialog and pane titles. */
-  --type-title: 1.25rem; /* 20px. A name standing on its own. */
-  --type-display: 1.5rem; /* 24px. The rare big thing. */
+  --type-small: 0.8125rem; /* 13px. Hints, captions, dense secondary text. */
+  --type-aside: 0.875rem; /* 14px. Second lines, notes, previews. */
+  --type-ui: 0.9375rem; /* 15px. Every control, and names in a list. */
+  --type-body: 1.0625rem; /* 17px. Messages and markdown. The anchor. */
+  --type-lede: 1.375rem; /* 22px. Dialog and pane titles. */
+  --type-title: 1.75rem; /* 28px. A name standing on its own. */
+  --type-display: 2.25rem; /* 36px. The rare big thing. */
 
   /* Tracking is a function of the step and the case, never a free parameter.
      It was 18 values, six of them the same uppercase-label job at 0.1, 0.11,
      0.12, 0.14, 0.16 and 0.18em. */
-  --track-tight: -0.005em; /* Display face at title sizes, and agent names. */
-  --track-flat: 0; /* Anything read as words. */
-  --track-caps: 0.08em; /* Uppercase labels. The default for caps. */
-  --track-caps-wide: 0.14em; /* Section heads, the wordmark, a typed code. */
+  --track-tight: -0.02em; /* Display face at title sizes, and agent names. */
+  --track-flat: -0.01em; /* Anything read as words. */
+  --track-caps: 0.1em; /* Uppercase labels. The default for caps. */
+  --track-caps-wide: 0.18em; /* Section heads, the wordmark, a typed code. */
 
   /* Leading, four steps. `--lead-flush` is a glyph or a single line in a box
      already the right height; it is not typography and it is not 0, which is
      the inline-descender reset a few SVG wrappers still want. */
   --lead-flush: 1;
-  --lead-tight: 1.3; /* Headings and names. */
-  --lead-ui: 1.45; /* Short text that may wrap to a second line. */
-  --lead-read: 1.6; /* Paragraphs, code blocks, anything read at length. */
+  --lead-tight: 1.2; /* Headings and names. */
+  --lead-ui: 1.4; /* Short text that may wrap to a second line. */
+  /* Tighter than it was, because the text under it is two points larger: leading
+     is a ratio and 1.6 of 17px is a gap you read across rather than down. */
+  --lead-read: 1.55; /* Paragraphs, code blocks, anything read at length. */
 
   /* ---- Space --------------------------------------------------------------
      Eight steps on a 2px base. This was 41 padding lengths, 32 pairs of them
@@ -126,7 +156,7 @@
      The indent is derived rather than written, because it was 2.85rem in four
      places and is the one number that cannot be allowed to drift from the
      portrait lane it sits behind. */
-  --column-inset: 1.15rem;
+  --column-inset: 1.5rem;
   --column-face: 1.7rem;
   --column-indent: calc(var(--column-inset) + var(--column-face));
 
@@ -141,12 +171,16 @@
 
   /* ---- Radius -------------------------------------------------------------
      Radius says what a box *is*, not how big it happens to be: a thing inside
-     a control, a control, a surface. The two existing values are kept exactly,
-     because 47 rules already read them and changing a value under a name is
-     the one migration nobody can review. */
-  --radius-xs: 0.25rem; /* Inside a control: menu row, chip, keycap, tag. */
-  --radius-sm: 0.4rem; /* The control: button, input, select, search. */
-  --radius: 0.7rem; /* A surface: card, dialog, bubble, panel. */
+     a control, a control, a surface. Three steps, near-square, because this
+     system separates things with rules and air rather than with rounded
+     containers: at 4px a card reads as a region of the page, and at 11px it
+     read as an object floating on top of one. The scale is kept rather than
+     flattened to zero, since a 0 here would take the softening off a chart
+     mark and a keycap as well, which are the two places the shape is doing
+     something other than framing. */
+  --radius-xs: 0.125rem; /* Inside a control: menu row, chip, keycap, tag. */
+  --radius-sm: 0.1875rem; /* The control: button, input, select, search. */
+  --radius: 0.25rem; /* A surface: card, dialog, bubble, panel. */
   --radius-pill: 999px; /* One spelling. `99px` was not a second one. */
 
   /* ---- Controls -----------------------------------------------------------
@@ -155,8 +189,8 @@
      because one was given 0.38rem of vertical padding and the other 0.48rem.
      Height is the token; vertical padding falls out of it, which is why no
      control below sets any. */
-  --control-h: 2rem; /* 32px. The default. */
-  --control-h-sm: 1.625rem; /* 26px. Dense rows, inline controls, the send. */
+  --control-h: 2.25rem; /* 36px. The default. */
+  --control-h-sm: 1.75rem; /* 28px. Dense rows, inline controls, the send. */
 
   /* ---- Motion -------------------------------------------------------------
      One curve, three tempos. Cohesion is mostly this: every surface in the app
@@ -179,13 +213,13 @@
      Every easing in this file is one of these three, `linear`, or `steps()`.
      There is no fourth opinion, and a new one has to argue it is a register
      rather than a preference. */
-  --ease: cubic-bezier(0.2, 0.8, 0.2, 1);
-  --ease-spring: cubic-bezier(0.34, 0.9, 0.3, 1);
+  --ease: cubic-bezier(0.18, 0.9, 0.22, 1);
+  --ease-spring: cubic-bezier(0.3, 1, 0.3, 1);
   --ease-loop: cubic-bezier(0.35, 0, 0.3, 1);
 
-  --tempo-tap: 120ms; /* Nothing moves: color, background, border, opacity. */
-  --tempo-move: 200ms; /* Something changes position or size in place. */
-  --tempo-enter: 280ms; /* A surface arrives. */
+  --tempo-tap: 110ms; /* Nothing moves: color, background, border, opacity. */
+  --tempo-move: 180ms; /* Something changes position or size in place. */
+  --tempo-enter: 300ms; /* A surface arrives. */
 
   /* How far a surface travels before it lands. One distance, so a menu and a
      dialog are one gesture at two sizes rather than two gestures. */
@@ -200,7 +234,7 @@
   /* What a dialog is separated from the page by. A token because the answer is
      different on dark paper, where a near-black wash over a near-black page
      separates nothing. */
-  --scrim: rgb(11 17 13 / 0.55);
+  --scrim: rgb(11 11 10 / 0.5);
 
   /* ---- Elevation ----------------------------------------------------------
      Three levels, and both halves of each are load-bearing: the ring is what
@@ -213,9 +247,9 @@
      border of its own and a ring beside one draws a two-pixel line. The two
      above it are for surfaces that float free and have nothing else holding
      their edge. */
-  --lift-1: 0 0.25rem 0.75rem -0.375rem rgb(24 33 27 / 0.16);
-  --lift-2: 0 0.5rem 1.25rem -0.5rem rgb(24 33 27 / 0.18), 0 0 0 1px var(--edge);
-  --lift-3: 0 1.5rem 3rem -1rem rgb(24 33 27 / 0.22), 0 0 0 1px var(--edge);
+  --lift-1: 0 0.125rem 0.5rem -0.25rem rgb(11 11 10 / 0.1);
+  --lift-2: 0 0.5rem 1.25rem -0.625rem rgb(11 11 10 / 0.13), 0 0 0 1px var(--edge);
+  --lift-3: 0 1.25rem 2.5rem -1rem rgb(11 11 10 / 0.17), 0 0 0 1px var(--edge);
   /* For the things that are dark whatever the operator picked: the rail, and
      anything sitting on top of a scrim. They cannot read `--lift-*`, because
      those resolve against the reading column and would put a paper-weight ring
@@ -231,35 +265,39 @@
    The reading column sits lighter than the rail here, which is the same
    relationship as on paper read the other way round: the rail is still the
    darker frame and the column is still the surface you read on.
-   The accents are lifted rather than kept, because the product's olive and
-   brown are chosen against white and neither can be read on ink. They stay
-   recognizably the same colors; they are not the same values. */
+   The accents are lifted rather than kept, because both are chosen against
+   white and neither can be read on ink: the amber goes light and loses its
+   burn, the slate goes pale enough to be a color rather than a shadow. They
+   stay recognizably the same two colors; they are not the same values.
+   The reading column here is the darkest ground in the app after the rail,
+   which is the poster read on ink: one surface, nothing framed, and the amber
+   doing every piece of work color does. */
 :root[data-surface="dark"] {
-  --ground: #1b1e1b;
-  --raised: #222622;
-  --sunken: #161916;
-  --edge: #30362f;
-  --text: #e7ebe2;
-  --muted: #a1aa9f;
-  /* Unchanged from paper on purpose: it is already the lightest of the three
-     grays and it is the one hints are set in, so it has the least contrast to
-     spare. */
-  --faint: #8a938a;
+  --ground: #0f0f0e;
+  --raised: #171715;
+  --sunken: #0a0a09;
+  --edge: #2a2926;
+  --text: #f7f5f0;
+  --muted: #a8a49c;
+  /* The one gray that barely moves between the surfaces: it is the lightest of
+     the three and the one hints are set in, so it has the least contrast to
+     spare in either direction. */
+  --faint: #85817a;
 
-  --flesh: #a8c95f;
-  --flesh-soft: #2b3320;
-  --pit: #c99a6a;
-  --pit-soft: #33281d;
-  --mint: #4fc48c;
-  --alarm: #e8705c;
+  --flesh: #f0a63c;
+  --flesh-soft: #33240e;
+  --pit: #8fb4c9;
+  --pit-soft: #16232b;
+  --mint: #46c47c;
+  --alarm: #ff6a55;
 
-  --scrim: rgb(0 0 0 / 0.62);
+  --scrim: rgb(0 0 0 / 0.66);
   /* The drop layer does almost nothing over a dark page, so the ring carries
      the separation and the drop only deepens the well underneath. Same three
      names, so nothing above this line knows which surface it is drawing on. */
-  --lift-1: 0 0.25rem 0.75rem -0.375rem rgb(0 0 0 / 0.4);
-  --lift-2: 0 0.5rem 1.25rem -0.5rem rgb(0 0 0 / 0.5), 0 0 0 1px var(--edge);
-  --lift-3: 0 1.5rem 3rem -1rem rgb(0 0 0 / 0.55), 0 0 0 1px var(--edge);
+  --lift-1: 0 0.125rem 0.5rem -0.25rem rgb(0 0 0 / 0.45);
+  --lift-2: 0 0.5rem 1.25rem -0.625rem rgb(0 0 0 / 0.55), 0 0 0 1px var(--edge);
+  --lift-3: 0 1.25rem 2.5rem -1rem rgb(0 0 0 / 0.6), 0 0 0 1px var(--edge);
 }
 
 * {
@@ -2005,7 +2043,11 @@ button {
   max-width: min(32rem, 100%);
   padding: var(--space-3) var(--space-5);
   border-radius: var(--radius);
-  background: var(--flesh-soft);
+  /* Recessed rather than accented. The amber means the app wants something
+     from you, and a message you already sent wants nothing: tinted with it,
+     every line you have ever typed reads as a pending request and competes
+     with the one card on the page that actually is one. */
+  background: var(--sunken);
 }
 
 /* Two of your own in a row are two bubbles with air between them. No tail on


### PR DESCRIPTION
A new design system, picked off a ten-way comparison drawn against the same conversation. Amber is now the whole color system and only ever means the app wants something from a person; everything else on screen is ink, paper or one of three grays, `--ground` and `--raised` are both white so a card is separated by a rule rather than by being a slightly different white, and the operator's own bubble goes recessed instead of tinted with the accent it was competing with. The type ladder moved up around a 17px reading anchor, which is what carries hierarchy now that no panel is tinted to do it, and radius, control heights and the three tempos moved with it. Instrument Sans replaces Space Grotesk on names and titles.

Token names are unchanged, so this is a change of values under the existing families plus the four copies of them that live in TypeScript where the stylesheet cannot reach: `--muted` and `--pit` on the two stand-in participants, and `--raised` in the palette's contrast gate, which still passes. `./scripts/ci.sh web` is green (1400 tests); no Rust changed.