### PR TITLE
feat: an agent can put a box round the part of a reply that needs you

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ src/                  React + TypeScript. A view over the runtime, nothing more.
   lib/orb.ts          How a crew stands inside its circle, and when it counts.
   lib/search.ts       One ranking over hits from SQLite and from the store.
   lib/trail.ts        A turn's own tool calls: what folds into one chip.
+  lib/callout.ts      The one part of a reply that is for you, in a box.
   lib/figure.ts       A fenced block the transcript draws instead of printing.
   lib/chart.ts        A chart spec, and where every mark goes. No DOM.
   lib/palette.ts      Eight hues in one order, and why that order and not another.
@@ -158,6 +159,7 @@ repo: the frontend renders state and forwards intent.
 | The guaca.bot account: signing in, what it is for, why it is optional | `docs/ACCOUNT.md`, then `account.rs` |
 | Channels, the rail, search: what the operator sees | `docs/WORKSPACE.md`, then `src/lib/transcript.ts` |
 | Charts, tables, a page an agent wrote: what a reply can be drawn as | *A reply can be a figure* in `docs/WORKSPACE.md`, then `src/lib/figure.ts` and `src/lib/chart.ts` |
+| A box round the part of a reply that needs the operator, and which marker draws which one | *A reply can mark the one part that needs a person* in `docs/WORKSPACE.md`, then `src/lib/callout.ts` |
 | A chart's colors, or how many series one may carry | *A chart's colors are the output of a check* in `docs/WORKSPACE.md`, then `src/lib/palette.ts` and the test beside it, which is the gate |
 | Running a model's own HTML, or anything about that origin | *A page an agent wrote runs somewhere else* in `docs/WORKSPACE.md`, then `src-tauri/src/artifact.rs` |
 | A page the operator can work, and what it may hand back | *A page can hand one value back* in `docs/WORKSPACE.md`, then `BRIDGE` in `src-tauri/src/artifact.rs` and `Answering` in `src/components/HtmlArtifact.tsx` |
@@ -674,6 +676,18 @@ the model takes a screenshot to see what `browse` did.
   draws as a page that is all new. A truthiness check collapses the first two
   and loses the only write where the whole page is the news. `Part::ToolCall`
   in `domain/envelope.rs`, then `trailStep`.
+- **A callout is a quote and a figure is a fence, and neither could be the
+  other.** A chart spec is text, so it fits in the one block markdown has for
+  text. What goes in a callout is prose: a list, a link, a mention, a table, a
+  line of code, none of which survive a fence. The syntax is GitHub's alert
+  marker rather than one of ours because models write `> [!IMPORTANT]`
+  unprompted, so it draws on a reply written before the prompt mentioned it and
+  on every transcript already stored; a marker the closed set does not know
+  stays a quote with its own words in it. Five markers draw two boxes and carry
+  two labels, and the label is the app's word: an agent writing `[!CAUTION]`
+  and one writing `[!WARNING]` mean the same thing, and what the operator needs
+  off the box is whether it is for them. The amber one is the only filled panel
+  in the reading column, and it means there what it means in the rail.
 - **A figure is a fence in the reply, not a tool call and not a new part.** An
   agent has the numbers in hand at the moment it writes the sentence about them,
   so a chart behind a tool call is a round trip spent sending back something it

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -356,6 +356,52 @@ either way, so the transcript does not fork from here on; `lib/trail.ts` answers
 to both because rows written before the rename cannot be migrated into a new
 spelling, which is the same reason `Part::Approval` was never widened.
 
+## A reply can mark the one part that needs a person
+
+An agent that has been working for ten minutes writes nine paragraphs, and one
+of them is the sentence that needs the operator: a key only they can rotate, a
+decision nobody else can take, a thing about to go out that should not. Written
+as prose it is the fourth paragraph of nine, and it is read last or not at all.
+So a quote a model opens with an alert marker is drawn as a box.
+
+**The syntax is GitHub's, and that is the point.** Models write `> [!IMPORTANT]`
+without being asked, so the box appears on a reply written before the prompt
+mentioned it, on one from an agent skimming its instructions, and on every
+transcript already in the database. A marker `lib/callout.ts` does not know
+stays a quote with its own words in it, which is the rule `figure.ts` keeps for
+a fence it cannot draw.
+
+**A quote and not a fence.** Figures are fences because a chart spec is text.
+What goes in a callout is prose: a list, a link, a mention, a table, a line of
+code, and a fence could hold none of them. It is a remark plugin for the reason
+mentions are one, and the element stops being a `blockquote` on the way out
+because it is not a quote: `hName` makes it a `div`, so no rule written for a
+quote reaches it and no landmark is opened in the middle of a message. The
+label goes in as the first child, so a screen reader reads *Needs you* where a
+sighted operator sees the box, with no ARIA holding the two together.
+
+**Five markers, two registers, two words.** `IMPORTANT`, `WARNING` and
+`CAUTION` draw the amber box; `NOTE` and `TIP` draw the quiet one. The amber is
+the app's one accent and it means here exactly what it means in the rail, on
+the desk and in the menu bar: a person has to do something. That is also why
+the label is the app's word rather than the model's. An agent that writes
+`[!CAUTION]` and one that writes `[!WARNING]` mean the same thing, and drawing
+both of their words is an operator learning a vocabulary that decides nothing;
+what they need off the box is whether it is for them, which is what *Needs you*
+says, in the words the rail already uses for an agent that is waiting on
+somebody.
+
+The amber box is the only filled panel in the reading column. That is the token
+block's own rule rather than a hole in it: hierarchy here is carried by size,
+weight and air, and the single exception is the accent that means answer me. A
+quiet callout gets the hairline and no fill, because a second tint would make
+the first one furniture.
+
+**And the prompt argues against it in the same breath.** An agent told it can
+draw an amber box draws one around every paragraph, which is the same failure
+the chart section is written to avoid and has the same fix: a reply with three
+boxes in it is a reply with none.
+
 ## A reply can be a figure, and a figure is a fenced block
 
 An operator asking for last quarter by region gets four numbers, and four

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -815,6 +815,15 @@ pub fn system_prompt(
              Your reply is drawn, not printed. Markdown works, and a table is usually the right \
              shape for anything with rows and columns: write one rather than a run of \
              \"Name: value\" lines.\n\n\
+             A quote opened with a marker is drawn as a box, so the one part of a long reply \
+             that is addressed to the operator is found before the rest of it is read:\n\n\
+             > [!IMPORTANT]\n\
+             > The staging key expires on Friday. I cannot rotate it; you can.\n\n\
+             `IMPORTANT`, `WARNING` and `CAUTION` draw the box in the one color this app keeps \
+             for something a person has to do. Spend one on what needs the operator and on \
+             nothing else: a reply with three boxes in it is a reply with none. `NOTE` and \
+             `TIP` draw the quiet box, which is worth seeing and needs nobody. Any other word \
+             stays an ordinary quote.\n\n\
              Two fenced blocks are drawn as figures instead of as code.\n\n\
              A ```chart fence holds one JSON object and becomes a real chart:\n\n\
              ```chart\n\
@@ -1311,6 +1320,13 @@ mod tests {
         // Asked for a breakdown by region, one with all of this working still
         // wrote out four "Region: number" lines.
         let prompt = prompt_for(&card("Analyst"), &[], "", ReplyMode::ToOperator);
+        // The box round the one paragraph that is addressed to the operator.
+        // An agent not told about it marks nothing, and the sentence that
+        // needed a person stays the fourth paragraph of nine.
+        assert!(prompt.contains("> [!IMPORTANT]"), "the callout is never mentioned");
+        // With the restraint in the same breath, for the reason the chart has
+        // it: an agent told it can draw an amber box draws one per paragraph.
+        assert!(prompt.contains("a reply with three boxes in it is a reply with none"));
         assert!(prompt.contains("```chart"), "the chart fence is never mentioned");
         assert!(prompt.contains("bar, line, area, pie, donut, scatter"));
         assert!(prompt.contains("```html"));
@@ -1329,6 +1345,9 @@ mod tests {
         // is tokens spent drawing something nobody will look at.
         let prompt = prompt_for(&card("Analyst"), &[], "", ReplyMode::ToPeer);
         assert!(!prompt.contains("```chart"), "the peer path carries the figure section");
+        // And nothing in a peer's reply is drawn at all, so a box round part of
+        // it is a marker the agent on the other end reads as text.
+        assert!(!prompt.contains("[!IMPORTANT]"), "the peer path is offered the callout");
         // And a peer has no operator to hand a value back to, so a page it
         // could answer with is a page nobody will ever press a button on.
         assert!(!prompt.contains("guaca.answer"), "the peer path is offered the answer channel");

--- a/src/components/Markdown.test.tsx
+++ b/src/components/Markdown.test.tsx
@@ -66,6 +66,85 @@ describe("Markdown", () => {
   });
 });
 
+describe("a callout in a body", () => {
+  /** The markup a marker actually produces, which is what the CSS hangs off. */
+  function drawn(body: string) {
+    return render(<Markdown>{body}</Markdown>).container;
+  }
+
+  it("draws the box the operator is meant to land on first", () => {
+    const container = drawn("> [!IMPORTANT]\n> Rotate the staging key before Friday.");
+
+    const box = container.querySelector(".callout--asks");
+    expect(box).toBeTruthy();
+    expect(box?.querySelector(".callout__label")?.textContent).toBe("Needs you");
+    expect(box?.textContent).toContain("Rotate the staging key before Friday.");
+  });
+
+  it("draws the quiet box for a marker that needs nobody", () => {
+    const container = drawn("> [!NOTE]\n> The rebuild took nine minutes.");
+
+    expect(container.querySelector(".callout--aside")).toBeTruthy();
+    expect(container.querySelector(".callout__label")?.textContent).toBe("Note");
+  });
+
+  it("stops being a quote, so no rule written for one reaches it", () => {
+    // `.md blockquote` is a rule down the left and a muted color, which is the
+    // opposite of a box. The element is what decides, not a class beside it.
+    const container = drawn("> [!WARNING]\n> This deletes the production bucket.");
+
+    expect(container.querySelector("blockquote")).toBeNull();
+    expect(container.querySelector("div.callout")).toBeTruthy();
+  });
+
+  it("holds the prose a box is worth having: a list, a link, a name", () => {
+    // The whole reason this is a quote and not a fence. A fence holds text.
+    const container = render(
+      <Roster.Provider value={["Chef"]}>
+        <Markdown>
+          {"> [!IMPORTANT]\n> Two things:\n>\n> - ask @Chef\n> - read [the note](https://x.test)"}
+        </Markdown>
+      </Roster.Provider>,
+    ).container;
+
+    expect(container.querySelectorAll(".callout li")).toHaveLength(2);
+    expect(container.querySelector(".callout .mention")?.textContent).toBe("@Chef");
+    expect(container.querySelector(".callout a")?.textContent).toBe("the note");
+  });
+
+  it("leaves no blank line where the marker was", () => {
+    // The marker owns its line, so stripping it leaves an empty paragraph
+    // behind: a gap between the label and the first thing said.
+    const container = drawn("> [!NOTE]\n> One line.");
+
+    const paragraphs = [...container.querySelectorAll(".callout p")];
+    expect(paragraphs.map((p) => p.textContent)).toEqual(["Note", "One line."]);
+  });
+
+  it("leaves a quote a quote when the marker is not one this app draws", () => {
+    const container = drawn("> [!DANGER]\n> Mind the step.");
+
+    expect(container.querySelector(".callout")).toBeNull();
+    expect(container.querySelector("blockquote")?.textContent).toContain("[!DANGER]");
+  });
+
+  it("draws a plain quote as a quote", () => {
+    const container = drawn("> They said it shipped.");
+
+    expect(container.querySelector("blockquote")?.textContent).toContain("They said it shipped.");
+    expect(container.querySelector(".callout")).toBeNull();
+  });
+
+  it("survives the half-written marker a stream produces", () => {
+    // Mid-reply the marker is `[!IMPO`, which is a quote, and a token later it
+    // is a box. Neither may throw and blank the message.
+    for (const body of ["> [!IMPO", "> [!IMPORTANT]", "> [!IMPORTANT]\n> "]) {
+      expect(() => drawn(body)).not.toThrow();
+    }
+    expect(drawn("> [!IMPORTANT]").querySelector(".callout--asks")).toBeTruthy();
+  });
+});
+
 describe("a mention in a body", () => {
   const NAMES = ["Critic", "Head Chef"];
 

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -2,6 +2,7 @@ import { createContext, type ReactNode, useContext, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+import { LABEL, readCallout } from "../lib/callout";
 import { fenceLanguage, fenceText, readFigure } from "../lib/figure";
 import { openExternal } from "../lib/ipc";
 import { splitMentions } from "../lib/mentions";
@@ -38,7 +39,7 @@ export const Roster = createContext<string[]>([]);
  */
 export function Markdown({ children, live = false }: { children: string; live?: boolean }) {
   const names = useContext(Roster);
-  const plugins = useMemo(() => [remarkGfm, remarkMentions(names)], [names]);
+  const plugins = useMemo(() => [remarkGfm, remarkCallouts, remarkMentions(names)], [names]);
 
   return (
     <div className="md">
@@ -117,7 +118,7 @@ function asFence(children: ReactNode): { language: string; source: string } | nu
 }
 
 /**
- * mdast, in the shape this walk needs and no more.
+ * mdast, in the shape these walks need and no more.
  *
  * The real types live in `@types/mdast`, which is not a dependency of this app:
  * it arrives under `react-markdown` and would be a version nothing here pins.
@@ -193,4 +194,53 @@ function mark(node: Node, names: string[]): void {
   }
 
   node.children = next;
+}
+
+/**
+ * Draws a quote that opens with an alert marker as a box, before anything is
+ * rendered.
+ *
+ * A remark plugin for the reason {@link remarkMentions} is one: a callout
+ * holds prose, and prose is a list, a link, a name, a table and a line of
+ * code, which the tree is the one place all of are the same thing.
+ *
+ * It stops being a `blockquote` on the way out, because it is not a quote.
+ * `hName` is a `div`, so every rule under `.md blockquote` misses it and no
+ * landmark is opened in the middle of a message; the label goes in as the
+ * first child, so a screen reader reads *Needs you* in the place a sighted
+ * operator sees the box, with no ARIA holding the two together.
+ */
+function remarkCallouts() {
+  return (tree: Node) => box(tree);
+}
+
+function box(node: Node): void {
+  if (!node.children) return;
+  if (node.type === "blockquote") open(node);
+  for (const child of node.children) box(child);
+}
+
+function open(quote: Node): void {
+  const first = quote.children?.[0];
+  if (first?.type !== "paragraph") return;
+  const opening = first.children?.[0];
+  if (opening?.type !== "text" || typeof opening.value !== "string") return;
+
+  const found = readCallout(opening.value);
+  if (!found) return;
+
+  opening.value = found.rest;
+  // A marker on a line of its own leaves an empty paragraph where it was,
+  // which draws as a blank line between the label and the first thing said.
+  if (found.rest === "" && first.children?.length === 1) quote.children?.shift();
+
+  quote.data = {
+    hName: "div",
+    hProperties: { className: `callout callout--${found.register}` },
+  };
+  quote.children?.unshift({
+    type: "calloutLabel",
+    data: { hName: "p", hProperties: { className: "callout__label" } },
+    children: [{ type: "text", value: LABEL[found.register] }],
+  });
 }

--- a/src/lib/callout.test.ts
+++ b/src/lib/callout.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { LABEL, readCallout } from "./callout";
+
+describe("a quote that opens with a marker", () => {
+  it.each([
+    ["IMPORTANT", "asks"],
+    ["WARNING", "asks"],
+    ["CAUTION", "asks"],
+    ["NOTE", "aside"],
+    ["TIP", "aside"],
+  ])("%s opens the %s box", (marker, register) => {
+    expect(readCallout(`[!${marker}]\nRotate the staging key.`)).toEqual({
+      register,
+      rest: "Rotate the staging key.",
+    });
+  });
+
+  it("takes the marker however the model cased it", () => {
+    // A model writes these from memory, and the ones it has read were written
+    // by people. Refusing `[!Note]` is a box that silently does not appear.
+    expect(readCallout("[!Important]\nx")?.register).toBe("asks");
+    expect(readCallout("[!note]\nx")?.register).toBe("aside");
+  });
+
+  it("leaves nothing behind when the marker had the line to itself", () => {
+    expect(readCallout("[!NOTE]\n")).toEqual({ register: "aside", rest: "" });
+    expect(readCallout("[!NOTE]")).toEqual({ register: "aside", rest: "" });
+    // Trailing blanks a model left and no operator can see.
+    expect(readCallout("[!NOTE]  \nx")).toEqual({ register: "aside", rest: "x" });
+  });
+
+  it("keeps the rest of a quote written as one wrapped paragraph", () => {
+    // Valid markdown and the same meaning: the soft break is in the text.
+    expect(readCallout("[!IMPORTANT]\nfirst\nsecond")).toEqual({
+      register: "asks",
+      rest: "first\nsecond",
+    });
+  });
+});
+
+describe("a quote that is only a quote", () => {
+  it("is one when the marker is a word this app does not draw", () => {
+    // The closed set is the whole discipline: an unknown marker drawn as a box
+    // is a box whose color nobody chose.
+    expect(readCallout("[!DANGER]\nx")).toBeNull();
+    expect(readCallout("[!]\nx")).toBeNull();
+  });
+
+  it("is one when the marker opens a sentence rather than a line", () => {
+    // `[!IMPORTANT] ship it` is prose that begins with a bracket, and a box
+    // round it would eat the two words after the marker.
+    expect(readCallout("[!IMPORTANT] ship it")).toBeNull();
+  });
+
+  it("is one when the words start before the marker does", () => {
+    expect(readCallout("Read this: [!WARNING]\nx")).toBeNull();
+  });
+});
+
+describe("the label", () => {
+  /**
+   * Five markers, two words. What the operator needs off the box is whether it
+   * is for them, and *Needs you* is the sentence the rail already says about an
+   * agent that is waiting on somebody.
+   */
+  it("says what the box is for, in the app's own words", () => {
+    expect(LABEL.asks).toBe("Needs you");
+    expect(LABEL.aside).toBe("Note");
+  });
+});

--- a/src/lib/callout.ts
+++ b/src/lib/callout.ts
@@ -1,0 +1,83 @@
+/**
+ * The one part of a reply that is addressed to the operator rather than read
+ * by them.
+ *
+ * An agent that has been working for ten minutes writes nine paragraphs, and
+ * one of them is the sentence that needs a person: a key only they can rotate,
+ * a decision nobody else can take, a thing about to go out that should not.
+ * Written as prose it is the fourth paragraph of nine, and the operator finds
+ * it last or not at all. A box is what fixes that, and it is the cheapest fix
+ * there is: the agent already knows which sentence it was as it writes it.
+ *
+ * The syntax is GitHub's alert marker, and that is the whole reason it is that
+ * rather than something of ours. Models write `> [!IMPORTANT]` unprompted, so
+ * this draws correctly on a reply written before the prompt mentioned it, on
+ * one from an agent skimming its instructions, and on every transcript already
+ * in the database. A marker this file does not know stays a quote with its own
+ * words in it, which is the rule `figure.ts` keeps for a
+ * fence it cannot draw.
+ *
+ * A quote and not a fence, because what goes in the box is prose: a list, a
+ * link, a name, a table, a line of code. A fence holds text and could hold
+ * none of them.
+ */
+
+/**
+ * Which of the two boxes a marker opens.
+ *
+ * Two, because the app has one accent and spending it on decoration is how it
+ * stops meaning "answer me". `asks` is that amber, and it says here what it
+ * says everywhere else in Guaca: a person has to do something. `aside` is the
+ * quiet box, for a thing worth seeing that needs nobody.
+ */
+export type Register = "asks" | "aside";
+
+/** GitHub's five, sorted into the two registers this app can draw. */
+const MARKERS = new Map<string, Register>([
+  ["important", "asks"],
+  ["warning", "asks"],
+  ["caution", "asks"],
+  ["note", "aside"],
+  ["tip", "aside"],
+]);
+
+/**
+ * The word over the box, which is the app's and never the model's.
+ *
+ * Five markers and two words. An agent that writes `[!CAUTION]` and one that
+ * writes `[!WARNING]` mean the same thing here, and drawing both of their
+ * words is an operator learning a vocabulary that decides nothing: what they
+ * need to know is whether this box is for them. *Needs you* is what the rail
+ * already says about an agent that is waiting on somebody, so the row in the
+ * rail and the box in the transcript say one thing in one set of words.
+ */
+export const LABEL: Record<Register, string> = { asks: "Needs you", aside: "Note" };
+
+/**
+ * The marker, alone on the first line of the quote.
+ *
+ * Alone is load-bearing: `[!IMPORTANT] ship it` is a sentence that opens with
+ * a bracket, and a box drawn round it would eat the two words after the
+ * marker into a label nobody wrote. Trailing blanks are allowed because a
+ * model leaves them and no operator can see one.
+ */
+const MARKER = /^\[!([a-z]+)\][^\S\n]*(?:\n|$)/i;
+
+/**
+ * Reads the opening text of a quote.
+ *
+ * `rest` is what is left of that text once the marker line is off it, which is
+ * usually nothing: the marker gets its own line and the words start on the
+ * next one. It is not always nothing, because a model that writes the whole
+ * quote as one soft-wrapped paragraph is writing valid markdown and means the
+ * same thing.
+ */
+export function readCallout(opening: string): { register: Register; rest: string } | null {
+  const found = MARKER.exec(opening);
+  if (!found) return null;
+
+  const register = MARKERS.get(found[1]!.toLowerCase());
+  if (!register) return null;
+
+  return { register, rest: opening.slice(found[0].length) };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2280,6 +2280,56 @@ button {
   50%, 100% { opacity: 0; }
 }
 
+/* --- a callout -----------------------------------------------------------
+
+   A quote a model opened with an alert marker, drawn as a box rather than as a
+   rule down the side, so the one paragraph addressed to the operator is found
+   before the eight around it are read. `lib/callout.ts` is which markers open
+   one and why there are two of them.
+
+   The amber box is the only filled panel in the reading column, and that is
+   the token block's rule rather than a hole in it: what carries hierarchy here
+   is size, weight and air, and the one exception is the accent that means a
+   person has to do something. A quiet callout gets the hairline and no fill,
+   because it is a thing worth seeing rather than a thing being asked for, and
+   a second tint would make the first one furniture.
+   ------------------------------------------------------------------------ */
+
+.md .callout {
+  margin: var(--space-4) 0;
+  padding: var(--space-5);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius);
+}
+
+/* A paragraph carries its own bottom margin, which inside a box is the last
+   line sitting a step off the floor it is standing on. */
+.md .callout > *:last-child {
+  margin-bottom: 0;
+}
+
+.md .callout--asks {
+  border-color: color-mix(in oklab, var(--flesh) 45%, var(--edge));
+  background: var(--flesh-soft);
+}
+
+/* The label is the app's word, not the model's, so it is drawn as the app's
+   own furniture: the same uppercase mono eyebrow every state in this file
+   is set in. */
+.md .callout__label {
+  font-family: var(--font-mono);
+  font-size: var(--type-mark);
+  letter-spacing: var(--track-caps);
+  line-height: var(--lead-ui);
+  text-transform: uppercase;
+  color: var(--faint);
+  margin: 0 0 var(--space-3);
+}
+
+.md .callout--asks .callout__label {
+  color: var(--flesh);
+}
+
 /* ==========================================================================
    Figures
 


### PR DESCRIPTION
A quote opened with a GitHub alert marker is now drawn as a box rather than as a rule down the side, so the one paragraph of nine that is addressed to the operator is found before the rest is read. GitHub's syntax rather than one of ours, because models write `> [!IMPORTANT]` unprompted: it draws on replies written before the prompt mentioned it and on every transcript already stored, and a marker outside the closed set stays a quote with its own words in it. A quote and not a fence, because a callout holds prose (a list, a link, a mention, a table, a line of code) and a fence holds none of them; it is a remark plugin beside the mentions one, and the element leaves as a `div`, so no rule written for a quote reaches it and no landmark opens mid-message.

Five markers, two boxes, two labels: `IMPORTANT`, `WARNING` and `CAUTION` draw the amber one, which means here what it means in the rail, and `NOTE` and `TIP` draw the hairline one. The label is the app's word and not the model's, because what an operator needs off a box is whether it is for them.