### PR TITLE
Make phone navigation reachable and predictable

### DIFF
--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -1834,16 +1834,18 @@ are exactly as worth stopping.
 ## A phone shows one pane at a time
 
 Below 48rem, and on touch-only devices in either orientation, the workspace
-shows Agents, Chat or Details, chosen by three
-persistent buttons. The rail and inspector no longer take width from the
-conversation. Hidden panes stay mounted: changing views must not discard a
+shows one pane at a time. A bottom bar keeps Chats, For you (with its attention
+count), Search and Settings within thumb reach. Chats opens the crew and agent
+list; a conversation has a back button, its crew name and a Details button.
+Details has its own back button and an Actions menu. The rail and inspector
+no longer take width from the conversation. Hidden panes stay mounted: changing views must not discard a
 draft, move the transcript or reconnect the event stream. Selecting an agent,
 including the one already selected, returns to Chat. A routine opened from the
 transcript reveals Details.
 
 Crews are selected by name on a phone. The desktop's proximity column is hidden,
 and a touch scrolling the agent list never starts a reorder. Settings uses a
-horizontal section list above its pane; dialogs fit the viewport, controls have
+labeled section picker above its pane, and Search has a visible Cancel button; dialogs fit the viewport, controls have
 touch-sized targets and inputs stay large enough to avoid Safari's focus zoom.
 The visual viewport sizes the workspace while the keyboard is up and follows
 Safari's pan. Pinch zoom does not resize that layout.

--- a/scripts/hosting-browser.mjs
+++ b/scripts/hosting-browser.mjs
@@ -220,7 +220,7 @@ try {
     "reconnected client restores partial reply",
   );
   await cdp("Target.closeTarget", { targetId: tab });
-  finish("Finished while the client was closed.\n\nThe workspace keeps working while you are away. You can read replies, switch agents, and review their notes from your phone.\n\n- Open Agents to choose a crew.\n- Return to Chat without losing your draft.\n- Open Details for memory and routines.\n\nA long reference should wrap: https://example.com/" + "reference".repeat(18));
+  finish("Finished while the client was closed.\n\nThe workspace keeps working while you are away. You can read replies, switch agents, and review their notes from your phone.\n\n- Open Chats to choose a crew.\n- Return to Chat without losing your draft.\n- Open Details for memory and routines.\n\nA long reference should wrap: https://example.com/" + "reference".repeat(18));
   await until(
     async () =>
       (await call("channel_messages", { channelId: agent.id })).some((m) =>
@@ -271,19 +271,43 @@ try {
     await size(width,844);
     await fits(".app");
     await fits(".pane");
+    assert.equal(await evaluate("document.querySelector('.pane__crew').textContent"), "Browser test");
     await fits(".pane__scroll");
     await fits(".composer");
     assert.equal(await evaluate("getComputedStyle(document.querySelector('.rail')).display"),"none");
     await tap(".composer__input");
     await cdp("Input.insertText", {text:"Draft survives navigation"},session);
-    await tap(".mobile-nav button:first-child");
+    await fits(".mobile-nav");
+    assert.ok(await evaluate("document.querySelector('.mobile-nav').getBoundingClientRect().top > visualViewport.height / 2"), "navigation is within thumb reach at the bottom");
+    await tap('[aria-label="Back to chats"]');
     await fits(".rail");
     await fits(".mobile-crews select");
-    await tap(".agent-row");
+    if (process.env.GUACA_BROWSER_SHOTS) {
+      await mkdir(process.env.GUACA_BROWSER_SHOTS,{recursive:true});
+      const shot=await cdp("Page.captureScreenshot",{format:"png"},session);
+      await writeFile(path.join(process.env.GUACA_BROWSER_SHOTS,`chats-${width}.png`),Buffer.from(shot.data,"base64"));
+    }
+    await tap(".mobile-nav button:nth-child(3)");
+    await until(() => evaluate("!!document.querySelector('.palette__input')"), "search opens from the list");
+    await tap(".palette__input");
+    await cdp("Input.insertText", {text:"Browser check"},session);
+    await until(() => evaluate("!!document.querySelector('.palette__row')"), "agent is found");
+    await tap(".palette__row");
+    await fits(".pane");
     assert.equal(await evaluate("document.querySelector('.composer__input').value"),"Draft survives navigation");
-    await tap(".mobile-nav button:last-child");
+    await tap(".mobile-details");
     await fits(".inspector");
-    await tap(".mobile-nav button:nth-child(2)");
+    await tap(".inspector__head .btn:not(.mobile-back)");
+    await until(() => evaluate("!!document.querySelector('.menu')"), "agent actions open by touch");
+    await fits(".menu");
+    await evaluate("document.querySelector('.menu__scrim').click()");
+    await tap('[aria-label="Back to conversation"]');
+    await tap(".mobile-nav button:nth-child(3)");
+    await until(() => evaluate("!!document.querySelector('.palette')"), "search opens from chat");
+    await fits(".palette");
+    await tap(".palette__query button");
+    await until(() => evaluate("!document.querySelector('.palette')"), "search cancels by touch");
+    assert.equal(await evaluate("document.querySelector('.composer__input').value"), "Draft survives navigation");
     await size(width,400);
     await fits(".composer");
     await size(width,844);
@@ -293,21 +317,20 @@ try {
       Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype,'value').set.call(n,'');
       n.dispatchEvent(new Event('input',{bubbles:true})); n.blur(); })()`);
     await tap(".mobile-nav button:first-child");
-    await tap(".rail__foot button:last-child");
+    await tap(".mobile-nav button:last-child");
     await until(() => evaluate("!!document.querySelector('.dialog--settings')"),"settings opens on phone");
     await delay(250);
     await fits(".dialog--settings");
     await fits(".settings__pane");
     await fits(".settings__foot");
     if (width === 320) {
-      const tabs = await evaluate("document.querySelectorAll('.settings__tab').length");
-      for (let i=1;i<=tabs;i++) {
-        await tap(`.settings__tab:nth-child(${i})`);
+      const sections = await evaluate("Array.from(document.querySelector('.settings__section select').options).map(o=>o.value)");
+      for (const section of sections) {
+        await evaluate(`(() => {const n=document.querySelector('.settings__section select'); n.value=${JSON.stringify(section)}; n.dispatchEvent(new Event('change',{bubbles:true}));})()`);
         await delay(100);
         await fits(".settings__pane");
         await fits(".settings__foot");
       }
-      await tap(".settings__tab:first-child");
     }
     if (process.env.GUACA_BROWSER_SHOTS) {
       await mkdir(process.env.GUACA_BROWSER_SHOTS,{recursive:true});
@@ -316,7 +339,7 @@ try {
     }
     await evaluate("document.querySelector('.scrim__close').click()");
     if (width === 320) {
-      for (const [button,dialog] of [[".rail__foot button:first-child",".dialog--cafeteria"],[".rail__foot button:nth-child(2)",".dialog--calendar"],[".rail__for-you",".for-you"]]) {
+      for (const [button,dialog] of [[".rail__foot button:first-child",".dialog--cafeteria"],[".rail__foot button:nth-child(2)",".dialog--calendar"],[".mobile-nav button:nth-child(2)",".for-you"]]) {
         await tap(button);
         await until(() => evaluate(`!!document.querySelector('${dialog}')`),`${dialog} opens`);
         await delay(250);

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -470,9 +470,9 @@ describe("phone navigation", () => {
     fireEvent.click(screen.getByRole("button", { name: "Details" }));
     expect(pane()).toBe("details");
     expect(container.querySelector(".inspector--closed")).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Hide this panel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Back to conversation" }));
     expect(pane()).toBe("conversation");
-    fireEvent.click(screen.getByRole("button", { name: "Agents" }));
+    fireEvent.click(screen.getByRole("button", { name: "Chats" }));
     expect(pane()).toBe("agents");
     fireEvent.click(railRow("Ada"));
     expect(pane()).toBe("conversation");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { ChannelView } from "./components/ChannelView";
 import { ForYou } from "./components/ForYou";
 import { GroupEditor } from "./components/GroupEditor";
 import { Inspector } from "./components/Inspector";
+import { MobileNavigation } from "./components/MobileNavigation";
 import { Search } from "./components/Search";
 import { type Section, SettingsDialog } from "./components/SettingsDialog";
 import { Sidebar } from "./components/Sidebar";
@@ -326,34 +327,11 @@ export default function App() {
 
   return (
     <div className="app" data-mobile-pane={openAgent ? mobilePane : "agents"}>
-      <nav className="mobile-nav" aria-label="Workspace views">
-        <button
-          type="button"
-          className="btn btn--ghost"
-          aria-pressed={!openAgent || mobilePane === "agents"}
-          onClick={() => setMobilePane("agents")}
-        >
-          Agents
-        </button>
-        <button
-          type="button"
-          className="btn btn--ghost"
-          aria-pressed={!!openAgent && mobilePane === "conversation"}
-          disabled={!openAgent}
-          onClick={openConversation}
-        >
-          Chat
-        </button>
-        <button
-          type="button"
-          className="btn btn--ghost"
-          aria-pressed={!!openAgent && mobilePane === "details"}
-          disabled={!openAgent}
-          onClick={openDetails}
-        >
-          Details
-        </button>
-      </nav>
+      <MobileNavigation
+        onChats={() => setMobilePane("agents")}
+        onSearch={() => setSearching(true)}
+        onSettings={() => setShowSettings(true)}
+      />
       <Sidebar
         onOpenChannel={openConversation}
         onEditAgent={(agent) => setEditing(agent)}
@@ -440,7 +418,12 @@ export default function App() {
             <p className="empty__body">Pick someone in the rail to open their channel.</p>
           </div>
         ) : (
-          <ChannelView channel={selected} onOpenMenu={(agent, at) => setMenu({ agent, ...at })} />
+          <ChannelView
+            channel={selected}
+            onOpenMenu={(agent, at) => setMenu({ agent, ...at })}
+            onBack={() => setMobilePane("agents")}
+            onDetails={openDetails}
+          />
         )}
       </main>
 
@@ -448,6 +431,7 @@ export default function App() {
         <Inspector
           agent={openAgent}
           onEditProfile={(agent) => setEditing(agent)}
+          onOpenActions={(agent, at) => setMenu({ agent, ...at })}
           reveal={mobilePane === "details"}
           onReveal={openDetails}
           onHide={openConversation}
@@ -521,6 +505,7 @@ export default function App() {
       )}
       {searching && (
         <Search
+          onOpenChannel={openConversation}
           onClose={() => setSearching(false)}
           onEditAgent={(agent) => setEditing(agent)}
           onEditGroup={(group) => setEditingGroup(group)}

--- a/src/components/ChannelView.tsx
+++ b/src/components/ChannelView.tsx
@@ -32,6 +32,8 @@ import { PeerBurstRow, RefusedRow, WritingRow } from "./WireRow";
 
 interface Props {
   channel: ChannelKey;
+  onBack?: () => void;
+  onDetails?: () => void;
   /** Where the operator asked for an agent's actions, and on whom. */
   onOpenMenu: (agent: AgentCard, at: { x: number; y: number }) => void;
 }
@@ -49,7 +51,7 @@ const FLASH_MS = 1800;
  */
 const WAITED_MS = 1000;
 
-export function ChannelView({ channel, onOpenMenu }: Props) {
+export function ChannelView({ channel, onOpenMenu, onBack, onDetails }: Props) {
   const lookups = useAgentLookup();
   const messages = useStore((s) => s.messages[channel]);
   const activity = useStore((s) => s.activity);
@@ -66,6 +68,7 @@ export function ChannelView({ channel, onOpenMenu }: Props) {
   const { ref: scrollRef, node: transcript, follow, pin } = useFollowBottom();
 
   const agent = lookups.byId(channel);
+  const crew = useStore((s) => s.groups.find((group) => group.id === agent?.groupId)?.name);
   // Held steady across renders: it is the value of a context read by every page
   // in the transcript, and a fresh object each time would redraw all of them
   // for every token that lands anywhere.
@@ -133,6 +136,16 @@ export function ChannelView({ channel, onOpenMenu }: Props) {
   return (
     <section className="pane">
       <header className="pane__header">
+        {onBack && (
+          <button
+            type="button"
+            className="mobile-only btn btn--ghost mobile-back"
+            aria-label="Back to chats"
+            onClick={onBack}
+          >
+            ‹
+          </button>
+        )}
         {agent ? (
           <>
             <AgentAvatar
@@ -143,7 +156,19 @@ export function ChannelView({ channel, onOpenMenu }: Props) {
               seed={agent.id}
               size="sm"
             />
-            <h1 className="pane__title">{agent.name}</h1>
+            <div className="pane__identity">
+              <h1 className="pane__title">{agent.name}</h1>
+              <span className="mobile-only pane__crew">{crew ?? "Independent agent"}</span>
+            </div>
+            {onDetails && (
+              <button
+                type="button"
+                className="mobile-only btn btn--ghost mobile-details"
+                onClick={onDetails}
+              >
+                Details
+              </button>
+            )}
             {/* The one thing about an agent that changes what this pane does.
                 Everything else it is set up with is edited rarely and read
                 behind the menu, rather than sitting over every message. */}
@@ -610,6 +635,8 @@ function LiveStreams({
   follow,
 }: {
   channel: ChannelKey;
+  onBack?: () => void;
+  onDetails?: () => void;
   lookups: ReturnType<typeof useAgentLookup>;
   follow: () => void;
 }) {
@@ -668,6 +695,8 @@ function Arrivals({
   lookups,
 }: {
   channel: ChannelKey;
+  onBack?: () => void;
+  onDetails?: () => void;
   messages: Envelope[] | undefined;
   lookups: ReturnType<typeof useAgentLookup>;
 }) {

--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -15,6 +15,7 @@ interface Props {
   onReveal?: () => void;
   onHide?: () => void;
   onEditProfile: (agent: AgentCard) => void;
+  onOpenActions?: (agent: AgentCard, at: { x: number; y: number }) => void;
 }
 
 const REMEMBERED = "guac.inspector";
@@ -71,7 +72,14 @@ function remembered(): boolean {
  * moving above them buys: the two stores are read against each other, and what
  * each is for is clearest when the other is under it.
  */
-export function Inspector({ agent, onEditProfile, reveal, onReveal, onHide }: Props) {
+export function Inspector({
+  agent,
+  onEditProfile,
+  onOpenActions,
+  reveal,
+  onReveal,
+  onHide,
+}: Props) {
   const [open, setOpen] = useState(remembered);
   const [routine, setRoutine] = useState<RoutineId | "new" | null>(null);
 
@@ -134,6 +142,16 @@ export function Inspector({ agent, onEditProfile, reveal, onReveal, onHide }: Pr
   return (
     <aside className="inspector" aria-label={`${agent.name}: screen and routines`}>
       <div className="inspector__head">
+        {onHide && (
+          <button
+            type="button"
+            className="mobile-only btn btn--ghost mobile-back"
+            aria-label="Back to conversation"
+            onClick={onHide}
+          >
+            ‹
+          </button>
+        )}
         {routine !== null ? (
           <>
             <button
@@ -149,6 +167,19 @@ export function Inspector({ agent, onEditProfile, reveal, onReveal, onHide }: Pr
           </>
         ) : (
           <>
+            <span className="inspector__agent-name mobile-only">{agent.name}</span>
+            {onOpenActions && (
+              <button
+                type="button"
+                className="mobile-only btn btn--ghost"
+                onClick={(event) => {
+                  const box = event.currentTarget.getBoundingClientRect();
+                  onOpenActions(agent, { x: box.left, y: box.bottom });
+                }}
+              >
+                Actions
+              </button>
+            )}
             <span style={{ flex: 1 }} />
             <button
               type="button"

--- a/src/components/MobileNavigation.tsx
+++ b/src/components/MobileNavigation.tsx
@@ -1,0 +1,62 @@
+import { useStore } from "../lib/store";
+
+interface Props {
+  onChats: () => void;
+  onSearch: () => void;
+  onSettings: () => void;
+}
+
+/** The destinations needed while away from the desktop, within thumb reach. */
+export function MobileNavigation({ onChats, onSearch, onSettings }: Props) {
+  const pending = useStore((s) => s.pending);
+  const stuck = useStore((s) => s.stuck);
+  const decisions = useStore((s) => s.decisions);
+  const forYou = useStore((s) => s.forYou);
+  const showForYou = useStore((s) => s.showForYou);
+  const count =
+    pending.length +
+    stuck.length +
+    decisions.filter(
+      (item) => item.status === "pending" || (item.status === "answered" && item.interrupted),
+    ).length;
+  return (
+    <nav className="mobile-nav" aria-label="Workspace navigation">
+      <button type="button" aria-current={!forYou ? "page" : undefined} onClick={onChats}>
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M5 4h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H9l-6 4V6a2 2 0 0 1 2-2Z" />
+        </svg>
+        <span>Chats</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => showForYou(true)}
+        aria-label={count ? `For you, ${count} needs attention` : "For you"}
+      >
+        <span className="mobile-nav__icon">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 4h16v16H4zM8 9h8M8 14h5" />
+          </svg>
+          {count > 0 && (
+            <span className="mobile-nav__badge" aria-hidden="true">
+              {count}
+            </span>
+          )}
+        </span>
+        <span>For you</span>
+      </button>
+      <button type="button" onClick={onSearch}>
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="10" cy="10" r="6" />
+          <path d="m15 15 6 6" />
+        </svg>
+        <span>Search</span>
+      </button>
+      <button type="button" onClick={onSettings}>
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M4 6h16M4 12h16M4 18h16M8 3v6M16 9v6M10 15v6" />
+        </svg>
+        <span>Settings</span>
+      </button>
+    </nav>
+  );
+}

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -17,6 +17,7 @@ import { type AgentCard, errorMessage, type Group, type SearchHits } from "../li
 
 interface Props {
   onClose: () => void;
+  onOpenChannel?: () => void;
   onEditAgent: (agent: AgentCard) => void;
   onEditGroup: (group: Group) => void;
   onNewAgent: () => void;
@@ -49,6 +50,7 @@ const LIMIT = 25;
  */
 export function Search({
   onClose,
+  onOpenChannel,
   onEditAgent,
   onEditGroup,
   onNewAgent,
@@ -110,9 +112,11 @@ export function Search({
       switch (action.do) {
         case "openChannel":
           void select(action.agentId);
+          onOpenChannel?.();
           break;
         case "openMessage":
           void openMessage(action.channelId, action.messageId);
+          onOpenChannel?.();
           break;
         case "openLink":
           void openExternal(action.url);
@@ -152,6 +156,7 @@ export function Search({
       onNewGroup,
       onOpenCafeteria,
       onOpenSettings,
+      onOpenChannel,
       openMessage,
       select,
     ],
@@ -219,6 +224,9 @@ export function Search({
               setCursor(0);
             }}
           />
+          <button type="button" className="mobile-only btn btn--ghost" onClick={onClose}>
+            Cancel
+          </button>
         </div>
 
         <div className="palette__tabs" role="tablist" aria-label="What to search">

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -524,6 +524,20 @@ export function SettingsDialog({ onClose, section: opening }: Props) {
           </p>
         </div>
 
+        <label className="mobile-only settings__section field">
+          <span className="field__label">Settings section</span>
+          <select
+            className="input"
+            value={section}
+            onChange={(event) => setSection(event.target.value as Section)}
+          >
+            {SECTIONS.map((key) => (
+              <option key={key} value={key}>
+                {SECTION_LABELS[key]}
+              </option>
+            ))}
+          </select>
+        </label>
         <div className="settings__body">
           <div
             className="settings__nav"

--- a/src/styles.css
+++ b/src/styles.css
@@ -7596,7 +7596,8 @@ input[type="file"]:disabled {
 /* A phone shows one workspace pane at a time. Keep the transcript mounted so
    drafts, scroll position and live events survive a trip to the agent list. */
 .mobile-nav,
-.mobile-crews {
+.mobile-crews,
+.mobile-only {
   display: none;
 }
 
@@ -7618,26 +7619,129 @@ input[type="file"]:disabled {
     height: var(--viewport-height, 100dvh);
     padding: var(--space-safe-top) var(--space-safe-right) var(--space-safe-bottom) var(--space-safe-left);
     display: grid;
-    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) auto;
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .mobile-nav {
+  .mobile-only {
     display: flex;
-    gap: var(--space-2);
-    padding: var(--space-3) var(--space-5);
-    border-bottom: 1px solid var(--edge);
+  }
+
+  .mobile-nav {
+    grid-row: 2;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    padding: var(--space-2) var(--space-3);
+    border-top: 1px solid var(--edge);
     background: var(--rail-ground);
   }
 
-  .mobile-nav .btn {
-    flex: 1;
+  .mobile-nav > button {
+    min-height: calc(var(--control-touch) + var(--space-4));
+    border: 0;
+    border-radius: var(--radius);
+    background: transparent;
+    color: var(--muted);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    font-size: var(--type-small);
+    font-weight: 500;
+    cursor: pointer;
   }
 
-  .mobile-nav [aria-pressed="true"] {
-    background: var(--raised);
+  .mobile-nav [aria-current="page"] {
+    background: var(--rail-raised);
     color: var(--text);
+  }
+
+  .mobile-nav svg {
+    width: var(--space-7);
+    height: var(--space-7);
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .mobile-nav__icon {
+    position: relative;
+    display: flex;
+  }
+
+  .mobile-nav__badge {
+    position: absolute;
+    left: 100%;
+    top: calc(-1 * var(--space-2));
+    padding: 0 var(--space-2);
+    border-radius: var(--radius-pill);
+    background: var(--flesh);
+    color: var(--text);
+    font-size: var(--type-meta);
+  }
+
+  .app > .rail,
+  .app > main,
+  .app > .inspector {
+    grid-row: 1;
+    min-height: 0;
+  }
+
+  .pane__identity {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .pane__crew {
+    color: var(--muted);
+    font-size: var(--type-small);
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mobile-back {
+    flex: none;
+    min-width: var(--control-touch);
+    font-size: var(--type-title);
+    justify-content: center;
+    align-items: center;
+  }
+
+  .mobile-details {
+    flex: none;
+  }
+
+  .inspector__agent-name {
     font-weight: 600;
+    flex: 1;
+    min-width: 0;
+    display: block;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .inspector__head > span:empty,
+  .inspector__head > .inspector__gear {
+    display: none;
+  }
+
+  .palette__query .btn {
+    flex: none;
+  }
+
+  .pane__header > .avatar,
+  .pane__more,
+  .inspector__head > .inspector__tab:last-child,
+  .rail__search,
+  .rail__for-you,
+  .rail__foot > button:last-child {
+    display: none;
   }
 
   .app > .grail,
@@ -7689,7 +7793,7 @@ input[type="file"]:disabled {
     height: auto;
     min-height: var(--control-touch);
     padding: var(--space-3) var(--space-5);
-    gap: var(--space-4);
+    gap: var(--space-2);
   }
 
   .pane__title {
@@ -7791,11 +7895,13 @@ input[type="file"]:disabled {
   }
 
   .settings__nav {
-    width: 100%;
-    flex-direction: row;
-    overflow-x: auto;
-    border-right: 0;
-    border-bottom: 1px solid var(--edge);
+    display: none;
+  }
+
+  .settings__section {
+    flex: none;
+    flex-direction: column;
+    padding: 0 var(--space-5) var(--space-5);
   }
 
   .settings__tab {


### PR DESCRIPTION
Phone navigation required switching between desktop panels using controls at the top of the screen, with approvals, search and settings buried in the agent list. Replace that navigation with a bottom bar for Chats, For you, Search and Settings, including the attention count.

Conversations show their crew, a back button and Details. Details provides explicit return navigation and agent actions; Search has a visible Cancel button and returns to an already-selected conversation correctly. Settings uses a labeled section picker instead of an overflowing tab strip. Drafts and transcripts remain mounted across navigation.

Validation: full frontend lint/build and 1,589 tests; real Chromium touch navigation at 320, 390, 430 and 768 pixels, phone landscape, a keyboard-sized viewport and desktop, against an isolated daemon with an offline model. Screenshots reviewed.
