### PR TITLE
feat(runtime): give a turn that ends on a promise its round back

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ src-tauri/src/
     repository.rs     A directory an agent may write code in, which of two
                       programs writes it, and whether it asks before pushing.
     worknote.rs       A line about work in flight, and why it is not memory.
+    promise.rs        A closing sentence that says the work is still coming,
+                      in a turn that is over. One rule, two readers.
     approval.rs       The two things an agent stops to ask a person, and why
                       only one of them may draw the model's own words.
     escalation.rs     The third thing, which stops nothing: work an agent

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ repo: the frontend renders state and forwards intent.
 | Messaging, replies, cascades, hop limits, the guard | `runtime/guard.rs`, then *Cascades terminate because of one asymmetry* and *The five limits* in `docs/ARCHITECTURE.md` |
 | A message that arrives while an agent is already working, and the coding job whose answer could not reach the turn that started it | *A working turn reads its inbox, and only what it can answer where it stands* in `docs/ARCHITECTURE.md`, then `Runtime::take_in` and `Intake` |
 | What a turn is told it was asked for: `expects_reply`, `intent`, `ReplyMode` | *Cascades terminate because of one asymmetry*, and `runtime/prompt.rs`, which has to agree with it |
+| A turn that ends on "checking now" and does nothing, the round it is given back, the fault that counts them | *A turn ends when the model stops calling tools, so a closing promise is silence* in `docs/gotchas/runtime.md`, then `src-tauri/src/domain/promise.rs` and the `## Your reply` block in `runtime/prompt.rs` |
 | Streaming, retries, the budget, when a run settles | *A failed model call is retried*, *A thought is shown and never kept*, *The budget counts model calls* |
 | What a turn shows of itself while it runs: the thinking, the calls, the line above the composer | *A thought is shown and never kept* and *A turn's own work is watched while it happens*, then `src/lib/reasoning.ts` |
 | How a turn is paid for: providers, the ChatGPT sign-in, the Responses API | *A subscription is a second provider, not a second endpoint*, then `llm/codex.rs` and `subscription.rs` |

--- a/docs/gotchas/runtime.md
+++ b/docs/gotchas/runtime.md
@@ -29,6 +29,28 @@ code.
   they were written. The outcome alone was enough until `replaced` arrived, at
   which point a live memory rewrite silently stopped opening as a diff while the
   recorded one still did.
+- **A turn ends when the model stops calling tools, so a closing promise is
+  silence.** "Checking both properly" was the last thing that happened in a turn
+  with a working plugin, two calls left to make and rounds and budget to make
+  them in: the loop broke on an empty `tool_calls`, the message was filed, and
+  the operator waited for a check that was never going to run. Three things
+  answer it and none of them is enough alone. The prompt states the mechanism
+  rather than a rule, because "do not announce work" is something a model talks
+  itself out of and "nothing of yours runs after this message" is not. The
+  runtime gives such a turn one more round, once, claimed from the same budget.
+  `eval` counts it afterward as `PromisedAndStopped`, which is the only half CI
+  can fail on, and the only reason a prompt change here is measurable at all.
+  The rule itself is `domain::promise`, in one place because a copy in the
+  runtime and a copy in the eval drift into a prompt fix that measures clean
+  while the runtime goes on nudging.
+- **The nudge is not gated on an empty tool trail, and is gated on `code`.** The
+  turn this was written for had already made two calls and still closed on a
+  promise about two more: what backs a sentence is a call made *before* it, not
+  anywhere in the turn. The one exemption is a started `code` job, which
+  genuinely outlives the message announcing it, and which `## Your repository`
+  explicitly tells an agent to announce. Without that exemption the nudge fires
+  on the one announcement the app asks for and every coding job buys a wasted
+  model call.
 - **A turn reads its inbox between rounds, and reads nothing that would change
   where its answer goes.** Those are one decision, not a rule with an exception
   bolted on. The mode, the reply target, the placeholder's channel and `cause`

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -7,6 +7,7 @@ pub mod escalation;
 pub mod group;
 pub mod ids;
 pub mod plugin;
+pub mod promise;
 pub mod repository;
 pub mod routine;
 pub mod search;

--- a/src-tauri/src/domain/promise.rs
+++ b/src-tauri/src/domain/promise.rs
@@ -1,0 +1,320 @@
+//! Whether a message ends on work that has not happened.
+//!
+//! A turn ends when the model stops calling tools, so the message is the
+//! terminator: nothing of the agent's runs after it. A closing sentence that
+//! says work is about to happen is therefore always unbacked, whatever else
+//! the turn did, and the operator reads a plan where there is only silence.
+//! Observed on a turn with a working plugin, two checks to run and rounds left
+//! to run them in; it closed on "Checking both properly", the turn ended, and
+//! the operator had to ask why nothing had happened.
+//!
+//! One definition, two readers. `runtime` acts on it inside the turn, `eval`
+//! counts it afterward, and a rule that drifted between them would mean a
+//! prompt change that measured clean while the runtime went on nudging.
+//!
+//! Deliberately a closed list rather than a classifier. A second model call to
+//! judge every turn's last sentence doubles the cost of every turn, and a
+//! judgment call is the one thing `eval` will not carry. What the lists buy is
+//! recall on the shape that actually ships; they will miss phrasings, and
+//! missing one leaves the behavior exactly as it is today.
+
+/// A sentence opening on work in progress. Kept to verbs that are almost never
+/// the start of a participial clause: "Checking both properly" is an
+/// announcement, and "Looking at the results, Drive is stale" is a report, so
+/// `looking`, `reading` and `getting` are deliberately not here.
+const STARTING: &[&str] = &[
+    "checking",
+    "rechecking",
+    "re-checking",
+    "double-checking",
+    "verifying",
+    "confirming",
+    "testing",
+    "retesting",
+    "re-testing",
+    "running",
+    "rerunning",
+    "re-running",
+    "pulling",
+    "fetching",
+    "querying",
+    "sweeping",
+    "kicking off",
+    "chasing",
+];
+
+/// A first-person lead that puts the action after the message rather than
+/// before it. Needs a verb from `ACTIONS` beside it: "I'll be brief" is not a
+/// promise of work.
+const LEADS: &[&str] = &[
+    "i'll ",
+    "i will ",
+    "i am going to ",
+    "i'm going to ",
+    "i am about to ",
+    "i'm about to ",
+    "let me ",
+    "going to ",
+    "about to ",
+    "next i ",
+    "then i ",
+];
+
+/// The work half of a lead.
+const ACTIONS: &[&str] = &[
+    "check",
+    "verify",
+    "confirm",
+    "test",
+    "run",
+    "look",
+    "pull",
+    "fetch",
+    "search",
+    "read",
+    "open",
+    "query",
+    "dig",
+    "sweep",
+    "scan",
+    "review",
+    "inspect",
+    "trace",
+    "count",
+    "load",
+    "grab",
+    "chase",
+    "find out",
+    "figure out",
+    "work out",
+    "get back",
+    "send",
+    "write",
+    "draft",
+    "file",
+    "post",
+    "email",
+    "message",
+    "ask",
+    "start",
+    "kick off",
+    "do that",
+    "do it",
+];
+
+/// A promise with no verb at all. These say the work is coming and nothing else.
+const STALLS: &[&str] = &[
+    "one moment",
+    "in a moment",
+    "bear with",
+    "give me a second",
+    "give me a minute",
+    "give me a moment",
+    "coming right up",
+];
+
+/// The same, for the ones short enough to turn up inside a sentence that means
+/// something else. "On it." is a promise and "Chef is on it" is a report about
+/// somebody else, so these only count where a promise would actually stand.
+const STALL_OPENERS: &[&str] = &["on it", "will do", "hold on", "stand by"];
+
+/// What makes a future statement a plan rather than an unbacked promise: the
+/// work waits on the operator, or on a day that is not this one. Both are a
+/// state somebody can act on, which is exactly what a promise is not.
+const DEFERRED: &[&str] = &[
+    "tomorrow",
+    "later",
+    "next week",
+    "next time",
+    "in the morning",
+    "overnight",
+    "once you",
+    "when you",
+    "if you",
+    "after you",
+    "unless you",
+    "as soon as you",
+    "when it lands",
+    "when it comes back",
+    "when that comes back",
+    "when the job",
+    "when it finishes",
+    "when this finishes",
+];
+
+/// An offer, which promises nothing until it is taken up. `let me know` is here
+/// because it collides head-on with the `let me` lead.
+const OFFERS: &[&str] = &[
+    "let me know",
+    "want me to",
+    "do you want",
+    "would you like",
+    "should i ",
+    "shall i ",
+    "happy to",
+    "if you'd like",
+    "if you want",
+];
+
+/// The closing sentence, when it promises work that has not happened.
+///
+/// `None` for everything else, including a message that describes work it has
+/// already done: the tense is the whole distinction, and it is the closing
+/// sentence that carries it. Earlier sentences are not read, because a message
+/// that says what it was about to do and then says what came of it is a report.
+pub fn promises_work(text: &str) -> Option<&str> {
+    let last = last_sentence(text)?;
+    let lower = last.to_lowercase();
+
+    if lower.ends_with('?') {
+        return None;
+    }
+    if OFFERS.iter().any(|p| lower.contains(p)) || DEFERRED.iter().any(|p| lower.contains(p)) {
+        return None;
+    }
+    if STALLS.iter().any(|p| lower.contains(p)) {
+        return Some(last);
+    }
+    if STALL_OPENERS.iter().chain(STARTING).any(|opener| lower.starts_with(opener)) {
+        return Some(last);
+    }
+    if LEADS.iter().any(|lead| lower.contains(lead))
+        && ACTIONS.iter().any(|action| has_word(&lower, action))
+    {
+        return Some(last);
+    }
+    None
+}
+
+/// The last sentence, with list markers and quoting stripped off the front.
+///
+/// Scanned from the end rather than split, because the terminator has to
+/// survive: a closing question is an offer, and telling the two apart after a
+/// split means putting the punctuation back.
+fn last_sentence(text: &str) -> Option<&str> {
+    let trimmed = text.trim_end();
+    let mut start = 0;
+    let mut back = trimmed.char_indices().rev();
+    // This sentence's own terminator, which is not the boundary being looked for.
+    back.next();
+    for (at, c) in back {
+        if matches!(c, '.' | '!' | '?' | '\n') {
+            start = at + c.len_utf8();
+            break;
+        }
+    }
+    let last = trimmed[start..].trim_matches(|c: char| c.is_whitespace() || "-*>#".contains(c));
+    (!last.is_empty()).then_some(last)
+}
+
+/// `needle` at the start of a word, so `ask` does not match `task`.
+fn has_word(hay: &str, needle: &str) -> bool {
+    let mut from = 0;
+    while let Some(at) = hay[from..].find(needle) {
+        let at = from + at;
+        match hay[..at].chars().next_back() {
+            Some(before) if before.is_alphanumeric() => from = at + 1,
+            _ => return true,
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_sentence_that_shipped_this_is_caught() {
+        // Verbatim, both of them. The first closed a turn that had genuinely
+        // run two checks, which is why an empty tool trail is not the test:
+        // work done earlier in the turn does not back a promise made at the end
+        // of it, because the message is where the turn stops.
+        assert_eq!(
+            promises_work(
+                "Both answered — the plugin is back. But the results surfaced two problems I \
+                 need to run down. Checking both properly."
+            ),
+            Some("Checking both properly.")
+        );
+        assert!(
+            promises_work("Retesting both right now — Drive and Gmail, one call each.").is_some()
+        );
+    }
+
+    #[test]
+    fn a_report_of_finished_work_is_not_a_promise() {
+        assert_eq!(promises_work("Checked both. Drive is stale and Gmail has nothing."), None);
+        assert_eq!(promises_work("I ran the sweep and found six messages."), None);
+        assert_eq!(promises_work("Both answered, so the plugin is back."), None);
+    }
+
+    #[test]
+    fn a_participial_opener_is_a_report_and_not_an_announcement() {
+        // Why `looking` and `reading` are not in the list. This reads as a
+        // promise to any rule that only looks at the first word.
+        assert_eq!(promises_work("Looking at the results, Drive is still stale."), None);
+        assert_eq!(promises_work("Reading the sweep, nothing from this morning is there."), None);
+    }
+
+    #[test]
+    fn an_offer_promises_nothing() {
+        // `let me know` shares its first two words with the `let me` lead, and
+        // it is the single most common way a reply ends.
+        assert_eq!(
+            promises_work("That is everything. Let me know if you want me to dig further."),
+            None
+        );
+        assert_eq!(promises_work("Want me to check the other two?"), None);
+        assert_eq!(promises_work("I can run it again if you want."), None);
+    }
+
+    #[test]
+    fn work_waiting_on_a_person_or_a_day_is_a_state_rather_than_a_promise() {
+        // The operator can act on both of these. Nothing is left running to
+        // keep them, and nothing needs to be.
+        assert_eq!(promises_work("I'll check the report tomorrow."), None);
+        assert_eq!(promises_work("I'll run the sweep once you confirm the address."), None);
+        assert_eq!(promises_work("I'll read the diff when it comes back."), None);
+    }
+
+    #[test]
+    fn a_stall_needs_no_verb() {
+        assert!(promises_work("One moment.").is_some());
+        assert!(promises_work("On it.").is_some());
+        assert!(promises_work("Will do.").is_some());
+    }
+
+    #[test]
+    fn a_short_stall_only_counts_where_a_promise_would_stand() {
+        // A run in the eval suite says exactly this, and it is a report about
+        // somebody else's work rather than a promise about this agent's.
+        assert_eq!(promises_work("Chef is on it."), None);
+        assert_eq!(promises_work("There is a hold on that account."), None);
+    }
+
+    #[test]
+    fn a_lead_needs_a_verb_beside_it() {
+        assert_eq!(promises_work("I'll be brief: the plugin is back."), None);
+        assert_eq!(promises_work("I'll be honest, that surprised me."), None);
+        assert!(promises_work("I'll pull the Drive listing.").is_some());
+    }
+
+    #[test]
+    fn a_verb_inside_another_word_is_not_a_verb() {
+        // `ask` in `task`, which is the one that fires without the boundary.
+        assert_eq!(promises_work("I'll be the task owner from here."), None);
+    }
+
+    #[test]
+    fn a_list_marker_does_not_hide_the_closing_line() {
+        assert!(promises_work("Two things left:\n- the Drive list\n- Checking both now").is_some());
+    }
+
+    #[test]
+    fn nothing_to_read_is_not_a_promise() {
+        assert_eq!(promises_work(""), None);
+        assert_eq!(promises_work("   \n  "), None);
+        assert_eq!(promises_work("."), None);
+    }
+}

--- a/src-tauri/src/eval.rs
+++ b/src-tauri/src/eval.rs
@@ -12,8 +12,9 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::domain::envelope::{Envelope, Participant};
+use crate::domain::envelope::{Envelope, Part, Participant};
 use crate::domain::ids::AgentId;
+use crate::domain::promise;
 
 /// What one run's traffic looked like.
 #[derive(Debug, Clone)]
@@ -64,6 +65,19 @@ pub enum Fault {
     /// agent was given something to do. A tool trail does not count as an
     /// answer: it is the working, and the operator reads channels, not traces.
     AssignedAndSaidNothing { agent: String },
+    /// A message that closed on work the agent had not done.
+    ///
+    /// The near neighbor of the fault above, and invisible to every check in
+    /// this file until now: the agent did speak, so `Silent` and
+    /// `AssignedAndSaidNothing` both read the run as answered, and what the
+    /// operator got was "Checking both properly" followed by nothing. Nothing
+    /// of an agent's runs after its message, so a closing promise is unbacked
+    /// however much work the turn did before it.
+    ///
+    /// Decided from the closing sentence alone. See `domain::promise`, which
+    /// the runtime reads too: a rule that drifted between the two would mean a
+    /// prompt change measuring clean here while the runtime went on nudging.
+    PromisedAndStopped { agent: String, said: String },
     /// Two things said to the operator that are near enough the same words.
     RepeatedToOperator { again: String },
     /// One agent, answering one instruction over and over.
@@ -95,6 +109,9 @@ impl Fault {
             Fault::Silent => "the operator asked for something and was never told anything".into(),
             Fault::AssignedAndSaidNothing { agent } => {
                 format!("{agent} was given work and never said what came of it")
+            }
+            Fault::PromisedAndStopped { agent, said } => {
+                format!("{agent} ended on work it had not done: {said:?}")
             }
             Fault::RepeatedToOperator { again } => {
                 format!("said the same thing to the operator twice: {again:?}")
@@ -213,6 +230,29 @@ pub fn faults(messages: &[Envelope], name_of: &dyn Fn(AgentId) -> String) -> Vec
         assigned.into_iter().filter(|id| !spoke.contains(id)).map(&name_of).collect();
     mute.sort();
     faults.extend(mute.into_iter().map(|agent| Fault::AssignedAndSaidNothing { agent }));
+
+    // Spoke, and said it was about to do something. Once per agent rather than
+    // once per message: this is a habit, and a run where it happened three
+    // times is one thing to fix, not three. In message order, which is the
+    // order the operator read them in.
+    let mut promised: HashSet<AgentId> = HashSet::new();
+    for envelope in messages {
+        let Participant::Agent { id } = envelope.from else { continue };
+        // A `code` call outlives the turn that made it, and the prompt tells an
+        // agent to start one, say so, and stop. That sentence is backed by a
+        // job that is genuinely running, which is the one case where something
+        // of this agent's does carry on after the message.
+        if envelope.parts.iter().any(
+            |part| matches!(part, Part::ToolCall { name, .. } if name == crate::llm::tools::CODE),
+        ) {
+            continue;
+        }
+        if let Some(said) = promise::promises_work(&envelope.plain_text()) {
+            if promised.insert(id) {
+                faults.push(Fault::PromisedAndStopped { agent: name_of(id), said: brief(said) });
+            }
+        }
+    }
 
     // One instruction, several answers. An update followed by a result is
     // reasonable; a third is the crew narrating itself.
@@ -343,7 +383,6 @@ fn overlap(a: &HashSet<String>, b: &HashSet<String>) -> f32 {
 mod tests {
     use super::*;
     use crate::domain::envelope::Intent;
-    use crate::domain::envelope::Part;
     use crate::domain::ids::{MessageId, RunId};
 
     fn agents() -> (AgentId, AgentId) {
@@ -504,6 +543,102 @@ mod tests {
                 .contains(&Fault::AssignedAndSaidNothing { agent: "Chef".into() }),
             "a tool trail is the working, not the report"
         );
+    }
+
+    #[test]
+    fn a_message_that_ends_on_a_promise_is_a_fault() {
+        // Verbatim from the run that produced this check. The plugin worked,
+        // there were two calls to make and rounds left to make them in.
+        let (a, b) = agents();
+        let run = [
+            msg(Participant::Human, Participant::Agent { id: a }, "is the plugin back?", 0, true),
+            msg(
+                Participant::Agent { id: a },
+                Participant::Human,
+                "Both answered, so the plugin is back. But the results surfaced two problems. \
+                 Checking both properly.",
+                0,
+                false,
+            ),
+        ];
+        assert!(faults(&run, &named(a, b)).contains(&Fault::PromisedAndStopped {
+            agent: "Manager".into(),
+            said: "Checking both properly.".into(),
+        }));
+    }
+
+    #[test]
+    fn every_other_check_here_reads_that_run_as_answered() {
+        // Why this fault has to exist at all. The agent spoke, so the operator
+        // was told something by somebody and nobody was left mute: the run
+        // scores clean on every count in this file while the operator sits
+        // waiting for a check that was never going to run.
+        let (a, b) = agents();
+        let run = [
+            msg(Participant::Human, Participant::Agent { id: a }, "is the plugin back?", 0, true),
+            msg(Participant::Agent { id: a }, Participant::Human, "Checking now.", 0, false),
+        ];
+        let found = faults(&run, &named(a, b));
+        assert!(!found.contains(&Fault::Silent));
+        assert!(!found.iter().any(|f| matches!(f, Fault::AssignedAndSaidNothing { .. })));
+        assert_eq!(found.len(), 1, "and this is the only one that sees it: {found:?}");
+    }
+
+    #[test]
+    fn an_agent_that_says_what_it_found_is_clean() {
+        let (a, b) = agents();
+        let run = [
+            msg(Participant::Human, Participant::Agent { id: a }, "is the plugin back?", 0, true),
+            msg(
+                Participant::Agent { id: a },
+                Participant::Human,
+                "Checked both. Drive answered and Gmail answered, so it is back.",
+                0,
+                false,
+            ),
+        ];
+        assert!(faults(&run, &named(a, b)).is_empty());
+    }
+
+    #[test]
+    fn a_started_coding_job_is_the_one_thing_that_outlives_the_message() {
+        // The prompt tells an agent to start a `code` job, say so, and end its
+        // turn, and that is right: the job comes back on a run of its own. So
+        // the sentence is backed, and a rule that could not tell the two apart
+        // would fire on the one announcement the app asks for.
+        let (a, b) = agents();
+        let started = Envelope {
+            parts: vec![
+                Part::text("Started the coding agent on it. Checking back on it shortly."),
+                Part::tool_call(
+                    crate::llm::tools::CODE,
+                    serde_json::Value::Null,
+                    crate::domain::envelope::ToolOutcome::Ok { summary: "started".into() },
+                ),
+            ],
+            ..msg(Participant::Agent { id: a }, Participant::Human, "", 0, false)
+        };
+        let run = [
+            msg(Participant::Human, Participant::Agent { id: a }, "fix the test", 0, true),
+            started,
+        ];
+        assert!(faults(&run, &named(a, b)).is_empty());
+    }
+
+    #[test]
+    fn one_agent_promising_twice_is_one_thing_to_fix() {
+        let (a, b) = agents();
+        let run = [
+            msg(Participant::Human, Participant::Agent { id: a }, "check it", 0, true),
+            msg(Participant::Agent { id: a }, Participant::Human, "Checking now.", 0, false),
+            msg(Participant::Human, Participant::Agent { id: a }, "well?", 0, true),
+            msg(Participant::Agent { id: a }, Participant::Human, "One moment.", 0, false),
+        ];
+        let promises = faults(&run, &named(a, b))
+            .into_iter()
+            .filter(|f| matches!(f, Fault::PromisedAndStopped { .. }))
+            .count();
+        assert_eq!(promises, 1, "a habit is one fault, not one per message");
     }
 
     #[test]

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -294,6 +294,20 @@ impl Stream {
 /// this same string, or the two disagree for as long as the turn runs.
 const ROUND_BREAK: &str = "\n\n";
 
+/// What a turn closing on work it has not done is told, once.
+///
+/// The prompt says the same thing before the turn starts, and this is the
+/// second half of the same fix rather than a duplicate of it: the prompt
+/// reaches models that read it, and this reaches the rest. The observed shape
+/// is a model that has run out of will rather than out of options, so it is
+/// given the mechanism again and told what to do with the round it just got.
+const UNBACKED_PROMISE: &str =
+    "You ended your message with work you had not done. Your message ends your turn, so nothing \
+     of yours runs after it: the check you described will not happen, and the operator will read \
+     a promise and wait for it. You still have this turn. Do the work now with the tools you \
+     have, then write the reply you meant to write, with what you found in it. If you cannot do \
+     it, say plainly what stopped you and what you need.";
+
 /// How many times one model call is attempted before the operator is told.
 ///
 /// The failure this exists for is a connection that never opened: a laptop that
@@ -343,6 +357,7 @@ use crate::domain::ids::{
 };
 use crate::domain::now_ms;
 use crate::domain::plugin::PluginKind;
+use crate::domain::promise;
 use crate::domain::repository::{Gate, Harness};
 use crate::domain::routine::{Routine, RunKind};
 use crate::domain::signin::{self, BrowserState, Signin, Surface};
@@ -3546,6 +3561,10 @@ impl Runtime {
         let mut hit_tool_ceiling = false;
         let mut budget_exhausted = false;
         let mut called_off = false;
+        // At most one per turn. A turn that promises again after being told is
+        // not going to be argued into working, and a second nudge is a model
+        // call spent on the same sentence.
+        let mut nudged = false;
 
         let max_rounds = limits.max_tool_rounds as usize;
         for round in 0..max_rounds {
@@ -3637,6 +3656,49 @@ impl Runtime {
             }
 
             if completion.tool_calls.is_empty() {
+                // Where a turn ends, and therefore the only place a promise can
+                // be caught before it becomes silence. The model has stopped
+                // calling tools, so this text is the last thing that happens:
+                // if it says work is under way, that work is not going to
+                // happen and the operator will wait for it.
+                //
+                // Not gated on an empty tool trail. The turn this was written
+                // for had made two calls already and still closed on a promise
+                // about two more, because what backs a sentence is a call made
+                // before it rather than anywhere in the turn.
+                //
+                // One exception, and it is the one the prompt asks for: a `code`
+                // job outlives the turn that started it, so "started it, will
+                // report back" is a report of a call that has already been made.
+                let started_a_job = tool_parts
+                    .iter()
+                    .any(|part| matches!(part, Part::ToolCall { name, .. } if name == tools::CODE));
+                let unbacked = (!nudged && !started_a_job && round + 1 < max_rounds)
+                    .then(|| promise::promises_work(&completion.content))
+                    .flatten();
+                if let Some(said) = unbacked {
+                    // The one place this is visible without reading a
+                    // transcript. `eval` counts the same thing afterward from
+                    // the envelopes, which is the half that can fail a build.
+                    tracing::info!(
+                        agent = %card.name,
+                        said,
+                        "turn closed on work it had not done; given another round"
+                    );
+                    nudged = true;
+                    messages.push(ChatMessage::Assistant {
+                        content: (!completion.content.is_empty())
+                            .then(|| completion.content.clone()),
+                        tool_calls: Vec::new(),
+                    });
+                    messages.push(ChatMessage::user(UNBACKED_PROMISE));
+                    // What was streamed stays streamed. The operator watched the
+                    // promise being written, so taking it back out of the
+                    // finished message would leave the bubble they read
+                    // disagreeing with the record; kept, it reads as the
+                    // sentence before the answer, which is what it becomes.
+                    continue;
+                }
                 break;
             }
 

--- a/src-tauri/src/runtime/prompt.rs
+++ b/src-tauri/src/runtime/prompt.rs
@@ -910,6 +910,34 @@ pub fn system_prompt(
         }
     });
 
+    // All four modes, because it is a fact about the machine rather than about
+    // who is reading. A model cannot infer it and gets it wrong the same way
+    // every time: chat-trained, it assumes speech and work interleave, because
+    // in most harnesses they do. Here the message is the terminator, so
+    // "Checking both properly" is not a plan, it is the end of the turn, and
+    // the operator waits for a check that was never going to run.
+    //
+    // Written as the mechanism rather than as a rule. "Do not announce work" is
+    // a rule a model talks itself out of, because announcing reads as courtesy;
+    // "nothing of yours runs after this message" leaves nothing to reason
+    // around. It also subsumes the one place this prompt sanctions announcing:
+    // `code` is started before it is described, so that sentence is a report of
+    // a call that has already been made, which is the ordering stated here.
+    out.push_str(
+        "\nYour message ends your turn. Nothing of yours runs after it: not the check you said \
+         you were about to run, not the thing you meant to do next. Nothing happens at all until \
+         somebody writes to you again.\n\n\
+         So the tool call comes first and the sentence comes after. Do not write that you are \
+         checking, looking something up, running something now, or confirming in a moment. \
+         Either the call has already been made and you are reporting what came back, or the work \
+         has not happened and saying it is under way is untrue. If it needs doing, do it in this \
+         turn and write what you found.\n\n\
+         When the work does not fit in one turn, say where you actually got to: what you did, \
+         what it showed, what is left, and what you need to finish it. That is a state the \
+         operator can act on. A promise is not, because there is nothing left running to keep \
+         it.\n",
+    );
+
     out
 }
 
@@ -2411,6 +2439,35 @@ mod tests {
 
         let note = prompt_for(&c, &roster, "", ReplyMode::NoteOnly);
         assert!(note.contains("filed as a short note"));
+    }
+
+    #[test]
+    fn every_reply_mode_is_told_that_the_message_is_the_end_of_the_turn() {
+        // The failure this closes: an agent with a working plugin, two checks
+        // to run and rounds left to run them in closed on "Checking both
+        // properly". The turn ended there, and the operator had to ask why
+        // nothing had happened. Nothing in this prompt had ever said that a
+        // message is the terminator, so the model assumed what it assumes
+        // everywhere else, which is that it can speak and carry on working.
+        let c = card("Manager");
+        for mode in
+            [ReplyMode::ToOperator, ReplyMode::ToPeer, ReplyMode::NoteOnly, ReplyMode::Assigned]
+        {
+            let prompt = prompt_for(&c, &[entry("Chef", &[])], "", mode);
+            assert!(
+                prompt.contains("Your message ends your turn"),
+                "{mode:?} has to be told the mechanism, not only the rule"
+            );
+            assert!(
+                prompt.contains("the tool call comes first and the sentence comes after"),
+                "{mode:?} needs the ordering, which is the part that is actionable"
+            );
+            assert!(
+                prompt.contains("say where you actually got to"),
+                "{mode:?} needs somewhere to go when the work genuinely does not fit, or the \
+                 rule reads as an instruction to finish everything or lie"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/tests/cascade.rs
+++ b/src-tauri/tests/cascade.rs
@@ -1300,6 +1300,82 @@ async fn a_turn_that_speaks_twice_is_watched_with_the_break_between_its_rounds()
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_turn_that_ends_on_a_promise_is_given_the_round_back() {
+    // The failure, verbatim: a plugin that had just started answering again,
+    // two checks left to run, rounds and budget to run them in, and a closing
+    // line of "Checking both properly". A turn ends when the model stops
+    // calling tools, so that sentence was the end of it. The operator read a
+    // promise, waited, and had to send another message to get the work done.
+    //
+    // The prompt now says a message ends the turn, which is the fix for a model
+    // that reads its prompt. This is the fix for the rest of them.
+    let stub = serve(|body| {
+        if has_tool_result(body) {
+            Script::Say("Drive's newest file is still 27 Aug.".into())
+        } else if anyone_said(body, "You ended your message with work you had not done") {
+            Script::Progress("Drive listing is stale".into())
+        } else {
+            Script::Say("Both answered, so the plugin is back. Checking both properly.".into())
+        }
+    })
+    .await;
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "is the plugin back?").unwrap();
+    h.settle(run).await;
+
+    let said = h.channel_texts("Manager").pop().unwrap();
+    assert!(
+        said.contains("still 27 Aug"),
+        "the work the turn promised has to happen in the turn that promised it: {said:?}"
+    );
+    // The promise stays in the message rather than being retracted. The
+    // operator watched it being written, so a finished message without it would
+    // disagree with the bubble they read; left where it is, it reads as the
+    // sentence before the answer, which is what it turned out to be.
+    assert_eq!(
+        said,
+        "Both answered, so the plugin is back. Checking both properly.\n\n\
+         Drive's newest file is still 27 Aug."
+    );
+    assert_eq!(
+        calls_by_agent(&stub).get("Manager"),
+        Some(&3),
+        "the nudge is one model call: the promise, the work, the answer"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_turn_that_promises_again_is_not_argued_with() {
+    // The bound. A model that answers the nudge with the same sentence is not
+    // going to be talked into working, and without a cap this is a turn that
+    // spends every round it has and the budget behind them on one promise.
+    let stub = serve(|_| Script::Say("Checking now.".into())).await;
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "is the plugin back?").unwrap();
+    h.settle(run).await;
+
+    assert_eq!(
+        calls_by_agent(&stub).get("Manager"),
+        Some(&2),
+        "one nudge per turn, however many times the model promises"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_turn_that_says_what_it_found_is_left_alone() {
+    // What the check costs when it is wrong, which is what decides how tight it
+    // has to be. A turn closing on a report is the overwhelmingly common case
+    // and it must not buy a second model call.
+    let stub =
+        serve(|_| Script::Say("Checked both. Drive is stale and Gmail has nothing.".into())).await;
+    let h = harness(&stub, &["Manager"], GuardLimits::default());
+    let run = h.runtime.send_from_human(h.id("Manager"), "is the plugin back?").unwrap();
+    h.settle(run).await;
+
+    assert_eq!(calls_by_agent(&stub).get("Manager"), Some(&1), "a report is not a promise");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn a_retried_round_opens_its_replacement_at_the_left_margin() {
     // The other half of that break. A retry throws away what was drawn and
     // starts a new placeholder, so the round it reopens for is the first thing

--- a/src-tauri/tests/coding.rs
+++ b/src-tauri/tests/coding.rs
@@ -395,6 +395,68 @@ async fn an_agent_is_told_what_the_harness_it_was_given_said() {
     let _ = std::fs::remove_dir_all(&repo);
 }
 
+/// The one announcement this app asks for, and the one thing that outlives the
+/// message announcing it.
+///
+/// A turn that closes on work it has not done is given its round back, because
+/// nothing of an agent's runs after its message. A started `code` job is the
+/// exception and has to be: the job is already running on a process of its own
+/// and comes back as its own envelope, so "started it, checking back" is a
+/// report of a call that has already been made. Without the exemption the
+/// nudge fires on exactly the shape `## Your repository` tells an agent to
+/// write, and every coding job in the app buys a wasted model call.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_started_job_is_not_an_unbacked_promise() {
+    stand_ins();
+    let repo = a_repository("announced");
+
+    let stub = serve(|body| {
+        if anyone_said(body, "has finished") {
+            Script::Say("The coding agent fixed the flaky test.".into())
+        } else if has_tool_result(body) {
+            Script::Say("Started it. Checking back on it shortly.".into())
+        } else {
+            Script::Code("fix the flaky test".into())
+        }
+    })
+    .await;
+    let h = harness(&stub, &["Engineer"], GuardLimits::default());
+
+    let engineer = h.agent_named("Engineer").unwrap();
+    let linked = h
+        .runtime
+        .store()
+        .create_repository(&CleanRepository {
+            group_id: engineer.group_id,
+            name: "guaca".into(),
+            path: repo.to_string_lossy().to_string(),
+            note: String::new(),
+            harness: Which::Claude,
+            gate: Gate::Open,
+            bench: Bench::Shared,
+        })
+        .unwrap();
+    h.runtime.store().set_agent_repository(engineer.id, Some(linked.id)).unwrap();
+
+    let run = h.runtime.send_from_human(h.id("Engineer"), "fix the flaky test").unwrap();
+    h.settle(run).await;
+
+    assert!(
+        h.channel_texts("Engineer").iter().any(|line| line.contains("Started it")),
+        "the announcement is the answer to that turn: {:?}",
+        h.channel_texts("Engineer")
+    );
+    assert!(
+        !stub
+            .transcript
+            .lock()
+            .iter()
+            .any(|body| anyone_said(body, "You ended your message with work you had not done")),
+        "a job that is genuinely running backs the sentence that announces it"
+    );
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
 /// A job is told where the tree is standing before it is told what to do.
 ///
 /// This is the other seam nothing else in the repo can see. Drop the


### PR DESCRIPTION
- feat(runtime): give a turn that ends on a promise its round back
- fix(prompt): say that a message ends the turn, and count when it does not

9 files changed, 740 insertions(+), 2 deletions(-)