### PR TITLE
chore: kernel handle beforeunload dialogs

### DIFF
--- a/docs/BROWSERS.md
+++ b/docs/BROWSERS.md
@@ -148,6 +148,43 @@ between, and a socket held across that is dead in a way nothing notices until an
 action hangs on it. The only thing that has to persist across actions is the
 element numbering, and that is on the page.
 
+## A dialog is answered, because nobody else is there to answer it
+
+`alert`, `confirm`, `prompt` and the *Leave site?* box block the renderer.
+Nothing on that page runs while one is up, so the call that raised it waits out
+the 30-second call timeout and fails, and so does every action after it: the box
+outlives the socket that caused it, and the connection-per-action design means
+there is no client sitting there to notice. An unanswered dialog is not a slow
+action. It is a browser that has stopped until the session times out, and what
+reached the agent was `the browser took too long to answer` on every page it
+tried afterward.
+
+So `Page.enable` is called on attach, and `Page::call` answers
+`Page.javascriptDialogOpening` out of its own read loop. It has to be there
+rather than after the action, because the call that raised the dialog is exactly
+the call that will not return.
+
+Three of the four are answered yes. `beforeunload` asks whether the navigation
+the agent just requested was meant; `confirm` asks whether the button it just
+pressed was meant, and that press has already been through the consent gate;
+`alert` has no other answer. `prompt` is declined, because it is the one that
+wants a value rather than a decision: yes submits the empty string as though the
+agent had typed it, where no is the answer a page is written to expect from
+somebody with nothing to say.
+
+Neither answer is silent. A dialog is a decision taken on the agent's behalf
+between the action it asked for and the page it reads afterward, and the page
+alone does not record that one happened: an agent that meant to leave a form
+sees the page it wanted, and an agent whose `prompt` was declined sees a page
+where nothing changed and no reason why. `note_dialogs` puts what was answered
+into the description, and `render_page` prints it under the same untrusted label
+as the rest of the page, because the wording is the site's.
+
+What this does not reach is a dialog raised while nothing is driving the
+browser: a `setTimeout` that fires between turns is handed to Chrome's own
+manager before this client attaches, and there is no event left to answer. That
+still arrives as a timeout.
+
 ## An action is done once, and the page it produced is read until it answers
 
 A navigation can replace the target a session is attached to, and Chrome then

--- a/docs/gotchas/machines.md
+++ b/docs/gotchas/machines.md
@@ -62,6 +62,16 @@ Chrome that is asked rather than looked at. `docs/MACHINES.md` and
 - **Every `use_screen` action answers with a picture, and only the newest one
   stays.** The first is what stops a model acting on a screen two actions old;
   the second is what keeps that affordable. Removing either breaks the other.
+- **A dialog is answered inside `Page::call`'s read loop, not after the
+  action.** `alert`, `confirm`, `prompt` and *Leave site?* block the renderer,
+  so the call that raises one is the call that never returns: there is no
+  "after" to handle it in. And because there is a connection per action, an
+  unanswered box outlives the socket and fails every action after it too, which
+  is a browser that has stopped rather than an action that was slow. It needs
+  `Page.enable` on attach as well: without it Chrome hands the dialog to its own
+  manager and this client is never told. Only `prompt` is declined, and that is
+  not caution about the others: yes to a prompt submits the empty string as
+  though the agent had typed it. `docs/BROWSERS.md`.
 - **A machine's Chrome opens no debugging port.** Two ways to use the web on one
   screen disagreed about which window was in front, and each fix moved the
   disagreement. `docs/BROWSERS.md` has the history before you add one back.

--- a/src-tauri/src/cdp.rs
+++ b/src-tauri/src/cdp.rs
@@ -27,7 +27,22 @@
 //! is a socket that is dead in a way nothing notices until an action hangs on
 //! it. What has to persist across actions is the element numbering, and that
 //! lives on the page rather than here.
+//!
+//! ## A dialog is answered on the socket that raised it
+//!
+//! `alert`, `confirm`, `prompt` and the *Leave site?* box block the renderer:
+//! nothing on that page runs, so every later call on it waits out
+//! [`CALL_TIMEOUT`] and fails. Because there is a connection per action there
+//! is no client sitting there to answer one, so an unanswered dialog is not a
+//! slow action, it is a browser that has stopped: the box outlives the socket
+//! and every action after it fails the same way until the session times out.
+//!
+//! So the Page domain is enabled on attach and [`Page::call`] answers dialogs
+//! out of its own read loop, which is the only place that sees the socket while
+//! a call is in flight. It has to be there rather than after the action:
+//! the call that raised the dialog is exactly the call that will not return.
 
+use serde::Serialize;
 use serde_json::{json, Value};
 
 use crate::domain::signin::CookieMark;
@@ -80,12 +95,34 @@ pub enum CdpError {
 type Socket =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 
+/// A dialog the page put up, and what this client answered it.
+///
+/// Kept because answering one is a decision taken on the agent's behalf,
+/// between the action it asked for and the page it gets back, and nothing else
+/// in that answer records it happened. `confirm` in particular is the page
+/// asking whether an action the agent already chose should go through, so the
+/// yes belongs in the transcript the operator reads.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Dialog {
+    /// `alert`, `confirm`, `prompt` or `beforeunload`, as Chrome names them.
+    pub kind: String,
+    /// What the box said, bounded: it is page-controlled text on its way to a
+    /// model, and a page can put a context window in one.
+    pub message: String,
+    pub accepted: bool,
+}
+
+/// How long a dialog's message may be by the time a model reads it.
+const DIALOG_MESSAGE_CHARS: usize = 200;
+
 /// One attached page, for the length of one action.
 pub struct Page {
     socket: Socket,
     next_id: u64,
     /// The attached target. Every method that touches the page carries it.
     session: String,
+    /// Dialogs answered while this socket was open, oldest first.
+    answered: Vec<Dialog>,
 }
 
 impl Page {
@@ -103,7 +140,7 @@ impl Page {
                 .map_err(|_| CdpError::TimedOut)?
                 .map_err(|e| CdpError::Transport(e.to_string()))?;
 
-        let mut page = Self { socket, next_id: 0, session: String::new() };
+        let mut page = Self { socket, next_id: 0, session: String::new(), answered: Vec::new() };
 
         let targets = page.browser_call("Target.getTargets", json!({})).await?;
         let target = targets["targetInfos"]
@@ -134,7 +171,18 @@ impl Page {
             .ok_or_else(|| CdpError::Protocol("attaching to the page returned no session".into()))?
             .to_string();
 
+        // What makes `javascriptDialogOpening` arrive at all. Without it Chrome
+        // hands a dialog to its own manager instead, which on a headful browser
+        // means the native box: nothing on the page runs again, and this client
+        // never hears that it happened.
+        page.page_call("Page.enable", json!({})).await?;
+
         Ok(page)
+    }
+
+    /// The dialogs this socket answered, oldest first.
+    pub fn answered(&self) -> &[Dialog] {
+        &self.answered
     }
 
     /// A method against the browser itself.
@@ -154,27 +202,20 @@ impl Page {
     /// protocol is bidirectional, so events for domains nobody enabled and
     /// replies for other sessions arrive in the same stream. Matching on the id
     /// is the only thing that identifies an answer.
+    ///
+    /// One event is not skipped, because skipping it means this call never
+    /// answers: a dialog blocks the renderer, so the call that raised one waits
+    /// out [`CALL_TIMEOUT`] and so does everything after it.
     async fn call(
         &mut self,
         method: &str,
         params: Value,
         session: Option<&str>,
     ) -> Result<Value, CdpError> {
-        use futures_util::{SinkExt, StreamExt};
+        use futures_util::StreamExt;
         use tokio_tungstenite::tungstenite::Message;
 
-        self.next_id += 1;
-        let want = self.next_id;
-
-        let mut request = json!({ "id": want, "method": method, "params": params });
-        if let Some(session) = session {
-            request["sessionId"] = json!(session);
-        }
-
-        self.socket
-            .send(Message::text(request.to_string()))
-            .await
-            .map_err(|e| CdpError::Transport(e.to_string()))?;
+        let want = self.send(method, params, session).await?;
 
         let deadline = tokio::time::Instant::now() + CALL_TIMEOUT;
         loop {
@@ -192,6 +233,10 @@ impl Page {
             let Ok(message) = serde_json::from_str::<Value>(&text) else {
                 continue;
             };
+            if message["method"] == "Page.javascriptDialogOpening" {
+                self.answer_dialog(&message).await?;
+                continue;
+            }
             if message["id"].as_u64() != Some(want) {
                 continue;
             }
@@ -200,6 +245,70 @@ impl Page {
             }
             return Ok(message["result"].clone());
         }
+    }
+
+    /// Writes one call to the socket and hands back the id its answer will
+    /// carry.
+    ///
+    /// Split out because a dialog has to be answered from inside the read loop
+    /// of the call it interrupted, and that answer is a call whose own reply is
+    /// of no interest: it arrives with an id nothing is waiting for and is
+    /// skipped like any other traffic.
+    async fn send(
+        &mut self,
+        method: &str,
+        params: Value,
+        session: Option<&str>,
+    ) -> Result<u64, CdpError> {
+        use futures_util::SinkExt;
+        use tokio_tungstenite::tungstenite::Message;
+
+        self.next_id += 1;
+        let id = self.next_id;
+
+        let mut request = json!({ "id": id, "method": method, "params": params });
+        if let Some(session) = session {
+            request["sessionId"] = json!(session);
+        }
+
+        self.socket
+            .send(Message::text(request.to_string()))
+            .await
+            .map_err(|e| CdpError::Transport(e.to_string()))?;
+        Ok(id)
+    }
+
+    /// Answers a dialog the page just put up, so the call it blocked can finish.
+    ///
+    /// Answered rather than reported, because there is nobody to report it to:
+    /// the agent is inside a tool call and the operator is not necessarily at
+    /// the machine, and until somebody answers, that page is stopped for good.
+    ///
+    /// [`accept`] decides yes or no, and what is answered is kept so it can
+    /// travel back with the page.
+    ///
+    /// The session is echoed from the event rather than assumed to be this
+    /// page's, because a `handleJavaScriptDialog` sent to the wrong scope
+    /// leaves the dialog exactly where it was.
+    async fn answer_dialog(&mut self, event: &Value) -> Result<(), CdpError> {
+        let kind = event["params"]["type"].as_str().unwrap_or_default().to_string();
+        let accepted = accept(&kind);
+        let session = event["sessionId"].as_str().map(str::to_string);
+
+        self.send("Page.handleJavaScriptDialog", json!({ "accept": accepted }), session.as_deref())
+            .await?;
+
+        self.answered.push(Dialog {
+            kind,
+            message: event["params"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .chars()
+                .take(DIALOG_MESSAGE_CHARS)
+                .collect(),
+            accepted,
+        });
+        Ok(())
     }
 
     /// Runs an expression in the page and hands back its value.
@@ -347,6 +456,22 @@ impl Page {
     }
 }
 
+/// Whether a dialog of this kind is answered yes.
+///
+/// Yes for three of the four, because each of them is the page asking about
+/// something the agent has already decided. `beforeunload` asks whether the
+/// navigation the agent just requested was meant; `confirm` asks whether the
+/// button it just pressed was meant, and that press has already been through
+/// the consent gate in `needs_consent`; `alert` has no other answer. No for
+/// `prompt`, which is the one that wants a value rather than a decision: yes
+/// submits the empty string, which is a thing the agent never typed, where no
+/// is the answer a page is written to expect from somebody with nothing to say.
+///
+/// Neither answer is silent. Both travel back with the page in [`Dialog`].
+fn accept(kind: &str) -> bool {
+    kind != "prompt"
+}
+
 /// What an error reply from the protocol means.
 ///
 /// One distinction, and it is the difference between "the web did something"
@@ -415,6 +540,17 @@ mod tests {
             // word for word, or the tool gets abandoned for a screenshot.
             assert!(err.to_string().contains("Read the page again"), "{err}");
         }
+    }
+
+    #[test]
+    fn a_dialog_that_asks_a_question_is_answered_and_one_that_wants_a_value_is_not() {
+        // Each of these blocks the renderer until somebody answers, so the
+        // question is never whether to answer but with what.
+        assert!(accept("beforeunload"), "the agent asked for the navigation");
+        assert!(accept("confirm"), "the press that raised it was already gated");
+        assert!(accept("alert"), "there is no other answer");
+        // Yes here submits the empty string as though the agent had typed it.
+        assert!(!accept("prompt"));
     }
 
     #[test]

--- a/src-tauri/src/kernel.rs
+++ b/src-tauri/src/kernel.rs
@@ -48,7 +48,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::cdp::{CdpError, Page};
+use crate::cdp::{CdpError, Dialog, Page};
 use crate::domain::signin::BrowserState;
 
 const API_BASE: &str = "https://api.onkernel.com";
@@ -558,17 +558,25 @@ impl KernelClient {
         //
         // Read again, never act again. The action has already happened, and a
         // click sent a second time is the one mistake this must not make.
-        let collected = match settle_and_collect(&mut page, settle_ms).await {
+        //
+        // Both sockets are asked what they answered, because a dialog is most
+        // of the reason a page goes missing under an action: the *Leave site?*
+        // box is answered on the first connection and the navigation it
+        // released is what replaced the target the second one had to attach to.
+        let (collected, answered) = match settle_and_collect(&mut page, settle_ms).await {
             Err(CdpError::TargetGone) => {
                 let mut replacement = Page::attach(&session.cdp_ws_url).await?;
-                settle_and_collect(&mut replacement, settle_ms).await?
+                let collected = settle_and_collect(&mut replacement, settle_ms).await?;
+                let mut answered = page.answered().to_vec();
+                answered.extend_from_slice(replacement.answered());
+                (collected, answered)
             }
-            other => other?,
+            other => (other?, page.answered().to_vec()),
         };
-        collected
+        let described = collected
             .as_str()
-            .map(str::to_string)
-            .ok_or_else(|| KernelError::Protocol("the page did not describe itself".into()))
+            .ok_or_else(|| KernelError::Protocol("the page did not describe itself".into()))?;
+        Ok(note_dialogs(described, &answered))
     }
 
     /// Asks a browser what it is signed in to.
@@ -595,6 +603,29 @@ async fn settle_and_collect(page: &mut Page, settle_ms: u32) -> Result<Value, Cd
         page.settle(settle_ms).await?;
     }
     page.evaluate(COLLECT).await
+}
+
+/// Puts the dialogs an action answered into the page it hands back.
+///
+/// A dialog is answered on the agent's behalf between the action it asked for
+/// and the page it reads afterward, and the page alone does not say one
+/// happened: an agent that meant to leave a form sees the page it wanted, and
+/// an agent whose `prompt` was declined sees a page where nothing changed and
+/// no reason why. `render_page` is what turns this into the sentence a model
+/// reads, under the same label as the rest of the page.
+///
+/// A description that will not parse is handed back untouched. That is not a
+/// failure worth reporting: `render_page` already treats an unparseable answer
+/// as page text, and losing the page to keep the note would be the wrong trade.
+fn note_dialogs(described: &str, answered: &[Dialog]) -> String {
+    if answered.is_empty() {
+        return described.to_string();
+    }
+    let Ok(mut page) = serde_json::from_str::<Value>(described) else {
+        return described.to_string();
+    };
+    page["dialogs"] = json!(answered);
+    page.to_string()
 }
 
 /// The element a `click` or `type` names, refused clearly when it is missing.
@@ -942,6 +973,9 @@ mod tests {
         url: String,
         evaluated: Arc<Mutex<Vec<String>>>,
         connections: Arc<AtomicUsize>,
+        /// Every `Page.handleJavaScriptDialog` it received, as the `accept` it
+        /// carried.
+        answers: Arc<Mutex<Vec<bool>>>,
     }
 
     impl FakeBrowser {
@@ -949,20 +983,39 @@ mod tests {
         /// target as gone, which is what Chrome does when a navigation replaces
         /// the target underneath an attached session.
         async fn start_losing(lose_first: usize) -> Self {
+            Self::start(lose_first, None).await
+        }
+
+        /// A browser whose current page raises a dialog of `kind` when it is
+        /// navigated away from, and which then behaves as Chrome does: the
+        /// renderer is blocked, so the navigation does not answer until the
+        /// dialog has been handled.
+        async fn start_asking(kind: &'static str) -> Self {
+            Self::start(0, Some(kind)).await
+        }
+
+        async fn start(lose_first: usize, asks: Option<&'static str>) -> Self {
             let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("a port");
             let address = listener.local_addr().expect("an address");
             let evaluated: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
             let connections = Arc::new(AtomicUsize::new(0));
+            let answers: Arc<Mutex<Vec<bool>>> = Arc::new(Mutex::new(Vec::new()));
 
-            let (recorded, counted) = (evaluated.clone(), connections.clone());
+            let (recorded, counted, collected) =
+                (evaluated.clone(), connections.clone(), answers.clone());
             tokio::spawn(async move {
                 loop {
                     let Ok((stream, _)) = listener.accept().await else { return };
                     let lost = counted.fetch_add(1, Ordering::SeqCst) < lose_first;
                     let recorded = recorded.clone();
+                    let collected = collected.clone();
                     tokio::spawn(async move {
                         let mut socket =
                             tokio_tungstenite::accept_async(stream).await.expect("a handshake");
+                        // The navigation the dialog is holding up, if there is
+                        // one. Nothing else on this page answers until it does.
+                        let mut held: Option<Value> = None;
+                        let mut enabled = false;
                         while let Some(Ok(frame)) = socket.next().await {
                             let Message::Text(text) = frame else { continue };
                             let call: Value = serde_json::from_str(&text).expect("a call");
@@ -975,7 +1028,52 @@ mod tests {
                                 "Target.attachToTarget" => {
                                     json!({"id": id, "result": {"sessionId": "S"}})
                                 }
-                                "Page.navigate" => json!({"id": id, "result": {}}),
+                                // Only an enabled Page domain is told about a
+                                // dialog, which is why the fake refuses to
+                                // raise one otherwise: a client that skipped
+                                // this would wait for an event Chrome is never
+                                // going to send it.
+                                "Page.enable" => {
+                                    enabled = true;
+                                    json!({"id": id, "result": {}})
+                                }
+                                "Page.navigate" => match asks.filter(|_| enabled) {
+                                    Some(kind) => {
+                                        let opening = json!({
+                                            "method": "Page.javascriptDialogOpening",
+                                            "sessionId": "S",
+                                            "params": {
+                                                "type": kind,
+                                                "message": "Changes you made may not be saved.",
+                                                "url": "https://example.com/before",
+                                            },
+                                        });
+                                        socket
+                                            .send(Message::text(opening.to_string()))
+                                            .await
+                                            .expect("the event");
+                                        held = Some(id);
+                                        continue;
+                                    }
+                                    None => json!({"id": id, "result": {}}),
+                                },
+                                "Page.handleJavaScriptDialog" => {
+                                    collected
+                                        .lock()
+                                        .push(call["params"]["accept"].as_bool().expect("accept"));
+                                    socket
+                                        .send(Message::text(
+                                            json!({"id": id, "result": {}}).to_string(),
+                                        ))
+                                        .await
+                                        .expect("a reply");
+                                    // Answered, so the page runs again and the
+                                    // navigation it was blocking completes.
+                                    match held.take() {
+                                        Some(waiting) => json!({"id": waiting, "result": {}}),
+                                        None => continue,
+                                    }
+                                }
                                 "Runtime.evaluate" => {
                                     recorded.lock().push(expression.to_string());
                                     // The settle and the description of the
@@ -1003,7 +1101,7 @@ mod tests {
                 }
             });
 
-            FakeBrowser { url: format!("ws://{address}"), evaluated, connections }
+            FakeBrowser { url: format!("ws://{address}"), evaluated, connections, answers }
         }
 
         fn session(&self) -> Session {
@@ -1063,6 +1161,64 @@ mod tests {
         client.browse(&browser.session(), "read", &json!({})).await.expect("read the page");
 
         assert_eq!(browser.connections(), 1, "a working page must not pay for a reconnection");
+    }
+
+    #[tokio::test]
+    async fn a_leave_site_box_is_answered_so_the_action_it_stopped_can_finish() {
+        // What this exists for. A form the agent typed into puts up "Are you
+        // sure you want to leave?" on the way out, the renderer stops until
+        // somebody answers, and there is nobody: the turn is inside a tool call
+        // and the operator is not necessarily at the machine. Unanswered, the
+        // navigation waits out the call timeout and so does every action after
+        // it, because the box outlives this socket.
+        let browser = FakeBrowser::start_asking("beforeunload").await;
+        let client = KernelClient::new("sk-test").expect("a client");
+
+        let page = client
+            .browse(&browser.session(), "open", &json!({ "url": "https://example.com" }))
+            .await
+            .expect("the navigation was released, so the page arrived");
+
+        assert_eq!(*browser.answers.lock(), vec![true], "the agent asked to leave");
+        assert!(page.contains("https://example.com/after"), "{page}");
+        // And it says so, because answering is a decision taken on the agent's
+        // behalf that the page it gets back does not otherwise record.
+        assert!(page.contains("beforeunload"), "{page}");
+        assert!(page.contains("Changes you made may not be saved."), "{page}");
+    }
+
+    #[tokio::test]
+    async fn a_prompt_is_declined_rather_than_answered_with_nothing() {
+        // The one dialog that wants a value instead of a decision. Accepting it
+        // submits the empty string as though the agent had typed it; declining
+        // is the answer a page is written to expect from somebody with nothing
+        // to say. Either way the page is released and the answer is reported.
+        let browser = FakeBrowser::start_asking("prompt").await;
+        let client = KernelClient::new("sk-test").expect("a client");
+
+        let page = client
+            .browse(&browser.session(), "open", &json!({ "url": "https://example.com" }))
+            .await
+            .expect("the page still arrives");
+
+        assert_eq!(*browser.answers.lock(), vec![false]);
+        assert!(page.contains("prompt"), "{page}");
+    }
+
+    #[test]
+    fn a_page_with_no_dialog_is_handed_back_exactly_as_the_browser_described_it() {
+        // The ordinary case, which is nearly every case: no key appears and the
+        // string is not so much as reparsed.
+        assert_eq!(note_dialogs(FAKE_PAGE, &[]), FAKE_PAGE);
+    }
+
+    #[test]
+    fn a_description_that_will_not_parse_keeps_the_page_and_loses_the_note() {
+        // `render_page` treats an unparseable answer as page text, so this is
+        // still read by the model. Dropping it to keep the note would be the
+        // wrong trade.
+        let answered = [Dialog { kind: "alert".into(), message: "hi".into(), accepted: true }];
+        assert_eq!(note_dialogs("<html>garbage", &answered), "<html>garbage");
     }
 
     #[tokio::test]

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -189,6 +189,23 @@ fn render_page(raw: &str) -> String {
         out.push_str(&format!("\nscrolled {scrolled} of {height} pixels"));
     }
 
+    // Before the controls, because it is the one thing here the model did not
+    // ask for: a dialog stops the page until somebody answers it, so `cdp.rs`
+    // answers it, and this is where that decision is reported back. Bounded
+    // there rather than here, along with the rest of what the page controls.
+    if let Some(dialogs) = page["dialogs"].as_array().filter(|held| !held.is_empty()) {
+        out.push_str("\n\nThe page put up a dialog and it was answered for you:\n");
+        for dialog in dialogs {
+            let answer =
+                if dialog["accepted"].as_bool() == Some(true) { "accepted" } else { "dismissed" };
+            out.push_str(&format!(
+                "  {} \"{}\" was {answer}\n",
+                dialog["kind"].as_str().unwrap_or("dialog"),
+                dialog["message"].as_str().unwrap_or_default()
+            ));
+        }
+    }
+
     if let Some(elements) = page["elements"].as_array() {
         out.push_str("\n\nYou can use these, by number:\n");
         for element in elements.iter().take(60) {
@@ -7226,6 +7243,35 @@ mod tests {
 
         // A reply that is not the driver's JSON at all is still page content.
         assert!(render_page("<html>garbage").starts_with(WEB_LABEL));
+    }
+
+    #[test]
+    fn a_dialog_answered_for_the_agent_is_reported_to_it() {
+        // `cdp.rs` answers these because an unanswered one stops the page for
+        // good, but the answer is a decision taken on the agent's behalf and
+        // the page alone does not record it: a declined `prompt` reads as a
+        // page where nothing happened and no reason why.
+        let described = serde_json::json!({
+            "title": "Draft",
+            "url": "https://example.com/next",
+            "elements": [],
+            "dialogs": [
+                { "kind": "beforeunload", "message": "Leave site?", "accepted": true },
+                { "kind": "prompt", "message": "Name this file", "accepted": false },
+            ],
+        })
+        .to_string();
+
+        let rendered = render_page(&described);
+        assert!(rendered.contains("beforeunload \"Leave site?\" was accepted"), "{rendered}");
+        assert!(rendered.contains("prompt \"Name this file\" was dismissed"), "{rendered}");
+        // It is still the page's own words, so it arrives under the same label
+        // as the rest of them.
+        assert!(rendered.starts_with(WEB_LABEL));
+
+        // And the ordinary page says nothing about dialogs at all.
+        let quiet = serde_json::json!({ "title": "Draft", "url": "u", "elements": [] }).to_string();
+        assert!(!render_page(&quiet).contains("dialog"), "{}", render_page(&quiet));
     }
 
     fn session(domain: &str) -> Signin {


### PR DESCRIPTION
- chore: kernel handle beforeunload dialogs

5 files changed, 409 insertions(+), 24 deletions(-)