### PR TITLE
feat: about names the commit this build was made from

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,7 @@ repo: the frontend renders state and forwards intent.
 | Deleting a group, and why a disband does not use the compost | *Deleting a group deletes the crew, and the machines they were renting* in `docs/WORKSPACE.md`, then `disband_group` in `src-tauri/src/commands.rs` |
 | Preset agents, hiring a crew | *The cafeteria is a copy machine* in `docs/WORKSPACE.md`, then `src/lib/cafeteria.ts` |
 | Settings, the surface, the scale, what may interrupt the operator | *Settings is nine places*, *The reading column has two surfaces* and *An interruption has to earn it* in `docs/WORKSPACE.md` |
+| What About says this build is, and where that string comes from | *About says which commit it is* in `docs/WORKSPACE.md`, then `src/lib/build.ts` and the `define` in `vite.config.ts` |
 | The group editor: what a crew overrides and what it inherits | *A group's settings are the app's, with the crew's answer on top* in `docs/WORKSPACE.md`, then `src/components/GroupEditor.tsx` |
 | What model an agent is offered, and how its job is guessed at | *The model field suggests three, and is still a text box* in `docs/WORKSPACE.md`, then `src/lib/roles.ts` and `llm/catalog.rs`, whose twelve use cases have to agree |
 | Whether a model can be shown a picture: an attachment, a screen, what an agent is told it is | *What a model can be sent is asked of the endpoint, not assumed* in `docs/ARCHITECTURE.md`, then `llm/modality.rs` and the four places `Modalities` is spent from `Runtime::run_turn` |

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -1344,6 +1344,20 @@ somebody else's server. A local endpoint is marked as local because that changes
 what the key field means: an empty key beside a warning about a missing key is a
 state an operator will try to fix forever.
 
+About says which commit it is, rather than a version. The number in
+`package.json` and `tauri.conf.json` has not moved since the first commit and is
+not going to: what ships here is a commit, so a version read off either file
+tells an operator nothing and tells a bug report less. It used to be read
+through Tauri's `getVersion`, which is exactly that placeholder arriving over
+IPC. So `vite.config.ts` asks git for the short hash while the bundle is being
+built and `src/lib/build.ts` is the one place it is read back from. Nothing is
+asked at runtime, because the built app carries no repository to ask. A tree
+with uncommitted edits on top of that commit gets `-dirty`, because an
+unqualified hash sends whoever reads it to check out a commit that did not
+produce the build in front of them. And a build made outside a repository at all
+draws a dash: it is the same answer the pane already gave for a version it could
+not read, and it is still a thing to say rather than a failure worth a banner.
+
 ## The reading column has two surfaces; the rail has one
 
 `styles.css` used to say the surface never follows the OS, and the argument was

--- a/src/components/SettingsDialog.test.tsx
+++ b/src/components/SettingsDialog.test.tsx
@@ -81,7 +81,6 @@ function signedIn(over: Partial<SubscriptionStatus> = {}): SubscriptionStatus {
 const updateSettings = vi.fn<(patch: SettingsPatch) => Promise<Settings>>(async () => stored());
 const testConnection = vi.fn<(patch?: SettingsPatch) => Promise<string>>(async () => "Reached it.");
 const notifyOperator = vi.fn<(title: string, body: string) => Promise<boolean>>(async () => true);
-const getVersion = vi.fn<() => Promise<string>>(async () => "0.4.2");
 const subscriptionStatus = vi.fn<() => Promise<SubscriptionStatus>>(async () => signedOut());
 const beginSubscriptionSignin = vi.fn<() => Promise<DeviceCode>>(async () => ({
   verificationUrl: "https://auth.openai.com/codex/device",
@@ -171,10 +170,6 @@ vi.mock("../lib/ipc", () => ({
   notifyOperator: (title: string, body: string) => notifyOperator(title, body),
   openExternal: (url: string) => openExternal(url),
 }));
-
-// The About pane reads the version through a dynamic import, so the module has
-// to answer here or the whole tree comes down on a webview with no Tauri host.
-vi.mock("@tauri-apps/api/app", () => ({ getVersion: () => getVersion() }));
 
 const { SettingsDialog } = await import("./SettingsDialog");
 const { useStore } = await import("../lib/store");
@@ -277,9 +272,6 @@ beforeEach(() => {
   signInAccount.mockResolvedValue(linked());
   accountConnectors.mockResolvedValue(held());
   signOutAccount.mockResolvedValue(noAccount());
-  // No Tauri host behind this webview, which is the state the About pane is
-  // built to shrug off. The one test that wants a version asks for one.
-  getVersion.mockRejectedValue(new Error("no host"));
 });
 
 describe("when the runtime refuses", () => {
@@ -1386,20 +1378,15 @@ describe("shortcuts", () => {
 });
 
 describe("about", () => {
-  it("shows a dash rather than a banner when the version cannot be read", async () => {
+  it("says which commit this build was made from", () => {
     open();
     pane("About");
 
-    await waitFor(() => expect(getVersion).toHaveBeenCalledTimes(1));
-    expect(screen.getByText("Version —")).toBeTruthy();
-    expect(document.querySelector(".banner")).toBeNull();
-  });
-
-  it("shows the version once the app reports one", async () => {
-    getVersion.mockResolvedValueOnce("0.4.2");
-    open();
-    pane("About");
-
-    expect(await screen.findByText("Version 0.4.2")).toBeTruthy();
+    // The value is baked in at build time, so the assertion is on the shape:
+    // a short hash, dirty or not, or the dash a build with no repository behind
+    // it draws. Nothing here is read from a host, so nothing can fail.
+    expect(document.querySelector(".about__version")?.textContent).toMatch(
+      /^Version (—|[0-9a-f]{7,}(-dirty)?)$/,
+    );
   });
 });

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -22,6 +22,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { applyAppearance, resolveSurface } from "../lib/appearance";
+import { buildLabel } from "../lib/build";
 import { api, openExternal } from "../lib/ipc";
 import { BINDINGS, comboLabel, SURFACES } from "../lib/keybinds";
 import { LIMITS } from "../lib/limits";
@@ -143,7 +144,6 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
     null,
   );
   const [busy, setBusy] = useState(false);
-  const [version, setVersion] = useState<string | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
   // The sign-in, which is three states rather than a boolean: not signed in,
@@ -200,23 +200,6 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
       .catch(() => {
         // Asked again next time Settings opens. A row that cannot say whether
         // the program is there says nothing, which is what null draws as.
-      });
-    return () => {
-      live = false;
-    };
-  }, []);
-
-  // Read on mount rather than at startup, so nothing pays for it until the one
-  // pane that shows it is opened.
-  useEffect(() => {
-    let live = true;
-    void import("@tauri-apps/api/app")
-      .then(({ getVersion }) => getVersion())
-      .then((value) => {
-        if (live) setVersion(value);
-      })
-      .catch(() => {
-        // A version nobody can read is worth a dash, not a banner.
       });
     return () => {
       live = false;
@@ -1232,7 +1215,7 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
               <>
                 <div className="about">
                   <h3 className="about__name">Guaca</h3>
-                  <p className="about__version">{version ? `Version ${version}` : "Version —"}</p>
+                  <p className="about__version">{buildLabel()}</p>
                 </div>
 
                 <div className="about__facts">

--- a/src/lib/build.test.ts
+++ b/src/lib/build.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { buildLabel, COMMIT } from "./build";
+
+describe("buildLabel", () => {
+  it("names the commit the build was made from", () => {
+    expect(buildLabel("9f2c1a4")).toBe("Version 9f2c1a4");
+  });
+
+  it("carries the mark that says the tree was not clean", () => {
+    expect(buildLabel("9f2c1a4-dirty")).toBe("Version 9f2c1a4-dirty");
+  });
+
+  it("says a dash when there was no repository to read", () => {
+    expect(buildLabel("")).toBe("Version —");
+  });
+
+  it("is built from a commit, which is what the define is for", () => {
+    // Guards the wiring rather than the value: an undefined `__COMMIT__` is a
+    // config that stopped substituting, and it would draw as a dash forever
+    // while every other test in this file still passed.
+    expect(typeof COMMIT).toBe("string");
+    expect(COMMIT === "" || /^[0-9a-f]{7,}(-dirty)?$/.test(COMMIT)).toBe(true);
+  });
+});

--- a/src/lib/build.ts
+++ b/src/lib/build.ts
@@ -1,0 +1,23 @@
+/**
+ * What this build is, which is the commit it was made from.
+ *
+ * `__COMMIT__` is replaced by `vite.config.ts` when the bundle is built. There
+ * is nothing to ask at runtime: the app ships without the repository it came
+ * from, and the version in `package.json` and `tauri.conf.json` is a placeholder
+ * that has never moved. Empty is a build made outside a repository (a source
+ * tarball, or a CI image that copied no `.git`), which is a thing to say rather
+ * than a failure to report.
+ */
+
+declare const __COMMIT__: string;
+
+/** The commit this build was made from, suffixed `-dirty` where the tree had
+ *  uncommitted edits on top of it, and empty where there was none to read. */
+export const COMMIT: string = __COMMIT__;
+
+/** The line About draws. A dash rather than a blank, for the reason every other
+ *  unreadable fact in this app gets one: an empty space reads as a bug in the
+ *  pane, and there is nothing here for an operator to act on either way. */
+export function buildLabel(commit: string = COMMIT): string {
+  return `Version ${commit || "—"}`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from "node:child_process";
+
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
@@ -6,9 +8,35 @@ import { defineConfig } from "vite";
 // rather than a silent port bump, otherwise the webview loads nothing.
 const host = process.env.TAURI_DEV_HOST;
 
+/**
+ * The commit this bundle is being built from.
+ *
+ * The number in `package.json` has not moved since the first commit and is not
+ * going to: what ships here is a commit rather than a release, so a version
+ * read off that file tells an operator nothing and tells a bug report less.
+ * Read here because the built app has no repository to ask, and at build time
+ * because that is when the answer stops changing: a dev server keeps the commit
+ * it started on, which is the commit the bundle behind it was built from.
+ */
+function builtOn(): string {
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  try {
+    const head = git("rev-parse", "--short=7", "HEAD");
+    // A tree with edits on top of that commit did not produce this build, and
+    // an unqualified hash says it did. The difference is somebody checking out
+    // that commit and hunting for a defect that was never in it.
+    return git("status", "--porcelain") ? `${head}-dirty` : head;
+  } catch {
+    // No git, no repository, or a source tarball. About draws a dash.
+    return "";
+  }
+}
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   clearScreen: false,
+  define: { __COMMIT__: JSON.stringify(builtOn()) },
   server: {
     port: 1420,
     strictPort: true,


### PR DESCRIPTION
The version row in About read `getVersion()`, which returns `tauri.conf.json`'s `0.1.0`: a number that has not moved since the first commit and is not going to, since releases here are commits.

`vite.config.ts` now asks git for the short hash while the bundle is built and injects it as `__COMMIT__`, and `src/lib/build.ts` is the one place it is read back from. A tree with uncommitted edits gets `-dirty`, because an unqualified hash sends whoever reads it to check out a commit that did not produce the build in front of them, and a build made outside a repository draws the dash the pane already drew for a version it could not read. Nothing is asked at runtime, so the dynamic import of `@tauri-apps/api/app` goes with it.

Verified with `./scripts/ci.sh web`, and by grepping the built bundle for the hash, which is the half no test in the vitest environment can prove.