### PR TITLE
fix: make the workspace usable on phones

### DIFF
--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -1830,3 +1830,26 @@ statement that this agent is working on that run, and the entry is dropped when
 the run settles. Not read from what `sendMessage` returned, which only knows
 about conversations the operator started — a routine's work and a peer's request
 are exactly as worth stopping.
+
+## A phone shows one pane at a time
+
+Below 48rem, and on touch-only devices in either orientation, the workspace
+shows Agents, Chat or Details, chosen by three
+persistent buttons. The rail and inspector no longer take width from the
+conversation. Hidden panes stay mounted: changing views must not discard a
+draft, move the transcript or reconnect the event stream. Selecting an agent,
+including the one already selected, returns to Chat. A routine opened from the
+transcript reveals Details.
+
+Crews are selected by name on a phone. The desktop's proximity column is hidden,
+and a touch scrolling the agent list never starts a reorder. Settings uses a
+horizontal section list above its pane; dialogs fit the viewport, controls have
+touch-sized targets and inputs stay large enough to avoid Safari's focus zoom.
+The visual viewport sizes the workspace while the keyboard is up and follows
+Safari's pan. Pinch zoom does not resize that layout.
+
+`scripts/hosting-browser.mjs` checks actual touch hit targets, phone widths,
+draft preservation, constrained viewport height, dialogs and the wide layout
+against a scratch daemon. Set `GUACA_BROWSER_SHOTS` to retain screenshots for
+visual review. The viewport event suite covers keyboard resize, pan and zoom
+without depending on a particular device keyboard.

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <title>Guaca</title>
   </head>
   <body>

--- a/scripts/hosting-browser.mjs
+++ b/scripts/hosting-browser.mjs
@@ -3,7 +3,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
-import { mkdtemp, mkdir, rm, readFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, readFile, writeFile } from "node:fs/promises";
 import http from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -193,7 +193,7 @@ try {
     tab = (await cdp("Target.createTarget", { url: `${base}/#token=${token}` })).targetId;
     session = (await cdp("Target.attachToTarget", { targetId: tab, flatten: true })).sessionId;
     await until(
-      () => evaluate(`document.body.innerText.includes('Browser check')`),
+      () => evaluate(`document.body?.innerText.includes('Browser check')`),
       "real app renders its roster",
     );
     await evaluate(
@@ -220,7 +220,7 @@ try {
     "reconnected client restores partial reply",
   );
   await cdp("Target.closeTarget", { targetId: tab });
-  finish("Finished while the client was closed.");
+  finish("Finished while the client was closed.\n\nThe workspace keeps working while you are away. You can read replies, switch agents, and review their notes from your phone.\n\n- Open Agents to choose a crew.\n- Return to Chat without losing your draft.\n- Open Details for memory and routines.\n\nA long reference should wrap: https://example.com/" + "reference".repeat(18));
   await until(
     async () =>
       (await call("channel_messages", { channelId: agent.id })).some((m) =>
@@ -236,6 +236,110 @@ try {
   console.log(
     "PASS: partial reply restored; backend finished with no client; transcript restored.",
   );
+
+  // Phone layout uses real touch hit testing. Keep a draft while changing
+  // panes, and shrink the viewport as a keyboard would before returning wide.
+  const tap = async (selector) => {
+    const point = await evaluate(`(() => {
+      const node = document.querySelector(${JSON.stringify(selector)});
+      if (!node) throw new Error('Missing target: ' + ${JSON.stringify(selector)});
+      node.scrollIntoView({block:'nearest'});
+      const r = node.getBoundingClientRect();
+      if (!r.width || !r.height) throw new Error('Hidden target');
+      return {x:r.x+r.width/2,y:r.y+r.height/2};
+    })()`);
+    await cdp("Input.dispatchTouchEvent", {type:"touchStart", touchPoints:[point]}, session);
+    await cdp("Input.dispatchTouchEvent", {type:"touchEnd", touchPoints:[]}, session);
+  };
+  const fits = async (selector) => {
+    const bounds = await evaluate(`(() => {
+      const n=document.querySelector(${JSON.stringify(selector)}), r=n.getBoundingClientRect();
+      return {left:r.left,right:r.right,top:r.top,bottom:r.bottom,width:r.width,height:r.height,
+        overflow:n.scrollWidth-n.clientWidth, vw:innerWidth, vh:visualViewport.height};
+    })()`);
+    assert.ok(bounds.width > 0 && bounds.height > 0, `${selector} is visible`);
+    assert.ok(bounds.left >= -1 && bounds.right <= bounds.vw+1, `${selector} fits horizontally: ${JSON.stringify(bounds)}`);
+    assert.ok(bounds.top >= -1 && bounds.bottom <= bounds.vh+1, `${selector} fits vertically: ${JSON.stringify(bounds)}`);
+    assert.ok(bounds.overflow <= 1, `${selector} has no horizontal overflow: ${JSON.stringify(bounds)}`);
+  };
+  const size = async (width,height,mobile=true) => {
+    await cdp("Emulation.setDeviceMetricsOverride", {width,height,deviceScaleFactor:1,mobile},session);
+    await cdp("Emulation.setTouchEmulationEnabled", {enabled:mobile},session);
+    await delay(150);
+  };
+  for (const width of [320,390,430,768]) {
+    await size(width,844);
+    await fits(".app");
+    await fits(".pane");
+    await fits(".pane__scroll");
+    await fits(".composer");
+    assert.equal(await evaluate("getComputedStyle(document.querySelector('.rail')).display"),"none");
+    await tap(".composer__input");
+    await cdp("Input.insertText", {text:"Draft survives navigation"},session);
+    await tap(".mobile-nav button:first-child");
+    await fits(".rail");
+    await fits(".mobile-crews select");
+    await tap(".agent-row");
+    assert.equal(await evaluate("document.querySelector('.composer__input').value"),"Draft survives navigation");
+    await tap(".mobile-nav button:last-child");
+    await fits(".inspector");
+    await tap(".mobile-nav button:nth-child(2)");
+    await size(width,400);
+    await fits(".composer");
+    await size(width,844);
+    await evaluate("document.querySelector('.composer__input').focus()");
+    // React must see the input event; assigning .value alone would not clear its draft.
+    await evaluate(`(() => { const n=document.querySelector('.composer__input');
+      Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype,'value').set.call(n,'');
+      n.dispatchEvent(new Event('input',{bubbles:true})); n.blur(); })()`);
+    await tap(".mobile-nav button:first-child");
+    await tap(".rail__foot button:last-child");
+    await until(() => evaluate("!!document.querySelector('.dialog--settings')"),"settings opens on phone");
+    await delay(250);
+    await fits(".dialog--settings");
+    await fits(".settings__pane");
+    await fits(".settings__foot");
+    if (width === 320) {
+      const tabs = await evaluate("document.querySelectorAll('.settings__tab').length");
+      for (let i=1;i<=tabs;i++) {
+        await tap(`.settings__tab:nth-child(${i})`);
+        await delay(100);
+        await fits(".settings__pane");
+        await fits(".settings__foot");
+      }
+      await tap(".settings__tab:first-child");
+    }
+    if (process.env.GUACA_BROWSER_SHOTS) {
+      await mkdir(process.env.GUACA_BROWSER_SHOTS,{recursive:true});
+      const shot=await cdp("Page.captureScreenshot",{format:"png"},session);
+      await writeFile(path.join(process.env.GUACA_BROWSER_SHOTS,`settings-${width}.png`),Buffer.from(shot.data,"base64"));
+    }
+    await evaluate("document.querySelector('.scrim__close').click()");
+    if (width === 320) {
+      for (const [button,dialog] of [[".rail__foot button:first-child",".dialog--cafeteria"],[".rail__foot button:nth-child(2)",".dialog--calendar"],[".rail__for-you",".for-you"]]) {
+        await tap(button);
+        await until(() => evaluate(`!!document.querySelector('${dialog}')`),`${dialog} opens`);
+        await delay(250);
+        await fits(dialog);
+        await evaluate("document.querySelector('.scrim__close').click()");
+      }
+    }
+    await tap(".agent-row");
+    if (process.env.GUACA_BROWSER_SHOTS) {
+      const shot=await cdp("Page.captureScreenshot",{format:"png"},session);
+      await writeFile(path.join(process.env.GUACA_BROWSER_SHOTS,`chat-${width}.png`),Buffer.from(shot.data,"base64"));
+    }
+  }
+  await size(844,390);
+  await fits(".pane");
+  await fits(".composer");
+  await fits(".mobile-nav");
+  await size(1280,900,false);
+  await fits(".pane");
+  await fits(".rail");
+  await fits(".inspector");
+  assert.equal(await evaluate("getComputedStyle(document.querySelector('.mobile-nav')).display"),"none");
+  console.log("PASS: phone widths, touch navigation, preserved drafts, keyboard-sized viewport, settings and desktop layout.");
 
   // Exercise the real artifact route in Chromium, including its opaque origin.
   const artifact = await call("frame_artifact", {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -455,3 +455,43 @@ it("refreshes the roster when the event connection returns", async () => {
   reconnect?.();
   await waitFor(() => expect(listAgents.mock.calls.length).toBeGreaterThan(before));
 });
+
+describe("phone navigation", () => {
+  it("opens the same channel again and preserves its draft across panes", async () => {
+    listAgents.mockResolvedValue([agent("Ada")]);
+    localStorage.setItem("guac.inspector", "closed");
+    const { container } = render(<App />);
+    await screen.findByText("Ada");
+    fireEvent.click(railRow("Ada"));
+    await screen.findByRole("heading", { name: "Ada" });
+    const pane = () => container.querySelector(".app")?.getAttribute("data-mobile-pane");
+    const input = container.querySelector(".composer__input") as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: "Keep this draft" } });
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+    expect(pane()).toBe("details");
+    expect(container.querySelector(".inspector--closed")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Hide this panel" }));
+    expect(pane()).toBe("conversation");
+    fireEvent.click(screen.getByRole("button", { name: "Agents" }));
+    expect(pane()).toBe("agents");
+    fireEvent.click(railRow("Ada"));
+    expect(pane()).toBe("conversation");
+    expect((container.querySelector(".composer__input") as HTMLTextAreaElement).value).toBe(
+      "Keep this draft",
+    );
+  });
+
+  it("lets a phone choose a crew by name without hovering", async () => {
+    const other = aGroup({ id: "crew-other", name: "Research" });
+    listGroups.mockResolvedValue([aGroup(), other]);
+    listAgents.mockResolvedValue([agent("Ada"), { ...agent("Lin"), groupId: other.id }]);
+    const { container } = render(<App />);
+    await screen.findByText("Ada");
+    fireEvent.change(screen.getByRole("combobox", { name: "Crew" }), {
+      target: { value: other.id },
+    });
+    await waitFor(() => expect(useStore.getState().railGroup).toBe(other.id));
+    expect(railNames()).toEqual(["Lin"]);
+    expect(container.querySelector(".app")?.getAttribute("data-mobile-pane")).toBe("agents");
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,8 +21,10 @@ import { away, burst, markQuiet, quiet, shouldNotify } from "./lib/notify";
 import { useLiveAgents, useStore } from "./lib/store";
 import { attached, hosted } from "./lib/transport";
 import { type AgentCard, errorMessage, type Group, type UiEvent } from "./lib/types";
+import { followViewport } from "./lib/viewport";
 
 export default function App() {
+  useEffect(followViewport, []);
   const agents = useLiveAgents();
   const selected = useStore((s) => s.selected);
   const settings = useStore((s) => s.settings);
@@ -83,6 +85,16 @@ export default function App() {
   const [ready, setReady] = useState(false);
   const [showCafeteria, setShowCafeteria] = useState(false);
   const [showCalendar, setShowCalendar] = useState(false);
+  const [mobilePane, setMobilePane] = useState<"agents" | "conversation" | "details">(
+    "conversation",
+  );
+  const openConversation = useCallback(() => setMobilePane("conversation"), []);
+  const openDetails = useCallback(() => setMobilePane("details"), []);
+
+  // Search and notifications can select a channel without going through the rail.
+  useEffect(() => {
+    if (selected) setMobilePane("conversation");
+  }, [selected]);
 
   // The three shortcuts that work wherever the operator is, matched against
   // the same table the Shortcuts pane draws from, so a key listed there is a key
@@ -313,8 +325,37 @@ export default function App() {
     !settings.apiKeySet;
 
   return (
-    <div className="app">
+    <div className="app" data-mobile-pane={openAgent ? mobilePane : "agents"}>
+      <nav className="mobile-nav" aria-label="Workspace views">
+        <button
+          type="button"
+          className="btn btn--ghost"
+          aria-pressed={!openAgent || mobilePane === "agents"}
+          onClick={() => setMobilePane("agents")}
+        >
+          Agents
+        </button>
+        <button
+          type="button"
+          className="btn btn--ghost"
+          aria-pressed={!!openAgent && mobilePane === "conversation"}
+          disabled={!openAgent}
+          onClick={openConversation}
+        >
+          Chat
+        </button>
+        <button
+          type="button"
+          className="btn btn--ghost"
+          aria-pressed={!!openAgent && mobilePane === "details"}
+          disabled={!openAgent}
+          onClick={openDetails}
+        >
+          Details
+        </button>
+      </nav>
       <Sidebar
+        onOpenChannel={openConversation}
         onEditAgent={(agent) => setEditing(agent)}
         onOpenCafeteria={() => setShowCafeteria(true)}
         onOpenCalendar={() => setShowCalendar(true)}
@@ -404,7 +445,13 @@ export default function App() {
       </main>
 
       {ready && agents.length > 0 && (
-        <Inspector agent={openAgent} onEditProfile={(agent) => setEditing(agent)} />
+        <Inspector
+          agent={openAgent}
+          onEditProfile={(agent) => setEditing(agent)}
+          reveal={mobilePane === "details"}
+          onReveal={openDetails}
+          onHide={openConversation}
+        />
       )}
 
       {/* Outside `main` and after the panes, so nothing that scrolls can clip it

--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -11,6 +11,9 @@ import { WorkingNotes } from "./WorkingNotes";
 
 interface Props {
   agent: AgentCard | undefined;
+  reveal?: boolean;
+  onReveal?: () => void;
+  onHide?: () => void;
   onEditProfile: (agent: AgentCard) => void;
 }
 
@@ -68,7 +71,7 @@ function remembered(): boolean {
  * moving above them buys: the two stores are read against each other, and what
  * each is for is clearest when the other is under it.
  */
-export function Inspector({ agent, onEditProfile }: Props) {
+export function Inspector({ agent, onEditProfile, reveal, onReveal, onHide }: Props) {
   const [open, setOpen] = useState(remembered);
   const [routine, setRoutine] = useState<RoutineId | "new" | null>(null);
 
@@ -79,6 +82,10 @@ export function Inspector({ agent, onEditProfile }: Props) {
       // As above: not worth telling the operator about.
     }
   }, [open]);
+
+  useEffect(() => {
+    if (reveal) setOpen(true);
+  }, [reveal]);
 
   // Switching agent comes back to the top of the panel. A routine id belongs
   // to one agent, and leaving it open would show another agent's schedule
@@ -98,9 +105,10 @@ export function Inspector({ agent, onEditProfile }: Props) {
   useEffect(() => {
     if (asked === null) return;
     setRoutine(asked);
+    onReveal?.();
     setOpen(true);
     taken();
-  }, [asked, taken]);
+  }, [asked, taken, onReveal]);
 
   // Nothing to inspect with no channel open, which is what going inside a crew
   // the open one was not in leaves behind.
@@ -156,7 +164,10 @@ export function Inspector({ agent, onEditProfile }: Props) {
         <button
           type="button"
           className="inspector__tab"
-          onClick={() => setOpen(false)}
+          onClick={() => {
+            setOpen(false);
+            onHide?.();
+          }}
           title="Hide this panel"
           aria-label="Hide this panel"
           aria-expanded={true}

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -898,3 +898,17 @@ describe("an agent that has stopped and said so", () => {
     expect(screen.getAllByText("stuck 2d")).toHaveLength(1);
   });
 });
+
+it("lets a touch scroll the rail without rearranging agents", () => {
+  const { container } = draw([group("Crew")], [agent("Ada"), agent("Lin")]);
+  fireEvent.pointerDown(row("Ada"), {
+    button: 0,
+    pointerType: "touch",
+    clientX: 100,
+    clientY: 300,
+  });
+  fireEvent.pointerMove(window, { pointerType: "touch", clientX: 100, clientY: 200 });
+  expect(container.querySelector('.rail[data-dragging="true"]')).toBeNull();
+  fireEvent.pointerUp(window, { pointerType: "touch", clientX: 100, clientY: 200 });
+  expect(moveAgent).not.toHaveBeenCalled();
+});

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -14,6 +14,7 @@ import { RailRepositories } from "./RailRepositories";
 import { SpendTag, useSpendTag } from "./Spend";
 
 interface Props {
+  onOpenChannel?: () => void;
   onEditAgent: (agent: AgentCard) => void;
   onEditGroup: (group: Group) => void;
   onOpenCafeteria: () => void;
@@ -55,6 +56,7 @@ interface Drag {
 }
 
 export function Sidebar({
+  onOpenChannel,
   onEditAgent,
   onEditGroup,
   onOpenCafeteria,
@@ -395,7 +397,10 @@ export function Sidebar({
         data-held={dragging === agent.id ? "true" : undefined}
         data-over={dragging && dragging !== agent.id && isOver(target) ? "true" : undefined}
         style={{ "--accent": agent.color } as React.CSSProperties}
-        onClick={() => void select(agent.id)}
+        onClick={() => {
+          void select(agent.id);
+          onOpenChannel?.();
+        }}
         onDoubleClick={() => onEditAgent(agent)}
         onContextMenu={(event) => {
           event.preventDefault();
@@ -404,7 +409,7 @@ export function Sidebar({
         // The press is remembered and nothing else happens yet: a row is a
         // button first, and it only becomes a handle once the pointer moves.
         onPointerDown={(event) => {
-          if (event.button !== 0) return;
+          if (event.button !== 0 || event.pointerType === "touch") return;
           press.current = { id: agent.id, x: event.clientX, y: event.clientY };
         }}
         onPointerEnter={() => hover(target)}
@@ -504,6 +509,22 @@ export function Sidebar({
           <span className="rail__wordmark">Guaca</span>
           <NewMenu onNewAgent={onNewAgent} onNewGroup={onNewGroup} />
         </div>
+
+        <label className="mobile-crews field">
+          <span className="field__label">Crew</span>
+          <select
+            className="input"
+            value={railGroup ?? ""}
+            onChange={(event) => void focusGroup(event.target.value || null)}
+          >
+            <option value="">All crews</option>
+            {groups.map((group) => (
+              <option key={group.id} value={group.id}>
+                {group.name}
+              </option>
+            ))}
+          </select>
+        </label>
 
         {/* Looks like a field and behaves like a button, because the field it
           opens onto is the one that does the searching. Two inputs would mean

--- a/src/lib/viewport.test.ts
+++ b/src/lib/viewport.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, expect, it, vi } from "vitest";
+
+import { followViewport } from "./viewport";
+
+afterEach(() => vi.unstubAllGlobals());
+
+it("leaves browsers without a visual viewport on the CSS fallback", () => {
+  vi.stubGlobal("visualViewport", undefined);
+  followViewport()();
+  expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("");
+});
+
+it("follows keyboard resize and pan, preserves pinch zoom, and removes listeners", () => {
+  const viewport = Object.assign(new EventTarget(), { height: 844, offsetTop: 0, scale: 1 });
+  vi.stubGlobal("visualViewport", viewport);
+  const stop = followViewport();
+  const style = document.documentElement.style;
+  expect(style.getPropertyValue("--viewport-height")).toBe("844px");
+  viewport.height = 380;
+  viewport.dispatchEvent(new Event("resize"));
+  expect(style.getPropertyValue("--viewport-height")).toBe("380px");
+  viewport.offsetTop = 80;
+  viewport.dispatchEvent(new Event("scroll"));
+  expect(style.getPropertyValue("--viewport-top")).toBe("80px");
+  viewport.scale = 2;
+  viewport.height = 190;
+  viewport.dispatchEvent(new Event("resize"));
+  expect(style.getPropertyValue("--viewport-height")).toBe("380px");
+  stop();
+  viewport.scale = 1;
+  viewport.dispatchEvent(new Event("resize"));
+  expect(style.getPropertyValue("--viewport-height")).toBe("");
+  expect(style.getPropertyValue("--viewport-top")).toBe("");
+});

--- a/src/lib/viewport.ts
+++ b/src/lib/viewport.ts
@@ -1,0 +1,23 @@
+/** Keep the composer above a mobile keyboard, including Safari's viewport pan.
+ * CSS consumes these measurements only in the narrow layout. Pinch zoom keeps
+ * the layout's original dimensions so magnifying text does not reflow it.
+ */
+export function followViewport(): () => void {
+  const viewport = window.visualViewport;
+  if (!viewport) return () => {};
+  const style = document.documentElement.style;
+  const update = () => {
+    if (viewport.scale !== 1) return;
+    style.setProperty("--viewport-height", `${viewport.height}px`);
+    style.setProperty("--viewport-top", `${viewport.offsetTop}px`);
+  };
+  update();
+  viewport.addEventListener("resize", update);
+  viewport.addEventListener("scroll", update);
+  return () => {
+    viewport.removeEventListener("resize", update);
+    viewport.removeEventListener("scroll", update);
+    style.removeProperty("--viewport-height");
+    style.removeProperty("--viewport-top");
+  };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -103,6 +103,12 @@
      than a size, because it is also what a script would read back. */
   --ui-scale: 1;
   --measure-attention: 46rem;
+  --control-touch: 2.75rem;
+  --type-touch: max(16px, 1rem);
+  --space-safe-top: env(safe-area-inset-top, 0px);
+  --space-safe-bottom: env(safe-area-inset-bottom, 0px);
+  --space-safe-left: env(safe-area-inset-left, 0px);
+  --space-safe-right: env(safe-area-inset-right, 0px);
 
   /* ---- Type ---------------------------------------------------------------
      Ten roles, whole pixels at scale 1, no two closer than 1px.
@@ -7585,4 +7591,241 @@ input[type="file"]:disabled {
 
 .for-you__body > .for-you__receipt {
   padding: var(--space-5) var(--space-7);
+}
+
+/* A phone shows one workspace pane at a time. Keep the transcript mounted so
+   drafts, scroll position and live events survive a trip to the agent list. */
+.mobile-nav,
+.mobile-crews {
+  display: none;
+}
+
+/* CSS media queries cannot read custom properties. 48rem is the point where
+   the two desktop columns leave too little room to read a conversation.
+   Touch-only devices keep this navigation in landscape as well. */
+@media (max-width: 48rem), (hover: none) and (pointer: coarse) {
+  :root {
+    --control-h: var(--control-touch);
+    --control-h-sm: var(--control-touch);
+    --column-inset: var(--space-5);
+  }
+
+  .app {
+    position: fixed;
+    top: var(--viewport-top, 0px);
+    left: 0;
+    width: 100%;
+    height: var(--viewport-height, 100dvh);
+    padding: var(--space-safe-top) var(--space-safe-right) var(--space-safe-bottom) var(--space-safe-left);
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .mobile-nav {
+    display: flex;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-5);
+    border-bottom: 1px solid var(--edge);
+    background: var(--rail-ground);
+  }
+
+  .mobile-nav .btn {
+    flex: 1;
+  }
+
+  .mobile-nav [aria-pressed="true"] {
+    background: var(--raised);
+    color: var(--text);
+    font-weight: 600;
+  }
+
+  .app > .grail,
+  .app:not([data-mobile-pane="agents"]) > .rail,
+  .app:not([data-mobile-pane="conversation"]) > main,
+  .app:not([data-mobile-pane="details"]) > .inspector {
+    display: none;
+  }
+
+  .app > .rail,
+  .app > .inspector {
+    width: 100%;
+    min-width: 0;
+    border: 0;
+  }
+
+  .mobile-crews {
+    display: flex;
+    flex-direction: column;
+    margin: 0 var(--space-6) var(--space-4);
+  }
+
+  .rail__brand {
+    padding-top: var(--space-5);
+  }
+
+  .rail__gear {
+    opacity: 1;
+  }
+
+  .agent-row {
+    touch-action: pan-y;
+    min-height: var(--control-touch);
+  }
+
+  .rail__search,
+  .rail__new,
+  .rail__gear,
+  .pane__more,
+  .inspector__tab,
+  .inspector__gear,
+  .composer__send,
+  .composer__attach {
+    min-width: var(--control-touch);
+    min-height: var(--control-touch);
+  }
+
+  .pane__header {
+    height: auto;
+    min-height: var(--control-touch);
+    padding: var(--space-3) var(--space-5);
+    gap: var(--space-4);
+  }
+
+  .pane__title {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .msg {
+    grid-template-columns: var(--space-7) minmax(0, 1fr);
+    gap: var(--space-2) var(--space-4);
+  }
+
+  .msg[data-operator="true"] {
+    grid-template-columns: minmax(0, 1fr);
+    padding-right: var(--space-5);
+    padding-left: var(--space-8);
+  }
+
+  .msg[data-operator="true"] .msg__body {
+    grid-column: 1;
+  }
+
+  .msg .msg__at {
+    grid-column: 2;
+    grid-row: 2;
+    opacity: 1;
+  }
+
+  .msg[data-operator="true"] .msg__at {
+    grid-column: 1;
+    justify-self: end;
+  }
+
+  .composer {
+    margin: var(--space-4) var(--space-5);
+  }
+
+  .composer__row {
+    align-items: flex-end;
+  }
+
+  .composer__foot {
+    display: none;
+  }
+
+  input,
+  select,
+  textarea,
+  .input,
+  .palette__input {
+    font-size: var(--type-touch);
+  }
+
+  .composer__input,
+  .composer__mirror {
+    font-size: var(--type-touch);
+    max-height: 30dvh;
+  }
+
+  .banner,
+  .settings__foot,
+  .cafeteria__head,
+  .cafeteria__foot,
+  .calendar__title-row,
+  .calendar__foot {
+    flex-wrap: wrap;
+  }
+
+  .scrim {
+    top: var(--viewport-top, 0px);
+    bottom: auto;
+    height: var(--viewport-height, 100dvh);
+    padding: var(--space-safe-top) var(--space-safe-right) var(--space-safe-bottom) var(--space-safe-left);
+  }
+
+  .scrim > .dialog,
+  .scrim > .palette {
+    width: 100%;
+    max-width: 100%;
+    max-height: 100%;
+    margin: auto;
+    border-radius: 0;
+    overflow-y: auto;
+  }
+
+  .scrim > .dialog--settings,
+  .scrim > .dialog--cafeteria,
+  .scrim > .dialog--calendar,
+  .scrim > .for-you {
+    height: 100%;
+    padding: 0;
+    overflow: hidden;
+  }
+
+  .settings__body {
+    flex-direction: column;
+  }
+
+  .settings__nav {
+    width: 100%;
+    flex-direction: row;
+    overflow-x: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--edge);
+  }
+
+  .settings__tab {
+    flex: none;
+    white-space: nowrap;
+  }
+
+  .settings__head,
+  .settings__pane,
+  .settings__foot,
+  .cafeteria__head,
+  .cafeteria__stations,
+  .cafeteria__foot,
+  .calendar__head,
+  .calendar__body,
+  .calendar__foot {
+    padding: var(--space-5);
+  }
+
+  .settings__pane {
+    min-width: 0;
+  }
+
+  .cafeteria__grid,
+  .calendar__pair,
+  .occasion {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .palette__results {
+    max-height: 65dvh;
+  }
 }


### PR DESCRIPTION
Phones previously kept both desktop sidebars beside the conversation and relied on hover to switch crews. Small screens and touch devices now show one pane at a time, with Agents, Chat, and Details navigation and a crew picker by name. Drafts survive switching panes.

Dialogs fit the screen, settings tabs scroll horizontally, controls have larger touch targets, and the composer follows the visible viewport when the keyboard opens. Touch scrolling no longer starts an agent reorder. Wider desktop layouts retain their columns.

Validation: full frontend and Rust gates passed (1,589 frontend tests). Real Chromium with a scratch daemon passed touch navigation, draft preservation, 320/390/430/768px layouts, phone landscape, a keyboard-sized viewport, every settings section, calendar, cafeteria, review queue, and desktop layout. Screenshots reviewed. Physical iPhone keyboard behavior remains for device verification.
