### PR TITLE
feat: the board moves to the crew's settings, and both edges are one paper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ src/                  React + TypeScript. A view over the runtime, nothing more.
   lib/rail.ts         What order the rail draws agents in, and where a drop lands.
   lib/presence.ts     A crew, in the two marks its circle can carry.
   lib/orb.ts          How a crew stands inside its circle, and when it counts.
+  lib/reach.ts        How close the pointer comes before the crews slide out.
   lib/search.ts       One ranking over hits from SQLite and from the store.
   lib/trail.ts        A turn's own tool calls: what folds into one chip.
   lib/figure.ts       A fenced block the transcript draws instead of printing.
@@ -136,6 +137,8 @@ repo: the frontend renders state and forwards intent.
 | Anything an agent stops to ask a person: the desk, the queue, the two kinds of request, `ask_operator` | `docs/ATTENTION.md`, then `domain/approval.rs` and `Runtime::park` |
 | An agent that cannot go on at all, what reaches the operator without parking a turn, `escalate` | *Three things an agent can do about a person* and *What an escalation is* in `docs/ATTENTION.md`, then `domain/escalation.rs` and `Store::raise_escalation` |
 | The crews' column, its badges, how a crew names itself, which crew the rail is inside | *A group is a place you can be inside* in `docs/WORKSPACE.md`, then `src/lib/presence.ts`, `src/components/GroupRail.tsx` and `src/components/OrbTag.tsx` |
+| When the crews' column comes out, how close is close enough, what holds it out | *The column does not stand open* in `docs/WORKSPACE.md`, then `src/lib/reach.ts` and the three boxes in `.grail` |
+| Who spoke to whom, what a run cost, where that board lives | *The flow board is analysis, so it is in a crew's settings* in `docs/WORKSPACE.md`, then `src/components/GroupActivity.tsx` and `Store::conversation_flow` |
 | What an agent may do with a page it has just read | *A page that was read this turn cannot quietly press a button* |
 | Screenshots, coordinates, what a screen action answers with | *A computer is looked at, never asked* in `docs/MACHINES.md` |
 | Attachments, previews, drops, handing a document to the operator | *Files are references, and what a model gets depends on what they are* |
@@ -167,6 +170,7 @@ repo: the frontend renders state and forwards intent.
 | Which of the two stores something belongs in, what `note_progress` is for, why one is a file and the other a table | *An agent's memory is what it knows, and its working notes are what it is doing* in `docs/WORKSPACE.md`, then `src-tauri/src/domain/worknote.rs`, whose header is the argument |
 | An `@` that names an agent: what resolves, and what it draws in either place | *A mention is one thing, in the box and in the message* in `docs/WORKSPACE.md`, then `src/lib/mentions.ts` and the layer under `Composer`'s textarea |
 | A size, a space, a radius, a duration or a shadow, anywhere in the app | *Every length is named* below, then the token block at the top of `src/styles.css`, and the closed-set suite in `styles.test.ts`, which is the gate |
+| What color a column is, a surface a panel is drawn on, anything about light or dark | *The page is the only white thing, and both edges are the same off-white* in `docs/WORKSPACE.md`, then the two token blocks in `src/styles.css` and the columns suite in `styles.test.ts` |
 | Anything announced to a screen reader, or a live region | *A transcript is a log, and says one thing out loud* in `docs/WORKSPACE.md` |
 | Scrolling a transcript, following the newest line, when the view may move | *A transcript follows the end for whoever is at the end, and nobody else* in `docs/WORKSPACE.md`, then `src/lib/follow.ts` |
 | The menu bar: the glyph, the count, what the menu offers, closing the window | *The menu bar is Guaca with the window shut* in `docs/WORKSPACE.md`, then `src-tauri/src/menubar.rs` |
@@ -174,7 +178,7 @@ repo: the frontend renders state and forwards intent.
 | Deleting an agent, putting one back, what the thirty days hold | *Deleting an agent is a thirty-day hold* in `docs/WORKSPACE.md`, then `Runtime::discard_agent` and `Runtime::purge_agent`, which are the two halves of what used to be one act |
 | Deleting a group, and why a disband does not use the compost | *Deleting a group deletes the crew, and the machines they were renting* in `docs/WORKSPACE.md`, then `disband_group` in `src-tauri/src/commands.rs` |
 | Preset agents, hiring a crew | *The cafeteria is a copy machine* in `docs/WORKSPACE.md`, then `src/lib/cafeteria.ts` |
-| Settings, the surface, the scale, what may interrupt the operator | *Settings is nine places*, *The reading column has two surfaces* and *An interruption has to earn it* in `docs/WORKSPACE.md` |
+| Settings, the surface, the scale, what may interrupt the operator | *Settings is nine places*, *The page is the only white thing, and both edges are the same off-white* and *An interruption has to earn it* in `docs/WORKSPACE.md` |
 | The group editor: what a crew overrides and what it inherits | *A group's settings are the app's, with the crew's answer on top* in `docs/WORKSPACE.md`, then `src/components/GroupEditor.tsx` |
 | What model an agent is offered, and how its job is guessed at | *The model field suggests three, and is still a text box* in `docs/WORKSPACE.md`, then `src/lib/roles.ts` and `llm/catalog.rs`, whose twelve use cases have to agree |
 | Whether a model can be shown a picture: an attachment, a screen, what an agent is told it is | *What a model can be sent is asked of the endpoint, not assumed* in `docs/ARCHITECTURE.md`, then `llm/modality.rs` and the four places `Modalities` is spent from `Runtime::run_turn` |
@@ -824,7 +828,7 @@ the model takes a screenshot to see what `browse` did.
   it wrote and checks the box is still there before writing again, which is why
   one pixel is enough and no threshold is. Its listener is bound by a ref
   callback for the same reason: the node is replaced whenever the pane shows a
-  pair thread or the activity board, and an effect cannot re-bind on that. The
+  pair thread or nothing at all, and an effect cannot re-bind on that. The
   size observer beside it is bound there for that reason too, and it is not
   decoration: everything under a transcript takes height from it without
   anything arriving or scrolling, so a composer growing a line or the working
@@ -1109,6 +1113,28 @@ the model takes a screenshot to see what `browse` did.
   stale card looks exactly like a live one. Both events invalidate it and the
   answer comes back from `pending_approvals`. The consequence is the feature:
   nothing can appear on the desk that is not a row somewhere.
+- **The flow board is not a channel, and `ACTIVITY_CHANNEL` is gone.** Who
+  spoke to whom is analysis: somebody arrives at it having decided to look into
+  something, and it sat at the top of the rail under the wordmark, which is a
+  claim about how often anybody wants it that every other row in the rail paid
+  for. It is a pane in the group editor now. Deleting the key is most of the
+  value: a board addressed as a channel meant seven functions took a channel
+  that was not an agent and carried a branch for it, including which crew the
+  rail follows, what `loadChannel` reads, and what `messageAppended` maintains
+  against a board nobody had necessarily opened. It is one crew's traffic,
+  scoped in SQL, because the board is the newest four hundred messages and a
+  busy crew filling that window would hand a quiet one an empty board.
+  `docs/WORKSPACE.md`.
+- **The crews' column slides out; it does not stand open.** Two thresholds, not
+  one, or a hand resting at the boundary flickers it. Both distances are read
+  off a box CSS sizes rather than written in the component, so they are lengths
+  in the one stylesheet at the operator's own scale. The zone starts below the
+  top of the window because macOS floats the close button over that corner, and
+  it is decided from the pointer rather than from `:hover` on a strip: a strip
+  wide enough to aim at is a strip laid over the left edge of every agent row
+  behind it. Proximity, a drag in progress and focus inside it each hold it out;
+  the drag one is load-bearing, since a column that slid away mid-gesture would
+  take the drop target with it. `src/lib/reach.ts`.
 - **`select` follows an agent into its crew; `focusGroup` lets a channel go.**
   One invariant from two ends — the rail draws the row of whatever the pane is
   showing — and the asymmetry is deliberate. `select` is the operator naming an
@@ -1116,6 +1142,10 @@ the model takes a screenshot to see what `browse` did.
   them naming a crew, and following the channel back out of it would undo the
   click. Before the crews had a column of their own, `select` dropped out to the
   overview instead, because that was the only view where every row was drawable.
+  What `focusGroup` falls back to is nothing, rather than the first row of the
+  crew being entered: opening a channel is the operator naming somebody, and a
+  crew that picked one for them would put an agent's history on screen as a side
+  effect of a click that was about the crew.
 - **A key in settings says what the workspace can hand out; the card says who
   was given it.** Both have to be true, and `Surfaces::given_to` is the only
   place they meet. Deciding from the key alone is what this replaced: every
@@ -1209,10 +1239,28 @@ the model takes a screenshot to see what `browse` did.
   parked on one run therefore cannot see that another run's work is queued behind
   it, which is why the pause park drains the queue whenever anything is stopped.
   Survivors go to a holding queue and stay counted in `depth`.
-- **`--flesh` and `--flesh-soft` are pinned on `.rail`.** The rail is dark in
-  both surfaces and reads both tokens, so a dark value for either would repaint
-  it and no test would notice. Pinning them on the one element every rail rule
-  descends from makes the rail a color scope rather than a naming convention.
+- **The rail and the inspector are one ground, and it is not the page's.** They
+  were a near-black column on the left and a white panel on the right, which is
+  three surfaces for two jobs: the app's own two edges did not look like each
+  other and the heavier of them carried the least reading. They do the same job,
+  so they are the same off-white, the page is the only white thing on screen,
+  and the only saturation left is an agent's color and the one amber. The
+  columns used to pin `--flesh` and `--flesh-soft` — the crews' column `--alarm`
+  too — because they were ink under a reading column that could go dark. Nothing
+  is pinned now, and what replaced the pins is the same trap read the other way:
+  a `--rail-*` or `--grail-*` color declared for paper and forgotten in the ink
+  block is a column that stays off-white in a dark room, which no DOM assertion
+  sees. `styles.test.ts` reads both blocks and is the gate.
+- **A column's recessed surface is not the page's either.** `--sunken` is a hair
+  off white, which is a field on paper and nothing at all on an off-white panel,
+  so the three columns remap it onto `--rail-sunken` in one rule that names all
+  of them. Remapped there rather than at each rule inside, so a row added to the
+  inspector tomorrow is recessed from what it is actually drawn on.
+- **One surface is ink whichever surface the operator picked, and it says so
+  itself.** The full-window machine viewer pins `--stage-*` on `.screen`,
+  shadow included: a pale chrome around somebody else's desktop is a chrome the
+  eye keeps reading instead of the picture, and a `--lift-*` there would resolve
+  against the reading column and put a paper-weight ring on a black surface.
 - **`data-surface` is only ever `light` or `dark`.** `system` is resolved before
   it reaches the document. A stylesheet rule keyed on `system` would have to
   duplicate the one keyed on `dark`, and CSS has no way to share them.

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -610,12 +610,12 @@ message landing off screen with nothing following it is the same complaint
 pointing the other way.
 
 The listener is bound by a ref callback rather than an effect, and that is
-load-bearing. A transcript is unmounted whenever the pane shows something else,
-a pair thread or the activity board, and comes back as a new node with the same
-class. An effect can only re-bind on a dependency it was given, and the node it
-holds is not one: a channel opened from the activity board spent the session
-listening to a node that had been thrown away, which is the shape the report
-arrived in.
+load-bearing. A transcript is unmounted whenever the pane shows something else —
+a pair thread, or nothing at all once the operator has gone inside a crew the
+open channel was not in — and comes back as a new node with the same class. An
+effect can only re-bind on a dependency it was given, and the node it holds is
+not one: a channel reopened after one of those spent the session listening to a
+node that had been thrown away, which is the shape the report arrived in.
 
 ## A mention is one thing, in the box and in the message
 
@@ -765,11 +765,48 @@ navigation for it, and four was a hard wall nobody had chosen. Upright, the axis
 is the one there is room on, and the crews that do not fit scroll instead of
 folding.
 
-Two things follow from the column that the strip could not buy. The crews are on
-screen wherever the operator is, including while the rail is inside one of them,
-which is what lets a circle carry a permanent statement about the crews nobody is
-looking at. And "which crew am I in" stops being something the rail has to
-answer, because the answer is a lit circle in a fixed place.
+Two things follow from the column that the strip could not buy. The crews are
+reachable wherever the operator is, including while the rail is inside one of
+them, which is what lets a circle carry a permanent statement about the crews
+nobody is looking at. And "which crew am I in" stops being something the rail has
+to answer, because the answer is a lit circle in a fixed place.
+
+**The column does not stand open, and that is the third change.** Standing open
+it charged every window four rem of its width for a choice most operators make a
+few times a day, in front of the rail that is read constantly. So what is left in
+the layout is a band of its own ground at the edge of the window — enough to say
+there is something here, not enough to be a column — and the column slides out
+over the rail when the pointer comes at it. Over rather than beside: nothing
+reflows, the rail keeps its measure, and the gesture is the one somebody heading
+for the left edge of the window is already making.
+
+`src/lib/reach.ts` owns when, and it uses two thresholds rather than one. A
+single line means the column closes at exactly the pixel that opens it, so a hand
+resting at the boundary flickers it and the moment it starts to close the pointer
+is inside the zone again. Coming within the zone opens it, going past the far
+side of the column plus that same distance again closes it, and in between it is
+left as it was. Neither number is written in the component: the zone is a box CSS
+positions and sizes and nothing can click, and `reaches` reads its geometry, so
+both distances are lengths in the one stylesheet at the operator's own interface
+scale like every other length in the app.
+
+The zone starts below the top of the window, and that is not fussiness. On macOS
+the window's own close, minimize and zoom float over the top left corner, which
+is this column: a zone that ran to the top would slide the crews out from under
+the pointer every time somebody went to close the app.
+
+Decided from the pointer rather than from `:hover` on a strip. A strip wide
+enough to be aimed at is a strip laid over the left edge of every agent row
+behind it, and a row that does nothing when it is clicked near its left side is a
+worse bug than the one this fixes.
+
+Three things hold the column out and none of them is a click. Proximity; a drag
+in progress, whatever the pointer is doing, because a drop onto a circle is the
+one thing this column is load-bearing for and a column that slid away as the hand
+carried a row across it would take the target with it half way through the
+gesture; and focus inside it, which is what makes the column reachable from the
+keyboard, since a circle tabbed to inside a column nobody can see is a selection
+nobody can read.
 
 The circles are faces, and the name is beside them. A crew is recognized by who
 is in it long before its name is read, which is true and was never enough on its
@@ -857,8 +894,8 @@ the badge would.
 The group being looked inside is in the store rather than in the sidebar, because
 it and the open channel have to agree, and both are in the store. One invariant
 holds them together: the rail draws the row of whatever the pane is showing. A
-search hit or a click on the flow board can land on an agent in another crew, and
-`select` repairs that by following the agent into its crew. It used to drop out
+search hit can land on an agent in another crew, and `select` repairs that by
+following the agent into its crew. It used to drop out
 to the overview instead, which was the only honest answer while the crews were a
 strip inside the rail: the overview was the one view where every row was
 drawable. With a column that is on screen whichever crew you are in, following
@@ -869,8 +906,10 @@ rail changing shape.
 than following. The asymmetry is the point: `select` is the operator naming an
 agent, so taking them to that agent's crew is what they asked for, and
 `focusGroup` is the operator naming a crew, so following the channel back out of
-it would undo the click. The pane falls back to the activity feed, which belongs
-to no crew and is never closed.
+it would undo the click. The pane falls back to nothing rather than to the first
+row of the crew being entered: opening a channel is the operator naming somebody,
+and a crew that picked one for them would put an agent's history on screen as a
+side effect of a click that was about the crew.
 
 Closing it is not tidiness. Two crews can hold two agents with the same name and
 the same face, and a rail that is not drawing the row leaves nothing on screen
@@ -979,6 +1018,44 @@ from the other and will not accept them, so a crew that tries the subscription f
 an hour and moves back has to find its endpoint model where it left it. Test
 connection is here for the same reason it is in Settings, and it sends what is on
 screen resolved over the app settings, which is what the next turn would do.
+
+## The flow board is analysis, so it is in a crew's settings
+
+Who spoke to whom, in what order, what set a run off and what the run cost. It
+is drawn as a sequence diagram cut into runs, newest first, and the reasoning
+for that shape is in `src/components/ActivityFlow.tsx` and has not changed.
+Where it lives has.
+
+It was a channel at the top of the rail, under the wordmark and one row above
+the search box: the first thing in the app after Guaca's own name, and one of
+the least pressed things in it. That placement is a claim about how often
+somebody wants it, and the claim was wrong. Nobody opens this board on the way
+past. They open it having decided to look into something — why a run went round
+four times, which agent started a cascade, what a Tuesday cost — and an entry in
+the primary navigation for a thing you arrive at deliberately is entry that
+every other thing in the rail pays for.
+
+So it is a pane in the group editor, beside the crew's provider and limits, and
+`ACTIVITY_CHANNEL` is gone. That last part is most of the value. A board
+addressed as a channel meant every function that took a channel took a value
+that was not an agent, and seven of them carried a branch for it: which crew the
+rail follows, whether the open channel survives going inside a crew, what
+`loadChannel` reads, what a fallback selects, and what `messageAppended` and
+`channelsCleared` maintain. A channel is an agent again.
+
+It is one crew's traffic, and scoped in SQL rather than filtered after the read.
+The board is the newest four hundred messages, so a workspace where one busy
+crew fills that window would hand a quiet crew a board with nothing on it and no
+way to tell that apart from a crew that has never spoken. The channel is the
+scope because agents in different groups cannot message each other: every
+message is filed under an agent, and that agent's group is the run's.
+
+Read when the pane is opened rather than held in the store, which is the same
+decision one more time. The store maintained a second copy of every arriving
+message against a board nobody had necessarily ever opened. A board somebody
+opens deliberately can afford one read at the moment they open it, and it does
+not follow the conversation afterward: a board that reshuffles under a reader is
+one they lose their place in, and what they came to read has already happened.
 
 ## Pinning is the head of a crew, and nothing else
 
@@ -1344,7 +1421,7 @@ somebody else's server. A local endpoint is marked as local because that changes
 what the key field means: an empty key beside a warning about a missing key is a
 state an operator will try to fix forever.
 
-## The reading column has two surfaces; the rail has one
+## The page is the only white thing, and both edges are the same off-white
 
 `styles.css` used to say the surface never follows the OS, and the argument was
 sound as far as it went: a chat log is read for minutes at a time and white wins
@@ -1352,13 +1429,41 @@ that in a lit room. It does not win it in a dark one. So the reading column is a
 token block behind `data-surface` — the same seven neutrals, four accents, a
 scrim and a shadow, and nothing else.
 
-The rail is not part of the question. It is dark in both surfaces, which is what
-makes the column read as a surface rather than as another panel, and it pins the
-two accents it draws with on `.rail` itself. That last part is load-bearing: the
-rail reads `--flesh` in twelve rules and `--flesh-soft` in two, so a dark value
-for either would have repainted it silently and no test in this repo would have
-caught it. Pinning them on the one element every rail rule descends from turns
-the rail into a color scope instead of a naming convention.
+The two navigation columns are part of that question rather than exempt from it,
+and that is the change. They were ink whichever surface the operator picked, on
+the argument that a dark rail against a white page is what makes the page read
+as paper rather than as another panel. What it actually produced was an app with
+three surfaces for two jobs: a near-black column on the left, a white page, and
+a white panel on the right, so the app's own two edges did not look like each
+other and the heavier of them was the one carrying the least reading. The rail
+and the inspector do the same job — everything about an agent that is not what
+it said — so they are one ground, a shade off the page rather than opposite it,
+and the page is the only white thing on screen.
+
+What is left with any saturation in it is an agent's own color and the one
+amber. That is the point rather than a side effect: a column that is itself a
+color is a column every agent's color is competing with, and the accent that
+means "answer me" had two values depending on which side of a border it was
+drawn on. Both columns used to pin `--flesh` and `--flesh-soft` — and the crews'
+column `--alarm` as well — because a dark reading column would otherwise have
+repainted them silently. Nothing is pinned now. What replaced the pins is the
+other half of the same trap, asserted in `styles.test.ts`: every `--rail-*` and
+`--grail-*` value that is a color has to be declared in both surface blocks, or
+a column stays off-white in a dark room and no DOM assertion sees it.
+
+One value did not exist before and had to. `--sunken` is a hair off white, which
+is a recessed field on paper and nothing at all on an off-white panel, so the
+columns remap it onto `--rail-sunken` in one rule that names all three of them.
+Remapped there rather than at each rule inside, so a row added to the inspector
+tomorrow is recessed from what it is actually drawn on without having to know
+which half of the app it is in.
+
+One surface is still ink under both, and now says so itself. The full-window
+machine viewer is a light-tight box around somebody else's desktop, because a
+pale chrome around a picture is a chrome the eye keeps reading instead of the
+picture. It pins four values of its own on `.screen`, including its shadow: a
+lift resolved against the reading column would put a paper-weight ring on a
+black surface.
 
 `system` is resolved before it reaches the document, so `data-surface` is only
 ever `light` or `dark`. A rule keyed on `system` would have to duplicate the one

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1720,10 +1720,14 @@ pub fn pair_messages(
     Ok(state.runtime.store().pair_messages(a, b, limit.unwrap_or(200).min(1000))?)
 }
 
-/// The whole conversation, for the flow board.
+/// One crew's conversation, for the flow board in its settings.
 #[tauri::command]
-pub fn conversation_flow(state: State<'_, AppState>, limit: Option<u32>) -> Reply<Vec<Envelope>> {
-    Ok(state.runtime.store().conversation_flow(limit.unwrap_or(400).min(2000))?)
+pub fn conversation_flow(
+    state: State<'_, AppState>,
+    group: GroupId,
+    limit: Option<u32>,
+) -> Reply<Vec<Envelope>> {
+    Ok(state.runtime.store().conversation_flow(group, limit.unwrap_or(400).min(2000))?)
 }
 
 /// What the transcript has to say about a query.

--- a/src-tauri/src/db/store.rs
+++ b/src-tauri/src/db/store.rs
@@ -3084,21 +3084,35 @@ impl Store {
         Ok(out)
     }
 
-    /// The conversation as a whole, oldest last, for the flow board.
+    /// One crew's conversation, oldest last, for the flow board.
     ///
     /// Includes the operator's messages and the replies back to them, not just
     /// peer traffic: a flow that starts partway through, at the first agent to
     /// agent message, hides who set it off. An agent's private activity records
     /// are excluded, since they are bookkeeping rather than a message passing
     /// between two participants.
-    pub fn conversation_flow(&self, limit: u32) -> Result<Vec<Envelope>, StoreError> {
+    ///
+    /// Scoped to a group in SQL rather than filtered after the read, and the
+    /// limit is why. The board is the newest `limit` messages, so a workspace
+    /// where one busy crew fills that window would hand a quiet crew a board
+    /// with nothing on it and no way to tell that apart from a crew that has
+    /// not spoken. The channel is the scope because agents in different groups
+    /// cannot message each other: every message in a run is filed under an
+    /// agent, and that agent's group is the run's.
+    pub fn conversation_flow(
+        &self,
+        group: GroupId,
+        limit: u32,
+    ) -> Result<Vec<Envelope>, StoreError> {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT id,run_id,channel_id,from_kind,from_agent,to_kind,to_agent,parts,trust,hop,expects_reply,intent,cause,created_at
-               FROM messages WHERE to_kind <> 'system'
-              ORDER BY created_at DESC, id DESC LIMIT ?1",
+               FROM messages
+              WHERE to_kind <> 'system'
+                AND channel_id IN (SELECT id FROM agents WHERE group_id=?1)
+              ORDER BY created_at DESC, id DESC LIMIT ?2",
         )?;
-        let rows = stmt.query_map(params![limit], row_to_envelope)?;
+        let rows = stmt.query_map(params![group.to_string(), limit], row_to_envelope)?;
         let mut out = Vec::new();
         for row in rows {
             out.push(row??);
@@ -5820,9 +5834,44 @@ mod tests {
         // An agent's own activity record is not a message between participants.
         send(agent(a.id), Participant::System, "tool trail");
 
-        let flow: Vec<String> =
-            f.store.conversation_flow(50).unwrap().iter().map(Envelope::plain_text).collect();
+        let flow: Vec<String> = f
+            .store
+            .conversation_flow(a.group_id, 50)
+            .unwrap()
+            .iter()
+            .map(Envelope::plain_text)
+            .collect();
         assert_eq!(flow, vec!["you asked", "peer msg", "answer"]);
+        assert!(b.group_id == a.group_id, "both land in the default group");
+    }
+
+    /// The board is drawn in one crew's settings, so it must hold one crew's
+    /// traffic. Scoped after the read instead, a busy crew filling the newest
+    /// four hundred messages would hand the quiet crew beside it an empty
+    /// board, which reads as a crew that has never spoken.
+    #[test]
+    fn the_flow_is_one_crew_and_not_the_workspace() {
+        let f = fixture();
+        let other = f.store.create_group(&group_named("Ops")).unwrap();
+        let mine = f.store.create_agent(&draft("A")).unwrap();
+        let theirs = f.store.create_agent(&draft_in("B", other.id)).unwrap();
+        let run = RunId::new();
+
+        let mut at = 1_000;
+        let mut send = |to, text: &str| {
+            let mut e = envelope(Participant::Human, to, text, run);
+            e.created_at = at;
+            at += 1;
+            f.store.append(&e).unwrap();
+        };
+        send(Participant::Agent { id: mine.id }, "mine");
+        send(Participant::Agent { id: theirs.id }, "theirs");
+
+        let read = |group| -> Vec<String> {
+            f.store.conversation_flow(group, 50).unwrap().iter().map(Envelope::plain_text).collect()
+        };
+        assert_eq!(read(mine.group_id), vec!["mine"]);
+        assert_eq!(read(other.id), vec!["theirs"]);
     }
 
     #[test]
@@ -5840,8 +5889,13 @@ mod tests {
             e.created_at = 1_000 + i as i64;
             f.store.append(&e).unwrap();
         }
-        let flow: Vec<String> =
-            f.store.conversation_flow(50).unwrap().iter().map(Envelope::plain_text).collect();
+        let flow: Vec<String> = f
+            .store
+            .conversation_flow(a.group_id, 50)
+            .unwrap()
+            .iter()
+            .map(Envelope::plain_text)
+            .collect();
         assert_eq!(flow, vec!["m0", "m1", "m2", "m3", "m4"]);
     }
 

--- a/src-tauri/src/domain/envelope.rs
+++ b/src-tauri/src/domain/envelope.rs
@@ -364,7 +364,7 @@ impl Envelope {
             .to_string()
     }
 
-    /// True when both ends are agents, which is what the activity feed shows.
+    /// True when both ends are agents, which is what the flow board shows.
     pub fn is_inter_agent(&self) -> bool {
         self.from.is_agent() && self.to.is_agent()
     }

--- a/src-tauri/tests/harness/mod.rs
+++ b/src-tauri/tests/harness/mod.rs
@@ -933,14 +933,21 @@ impl Harness {
     }
 
     /// Peer traffic only, which is what most of these tests reason about.
+    ///
+    /// Every crew's board, merged. The store scopes a flow to one group,
+    /// because that is the only unit the board is ever drawn for; a test that
+    /// puts agents in two groups is still asking about the whole run.
     pub fn feed(&self) -> Vec<Envelope> {
-        self.runtime
-            .store()
-            .conversation_flow(400)
+        let store = self.runtime.store();
+        let mut messages: Vec<Envelope> = store
+            .list_groups()
             .unwrap()
             .into_iter()
+            .flat_map(|group| store.conversation_flow(group.id, 400).unwrap())
             .filter(|e| e.from.is_agent() && e.to.is_agent())
-            .collect()
+            .collect();
+        messages.sort_by_key(|e| (e.created_at, e.id));
+        messages
     }
 
     /// What the run's machinery did, read from the events the UI is drawn

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import { applyAppearance, watchSystemSurface } from "./lib/appearance";
 import { api, notifyOperator, onRevealRequest, onRuntimeEvent } from "./lib/ipc";
 import { bindingFor } from "./lib/keybinds";
 import { away, burst, markQuiet, quiet, shouldNotify } from "./lib/notify";
-import { ACTIVITY_CHANNEL, useLiveAgents, useStore } from "./lib/store";
+import { useLiveAgents, useStore } from "./lib/store";
 import { type AgentCard, errorMessage, type Group, type UiEvent } from "./lib/types";
 
 export default function App() {
@@ -192,8 +192,7 @@ export default function App() {
   // not set up yet" stopped meaning anything.
   const needsKey =
     ready && settings !== null && settings.provider === "compatible" && !settings.apiKeySet;
-  const openAgent =
-    selected && selected !== ACTIVITY_CHANNEL ? agents.find((a) => a.id === selected) : undefined;
+  const openAgent = selected ? agents.find((a) => a.id === selected) : undefined;
 
   return (
     <div className="app">
@@ -257,11 +256,17 @@ export default function App() {
               </button>
             </div>
           </div>
+        ) : selected === null ? (
+          // Nothing open. Reached by going inside a crew the open channel was
+          // not in, and by deleting the last agent that had one: both are the
+          // operator ending up somewhere with no conversation attached, and
+          // picking one for them would put an agent's history on screen as a
+          // side effect of a click that was about something else.
+          <div className="empty" style={{ margin: "auto" }}>
+            <p className="empty__body">Pick someone in the rail to open their channel.</p>
+          </div>
         ) : (
-          <ChannelView
-            channel={selected ?? ACTIVITY_CHANNEL}
-            onOpenMenu={(agent, at) => setMenu({ agent, ...at })}
-          />
+          <ChannelView channel={selected} onOpenMenu={(agent, at) => setMenu({ agent, ...at })} />
         )}
       </main>
 

--- a/src/components/Cafeteria.test.tsx
+++ b/src/components/Cafeteria.test.tsx
@@ -285,10 +285,12 @@ describe("where a hire lands", () => {
     expect(screen.getByRole("button", { name: /hire 1 into kitchen/i })).toBeTruthy();
   });
 
-  it("keeps the crew it opened on when the activity board is what is open", () => {
+  it("keeps the crew it opened on with no channel open at all", () => {
+    // Which is where going inside a crew the open channel was not in leaves the
+    // operator, and the rail's own focus is still the answer.
     open([group(KITCHEN, "Kitchen"), group(GARDEN, "Garden")], [], {
       railGroup: GARDEN,
-      selected: "activity",
+      selected: null,
     });
     fireEvent.click(tile("Executive Assistant"));
     expect(screen.getByRole("button", { name: /hire 1 into garden/i })).toBeTruthy();

--- a/src/components/Cafeteria.tsx
+++ b/src/components/Cafeteria.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { AgentAvatar } from "../avatars/AgentAvatar";
 import { HIREABLE, type Hireable, pick, STARTER_CREW, STATIONS, toDraft } from "../lib/cafeteria";
 import { api } from "../lib/ipc";
-import { ACTIVITY_CHANNEL, useStore } from "../lib/store";
+import { useStore } from "../lib/store";
 import { errorMessage, type GroupId } from "../lib/types";
 
 interface Props {
@@ -49,10 +49,7 @@ export function Cafeteria({ onClose }: Props) {
    * the first group as before.
    */
   const [groupId, setGroupId] = useState<GroupId | "">(() => {
-    const open =
-      selected !== null && selected !== ACTIVITY_CHANNEL
-        ? agents.find((a) => a.id === selected)?.groupId
-        : undefined;
+    const open = selected !== null ? agents.find((a) => a.id === selected)?.groupId : undefined;
     return railGroup ?? open ?? groups[0]?.id ?? "";
   });
   const [error, setError] = useState<string | null>(null);

--- a/src/components/ChannelView.test.tsx
+++ b/src/components/ChannelView.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ACTIVITY_CHANNEL, useStore } from "../lib/store";
+import { useStore } from "../lib/store";
 import type { LiveCall } from "../lib/trail";
 import type { Activity, AgentCard, Envelope, MessageId, Part, ToolOutcome } from "../lib/types";
 import { ChannelView } from "./ChannelView";
@@ -650,42 +650,21 @@ describe("a transcript scrolled up", () => {
     };
   }
 
-  it("stays where it was put when a message arrives, even opened from the activity board", () => {
-    // The report: reading back through a cascade and being thrown to the end of
-    // it, at times nobody could name. This was one of them. The transcript is
-    // unmounted while the activity board is up, so the channel opened after it
-    // is a different node, and the listener that noticed the operator scrolling
-    // was still bound to the one that had been thrown away. Nothing reported a
-    // scroll, so nothing had moved, so every message won.
-    const rows = Array.from({ length: 12 }, () => envelope({}));
-    useStore.setState({
-      agents: [card(MANAGER, "Manager"), card(CHEF, "Chef")],
-      messages: { [MANAGER]: rows },
-      streams: {},
-      reasoning: {},
-      activity: {},
-      lastActive: {},
-      banner: null,
+  /**
+   * Puts messages in the channel and waits for the frame the transcript writes
+   * its offset on.
+   *
+   * `follow` writes now and again on the next frame, and skips the second call
+   * while one is already booked. Both are deliberate — see `lib/follow.ts` —
+   * and both mean the offset this asserts against is settled a frame later
+   * than the state change that caused it.
+   */
+  async function settle(next: () => Envelope[]) {
+    await act(async () => {
+      useStore.setState({ messages: { [MANAGER]: next() } });
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
     });
-
-    const { container, rerender } = render(
-      <ChannelView channel={ACTIVITY_CHANNEL} onOpenMenu={() => {}} />,
-    );
-    rerender(<ChannelView channel={MANAGER} onOpenMenu={() => {}} />);
-
-    const scroller = container.querySelector<HTMLElement>(".pane__scroll");
-    if (!scroller) throw new Error("no transcript to scroll");
-    const box = measure(scroller, 4000, 400);
-    // At the end, and then reading back through it.
-    box.to(3600);
-    box.to(1200);
-
-    act(() => {
-      useStore.setState({ messages: { [MANAGER]: [...rows, fromPeer("and another thing")] } });
-    });
-
-    expect(box.at()).toBe(1200);
-  });
+  }
 
   it("stays where it was put after a pair thread has been read and closed", async () => {
     // The transcript is unmounted while a thread is up, so what comes back is a
@@ -705,12 +684,20 @@ describe("a transcript scrolled up", () => {
     const scroller = container.querySelector<HTMLElement>(".pane__scroll");
     if (!scroller) throw new Error("no transcript to scroll");
     const box = measure(scroller, 4000, 400);
-    box.to(3600);
+
+    // The box only acquires a size here, so the transcript is brought to the
+    // end the way a real one arrives there: a message lands and it follows.
+    // Setting the offset by hand instead leaves the hook holding the end of a
+    // box that had no height when it last looked, which is a state no window
+    // can be in and which decided this assertion by whichever timer fired
+    // first.
+    await settle(() => [...rows, fromPeer("something newer")]);
+    expect(box.at()).toBe(3600);
+
+    // And now read back up it.
     box.to(900);
 
-    act(() => {
-      useStore.setState({ messages: { [MANAGER]: [...rows, fromPeer("and another thing")] } });
-    });
+    await settle(() => [...rows, fromPeer("something newer"), fromPeer("and another thing")]);
 
     expect(box.at()).toBe(900);
   });

--- a/src/components/ChannelView.tsx
+++ b/src/components/ChannelView.tsx
@@ -3,7 +3,7 @@ import { AgentAvatar } from "../avatars/AgentAvatar";
 import { useFollowBottom } from "../lib/follow";
 import { api } from "../lib/ipc";
 import { thoughtNow } from "../lib/reasoning";
-import { ACTIVITY_CHANNEL, type ChannelKey, useAgentLookup, useStore } from "../lib/store";
+import { type ChannelKey, useAgentLookup, useStore } from "../lib/store";
 import { elapsed, useNow } from "../lib/time";
 import {
   callInFlight,
@@ -22,7 +22,6 @@ import {
   errorMessage,
   plainText,
 } from "../lib/types";
-import { ActivityFlow } from "./ActivityFlow";
 import { CodingPanel } from "./CodingPanel";
 import { Composer } from "./Composer";
 import { Answering } from "./HtmlArtifact";
@@ -66,8 +65,7 @@ export function ChannelView({ channel, onOpenMenu }: Props) {
   // cascade is worse than a scrollbar that does not move: `lib/follow.ts`.
   const { ref: scrollRef, node: transcript, follow, pin } = useFollowBottom();
 
-  const isActivity = channel === ACTIVITY_CHANNEL;
-  const agent = isActivity ? undefined : lookups.byId(channel);
+  const agent = lookups.byId(channel);
   // Held steady across renders: it is the value of a context read by every page
   // in the transcript, and a fresh object each time would redraw all of them
   // for every token that lands anywhere.
@@ -135,20 +133,7 @@ export function ChannelView({ channel, onOpenMenu }: Props) {
   return (
     <section className="pane">
       <header className="pane__header">
-        {isActivity ? (
-          <>
-            <span
-              aria-hidden="true"
-              style={{ color: "var(--muted)", fontFamily: "var(--font-mono)" }}
-            >
-              #
-            </span>
-            <h1 className="pane__title">activity</h1>
-            <p className="pane__subtitle">
-              Who spoke to whom, in order. Click any arrow to read the message.
-            </p>
-          </>
-        ) : agent ? (
+        {agent ? (
           <>
             <AgentAvatar
               avatar={agent.avatar}
@@ -183,112 +168,102 @@ export function ChannelView({ channel, onOpenMenu }: Props) {
         )}
       </header>
 
-      {isActivity ? (
-        // A list cannot show who spoke to whom, so the activity view is a
-        // board rather than a transcript.
-        <ActivityFlow messages={messages ?? []} byId={lookups.byId} />
-      ) : (
-        // A log rather than a plain box, so a screen reader offers it as the
-        // transcript it is. `aria-live` is off deliberately: the role would
-        // otherwise announce politely, and opening a channel replaces three
-        // hundred rows at once, which is the whole history read aloud for the
-        // crime of clicking a name. What is worth hearing is announced by
-        // `Arrivals` below, one message at a time, as it lands.
-        <div
-          className="pane__scroll"
-          ref={scrollRef}
-          role="log"
-          aria-live="off"
-          aria-label={`Conversation with ${agent?.name ?? "this agent"}`}
-        >
-          {/* Who a page in this transcript may answer. Only here: the operator
+      {/* A log rather than a plain box, so a screen reader offers it as the
+          transcript it is. `aria-live` is off deliberately: the role would
+          otherwise announce politely, and opening a channel replaces three
+          hundred rows at once, which is the whole history read aloud for the
+          crime of clicking a name. What is worth hearing is announced by
+          `Arrivals` below, one message at a time, as it lands. */}
+      <div
+        className="pane__scroll"
+        ref={scrollRef}
+        role="log"
+        aria-live="off"
+        aria-label={`Conversation with ${agent?.name ?? "this agent"}`}
+      >
+        {/* Who a page in this transcript may answer. Only here: the operator
               is one of the two participants in a channel, so a value handed
               back has an obvious next message and an obvious recipient. */}
-          <Answering.Provider value={answering}>
-            {messages === undefined ? (
-              <p className="hint" style={{ padding: "1rem 1.15rem" }}>
-                Loading…
-              </p>
-            ) : messages.length === 0 ? (
-              <div className="empty">
-                <p className="empty__body">No messages with {agent?.name ?? "this agent"} yet.</p>
-              </div>
-            ) : (
-              rows.map((row) => {
-                const stands = rowStandsFor(row);
-                return (
-                  // Wrapped rather than marked on the entry itself: a row renders
-                  // as several different shapes depending on who sent what to
-                  // whom, and one of them is several rows.
-                  <div
-                    key={row.key}
-                    data-message={stands.join(" ")}
-                    data-found={focused && stands.includes(focused) ? "true" : undefined}
-                  >
-                    {row.kind === "peers" ? (
-                      <PeerBurstRow peers={row.peers} onOpen={setReading} />
-                    ) : row.kind === "refused" ? (
-                      <RefusedRow peer={row.peer} at={row.at} body={row.body} reason={row.reason} />
-                    ) : row.kind === "when" ? (
-                      <WhenRow at={row.at} />
-                    ) : (
-                      // Two participants, one of them named at the top of the
-                      // pane and the other reading this. Nothing here needs
-                      // telling whose words it is looking at.
-                      <MessageItem
-                        message={row.message}
-                        lookups={lookups}
-                        continued={row.continued}
-                        named={false}
-                      />
-                    )}
-                  </div>
-                );
-              })
-            )}
+        <Answering.Provider value={answering}>
+          {messages === undefined ? (
+            <p className="hint" style={{ padding: "1rem 1.15rem" }}>
+              Loading…
+            </p>
+          ) : messages.length === 0 ? (
+            <div className="empty">
+              <p className="empty__body">No messages with {agent?.name ?? "this agent"} yet.</p>
+            </div>
+          ) : (
+            rows.map((row) => {
+              const stands = rowStandsFor(row);
+              return (
+                // Wrapped rather than marked on the entry itself: a row renders
+                // as several different shapes depending on who sent what to
+                // whom, and one of them is several rows.
+                <div
+                  key={row.key}
+                  data-message={stands.join(" ")}
+                  data-found={focused && stands.includes(focused) ? "true" : undefined}
+                >
+                  {row.kind === "peers" ? (
+                    <PeerBurstRow peers={row.peers} onOpen={setReading} />
+                  ) : row.kind === "refused" ? (
+                    <RefusedRow peer={row.peer} at={row.at} body={row.body} reason={row.reason} />
+                  ) : row.kind === "when" ? (
+                    <WhenRow at={row.at} />
+                  ) : (
+                    // Two participants, one of them named at the top of the
+                    // pane and the other reading this. Nothing here needs
+                    // telling whose words it is looking at.
+                    <MessageItem
+                      message={row.message}
+                      lookups={lookups}
+                      continued={row.continued}
+                      named={false}
+                    />
+                  )}
+                </div>
+              );
+            })
+          )}
 
-            <LiveStreams channel={channel} lookups={lookups} follow={follow} />
-          </Answering.Provider>
-        </div>
-      )}
+          <LiveStreams channel={channel} lookups={lookups} follow={follow} />
+        </Answering.Provider>
+      </div>
 
-      {isActivity ? null : (
-        <>
-          {/* Outside the log on purpose. Inside it the sentence is a second
+      {/* Outside the log on purpose. Inside it the sentence is a second
               copy of the newest message for anybody reading the transcript
               itself, which is the cost of announcing it to everybody else. */}
-          <Arrivals channel={channel} messages={messages} lookups={lookups} />
-          {/* Above the line about the turn, because a coding job outlives the
+      <Arrivals channel={channel} messages={messages} lookups={lookups} />
+      {/* Above the line about the turn, because a coding job outlives the
               turn that started it: the turn footer is empty and the agent is
               idle while this is running. Keyed by agent so switching channels
               does not carry one job's tail into another's panel. */}
-          {agent && <CodingPanel key={`coding-${agent.id}`} agent={agent.id} />}
-          {/* Keyed by agent, so the disclosure below does not arrive already
+      {agent && <CodingPanel key={`coding-${agent.id}`} agent={agent.id} />}
+      {/* Keyed by agent, so the disclosure below does not arrive already
               open on a channel the operator has just switched to. */}
-          {agent && <TurnFooter key={agent.id} agent={agent} state={activity[agent.id]} />}
-          <Composer
-            placeholder={`Message ${agent?.name ?? "agent"}`}
-            group={agent?.groupId ?? null}
-            disabled={!agent || agent.lifecycle === "terminated"}
-            disabledReason="This agent has been deleted."
-            onSend={async (text, files) => {
-              if (!agent) return;
-              // Typing into the box is a decision to be at the end of the
-              // transcript, so this is the one thing besides opening a channel
-              // that overrides where the operator was reading. Their own
-              // message landing off screen, with nothing following it, is the
-              // same bug in the other direction.
-              pin();
-              try {
-                await api.sendMessage(agent.id, text, files);
-              } catch (error) {
-                setBanner({ tone: "error", text: errorMessage(error) });
-                throw error;
-              }
-            }}
-          />
-        </>
-      )}
+      {agent && <TurnFooter key={agent.id} agent={agent} state={activity[agent.id]} />}
+      <Composer
+        placeholder={`Message ${agent?.name ?? "agent"}`}
+        group={agent?.groupId ?? null}
+        disabled={!agent || agent.lifecycle === "terminated"}
+        disabledReason="This agent has been deleted."
+        onSend={async (text, files) => {
+          if (!agent) return;
+          // Typing into the box is a decision to be at the end of the
+          // transcript, so this is the one thing besides opening a channel
+          // that overrides where the operator was reading. Their own
+          // message landing off screen, with nothing following it, is the
+          // same bug in the other direction.
+          pin();
+          try {
+            await api.sendMessage(agent.id, text, files);
+          } catch (error) {
+            setBanner({ tone: "error", text: errorMessage(error) });
+            throw error;
+          }
+        }}
+      />
     </section>
   );
 }

--- a/src/components/GroupActivity.tsx
+++ b/src/components/GroupActivity.tsx
@@ -1,0 +1,66 @@
+/**
+ * A crew's traffic, as the flow board, inside that crew's settings.
+ *
+ * It was a channel at the top of the rail, under the wordmark and beside the
+ * search box: the first thing in the app after Guaca's own name, and one of the
+ * least-pressed things in it. What it answers — who spoke to whom, in what
+ * order, what set a run off and what the run cost — is analysis. Somebody
+ * arrives at it having decided to look into something, which is a completely
+ * different act from opening a channel, and a permanent row in the primary
+ * navigation is what said otherwise.
+ *
+ * Read here rather than held in the store, and that is the same decision again.
+ * The store maintained a second copy of every arriving message against a board
+ * nobody had necessarily ever opened; a board somebody opens deliberately can
+ * afford one read at the moment they open it. It does not follow the
+ * conversation afterward either, which is not a gap: a board that reshuffles
+ * under a reader is one they lose their place in, and the thing they came here
+ * to read has already happened.
+ */
+
+import { useEffect, useState } from "react";
+
+import { api } from "../lib/ipc";
+import { useAgentLookup } from "../lib/store";
+import { type Envelope, errorMessage, type GroupId } from "../lib/types";
+import { ActivityFlow } from "./ActivityFlow";
+
+/** How far back the board reaches. The store caps this at 2,000. */
+const WINDOW = 400;
+
+export function GroupActivity({ group }: { group: GroupId }) {
+  const lookups = useAgentLookup();
+  const [messages, setMessages] = useState<Envelope[] | null>(null);
+  const [failed, setFailed] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    setMessages(null);
+    setFailed(null);
+    void api
+      .conversationFlow(group, WINDOW)
+      .then((rows) => {
+        if (live) setMessages(rows);
+      })
+      .catch((caught) => {
+        if (live) setFailed(errorMessage(caught));
+      });
+    return () => {
+      live = false;
+    };
+  }, [group]);
+
+  if (failed) {
+    return (
+      <div className="empty">
+        <p className="empty__body">{failed}</p>
+      </div>
+    );
+  }
+
+  if (messages === null) {
+    return <p className="hint">Reading…</p>;
+  }
+
+  return <ActivityFlow messages={messages} byId={lookups.byId} />;
+}

--- a/src/components/GroupEditor.test.tsx
+++ b/src/components/GroupEditor.test.tsx
@@ -1,7 +1,14 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Group, GroupDraft, GroupReset, Settings, SubscriptionStatus } from "../lib/types";
+import type {
+  Envelope,
+  Group,
+  GroupDraft,
+  GroupReset,
+  Settings,
+  SubscriptionStatus,
+} from "../lib/types";
 import { aGroup } from "../test-fixtures";
 
 /**
@@ -78,6 +85,10 @@ const groupPlugins = vi.fn(async () => []);
 const pluginCatalog = vi.fn(async () => []);
 const groupRepositories = vi.fn(async () => []);
 const codingHarnesses = vi.fn(async () => []);
+const conversationFlow = vi.fn<(group: string, limit?: number) => Promise<Envelope[]>>(
+  async () => [],
+);
+const usageForRuns = vi.fn(async () => []);
 
 vi.mock("../lib/ipc", () => ({
   api: {
@@ -93,6 +104,8 @@ vi.mock("../lib/ipc", () => ({
     pluginCatalog: () => pluginCatalog(),
     groupRepositories: () => groupRepositories(),
     codingHarnesses: () => codingHarnesses(),
+    conversationFlow: (group: string, limit?: number) => conversationFlow(group, limit),
+    usageForRuns: () => usageForRuns(),
   },
 }));
 
@@ -482,5 +495,61 @@ describe("deleting a group", () => {
     open(null);
     expect(screen.queryByText("Delete")).toBeNull();
     expect(screen.queryByText("Start fresh")).toBeNull();
+  });
+});
+
+/**
+ * The flow board, which is here rather than in the rail.
+ *
+ * It sat at the top of the rail under the wordmark, one row above the search
+ * box: the first thing in the app after Guaca's own name, and one of the least
+ * pressed things in it. Who spoke to whom and what a run cost is analysis, and
+ * somebody arrives at it having decided to look into something.
+ */
+describe("a crew's activity", () => {
+  function said(over: Partial<Envelope> = {}): Envelope {
+    return {
+      id: "m1",
+      runId: "r1",
+      channelId: "chef",
+      from: { kind: "human" },
+      to: { kind: "agent", id: "chef" },
+      parts: [{ type: "text", text: "how is the prep going" }],
+      trust: "operator",
+      hop: 0,
+      expectsReply: true,
+      intent: "work",
+      cause: null,
+      createdAt: 1_700_000_000_000,
+      ...over,
+    };
+  }
+
+  it("reads this crew's conversation and nobody else's", async () => {
+    // Scoped in SQL rather than filtered here, and the limit is why: the board
+    // is the newest few hundred messages, so a busy crew filling that window
+    // would hand a quiet crew an empty board.
+    conversationFlow.mockResolvedValueOnce([said()]);
+    open(aGroup({ id: KITCHEN, name: "Kitchen" }));
+    pane("Activity");
+
+    await waitFor(() => expect(conversationFlow).toHaveBeenCalled());
+    expect(conversationFlow.mock.calls[0]![0]).toBe(KITCHEN);
+    // Twice on purpose: the run's own opening line, and the row inside it.
+    expect(await screen.findAllByText(/how is the prep going/)).toHaveLength(2);
+  });
+
+  it("says nothing has happened rather than drawing an empty board", async () => {
+    open();
+    pane("Activity");
+
+    expect(await screen.findByText(/Nothing has happened yet/)).toBeTruthy();
+  });
+
+  it("is not offered on a group that does not exist yet", () => {
+    // Nothing has been said in a crew nobody has created, and the read would
+    // have no id to ask about.
+    open(null);
+    expect(screen.getByRole("tab", { name: "Activity" }).hasAttribute("disabled")).toBe(true);
   });
 });

--- a/src/components/GroupEditor.tsx
+++ b/src/components/GroupEditor.tsx
@@ -28,6 +28,7 @@ import {
   type SubscriptionStatus,
 } from "../lib/types";
 import { CredentialList } from "./CredentialList";
+import { GroupActivity } from "./GroupActivity";
 import { PluginList } from "./PluginList";
 import { ProviderPresets, SubscriptionModel } from "./ProviderFields";
 import { RepositoryList } from "./RepositoryList";
@@ -38,7 +39,7 @@ interface Props {
   onClose: () => void;
 }
 
-const SECTIONS = ["general", "provider", "limits", "plugins", "repositories"] as const;
+const SECTIONS = ["general", "provider", "limits", "plugins", "repositories", "activity"] as const;
 
 type Section = (typeof SECTIONS)[number];
 
@@ -48,6 +49,7 @@ const SECTION_LABELS: Record<Section, string> = {
   limits: "Limits",
   plugins: "Plugins",
   repositories: "Repositories",
+  activity: "Activity",
 };
 
 /**
@@ -56,7 +58,7 @@ const SECTION_LABELS: Record<Section, string> = {
  * belong to something, and there is no row to hang any of them on until the
  * group is created.
  */
-const NEEDS_GROUP: readonly Section[] = ["plugins", "repositories"];
+const NEEDS_GROUP: readonly Section[] = ["plugins", "repositories", "activity"];
 
 /** What a group says when it has no opinion about who pays. */
 const INHERIT = "inherit";
@@ -366,7 +368,14 @@ export function GroupEditor({ group, onClose }: Props) {
             ))}
           </div>
 
-          <div className="settings__pane">
+          {/* The board brings its own scrolling and wants the whole pane, so
+              the pane stops being a padded column of prose for that one
+              section. See `.settings__pane--board`. */}
+          <div
+            className={
+              section === "activity" ? "settings__pane settings__pane--board" : "settings__pane"
+            }
+          >
             {section === "general" && (
               <>
                 <h3 className="settings__title">General</h3>
@@ -674,6 +683,17 @@ export function GroupEditor({ group, onClose }: Props) {
                   not inherit it.
                 </p>
                 <RepositoryList groupId={group.id} crew={members} />
+              </>
+            )}
+
+            {section === "activity" && group && (
+              <>
+                <h3 className="settings__title">Activity</h3>
+                <p className="settings__lede">
+                  Who spoke to whom in this crew, in order, one board per run. Click any arrow to
+                  read the message. Read when this pane was opened; reopen it for anything since.
+                </p>
+                <GroupActivity group={group.id} />
               </>
             )}
 

--- a/src/components/GroupRail.tsx
+++ b/src/components/GroupRail.tsx
@@ -1,4 +1,7 @@
+import { useEffect, useRef, useState } from "react";
+
 import type { DropTarget } from "../lib/rail";
+import { reaches } from "../lib/reach";
 import type { Activity, AgentCard, AgentId, Escalation, Group, GroupId } from "../lib/types";
 import { GroupOrb } from "./GroupOrb";
 import { OrbTag, useOrbTag } from "./OrbTag";
@@ -17,10 +20,20 @@ interface Props {
   isOver: (target: DropTarget) => boolean;
   onDragOver: (target: DropTarget) => void;
   onDragOut: () => void;
+  /**
+   * Whether the operator is currently holding an agent.
+   *
+   * Held out for the whole of a drag, whatever the pointer is doing. A drop
+   * onto a circle is the one thing this column is load-bearing for, and a
+   * column that slid away as the hand carried a row across it would take the
+   * target with it halfway through the gesture.
+   */
+  dragging: boolean;
 }
 
 /**
- * The crews, as a column of their own on the far left.
+ * The crews, as a column of their own on the far left, out of the way until
+ * it is reached for.
  *
  * This was a strip of circles inside the rail, wrapping onto a second line at
  * five crews and a third at nine. It did not overflow or scroll: it ate the
@@ -28,12 +41,26 @@ interface Props {
  * its agent list on the navigation for it. Four was a hard wall nobody chose.
  *
  * A column has the axis to spare, and it buys two things the strip could not.
- * The crews are on screen no matter where the operator is, including while the
+ * The crews are reachable no matter where the operator is, including while the
  * rail is inside one of them, so the badge on a circle is the only permanent
  * statement in the app about the crews you are not looking at: see
  * `lib/presence.ts` for what it may say. And "which crew am I in" stops being
  * something the rail has to give a heading to, because the answer is a lit
  * circle in a fixed place.
+ *
+ * Standing open, that column charged every window four rem of width for a
+ * choice most operators make a few times a day, in front of the rail that is
+ * read constantly. So it is a band at the edge of the window that slides out
+ * when the pointer comes at it, over the rail rather than pushing it: nothing
+ * reflows, the rail keeps its measure, and the gesture is the one somebody
+ * heading for the left edge is already making. `lib/reach.ts` owns when, and
+ * the two thresholds it uses and why there are two.
+ *
+ * Three things hold it out, and none of them is a click. Proximity, a drag in
+ * progress, and focus inside it, which is what makes the column reachable from
+ * the keyboard: tabbing into a circle slides the column out around it, and a
+ * column that came out only for a pointer would be one nobody could see what
+ * they had selected in.
  *
  * Still absent while there is one group, which is the state most workspaces are
  * in and the same rule the strip had. A column offering a choice of one is a
@@ -51,58 +78,86 @@ export function GroupRail({
   isOver,
   onDragOver,
   onDragOut,
+  dragging,
 }: Props) {
   const all = useOrbTag();
+  const zone = useRef<HTMLSpanElement>(null);
+  const slab = useRef<HTMLDivElement>(null);
+  const [near, setNear] = useState(false);
+
+  // On the window rather than on a strip the pointer can enter, because a strip
+  // wide enough to be aimed at overlays the left edge of every agent row behind
+  // it and swallows the click. Both boxes are measured on each movement rather
+  // than cached: the column's own edge is the thing that moves, and the zone's
+  // is a length in the stylesheet that changes with the interface scale.
+  useEffect(() => {
+    const move = (event: PointerEvent) => {
+      const reach = zone.current?.getBoundingClientRect();
+      const column = slab.current?.getBoundingClientRect();
+      if (!reach || !column) return;
+      setNear((open) => reaches(open, { x: event.clientX, y: event.clientY }, { reach, column }));
+    };
+    window.addEventListener("pointermove", move);
+    return () => window.removeEventListener("pointermove", move);
+  }, []);
 
   if (groups.length < 2) return null;
 
   return (
-    <nav className="grail" aria-label="Groups">
-      {/* Everybody, which is the view the rail had before crews were places you
-          could be inside. A count rather than the word, because the label
-          already says "all" and a group's name can be anything, including
-          "everyone". */}
-      <button
-        type="button"
-        className="orb orb--all"
-        aria-current={focused === null}
-        aria-label={`All groups, ${agents.length} agents`}
-        title="All groups"
-        onClick={() => onFocus(null)}
-        onPointerEnter={all.open}
-        onPointerLeave={all.close}
-        onFocus={all.open}
-        onBlur={all.close}
-      >
-        <span className="orb__ring">
-          <span className="orb__all-count">{agents.length}</span>
-        </span>
-        {all.at !== null && (
-          <OrbTag name="All groups" note={`${agents.length} agents`} at={all.at} />
-        )}
-      </button>
+    <nav className="grail" aria-label="Groups" data-out={near || dragging ? "true" : undefined}>
+      {/* The proximity zone, as a box. It carries no pixels and cannot be
+          clicked; what it is for is that its size and its distance from the top
+          of the window are lengths, and every length in this app is named in
+          one stylesheet rather than written into a component. */}
+      <span className="grail__reach" aria-hidden="true" ref={zone} />
 
-      <span className="grail__rule" aria-hidden="true" />
+      <div className="grail__slab" ref={slab}>
+        {/* Everybody, which is the view the rail had before crews were places you
+            could be inside. A count rather than the word, because the label
+            already says "all" and a group's name can be anything, including
+            "everyone". */}
+        <button
+          type="button"
+          className="orb orb--all"
+          aria-current={focused === null}
+          aria-label={`All groups, ${agents.length} agents`}
+          title="All groups"
+          onClick={() => onFocus(null)}
+          onPointerEnter={all.open}
+          onPointerLeave={all.close}
+          onFocus={all.open}
+          onBlur={all.close}
+        >
+          <span className="orb__ring">
+            <span className="orb__all-count">{agents.length}</span>
+          </span>
+          {all.at !== null && (
+            <OrbTag name="All groups" note={`${agents.length} agents`} at={all.at} />
+          )}
+        </button>
 
-      {/* Scrolls rather than wraps, which is the whole point of turning this
-          upright: a workspace can hold more crews than fit down the side of a
-          window, and the ones that do not fit have to be reachable rather than
-          folded into a second column. */}
-      <div className="grail__list">
-        {groups.map((group) => (
-          <GroupOrb
-            key={group.id}
-            group={group}
-            members={agents.filter((a) => a.groupId === group.id)}
-            activity={activity}
-            stuck={stuck}
-            current={focused === group.id}
-            over={isOver({ kind: "group", id: group.id })}
-            onOpen={() => onFocus(focused === group.id ? null : group.id)}
-            onDragOver={() => onDragOver({ kind: "group", id: group.id })}
-            onDragOut={onDragOut}
-          />
-        ))}
+        <span className="grail__rule" aria-hidden="true" />
+
+        {/* Scrolls rather than wraps, which is the whole point of turning this
+            upright: a workspace can hold more crews than fit down the side of a
+            window, and the ones that do not fit have to be reachable rather than
+            folded into a second column. */}
+        <div className="grail__list">
+          {groups.map((group) => (
+            <GroupOrb
+              key={group.id}
+              group={group}
+              members={agents.filter((a) => a.groupId === group.id)}
+              activity={activity}
+              stuck={stuck}
+              current={focused === group.id}
+              over={isOver({ kind: "group", id: group.id })}
+              onOpen={() => onFocus(focused === group.id ? null : group.id)}
+              onDragOver={() => onDragOver({ kind: "group", id: group.id })}
+              onDragOut={onDragOut}
+            />
+          ))}
+        </div>
       </div>
     </nav>
   );

--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -102,7 +102,8 @@ export function Inspector({ agent, onEditProfile }: Props) {
     taken();
   }, [asked, taken]);
 
-  // Nothing to inspect on the activity board, which is about the whole crew.
+  // Nothing to inspect with no channel open, which is what going inside a crew
+  // the open one was not in leaves behind.
   if (!agent) return null;
 
   if (!open) {

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -357,8 +357,94 @@ describe("pins", () => {
   });
 });
 
+describe("what the rail offers", () => {
+  it("does not offer the flow board", () => {
+    // It sat here, under the wordmark and above the search box: the first thing
+    // in the app after Guaca's own name, and one of the least pressed things in
+    // it. Who spoke to whom and what a run cost is analysis, so it is in a
+    // crew's settings where somebody who has decided to look into something
+    // will find it.
+    draw([group("everyone")], [agent("Manager")]);
+    expect(screen.queryByRole("button", { name: /activity/i })).toBeNull();
+  });
+});
+
 describe("groups as places", () => {
   const RESEARCH = "00000000-0000-4000-8000-000000000002";
+
+  /**
+   * Gives the two boxes the proximity decision reads a size.
+   *
+   * jsdom does no layout, so both come back as zeros and every threshold
+   * collapses onto the same pixel. These are the numbers a real window has: a
+   * zone reaching 20px in and starting under the window's own buttons, and a
+   * column that is 8px of itself when it is in and 64px when it is out.
+   */
+  function laid(out: boolean) {
+    const box = (over: Partial<DOMRect>) => () => ({ top: 0, right: 0, ...over }) as DOMRect;
+    document.querySelector<HTMLElement>(".grail__reach")!.getBoundingClientRect = box({
+      top: 36,
+      right: 20,
+    });
+    document.querySelector<HTMLElement>(".grail__slab")!.getBoundingClientRect = box({
+      right: out ? 64 : 8,
+    });
+  }
+
+  /** Whether the crews are drawn out over the rail. */
+  function out(): boolean {
+    return screen.getByLabelText("Groups").getAttribute("data-out") === "true";
+  }
+
+  it("keeps the crews in until the pointer comes at them", () => {
+    // The column stood open and charged every window four rem of its width for
+    // a choice most operators make a few times a day, in front of the rail that
+    // is read constantly.
+    draw(
+      [group("everyone"), group("research", null, RESEARCH)],
+      [agent("Manager"), agent("Reader", { groupId: RESEARCH, railOrder: 1 })],
+    );
+    laid(false);
+
+    fireEvent.pointerMove(window, { clientX: 700, clientY: 400 });
+    expect(out()).toBe(false);
+
+    fireEvent.pointerMove(window, { clientX: 6, clientY: 400 });
+    expect(out()).toBe(true);
+  });
+
+  it("leaves the window's own buttons alone", () => {
+    // macOS floats close, minimize and zoom over the top left corner, which is
+    // this column. Coming out on the way to them would put the crews under the
+    // pointer at the moment it was aimed at the button that closes the app.
+    draw(
+      [group("everyone"), group("research", null, RESEARCH)],
+      [agent("Manager"), agent("Reader", { groupId: RESEARCH, railOrder: 1 })],
+    );
+    laid(false);
+
+    fireEvent.pointerMove(window, { clientX: 6, clientY: 18 });
+    expect(out()).toBe(false);
+  });
+
+  it("stays out for the whole of a drag, wherever the hand has got to", async () => {
+    // A drop onto a circle is the one thing this column is load-bearing for. A
+    // column that slid away as the hand carried a row across the app would take
+    // the target with it half way through the gesture.
+    draw(
+      [group("everyone"), group("research", null, RESEARCH)],
+      [agent("Manager"), agent("Reader", { groupId: RESEARCH, railOrder: 1 })],
+    );
+    laid(false);
+
+    fireEvent.pointerDown(row("Manager"), { button: 0, clientX: 400, clientY: 200 });
+    fireEvent.pointerMove(window, { clientX: 400, clientY: 240 });
+
+    expect(out()).toBe(true);
+
+    fireEvent.pointerUp(window, { clientX: 400, clientY: 240 });
+    expect(out()).toBe(false);
+  });
 
   it("keeps the column out of the way while there is one group", () => {
     draw([group("everyone")], [agent("Manager")]);
@@ -577,7 +663,7 @@ describe("groups as places", () => {
     useStore.setState({ selected: "Chief" });
 
     fireEvent.click(screen.getByLabelText("research, 1 agent"));
-    await vi.waitFor(() => expect(useStore.getState().selected).toBe("activity"));
+    await vi.waitFor(() => expect(useStore.getState().selected).toBeNull());
 
     fireEvent.click(screen.getByLabelText("All groups, 2 agents"));
     fireEvent.click(row("Chief of research"));

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import { FLIGHT_MS, roleOf, usePulseChoreography } from "../lib/choreography";
 import { composted } from "../lib/compost";
 import { prefersReducedMotion } from "../lib/motion";
 import { type DropTarget, railOrder } from "../lib/rail";
-import { ACTIVITY_CHANNEL, useLiveAgents, useStore } from "../lib/store";
+import { useLiveAgents, useStore } from "../lib/store";
 import { relativeTime, useNow } from "../lib/time";
 import type { Activity, AgentCard, AgentId, Group } from "../lib/types";
 import { GroupRail } from "./GroupRail";
@@ -460,6 +460,7 @@ export function Sidebar({
         isOver={isOver}
         onDragOver={hover}
         onDragOut={() => hover(null)}
+        dragging={drag !== null}
       />
 
       <nav className="rail" aria-label="Agents" data-dragging={drag ? "true" : undefined}>
@@ -480,18 +481,6 @@ export function Sidebar({
           </span>
           <span className="rail__search-label">Search</span>
           <kbd className="rail__key">{FIND_KEY}</kbd>
-        </button>
-
-        <button
-          type="button"
-          className="btn btn--rail"
-          data-current={selected === ACTIVITY_CHANNEL}
-          onClick={() => void select(ACTIVITY_CHANNEL)}
-        >
-          <span aria-hidden="true" className="rail__hash">
-            #
-          </span>
-          activity
         </button>
 
         {/* The wire lives on this wrapper rather than on the scroll container, so

--- a/src/lib/appearance.test.ts
+++ b/src/lib/appearance.test.ts
@@ -25,9 +25,9 @@ import type { UiScale } from "./prefs";
  * Two of them are load-bearing past the obvious. `system` must never reach the
  * attribute, because the stylesheet has one dark block and it is keyed on
  * `dark`: written through verbatim, an operator who asked the OS gets paper in
- * a dark room. And no `--rail-*` name may be written at all, because the rail
- * is dark in both surfaces and a surface that quietly repainted it would look
- * deliberate.
+ * a dark room. And no `--rail-*` name may be written at all: the navigation
+ * columns follow the surface through the stylesheet's own dark block, so an
+ * inline override from here would pin them to one surface and look deliberate.
  */
 
 /** The stub `test-setup.ts` installs, so a test that replaces it can put it back. */
@@ -143,9 +143,9 @@ describe("what applying an appearance writes", () => {
   it("writes no --rail property, so a surface cannot repaint the rail", () => {
     applyAppearance(125, "dark");
 
-    // The rail is dark in both surfaces and pins its own accents. A `--rail-*`
-    // override written from here would look like a design decision, and no
-    // color assertion in jsdom could ever catch it.
+    // The columns follow the surface through the stylesheet's own dark block.
+    // A `--rail-*` override written from here would pin them to one surface and
+    // look like a design decision, and no color assertion in jsdom could catch it.
     expect(inlineProperties().filter((name) => name.startsWith("--rail"))).toEqual([]);
     expect(document.documentElement.getAttribute("style")).not.toContain("--rail");
   });

--- a/src/lib/appearance.ts
+++ b/src/lib/appearance.ts
@@ -28,7 +28,7 @@ import type { SurfaceMode, UiScale } from "./prefs";
  *
  * The same number appears in `styles.css` as `calc(16px * var(--ui-scale))`,
  * which is where it takes effect. This copy exists for the one thing that has
- * to do the arithmetic itself: the activity board draws its lanes as SVG
+ * to do the arithmetic itself: the flow board draws its lanes as SVG
  * coordinates, so it needs a width in pixels rather than in `rem`. If either
  * changes, both have to.
  */

--- a/src/lib/follow.test.ts
+++ b/src/lib/follow.test.ts
@@ -8,7 +8,7 @@ import { useFollowBottom } from "./follow";
  *
  * The report behind this: being scrolled up in a channel and thrown back to
  * the end of it, at times nobody could name. Two of them were nameable. A
- * channel opened from the activity board was listening for scrolls on a node
+ * channel reopened after a pair thread was listening for scrolls on a node
  * that had already been thrown away, so it never learned the operator had
  * moved at all; and the eighty-pixel threshold it used when it did work could
  * not be climbed out of while text was arriving, because every frame put the
@@ -335,8 +335,8 @@ describe("following the newest line", () => {
   });
 
   it("listens to the box that is on screen now, not the one that was", () => {
-    // A transcript is unmounted whenever the pane shows a pair thread or the
-    // activity board, and comes back as a different node. Bound to the old one,
+    // A transcript is unmounted whenever the pane shows a pair thread, or
+    // nothing at all, and comes back as a different node. Bound to the old one,
     // nothing ever reported a scroll and every message won.
     const view = attach();
     view.hook.pin();

--- a/src/lib/follow.ts
+++ b/src/lib/follow.ts
@@ -104,11 +104,12 @@ export function useFollowBottom(): FollowBottom {
 
   // A ref callback rather than an effect, because the element this listens to
   // is not the element that was here last render. A transcript is unmounted
-  // whenever the pane shows something else (a pair thread, the activity board)
-  // and comes back as a new node with the same class. An effect can only
-  // re-bind on a dependency it was given, and the node it holds is not one: a
-  // channel opened from the activity board bound its listener to the node that
-  // had just been thrown away, so the operator was never noticed coming back.
+  // whenever the pane shows something else — a pair thread, or nothing at all
+  // once the operator has gone inside a crew the open channel was not in — and
+  // comes back as a new node with the same class. An effect can only re-bind on
+  // a dependency it was given, and the node it holds is not one: a channel
+  // reopened after one of those bound its listener to the node that had just
+  // been thrown away, so the operator was never noticed coming back.
   const ref = useCallback<RefCallback<HTMLElement>>(
     (box) => {
       node.current = box;

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -473,8 +473,9 @@ export const api = {
   pairMessages: (a: AgentId, b: AgentId, limit?: number) =>
     invoke<Envelope[]>("pair_messages", { a, b, limit }),
 
-  /** The whole conversation, for the activity flow board. */
-  conversationFlow: (limit?: number) => invoke<Envelope[]>("conversation_flow", { limit }),
+  /** One crew's conversation, for the flow board in its settings. */
+  conversationFlow: (group: GroupId, limit?: number) =>
+    invoke<Envelope[]>("conversation_flow", { group, limit }),
 
   /**
    * Messages, files, links and routines matching a query.

--- a/src/lib/reach.test.ts
+++ b/src/lib/reach.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { type Reach, reaches } from "./reach";
+
+/** A collapsed column: the band is 8px wide, the zone reaches 20px in. */
+const SHUT: Reach = { reach: { top: 36, right: 20 }, column: { right: 8 } };
+
+/** The same column out: 64px of it, and the zone unchanged. */
+const OUT: Reach = { reach: { top: 36, right: 20 }, column: { right: 64 } };
+
+describe("the crews' column", () => {
+  it("comes out when the pointer reaches the edge of the window", () => {
+    expect(reaches(false, { x: 6, y: 400 }, SHUT)).toBe(true);
+  });
+
+  it("stays in for a pointer crossing the middle of the app", () => {
+    expect(reaches(false, { x: 700, y: 400 }, SHUT)).toBe(false);
+  });
+
+  it("leaves the window's own buttons alone", () => {
+    // macOS floats close, minimize and zoom over the top left corner, which is
+    // this column. Opening on the way to them would put the crews under the
+    // pointer at the moment it was aimed at the button that closes the app.
+    expect(reaches(false, { x: 6, y: 18 }, SHUT)).toBe(false);
+  });
+
+  it("stays out while the pointer is anywhere on it", () => {
+    expect(reaches(true, { x: 40, y: 400 }, OUT)).toBe(true);
+  });
+
+  it("stays out just past it, rather than closing at the pixel that opened it", () => {
+    // The gap between the two thresholds. Without it a hand resting on the
+    // boundary flickers the column: it closes, which puts the pointer back
+    // inside the zone, which opens it.
+    expect(reaches(true, { x: 70, y: 400 }, OUT)).toBe(true);
+  });
+
+  it("goes back in once the pointer has left it by the same distance again", () => {
+    expect(reaches(true, { x: 90, y: 400 }, OUT)).toBe(false);
+  });
+
+  it("comes out for a pointer coming back at it from the right", () => {
+    expect(reaches(false, { x: 3, y: 500 }, SHUT)).toBe(true);
+  });
+});

--- a/src/lib/reach.ts
+++ b/src/lib/reach.ts
@@ -1,0 +1,50 @@
+/**
+ * Whether the crews' column is out, decided from where the pointer is.
+ *
+ * The column stood open and cost every window four rem of its width to offer a
+ * choice most operators make a few times a day. Collapsed to a band at the edge
+ * it costs half a rem, and the way back to it is moving toward it, which is the
+ * gesture somebody reaching for the left edge of the window is already making.
+ *
+ * Two thresholds rather than one, and the gap between them is the whole point.
+ * A single line means the column closes at exactly the pixel that opens it, so
+ * a hand resting at the boundary flickers it, and the moment it starts to close
+ * the pointer is inside the zone again. So: coming within `reach.right` opens
+ * it, going past the far side of the column plus that same distance again
+ * closes it, and in between it is left as it was.
+ *
+ * The numbers are read off the DOM rather than written here, because both of
+ * them are lengths and every length in this app is named in one stylesheet at
+ * one scale. `reach` is a box CSS positions and sizes and nothing can click,
+ * and its `top` is the second half of that: on macOS the window's own buttons
+ * float over the top left corner, and a zone that ran to the top of the window
+ * would slide the crews out every time somebody went to close the app.
+ *
+ * Read from the pointer rather than from `:hover` on a strip over the rail.
+ * A strip wide enough to be aimed at is a strip that swallows clicks on the
+ * left edge of every agent row behind it, and a row that does nothing when it
+ * is clicked near its left side is a worse bug than the one this fixes.
+ */
+
+export interface Reach {
+  /**
+   * The proximity zone: come inside it and the column comes out. Its `top` is
+   * where the zone starts, which is under the window's own buttons.
+   */
+  reach: { top: number; right: number };
+  /** The column itself, wherever it currently is. */
+  column: { right: number };
+}
+
+/** Where the pointer is, in window coordinates. */
+export interface At {
+  x: number;
+  y: number;
+}
+
+export function reaches(open: boolean, at: At, boxes: Reach): boolean {
+  const { reach, column } = boxes;
+  if (at.x <= reach.right && at.y >= reach.top) return true;
+  if (at.x > column.right + reach.right) return false;
+  return open;
+}

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -21,7 +21,7 @@ vi.mock("./ipc", () => ({
   onRuntimeEvent: vi.fn(),
 }));
 
-const { ACTIVITY_CHANNEL, useStore } = await import("./store");
+const { useStore } = await import("./store");
 const { DEFAULT_PREFS } = await import("./prefs");
 
 function envelope(overrides: Partial<Envelope> = {}): Envelope {
@@ -150,33 +150,6 @@ describe("messageAppended", () => {
     apply({ type: "messageAppended", message: envelope({ id: "z", createdAt: 100 }) });
     apply({ type: "messageAppended", message: envelope({ id: "a", createdAt: 100 }) });
     expect(useStore.getState().messages.chef?.map((m) => m.id)).toEqual(["a", "z"]);
-  });
-
-  it("puts the whole conversation on the flow board", () => {
-    // Including the operator's own messages: a flow that starts at the first
-    // agent-to-agent message hides who set it off.
-    reset({ chef: [], [ACTIVITY_CHANNEL]: [] });
-    apply({ type: "messageAppended", message: envelope({ id: "a" }) });
-    apply({
-      type: "messageAppended",
-      message: envelope({
-        id: "b",
-        from: { kind: "agent", id: "manager" },
-        to: { kind: "agent", id: "chef" },
-      }),
-    });
-    expect(useStore.getState().messages[ACTIVITY_CHANNEL]).toHaveLength(2);
-  });
-
-  it("keeps private activity records off the flow board", () => {
-    // An agent's own tool trail is bookkeeping, not a message between two
-    // participants, so it has no arrow to draw.
-    reset({ chef: [], [ACTIVITY_CHANNEL]: [] });
-    apply({
-      type: "messageAppended",
-      message: envelope({ from: { kind: "agent", id: "chef" }, to: { kind: "system" } }),
-    });
-    expect(useStore.getState().messages[ACTIVITY_CHANNEL]).toHaveLength(0);
   });
 });
 
@@ -480,13 +453,6 @@ describe("the group the rail is inside", () => {
     expect(useStore.getState().railGroup).toBe(AGENTS[0]!.groupId);
   });
 
-  it("is left alone by the activity feed, which belongs to no group", async () => {
-    reset({ chef: [] });
-    await useStore.getState().focusGroup(AGENTS[0]!.groupId);
-    await useStore.getState().select(ACTIVITY_CHANNEL);
-    expect(useStore.getState().railGroup).toBe(AGENTS[0]!.groupId);
-  });
-
   it("follows the channel being opened into the crew it belongs to", async () => {
     // A search hit or a click on the flow board can land anywhere, and a rail
     // still showing one crew while the pane shows a member of another has the
@@ -561,11 +527,12 @@ describe("the channel open when the rail goes inside a crew", () => {
 
     await useStore.getState().focusGroup(AGENTS[1]!.groupId);
 
-    expect(useStore.getState().selected).toBe(ACTIVITY_CHANNEL);
+    // Nothing open, rather than the first row of the crew being entered.
+    // Opening a channel is the operator naming somebody, and a crew that
+    // picked one for them would put an agent's history on screen as a side
+    // effect of a click that was about the crew.
+    expect(useStore.getState().selected).toBeNull();
     expect(useStore.getState().railGroup).toBe(AGENTS[1]!.groupId);
-    // Landed on rather than merely pointed at: the feed the pane falls back to
-    // is read here, and nowhere else.
-    expect(useStore.getState().messages[ACTIVITY_CHANNEL]).toBeDefined();
   });
 
   it("stays open when it belongs to the crew being opened", async () => {
@@ -588,16 +555,6 @@ describe("the channel open when the rail goes inside a crew", () => {
     expect(useStore.getState().selected).toBe("chef-research");
     expect(useStore.getState().railGroup).toBeNull();
   });
-
-  it("leaves the activity feed alone, because it belongs to no crew", async () => {
-    twoCrews();
-    useStore.setState({ selected: ACTIVITY_CHANNEL });
-
-    await useStore.getState().focusGroup(RESEARCH);
-
-    expect(useStore.getState().selected).toBe(ACTIVITY_CHANNEL);
-    expect(useStore.getState().railGroup).toBe(RESEARCH);
-  });
 });
 
 describe("activity", () => {
@@ -617,20 +574,17 @@ describe("activity", () => {
 });
 
 describe("channelsCleared", () => {
-  it("drops what it is holding for the cleared channels, and the feed with them", async () => {
+  it("drops what it is holding for the cleared channels", async () => {
     // The bug this covers: clearing a group left the open transcript on screen
     // until the operator clicked away and back.
     reset({
       chef: [envelope()],
       manager: [envelope({ channelId: "manager" })],
-      activity: [envelope()],
     });
 
     apply({ type: "channelsCleared", agents: ["chef"] });
 
     expect(useStore.getState().messages.chef).toBeUndefined();
-    // The feed draws from every channel, so it is stale too.
-    expect(useStore.getState().messages.activity).toBeUndefined();
     // A channel that was not cleared keeps what it had.
     expect(useStore.getState().messages.manager).toHaveLength(1);
   });

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -51,9 +51,15 @@ import type {
 } from "./types";
 import { errorMessage } from "./types";
 
-/** The activity feed is addressed like a channel but is not an agent. */
-export const ACTIVITY_CHANNEL = "activity" as const;
-export type ChannelKey = AgentId | typeof ACTIVITY_CHANNEL;
+/**
+ * A channel is an agent, and nothing else is one.
+ *
+ * The flow board used to be addressed as a channel here, which made every
+ * function that took a channel take a value that was not an agent and cost
+ * seven of them a branch. It is analysis rather than a place you talk, so it
+ * moved into the group editor and reads its own history: `GroupActivity`.
+ */
+export type ChannelKey = AgentId;
 
 export interface StreamBuffer {
   channelId: AgentId;
@@ -384,9 +390,8 @@ function insert(existing: Envelope[] | undefined, message: Envelope): Envelope[]
  * Which crew the rail is inside once a channel has been opened.
  *
  * One invariant, from this end: the rail has to be drawing the row of whatever
- * the pane is showing. A search hit or a click on the flow board can land on a
- * member of any crew, and a rail still showing the one you were in has the open
- * channel nowhere on it.
+ * the pane is showing. A search hit can land on a member of any crew, and a
+ * rail still showing the one you were in has the open channel nowhere on it.
  *
  * It follows the agent rather than dropping out to the overview, which is what
  * it used to do. Dropping out was the only honest answer while the crews lived
@@ -400,7 +405,7 @@ function insert(existing: Envelope[] | undefined, message: Envelope): Envelope[]
  * it is already on screen and there is nothing to repair.
  */
 function keptFocus(state: State, key: ChannelKey): GroupId | null {
-  if (state.railGroup === null || key === ACTIVITY_CHANNEL) return state.railGroup;
+  if (state.railGroup === null) return state.railGroup;
   const agent = state.agents.find((a) => a.id === key);
   return agent ? agent.groupId : state.railGroup;
 }
@@ -410,8 +415,7 @@ function keptFocus(state: State, key: ChannelKey): GroupId | null {
  *
  * The same invariant as `keptFocus` read from the other end: the rail has to be
  * able to draw the channel that is open. Going back out to the overview keeps
- * whatever was open, because the overview draws everybody. The activity feed
- * belongs to no group and is never closed.
+ * whatever was open, because the overview draws everybody.
  *
  * This end still lets go rather than following, and the asymmetry is the point.
  * `select` is the operator naming an agent, so taking them to that agent's crew
@@ -420,7 +424,7 @@ function keptFocus(state: State, key: ChannelKey): GroupId | null {
  */
 function keptChannel(state: State, group: GroupId | null): boolean {
   const key = state.selected;
-  if (group === null || key === null || key === ACTIVITY_CHANNEL) return true;
+  if (group === null || key === null) return true;
   const agent = state.agents.find((a) => a.id === key);
   return agent === undefined || agent.groupId === group;
 }
@@ -536,11 +540,11 @@ export const useStore = create<State>((set, get) => ({
     // If the open channel was just deleted, fall back rather than showing a
     // dead pane.
     const selected = get().selected;
-    if (selected && selected !== ACTIVITY_CHANNEL) {
+    if (selected) {
       const still = agents.find((a) => a.id === selected && a.lifecycle !== "terminated");
       if (!still) {
         const next = agents.find((a) => a.lifecycle !== "terminated");
-        set({ selected: next ? next.id : ACTIVITY_CHANNEL });
+        set({ selected: next ? next.id : null });
         if (next) await get().loadChannel(next.id);
       }
     }
@@ -570,14 +574,14 @@ export const useStore = create<State>((set, get) => ({
    * a member of the group you are looking at, working while nobody here is. The
    * agent goes on working. It is the reading of it that was wrong.
    *
-   * Through `select` rather than by writing `selected`, so the feed the pane
-   * falls back to is read before it is drawn instead of arriving empty. It
-   * belongs to no group, so the focus set just above survives `keptFocus`.
+   * What it falls back to is nothing, rather than the first row of the crew
+   * being entered. Opening a channel is the operator naming somebody, and a
+   * crew that picked one for them would put an agent's history on screen as a
+   * side effect of a click that was about the crew.
    */
   async focusGroup(id) {
     const closing = !keptChannel(get(), id);
-    set({ railGroup: id });
-    if (closing) await get().select(ACTIVITY_CHANNEL);
+    set({ railGroup: id, ...(closing ? { selected: null, focused: null } : {}) });
   },
 
   /**
@@ -661,10 +665,7 @@ export const useStore = create<State>((set, get) => ({
   },
 
   async loadChannel(key, through) {
-    const messages =
-      key === ACTIVITY_CHANNEL
-        ? await api.conversationFlow(400)
-        : await api.channelMessages(key, 300, through);
+    const messages = await api.channelMessages(key, 300, through);
     set((state) => ({ messages: { ...state.messages, [key]: messages } }));
   },
 
@@ -764,11 +765,6 @@ export const useStore = create<State>((set, get) => ({
         set((state) => {
           const messages = { ...state.messages };
           messages[message.channelId] = insert(messages[message.channelId], message);
-          // The flow board covers the whole conversation, so everything except
-          // an agent's private activity record belongs on it.
-          if (message.to.kind !== "system") {
-            messages[ACTIVITY_CHANNEL] = insert(messages[ACTIVITY_CHANNEL], message);
-          }
 
           // Draw the pulse from the event, not from a channel read, so it
           // fires whether or not either channel is open. Bound to locals
@@ -951,14 +947,13 @@ export const useStore = create<State>((set, get) => ({
         set((state) => {
           const messages = { ...state.messages };
           for (const key of Object.keys(messages) as ChannelKey[]) {
-            // The activity feed draws from every channel, so it is stale too.
-            if (emptied.has(key) || key === ACTIVITY_CHANNEL) delete messages[key];
+            if (emptied.has(key)) delete messages[key];
           }
           return { messages };
         });
 
         const open = get().selected;
-        if (open && (emptied.has(open) || open === ACTIVITY_CHANNEL)) {
+        if (open && emptied.has(open)) {
           void get().loadChannel(open);
         }
         // The panels beside the transcript hold the two stores a reset also

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -46,7 +46,7 @@ describe("plainText", () => {
   it("counts a fired routine's instruction, which is what the model was sent", () => {
     // The transcript draws a firing as one line instead of a bubble, and does
     // it by choosing a row for the part. If that were done by hiding the words
-    // here, the activity board could not say what opened the run.
+    // here, the flow board could not say what opened the run.
     const message = envelope({
       from: { kind: "system" },
       parts: [{ type: "routine", routineId: "rt1", name: "Sweep", what: "check the listings" }],

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1209,7 +1209,7 @@ export function errorMessage(value: unknown): string {
  * Concatenated text of an envelope, matching the Rust `plain_text`.
  *
  * A fired routine's instruction counts, exactly as it does there: it is what
- * the model was sent, so the activity board naming what opened a run has to be
+ * the model was sent, so the flow board naming what opened a run has to be
  * able to say it. Drawing a firing as a bubble is prevented by the transcript
  * choosing a row for the part, not by this hiding the words.
  */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -78,9 +78,9 @@ if (!root) throw new Error("missing #root");
 /**
  * The names an `@` in a message body is allowed to resolve to.
  *
- * At the root because a body is drawn in a channel, in a pair's thread, in the
- * activity board and behind a search hit, and none of those should have to
- * remember to say so. The whole roster rather than the live one: a transcript
+ * At the root because a body is drawn in a channel, in a pair's thread, on the
+ * flow board and behind a search hit, and none of those should have to remember
+ * to say so. The whole roster rather than the live one: a transcript
  * is history, and an agent that has since been let go was still an agent when
  * somebody wrote to it. The composer answers the other question, which is who
  * a message can be delivered to, so it completes against the live crew.

--- a/src/styles.css
+++ b/src/styles.css
@@ -25,9 +25,12 @@
 
    Paper is the default and does not win in a dark room, which is the whole
    reason the reading column is a token block behind `data-surface` rather
-   than a set of literals. The rail is not part of that question. It is dark
-   in both surfaces, and it pins its own accents so nothing the reading column
-   does can reach it.
+   than a set of literals. The two navigation columns are part of that
+   question rather than exempt from it: they are the same ground as each
+   other, a shade off the page, and they move with it. They used to be ink
+   under both surfaces and pin their own accents against the reading column,
+   which is what made the left edge of the app look like a different app from
+   the right edge of it.
 
    Type is three roles, not one. Instrument Sans carries names and titles,
    where a tight fit at a large size is the point. Inter carries everything
@@ -37,19 +40,32 @@
    ========================================================================== */
 
 :root {
-  /* The rail stays dark in both halves of the app: it is Guaca's face, and a
-     dark rail against a white page is what makes the reading column read as
-     paper rather than as another panel. */
-  --rail-ground: #0c0c0b;
-  --rail-raised: #191917;
-  --rail-edge: #2b2a27;
-  --rail-text: #faf8f3;
-  --rail-muted: #9c9992;
-  --rail-wire: #2b2a27;
+  /* The navigation columns, both of them. They were one dark column on the
+     left with a white page beside it and a white panel on the right, which is
+     three surfaces for two jobs: the app's own two edges did not look like
+     each other, and the heavier of them was the one carrying the least
+     reading. So the rail and the inspector are the same ground, a shade off
+     the page rather than opposite it, and the page is the only white thing on
+     screen. What is left with any saturation in it is an agent's own color and
+     the one amber, which is the whole point: a column that is itself a color
+     is a column every agent's color is competing with.
+
+     They follow the surface now rather than pinning ink under both of them,
+     which is why the dark block below redeclares all seven. */
+  --rail-ground: #f5f3ee;
+  --rail-raised: #ffffff;
+  --rail-edge: #e5e2da;
+  --rail-text: #0b0b0a;
+  --rail-muted: #54524d;
+  --rail-wire: #ded9d0;
+  /* Recessed from a column, which is not the same value as recessed from the
+     page: `--sunken` is a hair off white, which is a field on paper and
+     nothing at all on an off-white panel. */
+  --rail-sunken: #eae7df;
   /* A shade under the rail. The crews sit behind the crew, and a column that
      is the same ground as the one it borders needs a rule drawn between them
      to be a second surface at all. */
-  --grail-ground: #050504;
+  --grail-ground: #eceae2;
 
   /* The reading surface, and the only half of the app a surface choice moves.
      Messages are long-form text read for minutes at a time, and paper is the
@@ -166,8 +182,17 @@
      narrower than a message can draw. */
   --rail-w: min(15.5rem, 28vw);
   /* The crews' own column, which holds one circle across and nothing else, so
-     it is capped in the same proportion as the rail beside it. */
+     it is capped in the same proportion as the rail beside it. It is drawn
+     over the rail rather than beside it, so this is not width the layout
+     spends: `--grail-lip` is. */
   --grail-w: min(4rem, 8vw);
+  /* What the column leaves behind when it is in. Enough to read as a surface
+     at the edge of the window and not enough to be a column. */
+  --grail-lip: 0.5rem;
+  /* How far in the pointer comes before the column does. Wider than the band,
+     because what it is aiming at is the edge of the window rather than the
+     band itself, and half a rem is not a target. */
+  --grail-reach: 1.25rem;
 
   /* ---- Radius -------------------------------------------------------------
      Radius says what a box *is*, not how big it happens to be: a thing inside
@@ -250,29 +275,34 @@
   --lift-1: 0 0.125rem 0.5rem -0.25rem rgb(11 11 10 / 0.1);
   --lift-2: 0 0.5rem 1.25rem -0.625rem rgb(11 11 10 / 0.13), 0 0 0 1px var(--edge);
   --lift-3: 0 1.25rem 2.5rem -1rem rgb(11 11 10 / 0.17), 0 0 0 1px var(--edge);
-  /* For the things that are dark whatever the operator picked: the rail, and
-     anything sitting on top of a scrim. They cannot read `--lift-*`, because
-     those resolve against the reading column and would put a paper-weight ring
-     on a black surface. Same argument as `--rail-ground`, one level up. */
-  --lift-dark: 0 0.5rem 1.5rem -0.375rem rgb(0 0 0 / 0.45);
 }
 
 /* Ink instead of paper.
-   Seven neutrals, four accents, a scrim and three lifts. Nothing else, and in
-   particular not one `--rail-*` name: the rail is dark in both surfaces and
-   redefining an accent it drew with would repaint it silently, which no test
-   would catch. `.rail` pins the two accents it does read.
-   The reading column sits lighter than the rail here, which is the same
-   relationship as on paper read the other way round: the rail is still the
-   darker frame and the column is still the surface you read on.
+   Seven neutrals, seven column values, four accents, a scrim and three lifts.
+   Nothing else, and every `--rail-*` and `--grail-*` name is in here: the
+   columns follow the surface, so one of them declared for paper and not for
+   ink is a column that stays the wrong color in a dark room and no DOM
+   assertion notices. `styles.test.ts` reads both blocks and fails on a name
+   that is in one and not the other.
+   The columns sit *lighter* than the reading column here, which is the paper
+   relationship read the other way round rather than a second idea: on paper
+   the page is the brightest thing and its edges step back from it, on ink the
+   page is the darkest thing and its edges step up from it. Either way the page
+   is the surface you read on and the columns are what frames it.
    The accents are lifted rather than kept, because both are chosen against
    white and neither can be read on ink: the amber goes light and loses its
    burn, the slate goes pale enough to be a color rather than a shadow. They
-   stay recognizably the same two colors; they are not the same values.
-   The reading column here is the darkest ground in the app after the rail,
-   which is the poster read on ink: one surface, nothing framed, and the amber
-   doing every piece of work color does. */
+   stay recognizably the same two colors; they are not the same values. */
 :root[data-surface="dark"] {
+  --rail-ground: #151513;
+  --rail-raised: #1f1f1c;
+  --rail-edge: #2b2a27;
+  --rail-text: #f7f5f0;
+  --rail-muted: #a8a49c;
+  --rail-wire: #302f2b;
+  --rail-sunken: #0e0e0d;
+  --grail-ground: #0b0b0a;
+
   --ground: #0f0f0e;
   --raised: #171715;
   --sunken: #0a0a09;
@@ -302,6 +332,20 @@
 
 * {
   box-sizing: border-box;
+}
+
+/* The three surfaces that are not the page.
+   Everything drawn inside one of them reaches for `--sunken` when it wants to
+   be recessed, and recessed from white is a value that disappears on an
+   off-white panel. Remapped once here, on the three elements every rule in
+   those columns descends from, rather than at each rule inside: a row added to
+   the inspector tomorrow is then recessed from what it is actually drawn on
+   without having to know which half of the app it is in. `styles.test.ts` is
+   the gate, and it reads this rule to know which names are covered. */
+.rail,
+.grail,
+.inspector {
+  --sunken: var(--rail-sunken);
 }
 
 /* Said, never drawn. `display: none` and `visibility: hidden` both take an
@@ -607,37 +651,83 @@ button {
 /* ==========================================================================
    Group column
 
-   The crews, upright on the far left. This was a wrapping strip inside the
-   rail: four circles across, then a second line, then a third, taking the
-   height out of the list it sat above. `components/GroupRail.tsx` has the rest
-   of the argument.
+   The crews, upright on the far left, out of the way until they are reached
+   for. This was a wrapping strip inside the rail, then a column that stood
+   open and charged every window four rem for it. `components/GroupRail.tsx`
+   has the rest of the argument, and `lib/reach.ts` owns when it comes out.
    ========================================================================== */
 
-/* Pinned here for the same reason the rail pins them, and it is the same trap:
-   this column is dark under both surfaces, so a token the reading column
-   redefines for dark paper would repaint it and nothing would draw attention to
-   it. `--alarm` is on the list because the waiting badge is the one thing in
-   either dark column that is drawn in it. */
+/* What is left in the layout: a band of the column's own ground at the edge of
+   the window. It reserves the width so nothing reflows when the column comes
+   out, and it is what says there is something here at all. The column itself
+   is drawn out of this box and slides over the rail. */
 .grail {
-  --flesh: #4e6b16;
-  --flesh-soft: #eef2d8;
-  --alarm: #b03728;
-
-  width: var(--grail-w);
+  width: var(--grail-lip);
   flex: none;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  position: relative;
+  /* Over the rail, which is the next thing in the row. */
+  z-index: 30;
   min-height: 0;
   background: var(--grail-ground);
   border-right: 1px solid var(--rail-edge);
   color: var(--rail-text);
   /* Not selectable, for the reason the rail is not. */
   user-select: none;
-  /* The window's own buttons float over the top left corner, which is now this
-     column rather than the rail. The first circle starts under them. */
+}
+
+/* The proximity zone, as a box with nothing in it.
+   `lib/reach.ts` measures this rather than carrying a number, so how far in
+   the pointer has to come is a length in this file at the operator's own
+   interface scale, like every other length. It starts below the window's own
+   buttons: on macOS those float over the top left corner, and a zone that ran
+   to the top of the window would slide the crews out from under the pointer
+   every time somebody went to close the app. */
+.grail__reach {
+  position: absolute;
+  left: 0;
+  top: var(--space-8);
+  bottom: 0;
+  width: var(--grail-reach);
+  pointer-events: none;
+}
+
+/* The column. Translated rather than resized, so what moves is one composited
+   layer and the circles inside it never reflow: an animated width would relay
+   out the list on every frame, and the scroll position in it would jump. */
+.grail__slab {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: var(--grail-w);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 0;
+  background: var(--grail-ground);
+  border-right: 1px solid var(--rail-edge);
+  /* The first circle starts under the window's own buttons. */
   padding: var(--space-8) 0 var(--space-4);
   gap: var(--space-2);
+  /* All the way off, rather than back by the width of the band. The band is
+     this element's own ground, so the column has nothing to contribute to it,
+     and leaving its last half rem on screen leaves whatever is drawn there:
+     the waiting badge hangs off the right of a circle, so a crew with a parked
+     turn in it put a red chip at the edge of the window with no circle under
+     it. */
+  transform: translateX(-100%);
+  transition: transform var(--tempo-move) var(--ease), box-shadow var(--tempo-move) var(--ease);
+}
+
+/* Out, and floating: over the rail rather than beside it, so the rail keeps
+   its measure and nothing under this moves. `:focus-within` is the third way
+   out and the one that makes the column reachable from the keyboard, since a
+   circle tabbed to inside a column nobody can see is a selection nobody can
+   read. */
+.grail[data-out="true"] .grail__slab,
+.grail:focus-within .grail__slab {
+  transform: none;
+  box-shadow: var(--lift-2);
 }
 
 .grail__rule {
@@ -672,17 +762,14 @@ button {
    Rail
    ========================================================================== */
 
-/* The rail is dark in both surfaces, so the two accents it draws with are the
-   paper values whatever the reading column is doing. Pinned here, on the one
-   element every rail rule descends from, rather than renamed at the twenty-odd
-   call sites in the reading half: this makes the rail a real color scope
-   instead of a naming convention, and a new dark value for either token cannot
-   reach it by accident. `:focus-visible` is deliberately not covered — a focus
-   ring is drawn in both halves and should follow the surface it is drawn on. */
+/* Nothing is pinned here. Both columns used to hold paper values for `--flesh`
+   and `--flesh-soft` — and the crews' column for `--alarm` as well — because
+   they were ink under both surfaces and a reading column that went dark would
+   otherwise have repainted them silently. They follow the surface now, so the
+   one amber in the app is the same amber in all three columns, which is what
+   it was always meant to be: the accent means "answer me" and had two values
+   for it depending on which side of a border it was drawn on. */
 .rail {
-  --flesh: #4e6b16;
-  --flesh-soft: #eef2d8;
-
   /* A right-click leaves nothing highlighted behind it. WebKit selects the word
      under the pointer before it dispatches `contextmenu`, for the menu it is
      about to draw, so a row that answers with a menu of its own cannot undo
@@ -1080,7 +1167,10 @@ button {
    something. A parked agent stays parked until the operator answers, and the
    request is in a channel they may not have open. */
 .agent-row__meta[data-state="asking"] {
-  color: var(--rail-ground);
+  /* On the amber rather than beside it, so the text is the page's ground and
+     not the column's: the amber is dark on paper and light on ink, and a
+     column-colored label is unreadable on one of the two. */
+  color: var(--ground);
   background: var(--flesh);
   border-radius: var(--radius-xs);
   padding: var(--space-1) var(--space-2);
@@ -1420,7 +1510,7 @@ button {
   border-radius: var(--radius-sm);
   background: var(--rail-raised);
   border: 1px solid var(--rail-edge);
-  box-shadow: var(--lift-dark);
+  box-shadow: var(--lift-2);
   opacity: 0.95;
 }
 
@@ -1605,7 +1695,7 @@ button {
   padding: var(--space-3) var(--space-5);
   border-radius: var(--radius-sm);
   background: var(--rail-raised);
-  box-shadow: inset 0 0 0 1px var(--rail-edge), var(--lift-dark);
+  box-shadow: inset 0 0 0 1px var(--rail-edge), var(--lift-2);
 }
 
 .orb__tag-name {
@@ -1910,14 +2000,6 @@ button {
   margin: 0;
 }
 
-.pane__subtitle {
-  font-size: var(--type-small);
-  color: var(--muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  margin: 0;
-}
 
 /* An agent that will not answer, said once. It replaces a Pause button whose
    label was the only place this was written down, which meant reading a
@@ -5116,8 +5198,12 @@ button {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  border-left: 1px solid var(--edge);
-  background: var(--ground);
+  /* The rail's ground, not the page's. These are the app's two edges and they
+     have the same job: everything about an agent that is not what it said.
+     Drawn on the page's own white it read as more transcript, which is the one
+     thing it is not, and it made the window three surfaces wide. */
+  border-left: 1px solid var(--rail-edge);
+  background: var(--rail-ground);
 }
 
 /* Closed it is the tab and nothing else, still holding its own sliver of the
@@ -5362,6 +5448,20 @@ button {
   /* Shared with the space held open below, so the picture and the gap it leaves
      behind cannot disagree about how tall the screen is. */
   --screen-aspect: 16 / 10;
+
+  /* The one surface in this app that is ink whichever surface the operator
+     picked, and the only thing left holding the values the rail used to. A
+     full-window frame around somebody else's desktop is a light-tight box on
+     purpose: a pale chrome around a picture is a chrome the eye keeps reading
+     instead of the picture. It cannot spend `--lift-*` either, because those
+     resolve against the reading column and would put a paper-weight ring on a
+     black surface. */
+  --stage-ground: #0c0c0b;
+  --stage-edge: #2b2a27;
+  --stage-text: #faf8f3;
+  --stage-muted: #9c9992;
+  --stage-lift: 0 0.5rem 1.5rem -0.375rem rgb(0 0 0 / 0.45);
+
   margin-bottom: var(--space-6);
 }
 
@@ -5481,10 +5581,10 @@ button {
   z-index: 40;
   display: flex;
   flex-direction: column;
-  background: var(--rail-ground);
-  border: 1px solid var(--rail-edge);
+  background: var(--stage-ground);
+  border: 1px solid var(--stage-edge);
   border-radius: var(--radius);
-  box-shadow: var(--lift-dark);
+  box-shadow: var(--stage-lift);
   overflow: hidden;
 }
 
@@ -5501,9 +5601,9 @@ button {
   align-items: center;
   gap: var(--space-3);
   padding: var(--space-4) var(--space-4) var(--space-4) var(--space-5);
-  background: var(--rail-ground);
-  border-bottom: 1px solid var(--rail-edge);
-  color: var(--rail-text);
+  background: var(--stage-ground);
+  border-bottom: 1px solid var(--stage-edge);
+  color: var(--stage-text);
 }
 
 /* The actions, as one group rather than a row of equally-weighted buttons.
@@ -5520,7 +5620,7 @@ button {
 }
 
 .screen__bar .screen__state {
-  color: var(--rail-muted);
+  color: var(--stage-muted);
 }
 
 .screen__title {
@@ -6611,6 +6711,18 @@ button {
   flex: 1;
   overflow-y: auto;
   padding: var(--space-6) var(--space-7) var(--space-7);
+}
+
+/* The one pane that holds a board rather than a column of fields. `.flow` is a
+   flex column that scrolls itself and expects to be given a height, so the pane
+   stops scrolling and becomes that column: two scroll containers, one inside
+   the other, is a board whose header scrolls away and a run you cannot reach
+   the bottom of. */
+.settings__pane--board {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding-bottom: var(--space-5);
 }
 
 .settings__title {

--- a/src/styles.test.ts
+++ b/src/styles.test.ts
@@ -72,78 +72,106 @@ describe("the file reading view", () => {
   });
 });
 
-describe("the dark columns", () => {
+describe("the columns that are not the page", () => {
   /**
-   * The rail and the group column are dark under both surfaces, so a token the
-   * reading column redefines for dark paper repaints them unless they pin it.
-   * `--flesh` on dark paper is a bright leaf green meant to sit on a near-black
-   * page; landing it on the rail turns Guaca's one accent into a highlighter,
-   * and no DOM assertion notices, which is the whole of the note about it in
-   * `docs/WORKSPACE.md`.
+   * The rail, the crews' column and the inspector follow the surface, and every
+   * value they are drawn from has to be declared for both of them.
+   *
+   * They used to be ink whichever surface the operator picked, which meant they
+   * pinned their own `--flesh`, `--flesh-soft` and `--alarm` against a reading
+   * column that could go dark underneath them. That is gone: the left edge of
+   * the app and the right edge of it are now the same ground, a shade off the
+   * page rather than opposite it. What is left to keep true is the other half
+   * of the same trap. A `--rail-*` name declared for paper and forgotten in the
+   * ink block is a column that stays off-white in a dark room, and no DOM
+   * assertion sees a color.
    *
    * Checked in the source rather than through the cascade, and that is not
    * laziness: jsdom resolves a custom property declared on an element but does
-   * not inherit one down a subtree, so reading `--alarm` off a child of the
-   * column reports nothing at all whether it is pinned or not. The declaration
-   * is the thing that has to be there, so the declaration is what is read.
-   *
-   * Only the two families that are drawn nowhere else are covered. A rule under
-   * `.agent-row` reaching for an unpinned token is the same defect and is not
-   * caught here: that family predates this check and pinning is a property of a
-   * column, so the map below has to say which column a class is inside.
+   * not inherit one down a subtree, so reading a token off a child of a column
+   * reports nothing at all whether it is declared or not. The declaration is
+   * the thing that has to be there, so the declaration is what is read.
    */
-  const SURFACE_VARYING = new Set(
-    [
-      ...(css.match(/:root\[data-surface="dark"\] \{[\s\S]*?\n\}/)?.[0] ?? "").matchAll(
-        /^\s{2}(--[a-z-]+):/gm,
-      ),
-    ].map((found) => found[1]!),
-  );
+  function declared(selector: string): Set<string> {
+    const block = css.match(
+      new RegExp(`${selector.replace(/[[\]"=]/g, "\\$&")} \\{[\\s\\S]*?\\n\\}`),
+    );
+    if (!block) throw new Error(`no ${selector} block`);
+    return new Set([...block[0].matchAll(/^\s{2}(--[a-z-]+):/gm)].map((found) => found[1]!));
+  }
+
+  /** What a block declares a token as, trimmed. */
+  function declaredAs(selector: string, token: string): string {
+    const block = css.match(
+      new RegExp(`${selector.replace(/[[\]"=]/g, "\\$&")} \\{[\\s\\S]*?\\n\\}`),
+    );
+    return block?.[0].match(new RegExp(`^\\s{2}${token}: (.+);$`, "m"))?.[1]?.trim() ?? "";
+  }
+
+  const PAPER = declared(":root");
+  const INK = declared(':root[data-surface="dark"]');
 
   /** Every rule in the file, as its selector and its body. */
   const RULES = [...css.matchAll(/^([^\n@}][^{\n]*)\{\n([\s\S]*?)^\}/gm)];
 
-  /**
-   * Selectors naming one of these class families.
-   *
-   * The suffixes are part of the match on purpose: `.orb__waiting` is drawn
-   * inside the group column exactly as `.orb` is, and a pattern that stopped at
-   * the base class would skip every element that carries the color.
-   */
-  function family(...names: string[]): RegExp {
-    return new RegExp(`(?:^|[\\s,>])\\.(?:${names.join("|")})(?:__|--)?[\\w-]*`);
-  }
-
-  /** What a scope's own base rule declares. */
-  function pinnedOn(scope: string): Set<string> {
-    const base = RULES.find((rule) => rule[1]!.trim() === scope);
-    if (!base) throw new Error(`no base rule for ${scope}`);
-    return new Set([...base[2]!.matchAll(/^\s{2}(--[a-z-]+):/gm)].map((found) => found[1]!));
-  }
-
-  it("found the tokens a surface moves", () => {
-    // Every assertion below is vacuous if this regex stops matching.
-    expect(SURFACE_VARYING.has("--flesh")).toBe(true);
-    expect(SURFACE_VARYING.has("--alarm")).toBe(true);
+  it("found both surface blocks", () => {
+    // Every assertion below is vacuous if these regexes stop matching.
+    expect(PAPER.has("--rail-ground")).toBe(true);
+    expect(INK.has("--ground")).toBe(true);
     expect(RULES.length).toBeGreaterThan(50);
   });
 
-  it.each([
-    [".grail", family("grail", "orb")],
-    [".rail", family("rail")],
-  ])("pin every accent %s draws with", (scope, family) => {
-    const pinned = pinnedOn(scope);
+  /**
+   * The column values that are colors. A width is geometry and has no surface:
+   * `--grail-w` is the same four rem in a dark room. Told apart by the value
+   * rather than by a list, so a color added to the family tomorrow is covered
+   * without anybody remembering to add it here.
+   */
+  const COLORS = [...PAPER].filter(
+    (token) =>
+      /^--(?:rail|grail)-/.test(token) && /^#[0-9a-f]{3,8}$/i.test(declaredAs(":root", token)),
+  );
 
-    for (const [, selector, body] of RULES) {
-      if (!family.test(selector!)) continue;
-      for (const [, token] of body!.matchAll(/var\((--[a-z-]+)/g)) {
-        if (!SURFACE_VARYING.has(token!)) continue;
-        expect(
-          pinned.has(token!),
-          `${selector!.trim()} draws with ${token}, which ${scope} does not pin`,
-        ).toBe(true);
-      }
+  it.each(COLORS)("moves %s with the surface", (token) => {
+    expect(INK.has(token)).toBe(true);
+  });
+
+  /**
+   * Nothing in either navigation column pins an accent any more.
+   *
+   * The pins were right while the columns were ink under both surfaces and are
+   * exactly wrong now: the app has one amber, it means "answer me", and a
+   * column holding a second value for it is a column where the same state is a
+   * different color on the wrong side of a border.
+   */
+  it.each([".rail", ".grail"])("pins no accent of its own (%s)", (scope) => {
+    for (const token of declared(scope)) {
+      expect(
+        /^--(?:flesh|pit|mint|alarm)/.test(token),
+        `${scope} pins ${token}, which the reading column owns`,
+      ).toBe(false);
     }
+  });
+
+  /**
+   * A column's recessed surface is recessed from the column.
+   *
+   * `--sunken` is a hair off white, which is a field on paper and nothing at
+   * all on an off-white panel. It is remapped once, on the three elements every
+   * rule in those columns descends from, so a row added to the inspector
+   * tomorrow is recessed from what it is actually drawn on. This asserts the
+   * remap exists and covers all three, because losing one of them is a panel
+   * whose fields quietly stop having edges.
+   */
+  it("recesses from the column rather than from the page", () => {
+    // Matched against the source rather than against `RULES`, whose selector
+    // group stops at a newline: this rule names its three scopes one per line.
+    const remap = css.match(/([^{}]*)\{\s*--sunken: var\(--rail-sunken\);\s*\}/);
+    expect(remap, "no rule remaps --sunken onto --rail-sunken").toBeTruthy();
+    for (const scope of [".rail,", ".grail,", ".inspector"]) {
+      expect(remap![1]!).toContain(scope);
+    }
+    expect(PAPER.has("--rail-sunken")).toBe(true);
   });
 });
 
@@ -581,12 +609,19 @@ describe("every length is named, not spelled", () => {
    * The px ones this replaced are why the rule mentions units at all: in an app
    * where every other length is a rem, a `24px` blur is a blur that ignores the
    * operator's interface scale.
+   *
+   * `--stage-lift` is the fourth and only lives on one surface, the full-window
+   * machine viewer, which is ink whichever surface the operator picked and so
+   * cannot spend a lift resolved against the reading column. It is named beside
+   * the three other values that surface pins, which is what makes it a decision
+   * rather than a shadow somebody typed.
    */
   it("shadows are a lift, a ring or a glow", () => {
     const bad = declarations()
       .filter((d) => d.property === "box-shadow")
       .filter((d) => d.value !== "none")
       .filter((d) => !d.value.includes("var(--lift-"))
+      .filter((d) => d.value !== "var(--stage-lift)")
       .filter((d) => !d.value.includes("inset"))
       // A glow sits on the thing that casts it: no offset, so nothing about it
       // is claiming height off the page.


### PR DESCRIPTION
The flow board was the first row in the rail and one of the least pressed things in the app, so it is a pane in the group editor now and `ACTIVITY_CHANNEL` is deleted with it: seven functions took a channel that was not an agent and carried a branch for it, and the board is one crew's traffic scoped in SQL rather than the workspace's filtered after the read.

The rail and the inspector are one off-white ground instead of a near-black column facing a white panel, so the page is the only white thing and the only saturation left is an agent's color and the one amber; the columns stop pinning their own accents and `styles.test.ts` now enforces the replacement invariant, that every column color declared for paper is declared for ink.

The crews' column slides out on pointer proximity rather than standing open and charging every window four rem, with two thresholds so it does not flicker at the boundary, both distances read off a CSS-sized box, and a drag or focus inside it holding it out.

One follow test was passing on the order two timers happened to fire in and is deterministic now.

`./scripts/ci.sh` is green.