### PR TITLE
feat: work re-arms the reply path, and the gather waits on who owes it

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,9 +63,9 @@ The loop guard (`runtime/guard.rs`) bounds the worst case, but bounding is not
 the same as terminating well. What actually makes a cascade converge is
 `expects_reply`:
 
-- A human message, or a message to a peer that has not written to this agent in
-  this run, expects an answer.
-- A message back to someone who has already written expects nothing: it is a
+- A human message, a message to a peer that has not written to this agent in
+  this run, or a message declared `work` wherever it lands, expects an answer.
+- A courtesy back to someone who has already written expects nothing: it is a
   continuation, not an approach.
 
 An agent that receives a non-reply-expecting message still takes a turn to read
@@ -100,22 +100,38 @@ delegation that takes two rounds died at exactly that point.
 
 **Being asked for an answer and being given work are different questions.**
 `expects_reply` is the first and `intent` is the second, and they came apart the
-moment an agent could instruct a peer that had already answered: such a message
-carries work and expects no reply. The runtime had only `expects_reply` to go
-on, so that turn ran in the mode whose prompt says nothing is being asked of it
-and that silence is usually right. The agent read an explicit instruction to
-send an email, spent a model call, said nothing, and to the operator had simply
-stopped. `intent` is now on the envelope and `ReplyMode::Assigned` is the
-combination of work with nobody waiting: do it, then file what you did as a note
-in your own channel. The asymmetry that terminates cascades is untouched, because
-what changed is what the recipient is told, not where its answer goes.
+moment an agent could instruct a peer that had already answered. The runtime had
+only `expects_reply` to go on, so that turn ran in the mode whose prompt says
+nothing is being asked of it and that silence is usually right. The agent read
+an explicit instruction to send an email, spent a model call, said nothing, and
+to the operator had simply stopped. `intent` went onto the envelope for that,
+and for a while the combination of work with a peer that had already written ran
+as `ReplyMode::Assigned`: do it, then file what you did as a note in your own
+channel.
+
+That filing rule turned out to be its own defect, one layer up. The doer did the
+work and reported it into its own channel, but the coordinator that asked was
+told nothing: its prompt's own outstanding-asks list, which is derived from
+`intent` on sent messages, went on saying the peer owed it an answer, and the
+list's advice is to chase. Work now re-arms the reply path instead —
+`expects_reply` is true for any message declared `work`, wherever in the
+exchange it lands — so a second instruction runs exactly as the first did, as an
+ordinary `ToPeer` turn whose answer is delivered to the agent that asked. The
+asymmetry that terminates cascades is untouched, because it lives on the answer:
+a reply still expects nothing, whatever the message it answers declared, so a
+chain of instruction and report still costs its own declared work each round and
+still runs out of pair budget, hops and steps. `Assigned` remains for work with
+no peer behind it, which is a routine coming due, a coding job reporting in, or
+an operator line absorbed into a turn that was already running: there the note
+in the agent's own channel is exactly where the person who asked is reading.
 
 The mode follows the work rather than the sender, and the second incident is
 why. The first version matched on who the message came from, and a routine
 coming due comes from neither the operator nor a peer: it matched no arm of that
 match and fell through to the silent mode, so every schedule an agent kept was
 answered by an agent that had just been told nothing was being asked of it.
-Anything carrying work is `Assigned`, whoever sent it. See `ROUTINES.md`.
+Anything carrying work with nobody to answer is `Assigned`, whoever sent it.
+See `ROUTINES.md`.
 
 The field is trusted, and that is deliberate. A model can label a courtesy as
 work, and then the run pays for one extra turn and hits the same per-pair,
@@ -145,12 +161,21 @@ went is the only part of the turn that has reached nobody at all, and the agent
 that asked for the work is who it belongs to. It goes to them, guard and all.
 
 Messages that do not expect a reply are batched: an agent waking to four replies
-reads all four in one turn. Because real replies arrive seconds apart rather
-than together, an agent will also wait briefly for replies it is still owed,
-counted as peers it has written to that have not written back, before reading
-what it already has. Waiting instead on "is anyone in this run still busy" was
-tried and was wrong: it made an agent sit through peers that had already
-answered and were finishing their own notes.
+reads all four in one turn. Because real replies land tens of seconds apart
+rather than together, an agent also waits for answers it is still owed — sends
+of its own that expected a reply and have not had one — as long as somebody who
+owes one is still working on it, before reading what it already has. Both
+halves of that condition replaced something that was tried and was wrong.
+Waiting on "is anyone in this run still busy" made an agent sit through peers
+that had already answered and were finishing their own notes. Waiting on owed
+alone, under a 2.5-second clock sized to a scripted server, expired before the
+second answer of every real fan-out, so a coordinator read its replies one
+model call at a time: the offline suite could not see that, because a stub
+answers in milliseconds. The activity check is what lets the window be generous
+(two minutes) rather than a guess at model latency: a peer that failed, went
+quiet or had its answer refused by the guard reads as idle, and the gather ends
+in milliseconds rather than sitting out a window for an answer that is not
+coming.
 
 ## A working turn reads its inbox, and only what it can answer where it stands
 
@@ -553,9 +578,14 @@ it, which is worth doing whether or not the agent can see.
 ## A failed model call is retried before the operator hears about it
 
 `stream_with_retries` is the loop and `LlmError::is_transient` decides. Rate
-limits, timeouts, transport failures and 5xx are worth another attempt; a
-rejected key or an unknown model is not, because it answers the same way every
-time and retrying only delays the message the operator needs to read. Three
+limits, timeouts, transport failures, 5xx, and an error frame arriving inside
+an accepted 200 stream are worth another attempt; a rejected key or an unknown
+model is not, because it answers the same way every time and retrying only
+delays the message the operator needs to read. The 200 case is the one that
+does not look transient and is: everything about the request was validated
+before the stream opened, so what broke was the provider mid-answer, and read
+as a rejection one "Upstream idle timeout exceeded" frame killed each of four
+concurrent live turns on its only attempt. Three
 attempts, one and three seconds apart, or the provider's own `Retry-After`
 capped at twenty seconds.
 
@@ -1221,13 +1251,6 @@ Stated plainly rather than discovered later.
   the machine's own screen, because a screenshot carries no URL to match. Both
   predate the split into a computer and a browser and neither was made worse by
   it. Wording is still the only thing holding them.
-- **A peer's answer to a follow-up instruction goes to its own channel, not back
-  to the agent that instructed it.** `expects_reply` stays false for a message
-  to a peer that has already written, because that asymmetry is what makes
-  cascades terminate. So a coordinator can now instruct twice in one run, but
-  reads the outcome where the operator does rather than being handed it. Routing
-  it back means recording the declared intent on the envelope, which is a
-  schema change.
 - **Prompt instructions are guidance, not guarantees.** Several behaviors here
   are steered by wording in `runtime/prompt.rs`: staying quiet when there is
   nothing to add, and not narrating that silence. A model can ignore any of it, so

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -267,5 +267,6 @@ how it looks is not worth being able to say the record was edited.
 It arrives from neither the operator nor a peer, which is the case the reply
 mode originally had no arm for: every schedule an agent kept was answered by an
 agent that had just been told nothing was being asked of it. Anything carrying
-work is `ReplyMode::Assigned`, whoever sent it. See *Cascades terminate because
-of one asymmetry* in `ARCHITECTURE.md`.
+work with nobody to answer is `ReplyMode::Assigned`, whoever sent it; work from
+a peer answers that peer instead. See *Cascades terminate because of one
+asymmetry* in `ARCHITECTURE.md`.

--- a/src-tauri/src/eval.rs
+++ b/src-tauri/src/eval.rs
@@ -77,8 +77,10 @@ pub enum Fault {
     /// manager and once from the researcher is two channels with one message
     /// each, which is not the complaint.
     AnsweredMoreThanOnce { agent: String, times: usize },
-    /// A message demanding an answer, sent to a peer that had already answered.
-    /// The exact shape of a cascade that will not converge.
+    /// A courtesy demanding an answer, sent to a peer that had already
+    /// answered. The exact shape of a cascade that will not converge. Work is
+    /// exempt: a second instruction expects the report of what came of it, and
+    /// that is delegation.
     DemandedAnswerFromSettledPeer { from: String, to: String },
     /// An acknowledgment of an acknowledgment.
     AcknowledgedAnAcknowledgment { from: String, to: String },
@@ -264,8 +266,12 @@ pub fn faults(messages: &[Envelope], name_of: &dyn Fn(AgentId) -> String) -> Vec
             continue;
         };
 
+        // Work is allowed to demand an answer wherever in the exchange it
+        // lands: a second instruction expects the report of what came of it,
+        // and that is delegation rather than divergence. A courtesy demanding
+        // one from a peer that has already had its say is the cascade shape.
         let they_answered = written.contains(&(to, from));
-        if envelope.expects_reply && they_answered {
+        if envelope.expects_reply && they_answered && !envelope.intent.is_work() {
             faults.push(Fault::DemandedAnswerFromSettledPeer {
                 from: name_of(from),
                 to: name_of(to),

--- a/src-tauri/src/llm/openrouter.rs
+++ b/src-tauri/src/llm/openrouter.rs
@@ -340,7 +340,15 @@ impl LlmError {
     pub fn is_transient(&self) -> bool {
         match self {
             LlmError::RateLimited { .. } | LlmError::Timeout { .. } | LlmError::Truncated => true,
-            LlmError::Upstream { status, .. } => *status >= 500,
+            // 200 is an error frame arriving mid-stream: the request was
+            // accepted — a bad key, an unknown model or a rejected parameter
+            // all refuse before a stream opens — and the provider broke while
+            // answering, which is the same family as a dropped connection.
+            // Classified by the status alone it read as a rejection, and four
+            // concurrent turns on one live crew each died on their only
+            // attempt to "Upstream idle timeout exceeded" while an identical
+            // fifth call sailed through.
+            LlmError::Upstream { status, .. } => *status >= 500 || *status == 200,
             LlmError::ProgramMissing { .. } | LlmError::ProgramFailed { .. } => false,
             // The one failure of a program provider worth asking again.
             // Nothing about the request was rejected: the model wrote an answer
@@ -1250,6 +1258,11 @@ mod tests {
             LlmError::Upstream { ref message, .. } => assert!(message.contains("provider dropped")),
             other => panic!("expected Upstream, got {other:?}"),
         }
+        // And worth another attempt: the request was accepted and the provider
+        // broke while answering, which no part of the request caused. Read as
+        // a rejection, one idle-timeout frame killed each of four concurrent
+        // live turns on its only attempt.
+        assert!(err.is_transient(), "a mid-stream provider failure must be retried");
     }
 
     #[tokio::test]

--- a/src-tauri/src/runtime/guard.rs
+++ b/src-tauri/src/runtime/guard.rs
@@ -236,6 +236,17 @@ pub struct RunState {
     steps_used: u32,
     fingerprints: HashSet<String>,
     pair_counts: HashMap<(AgentId, AgentId), u32>,
+    /// Pairs whose last delivered send asked the recipient for something and
+    /// has not been answered: `(asker, ower)`.
+    ///
+    /// Written by [`Self::note_sent`] when the runtime delivers an expectant
+    /// message, and cleared by [`Self::evaluate`] the moment anything travels
+    /// the other way, because any message from the ower is the reply the asker
+    /// was owed. Derived from `pair_counts` before work could re-arm the reply
+    /// path, which broke the moment it could: "has ever written to me" and
+    /// "owes me an answer" are different questions, and a peer that answered
+    /// an earlier round still owes one for the instruction sent after it.
+    expecting: HashSet<(AgentId, AgentId)>,
     last_touched: i64,
 }
 
@@ -246,6 +257,7 @@ impl RunState {
             steps_used: 0,
             fingerprints: HashSet::new(),
             pair_counts: HashMap::new(),
+            expecting: HashSet::new(),
             last_touched: now_ms(),
         }
     }
@@ -347,22 +359,35 @@ impl RunState {
         }
 
         self.pair_counts.insert(pair, sent + 1);
+        // Whatever this message is, it reaches someone who may have been owed
+        // it: an answer, a report, or new work all settle the sender's debt.
+        self.expecting.remove(&(req.to, req.from));
         Verdict::Allow { hop }
     }
 
-    /// Checks fan-out width before any individual recipient is evaluated.
-    /// How many peers this agent has written to that have not written back.
+    /// Records whether a send the runtime went on to deliver asked its
+    /// recipient for something.
     ///
-    /// The number of replies it is still owed, which is the only thing worth
-    /// waiting for. Waiting on "is anyone in this run busy" instead made an
-    /// agent sit through peers that were merely finishing their own notes.
-    pub fn awaiting(&self, me: AgentId) -> usize {
-        self.pair_counts
-            .keys()
-            .filter(|(from, to)| *from == me && !self.has_written(*to, me))
-            .map(|(_, to)| *to)
-            .collect::<HashSet<_>>()
-            .len()
+    /// Separate from [`Self::evaluate`] because whether a message expects an
+    /// answer is decided by the runtime after the verdict, from the sender's
+    /// declared intent and the state of the exchange. Only a delivered message
+    /// creates a debt: a refused one reached nobody.
+    pub fn note_sent(&mut self, from: AgentId, to: AgentId, expects_reply: bool) {
+        if expects_reply {
+            self.expecting.insert((from, to));
+        }
+    }
+
+    /// The peers that owe this agent an answer.
+    ///
+    /// The only thing worth waiting for between turns. Waiting on "is anyone
+    /// in this run busy" was tried and made an agent sit through peers that
+    /// were merely finishing their own notes; deriving it from "has written to
+    /// me at all" was tried next and stopped counting the moment a peer could
+    /// be instructed twice, because a peer that answered round one still owes
+    /// the answer to round two.
+    pub fn awaited(&self, me: AgentId) -> HashSet<AgentId> {
+        self.expecting.iter().filter(|(from, _)| *from == me).map(|(_, to)| *to).collect()
     }
 
     /// Whether `from` has written to `to` at any point in this run.
@@ -375,6 +400,7 @@ impl RunState {
         self.pair_counts.get(&(from, to)).copied().unwrap_or(0) > 0
     }
 
+    /// Checks fan-out width before any individual recipient is evaluated.
     pub fn check_fanout(&self, requested: usize) -> Option<Refusal> {
         if requested > self.limits.max_fanout_per_call {
             return Some(Refusal::FanOutTooWide {
@@ -792,6 +818,60 @@ mod tests {
         reg.runs.get_mut(&old).unwrap().last_touched = now_ms() - (2 * 60 * 60 * 1000);
         reg.run_within(RunId::new(), GuardLimits::default());
         assert!(reg.peek(old).is_none(), "stale run should have been reaped");
+    }
+
+    #[test]
+    fn a_delivered_ask_is_awaited_until_anything_travels_back() {
+        let mut state = RunState::new(permissive());
+        let (manager, chef) = (AgentId::new(), AgentId::new());
+
+        assert!(matches!(
+            state.evaluate(&req(manager, chef, "make bread", 0)),
+            Verdict::Allow { .. }
+        ));
+        state.note_sent(manager, chef, true);
+        assert_eq!(state.awaited(manager), HashSet::from([chef]));
+
+        // Anything from the ower settles the debt, whatever it declares
+        // itself to be: the asker wanted to hear back, and it has.
+        assert!(matches!(state.evaluate(&req(chef, manager, "done", 1)), Verdict::Allow { .. }));
+        assert!(state.awaited(manager).is_empty());
+    }
+
+    #[test]
+    fn a_send_that_expects_nothing_is_not_awaited() {
+        let mut state = RunState::new(permissive());
+        let (manager, chef) = (AgentId::new(), AgentId::new());
+        assert!(matches!(state.evaluate(&req(manager, chef, "thanks", 0)), Verdict::Allow { .. }));
+        state.note_sent(manager, chef, false);
+        assert!(state.awaited(manager).is_empty());
+    }
+
+    #[test]
+    fn a_second_instruction_is_awaited_although_the_peer_answered_the_first() {
+        // The case the pair-count derivation could not see: after one round
+        // trip the peer "has written", and an agent that instructs it again is
+        // owed an answer the old question answered no about.
+        let mut state = RunState::new(permissive());
+        let (manager, chef) = (AgentId::new(), AgentId::new());
+
+        assert!(matches!(
+            state.evaluate(&req(manager, chef, "round one", 0)),
+            Verdict::Allow { .. }
+        ));
+        state.note_sent(manager, chef, true);
+        assert!(matches!(
+            state.evaluate(&req(chef, manager, "answer one", 1)),
+            Verdict::Allow { .. }
+        ));
+        assert!(state.awaited(manager).is_empty());
+
+        assert!(matches!(
+            state.evaluate(&req(manager, chef, "round two", 2)),
+            Verdict::Allow { .. }
+        ));
+        state.note_sent(manager, chef, true);
+        assert_eq!(state.awaited(manager), HashSet::from([chef]));
     }
 
     #[test]

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -422,12 +422,21 @@ fn told_to_a_model(err: crate::e2b::E2bError) -> String {
     }
 }
 
-/// How long an agent will wait for peers that are still answering the same
-/// thing, before reading what it already has.
+/// How long an agent will wait for answers it is owed by peers that are still
+/// working on them, before reading what it already has.
 ///
-/// Long enough to cover the spread between several model calls that started
-/// together, short enough that nobody watching notices.
-const BURST_WINDOW: Duration = Duration::from_millis(2500);
+/// This was two and a half seconds, sized to "the spread between several model
+/// calls that started together", and the scripted suite agreed because a stub
+/// answers in milliseconds. Real model calls land tens of seconds apart, so in
+/// production the window expired before the second answer of every fan-out and
+/// the coordinator read its replies one turn at a time: a whole prompt and a
+/// model call per answer, for a wait that costs nothing. The window can be
+/// this generous because it no longer runs on time alone: the gather ends the
+/// moment nobody owing an answer is still working, so a peer that failed, went
+/// quiet or had its answer refused ends the wait in milliseconds, and this
+/// ceiling only decides how long one honestly-working peer can hold a batch
+/// open before the gatherer reads what it has and catches the rest next turn.
+const GATHER_WINDOW: Duration = Duration::from_secs(120);
 const BURST_POLL: Duration = Duration::from_millis(25);
 
 /// How stale an agent's list of signed-in sites may get before browsing again
@@ -2311,13 +2320,39 @@ impl Runtime {
         Ok(run_id)
     }
 
-    /// Replies this agent is still owed in this run.
+    /// Whether an answer this agent is owed in this run is still being worked
+    /// on by whoever owes it.
+    ///
+    /// Both halves are load-bearing, because each was the whole condition once
+    /// and each refused honest waits. Owed alone waits out the full window for
+    /// a peer whose turn failed, whose answer the guard refused, or who chose
+    /// silence: all three end with the ower idle and nothing coming, which is
+    /// what lets the window above this be generous instead of a guess at model
+    /// latency. Working alone made an agent sit through peers that had already
+    /// answered and were finishing their own notes.
+    ///
+    /// The race this cannot lose: a peer's answer is delivered before its turn
+    /// ends, and its expectation is cleared before the answer is delivered, so
+    /// by the time the ower reads as idle either the answer is in this agent's
+    /// inbox, where the gather's next pass takes it, or it was never sent.
     ///
     /// A peek, so asking cannot be what creates a run's state. The limits that
     /// state is created on belong to the asking agent's group, and this is the
     /// one question about a run that is asked without one to hand.
-    fn awaiting_replies(&self, run: RunId, me: AgentId) -> usize {
-        self.inner.guard.lock().peek(run).map(|state| state.awaiting(me)).unwrap_or(0)
+    fn awaited_still_working(&self, run: RunId, me: AgentId) -> bool {
+        let awaited = {
+            self.inner.guard.lock().peek(run).map(|state| state.awaited(me)).unwrap_or_default()
+        };
+        if awaited.is_empty() {
+            return false;
+        }
+        let activity = self.inner.activity.lock();
+        awaited.iter().any(|peer| {
+            matches!(
+                activity.get(peer),
+                Some(Activity::Thinking | Activity::Queued { .. } | Activity::AwaitingApproval)
+            )
+        })
     }
 
     fn track_inflight(&self, run: RunId, delta: i64) {
@@ -3133,6 +3168,15 @@ impl Runtime {
 
         let roster = self.roster_excluding(agent_id);
         let names = self.name_table();
+        // Nothing newer than what this turn is answering. `deliver` writes to
+        // the store before the inbox, so an operator's second line typed while
+        // the first was being picked up is in this read while still queued
+        // behind the batch — and rendered from here it would sit *above* the
+        // message it corrects, because the batch is rendered last. Left out,
+        // it reaches the model through intake instead, in the order it was
+        // said. Ties are kept: within one millisecond there is no order to
+        // restore, and the id filter already keeps the batch itself out.
+        let newest = batch.iter().map(|e| e.created_at).max().unwrap_or(i64::MAX);
         let history = self
             .inner
             .store
@@ -3141,7 +3185,7 @@ impl Runtime {
             .into_iter()
             // The batch is rendered separately; including it twice would make
             // the model answer itself.
-            .filter(|e| !batch.iter().any(|b| b.id == e.id))
+            .filter(|e| !batch.iter().any(|b| b.id == e.id) && e.created_at <= newest)
             .collect::<Vec<_>>();
 
         // Everything the prompt already carries, which is what stops a message
@@ -3547,6 +3591,7 @@ impl Runtime {
                 // hop. Not sending on is the whole of what a stop is.
                 if called_off { ReplyMode::NoteOnly } else { mode },
                 reply_target,
+                assigned,
                 &addressed,
                 collected_text,
                 tool_parts,
@@ -3812,6 +3857,11 @@ impl Runtime {
         cause: Option<MessageId>,
         mode: ReplyMode,
         reply_target: Option<Participant>,
+        // Whether anything this turn woke to declared itself work. Decided
+        // from the batch in `run_turn` and carried here because the one wrong
+        // answer to work is silence, and only this function knows whether the
+        // turn ended in it.
+        assigned: bool,
         addressed: &HashSet<AgentId>,
         text: String,
         mut tool_parts: Vec<Part>,
@@ -3846,7 +3896,12 @@ impl Runtime {
         );
         let commentary = mode == ReplyMode::ToPeer && already_answered && files.is_empty();
 
-        if mode == ReplyMode::ToPeer && !commentary {
+        // An empty reply is delivering nothing, so it is not put to the guard:
+        // evaluated anyway it would spend a pair-budget slot and clear the
+        // asker's expectation for an answer that never goes out.
+        let delivers = !(text.is_empty() && files.is_empty());
+
+        if mode == ReplyMode::ToPeer && !commentary && delivers {
             if let Some(Participant::Agent { id: peer }) = reply_target {
                 // An automatic reply still travels a hop and still counts
                 // against the pair budget, otherwise two agents could bounce
@@ -3890,14 +3945,26 @@ impl Runtime {
             }
         }
 
-        // Work handed over, and nothing said about it. `Assigned` is the one
-        // mode where silence is always wrong: somebody gave this agent a job,
-        // its answer is filed as a note rather than delivered, and a note it
-        // never writes leaves the operator watching an agent that has
+        // Work handed over, and nothing said about it. Silence is the one
+        // wrong answer to work: somebody gave this agent a job, and a report
+        // it never writes leaves the operator watching an agent that has
         // apparently stopped. That is exactly what shipped, and nothing in the
         // transcript said so, because a turn that produces no text produces no
         // envelope either. Say it out loud instead of returning quietly.
-        if mode == ReplyMode::Assigned && text.is_empty() {
+        //
+        // Two shapes of it, because work arrives in two modes. `Assigned` is
+        // work with nobody waiting, where the missing thing is the note. A
+        // `ToPeer` turn that was handed work and delivered nothing — no text,
+        // no file, no `send_message` to the asker — leaves a peer waiting on
+        // an answer that is not coming, which its gather survives (the idle
+        // check ends it) and the operator should still get to read about.
+        let owed_and_silent = text.is_empty()
+            && match mode {
+                ReplyMode::Assigned => true,
+                ReplyMode::ToPeer => assigned && !already_answered && files.is_empty(),
+                _ => false,
+            };
+        if owed_and_silent {
             tool_parts.push(Part::Notice {
                 kind: NoticeKind::GuardStop,
                 text: format!(
@@ -5609,7 +5676,19 @@ impl Runtime {
                         continue;
                     }
 
-                    let answering = heard_from;
+                    // An answer is a continuation and work is an approach,
+                    // wherever in the exchange it lands. The first version
+                    // read "has already written" as "is answering", which was
+                    // right until a peer could be instructed twice in one run:
+                    // the second instruction ran in the mode that files its
+                    // answer as a note in the doer's own channel, the
+                    // coordinator that asked was told nothing, and its own
+                    // prompt went on listing the ask as outstanding and
+                    // recommending a chase. Work re-arms the reply path; the
+                    // asymmetry that terminates cascades is untouched, because
+                    // it lives on the answer (`emit_reply`), which still
+                    // expects nothing.
+                    let expects_reply = !heard_from || intent.is_work();
 
                     let envelope = Envelope {
                         id: MessageId::new(),
@@ -5620,7 +5699,7 @@ impl Runtime {
                         parts: with_files(text, files.to_vec()),
                         trust: Trust::Peer,
                         hop,
-                        expects_reply: !answering,
+                        expects_reply,
                         intent,
                         cause,
                         created_at: now_ms(),
@@ -5629,6 +5708,12 @@ impl Runtime {
                     match self.deliver(envelope) {
                         Ok(()) => {
                             addressed.insert(target.id);
+                            // Only a delivered ask is a debt worth waiting on.
+                            self.inner.guard.lock().run_within(run_id, limits).note_sent(
+                                card.id,
+                                target.id,
+                                expects_reply,
+                            );
                             out.push(Delivery::Queued { to: target.name.clone() })
                         }
                         Err(err) => out.push(Delivery::Refused {
@@ -6582,11 +6667,12 @@ async fn actor_loop(
         // takes as long as its own model call, so they land seconds apart.
         // Draining only what had already queued meant three separate turns,
         // three prompts, and three notes in the operator's channel for one
-        // instruction. So while the run still has someone else working, this
-        // waits a moment for them rather than reading the first arrival alone.
+        // instruction. So while an answer this agent is owed is still being
+        // worked on, this waits for it rather than reading the first arrival
+        // alone.
         if !batch[0].expects_reply {
             let run = batch[0].run_id;
-            let patience = Instant::now() + BURST_WINDOW;
+            let patience = Instant::now() + GATHER_WINDOW;
             while batch.len() < MAX_BATCH {
                 // The holding queue first: anything in it arrived before
                 // whatever is still in the channel, and batching around it
@@ -6609,12 +6695,16 @@ async fn actor_loop(
                     Err(mpsc::error::TryRecvError::Empty) => {}
                 }
 
-                // Nothing queued. Worth waiting only for replies this agent is
-                // actually still owed, and never for long: an agent that has
-                // been told something is expected to act on it. Waiting on "is
-                // anyone still busy" made it sit through peers that had already
-                // answered and were finishing their own notes.
-                if Instant::now() >= patience || runtime.awaiting_replies(run, id) == 0 {
+                // Nothing queued. Worth waiting only for answers this agent
+                // is owed that somebody is genuinely still working on, and
+                // never once the run is called off: a stopped run's notice
+                // comes from the turn's own boundary, and a gather that sat
+                // out its window first would hold that notice, and the run's
+                // settlement, open for exactly that long.
+                if Instant::now() >= patience
+                    || runtime.stopped(run)
+                    || !runtime.awaited_still_working(run, id)
+                {
                     break;
                 }
                 tokio::time::sleep(BURST_POLL).await;

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -880,7 +880,8 @@ pub fn system_prompt(
              Do not write to a peer to acknowledge one. Nobody is waiting on you, so a thank-you \
              or a note that you have read something will be refused. The one exception is real \
              work: if what you have just read means a peer has something to do, send it with \
-             `send_message` and intent \"work\", saying plainly what you need done. Wanting to \
+             `send_message` and intent \"work\", saying plainly what you need done. They will \
+             report back to you when it is done, so do not chase them for it. Wanting to \
              stay in touch is not work. Anything else you still need belongs in your note rather \
              than in a message.\n\n\
              If something does need saying, your final message is filed as a short note in your \
@@ -893,11 +894,10 @@ pub fn system_prompt(
              woke you asked for an action, and reading it is not doing it. If part of it is \
              beyond you or a check fails, do the part you can and say exactly what stopped the \
              rest.\n\n\
-             Do not answer the agent that asked. Your reply is filed as a short note in your own \
-             channel, where the operator reads it, so write what you did and what came of it: \
-             what you sent, to whom, and what the result was. Saying nothing here is the one \
-             wrong answer, because it leaves the operator watching an agent that appears to have \
-             stopped.\n"
+             Your reply is filed as a short note in your own channel, where the operator reads \
+             it, so write what you did and what came of it: what you sent, to whom, and what the \
+             result was. Saying nothing here is the one wrong answer, because it leaves the \
+             operator watching an agent that appears to have stopped.\n"
         }
     });
 

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -404,6 +404,171 @@ async fn replies_queued_together_are_read_in_a_single_turn() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_reply_still_being_worked_on_is_waited_for_rather_than_read_alone() {
+    // The gather used to run on a 2.5-second clock sized to this suite's own
+    // stub, which answers in milliseconds. Real model calls land tens of
+    // seconds apart, so in production the window expired before the second
+    // answer of every fan-out and a coordinator read its replies one whole
+    // prompt and one model call at a time. The wait now follows the work: as
+    // long as a peer that owes an answer is still on it, the gatherer holds
+    // out. Grocer's answer here takes longer than the whole of the old window,
+    // and it must still be read in the same turn as Chef's.
+    let stub = serve(move |body| {
+        let who = speaker(body);
+        if who == "Manager" {
+            if reading_peer_replies(body) {
+                Script::Say("Both heard from.".into())
+            } else if has_tool_result(body) {
+                Script::Say("Sent.".into())
+            } else {
+                Script::SendTo {
+                    recipients: vec!["Chef".into(), "Grocer".into()],
+                    text: "Hello there.".into(),
+                }
+            }
+        } else {
+            if who == "Grocer" {
+                std::thread::sleep(Duration::from_millis(3200));
+            }
+            Script::Say(format!("Acknowledged, from {who}."))
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager", "Chef", "Grocer"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "Say hello to both.").unwrap();
+    h.settle(run).await;
+
+    let prompts_reading_replies: Vec<usize> = stub
+        .transcript
+        .lock()
+        .iter()
+        .filter(|body| speaker(body) == "Manager" && reading_peer_replies(body))
+        .map(|body| {
+            body["messages"]
+                .as_array()
+                .and_then(|m| m.last())
+                .and_then(|m| m["content"].as_str())
+                .map(|c| c.matches("[AGENT").count())
+                .unwrap_or(0)
+        })
+        .collect();
+    assert_eq!(
+        prompts_reading_replies.len(),
+        1,
+        "a slow reply must be waited for, not read in a turn of its own\n{}",
+        h.transcript()
+    );
+    assert_eq!(
+        prompts_reading_replies[0], 2,
+        "both replies must appear in the single reading prompt"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_answer_owed_by_a_peer_that_failed_is_not_waited_out() {
+    // The other half of the generous window, and the reason it can be generous
+    // at all. A peer whose model call fails every attempt never answers, and
+    // an agent that waited the full window for it would hold its own turn, and
+    // the run's settlement, open for two minutes of nothing. The gather ends
+    // when nobody owing an answer is still working, so the failed peer ends it
+    // within this test's ordinary settle window rather than at the ceiling.
+    let stub = serve(move |body| {
+        let who = speaker(body);
+        if who == "Manager" {
+            if reading_peer_replies(body) {
+                Script::Say("Heard from Chef.".into())
+            } else if has_tool_result(body) {
+                Script::Say("Sent.".into())
+            } else {
+                Script::SendTo {
+                    recipients: vec!["Chef".into(), "Grocer".into()],
+                    text: "Hello there.".into(),
+                }
+            }
+        } else if who == "Grocer" {
+            Script::Unavailable
+        } else {
+            Script::Say("Acknowledged, from Chef.".into())
+        }
+    })
+    .await;
+
+    let h = harness(&stub, &["Manager", "Chef", "Grocer"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "Say hello to both.").unwrap();
+    // The whole assertion: 20 seconds covers Grocer's retries and nothing like
+    // the gather ceiling, so settling here means the wait ended with the peer.
+    h.settle(run).await;
+
+    assert!(
+        h.channel_texts("Manager").iter().any(|t| t.contains("Acknowledged, from Chef.")),
+        "Chef's reply still has to arrive:\n{}",
+        h.transcript()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_second_operator_line_reaches_the_model_after_the_first_rather_than_above_it() {
+    // `deliver` writes to the store before the inbox, so an operator's second
+    // line typed while the first is being picked up is in the history the turn
+    // reads while still queued behind the batch. Rendered from the history it
+    // sat *above* the message it follows, because the batch is rendered last:
+    // a correction read before the thing it corrects. It is kept out of the
+    // history now and reaches the model through intake, in the order it was
+    // said.
+    let stub = serve(|body| {
+        let _ = body;
+        Script::Say("Both noted.".into())
+    })
+    .await;
+
+    let h = harness(&stub, &["Writer"], GuardLimits::default());
+    let writer = h.id("Writer");
+
+    h.pause("Writer");
+    let run = h.runtime.send_from_human(writer, "First thing: book the 4pm slot.").unwrap();
+    // Distinct millisecond stamps, so the second line is provably newer than
+    // the batch. Two lines in one millisecond have no order to restore.
+    tokio::time::sleep(Duration::from_millis(5)).await;
+    h.runtime.send_from_human(writer, "Second thing: actually make that 5pm.").unwrap();
+    h.wait_until("both lines to be filed", |h| h.channel_texts("Writer").len() == 2).await;
+    h.resume("Writer");
+    h.settle(run).await;
+
+    let order: Vec<(usize, usize)> = stub
+        .transcript
+        .lock()
+        .iter()
+        .filter(|body| speaker(body) == "Writer")
+        .map(|body| {
+            let contents: Vec<&str> = body["messages"]
+                .as_array()
+                .map(|m| {
+                    m.iter()
+                        .filter(|m| m["role"] != "system")
+                        .filter_map(|m| m["content"].as_str())
+                        .collect()
+                })
+                .unwrap_or_default();
+            let position = |needle: &str| {
+                contents.iter().position(|c| c.contains(needle)).unwrap_or(usize::MAX)
+            };
+            (position("First thing"), position("Second thing"))
+        })
+        .collect();
+
+    assert!(!order.is_empty(), "the turn never reached the model");
+    for (first, second) in order {
+        assert!(first != usize::MAX && second != usize::MAX, "both lines must reach the model");
+        assert!(
+            first < second,
+            "the second line was rendered above the first: correction before the thing corrected\n{}",
+            h.transcript()
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn two_agents_told_to_talk_forever_stop_on_their_own() {
     // Both agents are scripted to always message the other. Without the guard
     // this never terminates.
@@ -1748,6 +1913,10 @@ async fn a_second_instruction_to_a_peer_that_already_answered_is_delivered() {
             } else {
                 Script::Say("Ready, but I need you to confirm before I send.".into())
             }
+        } else if text.contains("Sent.") {
+            // The answer to the second instruction came back, so the Manager
+            // can close the loop it opened.
+            Script::Say("Done: Chef sent the mailing.".into())
         } else if text.contains("I need you to confirm") {
             // The turn this test exists for: woken by an answer, nobody is
             // waiting on the Manager, and it has genuinely new work to give.
@@ -1777,9 +1946,17 @@ async fn a_second_instruction_to_a_peer_that_already_answered_is_delivered() {
         to_chef.iter().any(|t| t.contains("go ahead and send it")),
         "the follow-up instruction never reached Chef: {to_chef:?}"
     );
+    // The instruction was work, so its answer comes back to the agent that
+    // gave it rather than stranding in Chef's own channel: the Manager can
+    // assemble what came of the work it placed.
     assert!(
-        h.channel_texts("Chef").iter().any(|t| t.contains("Sent.")),
-        "and Chef never acted on it:\n{}",
+        h.channel_texts("Manager").iter().any(|t| t.contains("Sent.")),
+        "Chef's answer never reached the Manager that instructed it:\n{}",
+        h.transcript()
+    );
+    assert!(
+        h.channel_texts("Manager").iter().any(|t| t.contains("Done: Chef sent the mailing.")),
+        "and the Manager never closed the loop for the operator:\n{}",
         h.transcript()
     );
 }
@@ -1794,7 +1971,9 @@ async fn a_peer_instructed_after_it_answered_does_the_work_rather_than_going_qui
     // Nothing was waiting on a reply, so the turn ran in the mode that tells an
     // agent nobody is asking it for anything and silence is usually right. It
     // spent a model call and complied. From the operator's side an agent had
-    // simply stopped.
+    // simply stopped. Work re-arms the reply path now, so the second
+    // instruction runs as an ordinary reply turn: the prompt says someone is
+    // waiting, and the answer lands with them.
     let stub = serve(|body| {
         let who = speaker(body);
         let text = body["messages"]
@@ -1806,14 +1985,16 @@ async fn a_peer_instructed_after_it_answered_does_the_work_rather_than_going_qui
             if !text.contains("go ahead and send it") {
                 Script::Say("I have the file open, confirm before I send.".into())
             } else if text.contains("Nothing here needs an answer") {
-                // A model that reads its prompt. Told nothing is being asked of
-                // it and that silence is usually right, it stays silent, which
-                // is exactly what the live agent did with a real instruction to
-                // send an email in front of it.
+                // The old failure, kept as a tripwire: if the second
+                // instruction ever runs in the silent mode again, this arm
+                // plays the model that reads its prompt and complies, and the
+                // assertion below fails on an agent that went quiet.
                 Script::Say(String::new())
             } else {
                 Script::Say("Sent it.".into())
             }
+        } else if text.contains("Sent it.") {
+            Script::Say("Mailing confirmed sent.".into())
         } else if text.contains("confirm before I send") {
             Script::Instruct {
                 recipients: vec!["Chef".into()],
@@ -1832,8 +2013,8 @@ async fn a_peer_instructed_after_it_answered_does_the_work_rather_than_going_qui
     h.settle(run).await;
 
     assert!(
-        h.channel_texts("Chef").iter().any(|t| t.contains("Sent it.")),
-        "the instruction landed and the agent went quiet:\n{}",
+        h.channel_texts("Manager").iter().any(|t| t.contains("Sent it.")),
+        "the instruction landed and the agent went quiet, or its answer stranded:\n{}",
         h.transcript()
     );
 }
@@ -1868,7 +2049,8 @@ async fn work_and_a_reply_are_different_questions_on_the_wire() {
     assert!(instruction.intent.is_work(), "what the sender declared has to survive the wire");
     assert!(
         instruction.expects_reply,
-        "the first message of an exchange still expects an answer; only a settled pair does not"
+        "work expects an answer wherever in the exchange it lands; only a courtesy into a \
+         settled pair does not"
     );
 }
 
@@ -3676,11 +3858,12 @@ async fn retrying_something_that_is_no_longer_there_says_so() {
 #[tokio::test]
 async fn an_agent_given_work_that_says_nothing_is_reported_rather_than_vanishing() {
     // The shipped bug, from the operator's side, on the path that produces it:
-    // a peer that has already answered is instructed again, so the message
-    // carries work and expects no reply. That is `ReplyMode::Assigned`, whose
-    // own prompt says silence is the one wrong answer. A turn that produced no
-    // text used to produce no envelope either, so there was nothing in Chef's
-    // channel, nothing in the feed, and an agent that to the operator had
+    // a peer that has already answered is instructed again. Work re-arms the
+    // reply path, so the second instruction expects an answer and the turn
+    // runs as an ordinary reply turn — whose silence used to be the invisible
+    // kind. A turn that produced no text produced no envelope either, so there
+    // was nothing in Chef's channel, nothing in the feed, nothing for the
+    // Manager that was owed the answer, and an agent that to the operator had
     // simply stopped. The turn may still be silent; it may no longer be silent
     // invisibly.
     let stub = serve(|body| {
@@ -3725,8 +3908,8 @@ async fn an_agent_given_work_that_says_nothing_is_reported_rather_than_vanishing
         .expect("the second instruction reached Chef");
     assert!(instruction.intent.is_work(), "the scenario depends on this arriving as work");
     assert!(
-        !instruction.expects_reply,
-        "work with nobody waiting is the combination that produces Assigned"
+        instruction.expects_reply,
+        "work re-arms the reply path even for a peer that has already answered"
     );
 
     // Read as a notice part rather than as text: this is Guaca speaking into

--- a/src-tauri/tests/evals.rs
+++ b/src-tauri/tests/evals.rs
@@ -461,11 +461,15 @@ async fn replies_that_arrive_apart_are_still_read_together() {
             return report_once(body, "the team knows");
         }
         if text.contains("hello from manager") {
-            // Staggered, the way real model calls come back.
+            // Staggered, the way real model calls come back — and both gaps
+            // are past what the old fixed window covered, because that window
+            // was sized to this stub and expired before the second answer of
+            // every real fan-out. With one slow peer instead of two, a run
+            // that reads one reply late still slips under the call ceiling.
             let pause = if text.contains("Baker") {
-                500
+                2800
             } else if text.contains("Grocer") {
-                1000
+                5600
             } else {
                 0
             };


### PR DESCRIPTION
A peer instructed with intent `work` now expects a reply even when it has already written, so a second-round instruction's answer returns to the coordinator that asked instead of dying as a note in the peer's own channel; the asymmetry that terminates cascades is untouched because it lives on the answer, which still expects nothing. Reply gathering now waits while a peer that owes an answer is still working, under a 120-second ceiling, replacing a 2.5-second window sized to the offline stub that read every real fan-out one reply per model call; a peer that failed, was refused, or went quiet ends the wait immediately. Prompt history is capped at the batch's newest timestamp, so an operator correction typed behind a queued line reaches the model through intake in said order rather than rendering above the thing it corrects. Provider errors arriving inside an accepted 200 stream (OpenRouter's `Upstream idle timeout exceeded`) are now transient and get the standard retries. Each behavioral test fails against the old code, and the mechanisms were validated live on GLM 5.3 Flash with recordings under `runs/`.